### PR TITLE
Typo in KeyVaultClient causes invalid authorization request

### DIFF
--- a/sdk/key_vault/src/client.rs
+++ b/sdk/key_vault/src/client.rs
@@ -75,7 +75,12 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
             // Token is valid, return it.
             return Ok(());
         }
-        let resource = format!("https://{}/", &self.endpoint_suffix);
+
+        let mut resource = format!("https://{}", &self.endpoint_suffix);
+        if !self.endpoint_suffix.ends_with("/") {
+            resource.push_str("/");
+        }
+
         let token = self
             .token_credential
             .get_token(&resource)

--- a/sdk/key_vault/src/client.rs
+++ b/sdk/key_vault/src/client.rs
@@ -75,7 +75,7 @@ impl<'a, T: TokenCredential> KeyVaultClient<'a, T> {
             // Token is valid, return it.
             return Ok(());
         }
-        let resource = format!("https://{}", &self.endpoint_suffix);
+        let resource = format!("https://{}/", &self.endpoint_suffix);
         let token = self
             .token_credential
             .get_token(&resource)


### PR DESCRIPTION
I got this error while trying out the `KeyVaultClient`
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Azure("AuthorizationError(Failed to authenticate to Azure Active Directory
Caused by:
   Generic error: AADSTS70011: The provided request must include a \'scope\' input parameter. The provided value for the input parameter \'scope\' is not valid. 
   The scope https://vault.azure.net.default is not valid
```

adding a forward slash fixes the crash