### PR TITLE
build --all-targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,8 @@ jobs:
         ./scripts/check_json_format.sh
       if: matrix.rust == 'stable'
 
+    - name: build
+      run: cargo build --all-targets
+
     - name: tests
       run: cargo test --all 


### PR DESCRIPTION
This makes sure that we build all the examples as well.