### PR TITLE
Using TokenCredential trait in KeyVaultClient

### DIFF
--- a/sdks/keyvault/Cargo.toml
+++ b/sdks/keyvault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure-keyvault"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Microsoft Corp."]
 description = "Rust wrapper around Microsoft Azure REST APIs for Azure Key Vault"
 documentation = "https://docs.rs/azure-sdk-keyvault"

--- a/sdks/keyvault/Cargo.toml
+++ b/sdks/keyvault/Cargo.toml
@@ -26,6 +26,8 @@ serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
 oauth2 = { version = "3.0.0-alpha.9", features = ["reqwest-010", "futures-03"], default-features = false}
 azure_auth_aad = { version = "0.1", path = "../auth_aad" }
+azure_sdk_core = { path = "../core", version = "0.43.5" }
+async-trait = "0.1"
 
 [dev-dependencies]
 mockito = "0.27"

--- a/sdks/keyvault/Cargo.toml
+++ b/sdks/keyvault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure-keyvault"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Microsoft Corp."]
 description = "Rust wrapper around Microsoft Azure REST APIs for Azure Key Vault"
 documentation = "https://docs.rs/azure-sdk-keyvault"

--- a/sdks/keyvault/Cargo.toml
+++ b/sdks/keyvault/Cargo.toml
@@ -27,7 +27,7 @@ getset = "0.1"
 oauth2 = { version = "3.0.0-alpha.9", features = ["reqwest-010", "futures-03"], default-features = false}
 azure_auth_aad = { version = "0.1", path = "../auth_aad" }
 azure_sdk_core = { path = "../core", version = "0.43.5" }
-async-trait = "0.1"
 
 [dev-dependencies]
 mockito = "0.27"
+async-trait = "0.1"

--- a/sdks/keyvault/examples/backup_secret.rs
+++ b/sdks/keyvault/examples/backup_secret.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::KeyVaultClient;
 use std::env;
 
@@ -11,7 +12,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env::var("KEYVAULT_NAME").expect("Missing KEYVAULT_NAME environment variable.");
     let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
 
     let backup_response = client.backup_secret(&secret_name).await?;
     dbg!(&backup_response);

--- a/sdks/keyvault/examples/delete_secret.rs
+++ b/sdks/keyvault/examples/delete_secret.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::KeyVaultClient;
 use std::env;
 
@@ -11,7 +12,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env::var("KEYVAULT_NAME").expect("Missing KEYVAULT_NAME environment variable.");
     let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
     client.delete_secret(&secret_name).await?;
 
     Ok(())

--- a/sdks/keyvault/examples/get_secret.rs
+++ b/sdks/keyvault/examples/get_secret.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::KeyVaultClient;
 use std::env;
 
@@ -11,7 +12,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env::var("KEYVAULT_NAME").expect("Missing KEYVAULT_NAME environment variable.");
     let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
 
     let secret = client.get_secret(&secret_name).await?;
     dbg!(&secret.value());

--- a/sdks/keyvault/examples/get_secret_versions.rs
+++ b/sdks/keyvault/examples/get_secret_versions.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::KeyVaultClient;
 use std::env;
 
@@ -11,7 +12,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env::var("KEYVAULT_NAME").expect("Missing KEYVAULT_NAME environment variable.");
     let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
 
     let secrets = client.get_secret_versions(&secret_name).await?;
     dbg!(&secrets);

--- a/sdks/keyvault/examples/list_secrets.rs
+++ b/sdks/keyvault/examples/list_secrets.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::KeyVaultClient;
 use std::env;
 
