### PR TITLE
build on any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build and Test
 on: 
   pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   test:
@@ -21,9 +19,9 @@ jobs:
         override: true
         components: rustfmt
 
-    - name: tests
-      run: cargo test --all 
-
     - name: fmt
       run: cargo fmt --all -- --check
       if: matrix.rust == 'nightly'
+
+    - name: tests
+      run: cargo test --all 


### PR DESCRIPTION
This removes the branch restriction of `master`. When working on my fork, I want CI to run before I make a pull request. This also moves the format check earlier. It is annoying to wait for 9 minutes of building and tests, only to fail on a format check.