### PR TITLE
bump oauth2 to latest

### DIFF
--- a/sdks/auth_aad/Cargo.toml
+++ b/sdks/auth_aad/Cargo.toml
@@ -14,7 +14,7 @@ edition            = "2018"
 
 [dependencies]
 azure_sdk_core       = { path = "../core", version = "0.43.5" }
-oauth2               = { version = "3.0.0", features = ["reqwest-010", "futures-03"], default-features = false}
+oauth2               = { version = "4.0.0-alpha.2" }
 url                  = "2.1"
 futures              = "0.3"
 serde                = "1.0"

--- a/sdks/auth_aad/src/lib.rs
+++ b/sdks/auth_aad/src/lib.rs
@@ -6,7 +6,6 @@ use azure_sdk_core::errors::AzureError;
 use log::debug;
 use oauth2::basic::BasicClient;
 use oauth2::reqwest::async_http_client;
-use oauth2::AsyncCodeTokenRequest;
 use oauth2::{
     AuthType, AuthUrl, AuthorizationCode, CsrfToken, PkceCodeChallenge, PkceCodeVerifier,
     RedirectUrl, TokenUrl,

--- a/sdks/auth_aad/src/token_credentials/client_secret_credentials.rs
+++ b/sdks/auth_aad/src/token_credentials/client_secret_credentials.rs
@@ -3,8 +3,8 @@ use crate::token_credentials::TokenCredential;
 use azure_sdk_core::errors::AzureError;
 use chrono::Utc;
 use oauth2::{
-    basic::BasicClient, reqwest::async_http_client, AccessToken,
-    AsyncClientCredentialsTokenRequest, AuthType, AuthUrl, Scope, TokenResponse, TokenUrl,
+    basic::BasicClient, reqwest::async_http_client, AccessToken, AuthType, AuthUrl, Scope,
+    TokenResponse, TokenUrl,
 };
 use std::{str, time::Duration};
 use url::Url;

--- a/sdks/keyvault/Cargo.toml
+++ b/sdks/keyvault/Cargo.toml
@@ -18,14 +18,14 @@ edition = "2018"
 anyhow = "1.0"
 thiserror = "1.0"
 reqwest = { version = "0.10", features = ["blocking", "json"] }
-tokio = { version = "0.2", features = ["full"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"
 url = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-oauth2 = { version = "3.0.0-alpha.9", features = ["reqwest-010", "futures-03"], default-features = false}
+oauth2 = { version = "4.0.0-alpha.2" }
 azure_auth_aad = { version = "0.1", path = "../auth_aad" }
 
 [dev-dependencies]
 mockito = "0.27"
+tokio = { version = "0.2", features = ["full"] }


### PR DESCRIPTION
The latest oauth2 supports std futures and errors. https://github.com/ramosbugs/oauth2-rs/releases
This also moves tokio to be a dev-dependency for keyvault.