@@ -10,7 +11,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let keyvault_name =
         env::var("KEYVAULT_NAME").expect("Missing KEYVAULT_NAME environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
 
     let secrets = client.list_secrets().await?;
     dbg!(&secrets);

--- a/sdks/keyvault/examples/restore_secret.rs
+++ b/sdks/keyvault/examples/restore_secret.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::KeyVaultClient;
 use std::env;
 
@@ -11,7 +12,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env::var("KEYVAULT_NAME").expect("Missing KEYVAULT_NAME environment variable.");
     let backup_blob = env::var("BACKUP_BLOB").expect("Missing BACKUP_BLOB environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
+
     client.restore_secret(&backup_blob).await?;
 
     Ok(())

--- a/sdks/keyvault/examples/set_secret.rs
+++ b/sdks/keyvault/examples/set_secret.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::KeyVaultClient;
 use std::env;
 
@@ -13,7 +14,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let secret_value =
         env::var("SECRET_VALUE").expect("Missing SECRET_VALUE environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
 
     client.set_secret(&secret_name, &secret_value).await?;
 

--- a/sdks/keyvault/examples/update_secret.rs
+++ b/sdks/keyvault/examples/update_secret.rs
@@ -1,3 +1,4 @@
+use azure_auth_aad::ClientSecretCredential;
 use azure_keyvault::{KeyVaultClient, RecoveryLevel};
 use chrono::prelude::*;
 use chrono::Duration;
@@ -15,7 +16,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let secret_version =
         env::var("SECRET_VERSION").expect("Missing SECRET_VERSION environment variable.");
 
-    let mut client = KeyVaultClient::new(&client_id, &client_secret, &tenant_id, &keyvault_name);
+    let creds = ClientSecretCredential::new(tenant_id, client_id, client_secret);
+    let mut client = KeyVaultClient::new(&creds, &keyvault_name);
 
     // Disable secret.
     client

--- a/sdks/keyvault/src/client.rs
+++ b/sdks/keyvault/src/client.rs
@@ -77,7 +77,8 @@ impl<'a, T:TokenCredential> KeyVaultClient<'a, T> {
             // Token is valid, return it.
             return Ok(());
         }
-        let token = self.token_credential.get_token(&self.keyvault_endpoint)
+        let resource = format!("https://{}", endpoint_suffix);
+        let token = self.token_credential.get_token(&resource)
         .await
         .with_context(|| "Failed to authenticate to Azure Active Directory")
         .map_err(|e| KeyVaultError::AuthorizationError(e))?;

--- a/sdks/keyvault/src/client.rs
+++ b/sdks/keyvault/src/client.rs
@@ -12,7 +12,9 @@ pub(crate) const API_VERSION: &str = "7.0";
 ///
 /// ```no_run
 /// use azure_keyvault::KeyVaultClient;
-/// let client = KeyVaultClient::new(&"{client_id}", &"{client_secret}", &"{tenant_id}", &"test-keyvault");
+/// use azure_auth_aad::DefaultCredential;
+/// let creds = DefaultCredential::default();
+/// let client = KeyVaultClient::new(&creds, &"test-keyvault");
 /// ```
 #[derive(Debug)]
 pub struct KeyVaultClient<'a, T> {
@@ -32,7 +34,8 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
     /// use azure_auth_aad::DefaultCredential;
-    /// let client = KeyVaultClient::with_endpoint_suffix(&DefaultCredential::default(), &"test-keyvault", "vault.azure.net".to_owned());
+    /// let creds = DefaultCredential::default();
+    /// let client = KeyVaultClient::with_endpoint_suffix(&creds, &"test-keyvault", "vault.azure.net".to_owned());
     /// ```
     pub fn with_endpoint_suffix(
         token_credential: &'a T,
@@ -56,7 +59,8 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
     /// use azure_auth_aad::DefaultCredential;
-    /// let client = KeyVaultClient::new(&DefaultCredential::default(), &"test-keyvault");
+    /// let creds = DefaultCredential::default();
+    /// let client = KeyVaultClient::new(&creds, &"test-keyvault");
     /// ```
     pub fn new(token_credential: &'a T, keyvault_name: &'a str) -> Self {
         KeyVaultClient::with_endpoint_suffix(

--- a/sdks/keyvault/src/client.rs
+++ b/sdks/keyvault/src/client.rs
@@ -77,7 +77,7 @@ impl<'a, T:TokenCredential> KeyVaultClient<'a, T> {
             // Token is valid, return it.
             return Ok(());
         }
-        let resource = format!("https://{}", endpoint_suffix);
+        let resource = format!("https://{}", &self.endpoint_suffix);
         let token = self.token_credential.get_token(&resource)
         .await
         .with_context(|| "Failed to authenticate to Azure Active Directory")

--- a/sdks/keyvault/src/client.rs
+++ b/sdks/keyvault/src/client.rs
@@ -1,7 +1,7 @@
 use crate::KeyVaultError;
 use anyhow::Context;
 use anyhow::Result;
-use azure_auth_aad::authorize_client_credentials_flow;
+use azure_auth_aad::{TokenCredential, TokenResponse};
 use chrono::{DateTime, Utc};
 use oauth2::{AccessToken, ClientId, ClientSecret};
 use std::sync::Arc;
@@ -18,18 +18,15 @@ pub(crate) const API_VERSION: &str = "7.0";
 /// let client = KeyVaultClient::new(&"{client_id}", &"{client_secret}", &"{tenant_id}", &"test-keyvault");
 /// ```
 #[derive(Debug)]
-pub struct KeyVaultClient<'a> {
-    pub(crate) aad_client_id: &'a str,
-    pub(crate) aad_client_secret: &'a str,
-    pub(crate) aad_tenant_id: &'a str,
+pub struct KeyVaultClient<'a, T> {
+    pub(crate) token_credential: &'a T,
     pub(crate) keyvault_name: &'a str,
     pub(crate) endpoint_suffix: String,
     pub(crate) keyvault_endpoint: String,
-    pub(crate) token: Option<AccessToken>,
-    pub(crate) token_expiration: Option<DateTime<Utc>>,
+    pub(crate) token: Option<TokenResponse>,
 }
 
-impl<'a> KeyVaultClient<'a> {
+impl<'a, T:TokenCredential> KeyVaultClient<'a, T> {
     /// Creates a new `KeyVaultClient` with an endpoint suffix. Useful for non-public Azure clouds.
     /// For the default public environment, use `KeyVaultClient::new`.
     ///
@@ -37,87 +34,21 @@ impl<'a> KeyVaultClient<'a> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
-    /// let client = KeyVaultClient::with_endpoint_suffix(&"c1a6d79b-082b-4798-b362-a77e96de50db", &"SUPER_SECRET_KEY", &"bc598e67-03d8-44d5-aa46-8289b9a39a14", &"test-keyvault", "vault.azure.net".to_owned());
+    /// use azure_auth_aad::DefaultCredential;
+    /// let client = KeyVaultClient::with_endpoint_suffix(&DefaultCredential::default(), &"test-keyvault", "vault.azure.net".to_owned());
     /// ```
     pub fn with_endpoint_suffix(
-        aad_client_id: &'a str,
-        aad_client_secret: &'a str,
-        aad_tenant_id: &'a str,
+        token_credential: &'a T,
         keyvault_name: &'a str,
         endpoint_suffix: String,
     ) -> Self {
         let endpoint = format!("https://{}.{}", keyvault_name, endpoint_suffix);
         Self {
-            aad_client_id,
-            aad_client_secret,
-            aad_tenant_id,
+            token_credential,
             keyvault_name,
             endpoint_suffix,
             keyvault_endpoint: endpoint,
             token: None,
-            token_expiration: None,
-        }
-    }
-
-    /// Creates a new `KeyVaultClient` with a pre-existing AAD token.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use azure_keyvault::KeyVaultClient;
-    /// use chrono::{Utc, Duration};
-    /// use oauth2::AccessToken;
-    /// let client = KeyVaultClient::with_aad_token(&"c1a6d79b-082b-4798-b362-a77e96de50db", &"SUPER_SECRET_KEY", &"bc598e67-03d8-44d5-aa46-8289b9a39a14", &"test-keyvault", AccessToken::new(String::new()), Utc::now() + Duration::days(14));
-    /// ```
-    pub fn with_aad_token(
-        aad_client_id: &'a str,
-        aad_client_secret: &'a str,
-        aad_tenant_id: &'a str,
-        keyvault_name: &'a str,
-        aad_token: AccessToken,
-        aad_token_expiration: DateTime<Utc>,
-    ) -> Self {
-        let endpoint = format!("https://{}.{}", keyvault_name, PUBLIC_ENDPOINT_SUFFIX);
-        Self {
-            aad_client_id,
-            aad_client_secret,
-            aad_tenant_id,
-            keyvault_name,
-            endpoint_suffix: PUBLIC_ENDPOINT_SUFFIX.to_owned(),
-            keyvault_endpoint: endpoint,
-            token: Some(aad_token),
-            token_expiration: Some(aad_token_expiration),
-        }
-    }
-
-    /// Creates a new `KeyVaultClient` with a pre-existing AAD token.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use azure_keyvault::KeyVaultClient;
-    /// use chrono::{Utc, Duration};
-    /// use oauth2::AccessToken;
-    /// let client = KeyVaultClient::with_aad_token(&"c1a6d79b-082b-4798-b362-a77e96de50db", &"SUPER_SECRET_KEY", &"bc598e67-03d8-44d5-aa46-8289b9a39a14", &"test-keyvault", AccessToken::new(String::new()), Utc::now() + Duration::days(14));
-    /// ```
-    pub fn with_aad_token_and_endpoint_suffix(
-        aad_client_id: &'a str,
-        aad_client_secret: &'a str,
-        aad_tenant_id: &'a str,
-        keyvault_name: &'a str,
-        aad_token: AccessToken,
-        aad_token_expiration: DateTime<Utc>,
-    ) -> Self {
-        let endpoint = format!("https://{}.{}", keyvault_name, PUBLIC_ENDPOINT_SUFFIX);
-        Self {
-            aad_client_id,
-            aad_client_secret,
-            aad_tenant_id,
-            keyvault_name,
-            endpoint_suffix: PUBLIC_ENDPOINT_SUFFIX.to_owned(),
-            keyvault_endpoint: endpoint,
-            token: Some(aad_token),
-            token_expiration: Some(aad_token_expiration),
         }
     }
 
@@ -127,42 +58,30 @@ impl<'a> KeyVaultClient<'a> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
-    /// let client = KeyVaultClient::new(&"c1a6d79b-082b-4798-b362-a77e96de50db", &"SUPER_SECRET_KEY", &"bc598e67-03d8-44d5-aa46-8289b9a39a14", &"test-keyvault");
+    /// use azure_auth_aad::DefaultCredential;
+    /// let client = KeyVaultClient::new(&DefaultCredential::default(), &"test-keyvault");
     /// ```
     pub fn new(
-        aad_client_id: &'a str,
-        aad_client_secret: &'a str,
-        aad_tenant_id: &'a str,
+        token_credential: &'a T,
         keyvault_name: &'a str,
     ) -> Self {
         KeyVaultClient::with_endpoint_suffix(
-            aad_client_id,
-            aad_client_secret,
-            aad_tenant_id,
+            token_credential,
             keyvault_name,
             PUBLIC_ENDPOINT_SUFFIX.to_owned(),
         )
     }
 
     pub(crate) async fn refresh_token(&mut self) -> Result<(), KeyVaultError> {
-        if matches!(self.token_expiration, Some(exp) if exp > chrono::Utc::now()) {
+        if matches!(&self.token, Some(token) if token.expires_on > chrono::Utc::now()) {
             // Token is valid, return it.
             return Ok(());
         }
-        let aad_client_id = ClientId::new(self.aad_client_id.to_owned());
-        let aad_client_secret = ClientSecret::new(self.aad_client_secret.to_owned());
-        let token = authorize_client_credentials_flow(
-            Arc::new(reqwest::Client::new()),
-            &aad_client_id,
-            &aad_client_secret,
-            &format!("https://{}", self.endpoint_suffix),
-            self.aad_tenant_id,
-        )
+        let token = self.token_credential.get_token(&self.keyvault_endpoint)
         .await
         .with_context(|| "Failed to authenticate to Azure Active Directory")
         .map_err(|e| KeyVaultError::AuthorizationError(e))?;
-        self.token = Some(token.access_token().clone());
-        self.token_expiration = token.expires_on;
+        self.token = Some(token);
         Ok(())
     }
 
@@ -173,7 +92,7 @@ impl<'a> KeyVaultClient<'a> {
             .get(&uri)
             .header(
                 "Authorization",
-                format!("Bearer {}", self.token.as_ref().unwrap().secret()),
+                format!("Bearer {}", self.token.as_ref().unwrap().token.secret()),
             )
             .send()
             .await
@@ -189,7 +108,7 @@ impl<'a> KeyVaultClient<'a> {
             .put(&uri)
             .header(
                 "Authorization",
-                format!("Bearer {}", self.token.as_ref().unwrap().secret()),
+                format!("Bearer {}", self.token.as_ref().unwrap().token.secret()),
             )
             .header("Content-Type", "application/json")
             .body(body)
@@ -205,7 +124,7 @@ impl<'a> KeyVaultClient<'a> {
 
         let mut req = reqwest::Client::new().post(&uri).header(
             "Authorization",
-            format!("Bearer {}", self.token.as_ref().unwrap().secret()),
+            format!("Bearer {}", self.token.as_ref().unwrap().token.secret()),
         );
 
         if let Some(body) = json_body {
@@ -227,7 +146,7 @@ impl<'a> KeyVaultClient<'a> {
             .patch(&uri)
             .header(
                 "Authorization",
-                format!("Bearer {}", self.token.as_ref().unwrap().secret()),
+                format!("Bearer {}", self.token.as_ref().unwrap().token.secret()),
             )
             .header("Content-Type", "application/json")
             .body(body)
@@ -256,7 +175,7 @@ impl<'a> KeyVaultClient<'a> {
             .delete(&uri)
             .header(
                 "Authorization",
-                format!("Bearer {}", self.token.as_ref().unwrap().secret()),
+                format!("Bearer {}", self.token.as_ref().unwrap().token.secret()),
             )
             .header("Content-Type", "application/json")
             .send()

--- a/sdks/keyvault/src/secret.rs
+++ b/sdks/keyvault/src/secret.rs
@@ -1,7 +1,7 @@
 use crate::KeyVaultClient;
 use crate::{client::API_VERSION, KeyVaultError};
-use azure_auth_aad::TokenCredential;
 use anyhow::{Context, Result};
+use azure_auth_aad::TokenCredential;
 use chrono::serde::ts_seconds;
 use chrono::{DateTime, Utc};
 use getset::Getters;
@@ -106,7 +106,7 @@ pub struct KeyVaultSecret {
     time_updated: DateTime<Utc>,
 }
 
-impl<'a, T:TokenCredential> KeyVaultClient<'a, T> {
+impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     /// Gets a secret from the Key Vault.
     /// Note that the latest version is fetched. For a specific version, use `get_version_with_version`.
     ///

--- a/sdks/keyvault/src/secret.rs
+++ b/sdks/keyvault/src/secret.rs
@@ -1,5 +1,6 @@
 use crate::KeyVaultClient;
 use crate::{client::API_VERSION, KeyVaultError};
+use azure_auth_aad::TokenCredential;
 use anyhow::{Context, Result};
 use chrono::serde::ts_seconds;
 use chrono::{DateTime, Utc};
@@ -103,7 +104,7 @@ pub struct KeyVaultSecret {
     time_updated: DateTime<Utc>,
 }
 
-impl<'a> KeyVaultClient<'a> {
+impl<'a, T:TokenCredential> KeyVaultClient<'a, T> {
     /// Gets a secret from the Key Vault.
     /// Note that the latest version is fetched. For a specific version, use `get_version_with_version`.
     ///

--- a/sdks/keyvault/src/secret.rs
+++ b/sdks/keyvault/src/secret.rs
@@ -114,13 +114,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     let secret = client.get_secret(&"SECRET_NAME").await.unwrap();
@@ -143,13 +143,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     let secret = client.get_secret_with_version(&"SECRET_NAME", &"SECRET_VERSION").await.unwrap();
@@ -187,13 +187,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     let secrets = client.list_secrets().await.unwrap();
@@ -248,13 +248,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     let secret_versions = client.get_secret_versions(&"SECRET_NAME").await.unwrap();
@@ -320,13 +320,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     client.set_secret(&"SECRET_NAME", &"NEW_VALUE").await.unwrap();
@@ -369,13 +369,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     client.update_secret_enabled(&"SECRET_NAME", &"", true).await.unwrap();
@@ -410,13 +410,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::{KeyVaultClient, RecoveryLevel};
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     client.update_secret_recovery_level(&"SECRET_NAME", &"", RecoveryLevel::Purgeable).await.unwrap();
@@ -454,14 +454,14 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::{KeyVaultClient, RecoveryLevel};
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     /// use chrono::{Utc, Duration};
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     client.update_secret_expiration_time(&"SECRET_NAME", &"", Utc::now() + Duration::days(14)).await.unwrap();
@@ -518,13 +518,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     client.restore_secret(&"KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taW").await.unwrap();
@@ -558,13 +558,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::KeyVaultClient;
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     client.backup_secret(&"SECRET_NAME").await.unwrap();
@@ -607,13 +607,13 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_keyvault::{KeyVaultClient, RecoveryLevel};
+    /// use azure_auth_aad::DefaultCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
+    ///     let creds = DefaultCredential::default();
     ///     let mut client = KeyVaultClient::new(
-    ///     &"CLIENT_ID",
-    ///     &"CLIENT_SECRET",
-    ///     &"TENANT_ID",
+    ///     &creds,
     ///     &"KEYVAULT_NAME",
     ///     );
     ///     client.delete_secret(&"SECRET_NAME").await.unwrap();
@@ -639,7 +639,9 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
 mod tests {
     use super::*;
 
+    use async_trait;
     use azure_auth_aad::{TokenCredential, TokenResponse};
+    use azure_sdk_core::errors::AzureError;
     use chrono::{Duration, Utc};
     use mockito::{mock, Matcher};
     use oauth2::AccessToken;
@@ -649,7 +651,7 @@ mod tests {
 
     #[async_trait::async_trait]
     impl TokenCredential for MockSecretCredential {
-        async fn get_token(&self, resource: &str) -> Result<TokenResponse, AzureError> {
+        async fn get_token(&self, _resource: &str) -> Result<TokenResponse, AzureError> {
             Ok(TokenResponse::new(
                 AccessToken::new("TOKEN".to_owned()),
                 Utc::now() + Duration::days(14),
@@ -666,9 +668,8 @@ mod tests {
     }
 
     macro_rules! mock_client {
-        ($keyvault_name:expr) => {{
-            let creds = MockSecretCredential;
-            let mut client = KeyVaultClient::new(&creds, $keyvault_name);
+        ($creds:expr, $keyvault_name:expr) => {{
+            let mut client = KeyVaultClient::new($creds, $keyvault_name);
             client.keyvault_endpoint = mockito::server_url();
             client
         }};
@@ -697,7 +698,8 @@ mod tests {
             .with_status(200)
             .create();
 
-        let mut client = mock_client!(&"test-keyvault");
+        let creds = MockSecretCredential;
+        let mut client = mock_client!(&creds, &"test-keyvault");
 
         let secret: KeyVaultSecret = client.get_secret(&"test-secret").await.unwrap();
 
@@ -765,7 +767,8 @@ mod tests {
             .with_status(200)
             .create();
 
-        let mut client = mock_client!(&"test-keyvault");
+        let creds = MockSecretCredential;
+        let mut client = mock_client!(&creds, &"test-keyvault");
 
         let secret_versions = client.get_secret_versions(&"test-secret").await.unwrap();
 


### PR DESCRIPTION
resolve #5 

`ClientSecretCredential` is used in examples to have the least change (the same env should result in the same response), but for the doc-examples I've used the DefaultCredentail.

As it is a breaking change the semver should be updated before releasing a new version of the crate !


