### PR TITLE
Move the TokenCredential trait to azure_core

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -30,10 +30,12 @@ uuid = { version = "0.8", features = ["v4"] }
 bytes = "0.5"
 hyper-rustls = "0.21"
 failure = "0.1"
+async-trait = "0.1.36"
+oauth2 = { version = "4.0.0-alpha.2" }
 
 [dev-dependencies]
-tokio = "0.2"
-env_logger = "0.7"
+tokio = "0.3"
+env_logger = "0.8"
 
 [features]
 test_e2e = []

--- a/sdk/identity/examples/cli_credentials.rs
+++ b/sdk/identity/examples/cli_credentials.rs
@@ -1,3 +1,4 @@
+use azure_core::TokenCredential;
 use azure_identity::token_credentials::*;
 use std::error::Error;
 use url::Url;

--- a/sdk/identity/examples/default_credentials.rs
+++ b/sdk/identity/examples/default_credentials.rs
@@ -1,3 +1,4 @@
+use azure_core::TokenCredential;
 use azure_identity::token_credentials::*;
 use std::error::Error;
 use url::Url;

--- a/sdk/identity/examples/environment_credentials.rs
+++ b/sdk/identity/examples/environment_credentials.rs
@@ -1,3 +1,4 @@
+use azure_core::TokenCredential;
 use azure_identity::token_credentials::*;
 use std::error::Error;
 use url::Url;

--- a/sdk/identity/src/token_credentials/cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/cli_credentials.rs
@@ -1,6 +1,5 @@
-use crate::token_credentials::{TokenCredential, TokenResponse};
-
 use azure_core::errors::AzureError;
+use azure_core::{TokenCredential, TokenResponse};
 use chrono::{DateTime, Utc};
 use oauth2::AccessToken;
 use serde::Deserialize;

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -1,6 +1,5 @@
-use super::{TokenCredential, TokenResponse};
-
 use azure_core::errors::AzureError;
+use azure_core::{TokenCredential, TokenResponse};
 use chrono::Utc;
 use oauth2::{
     basic::BasicClient, reqwest::async_http_client, AccessToken, AuthType, AuthUrl, Scope, TokenUrl,

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -1,8 +1,6 @@
-use super::{
-    AzureCliCredential, EnvironmentCredential, ManagedIdentityCredential, TokenCredential,
-    TokenResponse,
-};
+use super::{AzureCliCredential, EnvironmentCredential, ManagedIdentityCredential};
 use azure_core::errors::AzureError;
+use azure_core::{TokenCredential, TokenResponse};
 use log::debug;
 
 /// Provides a mechanism of selectively disabling credentials used for a `DefaultCredential` instance

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -1,5 +1,6 @@
-use super::{ClientSecretCredential, TokenCredential, TokenResponse};
+use super::ClientSecretCredential;
 use azure_core::errors::AzureError;
+use azure_core::{TokenCredential, TokenResponse};
 
 const AZURE_TENANT_ID_ENV_KEY: &str = "AZURE_TENANT_ID";
 const AZURE_CLIENT_ID_ENV_KEY: &str = "AZURE_CLIENT_ID";

--- a/sdk/identity/src/token_credentials/managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/managed_identity_credentials.rs
@@ -1,6 +1,5 @@
-use super::{TokenCredential, TokenResponse};
-
 use azure_core::errors::AzureError;
+use azure_core::{TokenCredential, TokenResponse};
 use chrono::{DateTime, Utc};
 use oauth2::AccessToken;
 use serde::Deserialize;

--- a/sdk/identity/src/token_credentials/mod.rs
+++ b/sdk/identity/src/token_credentials/mod.rs
@@ -16,30 +16,3 @@ pub use client_secret_credentials::*;
 pub use default_credentials::*;
 pub use environment_credentials::*;
 pub use managed_identity_credentials::*;
-
-use azure_core::errors::AzureError;
-use chrono::{DateTime, Utc};
-use oauth2::AccessToken;
-
-/// Represents an Azure service bearer access token with expiry information.
-#[derive(Debug, Clone)]
-pub struct TokenResponse {
-    /// Get the access token value.
-    pub token: AccessToken,
-    /// Gets the time when the provided token expires.
-    pub expires_on: DateTime<Utc>,
-}
-
-impl TokenResponse {
-    /// Create a new `TokenResponse`
-    pub fn new(token: AccessToken, expires_on: DateTime<Utc>) -> Self {
-        Self { token, expires_on }
-    }
-}
-
-/// Represents a credential capable of providing an OAuth token.
-#[async_trait::async_trait]
-pub trait TokenCredential {
-    /// Gets a `TokenResponse` for the specified resource
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse, AzureError>;
-}

--- a/sdk/key_vault/src/client.rs
+++ b/sdk/key_vault/src/client.rs
@@ -1,7 +1,7 @@
 use crate::KeyVaultError;
 use anyhow::Context;
 use anyhow::Result;
-use azure_identity::token_credentials::{TokenCredential, TokenResponse};
+use azure_core::{TokenCredential, TokenResponse};
 
 pub(crate) const PUBLIC_ENDPOINT_SUFFIX: &str = "vault.azure.net";
 pub(crate) const API_VERSION: &str = "7.0";

--- a/sdk/key_vault/src/secret.rs
+++ b/sdk/key_vault/src/secret.rs
@@ -1,7 +1,7 @@
 use crate::KeyVaultClient;
 use crate::{client::API_VERSION, KeyVaultError};
 use anyhow::{Context, Result};
-use azure_identity::token_credentials::TokenCredential;
+use azure_core::TokenCredential;
 use chrono::serde::ts_seconds;
 use chrono::{DateTime, Utc};
 use getset::Getters;
@@ -641,7 +641,7 @@ mod tests {
 
     use async_trait;
     use azure_core::errors::AzureError;
-    use azure_identity::token_credentials::{TokenCredential, TokenResponse};
+    use azure_core::{TokenCredential, TokenResponse};
     use chrono::{Duration, Utc};
     use mockito::{mock, Matcher};
     use oauth2::AccessToken;

--- a/sdk/storage/examples/blob_05_default_credential.rs
+++ b/sdk/storage/examples/blob_05_default_credential.rs
@@ -2,7 +2,8 @@
 extern crate log;
 
 use azure_core::prelude::*;
-use azure_identity::token_credentials::{DefaultCredential, TokenCredential};
+use azure_core::TokenCredential;
+use azure_identity::token_credentials::DefaultCredential;
 use azure_storage::blob::prelude::*;
 use azure_storage::core::prelude::*;
 use std::error::Error;


### PR DESCRIPTION
Fixes #52 

This moves token credential into the core crate. 

Unfortunately this requires adding two new dependencies to azure_core:
* async-trait
* oauth2