### PR TITLE
Support getting and setting the module/device twin for Azure IoT Hub Service

### DIFF
--- a/sdk/iothub/examples/directmethod.rs
+++ b/sdk/iothub/examples/directmethod.rs
@@ -4,7 +4,6 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // First we retrieve the account name and master key from environment variables.
     let iothub_connection_string = std::env::var("IOTHUB_CONNECTION_STRING")
         .expect("Set env variable IOTHUB_CONNECTION_STRING first!");
 

--- a/sdk/iothub/examples/gettwin.rs
+++ b/sdk/iothub/examples/gettwin.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // First we retrieve the account name and master key from environment variables.
     let iothub_connection_string = std::env::var("IOTHUB_CONNECTION_STRING")
         .expect("Set env variable IOTHUB_CONNECTION_STRING first!");
 

--- a/sdk/iothub/examples/gettwin.rs
+++ b/sdk/iothub/examples/gettwin.rs
@@ -1,0 +1,22 @@
+use iothub::service::ServiceClient;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // First we retrieve the account name and master key from environment variables.
+    let iothub_connection_string = std::env::var("IOTHUB_CONNECTION_STRING")
+        .expect("Set env variable IOTHUB_CONNECTION_STRING first!");
+
+    let device_id = std::env::args()
+        .nth(1)
+        .expect("Please pass the device id as the first parameter");
+
+    println!("Getting device twin for device: {}", device_id);
+
+    let service_client = ServiceClient::from_connection_string(iothub_connection_string, 3600)?;
+    let twin = service_client.get_device_twin(device_id).await?;
+
+    println!("Received device twin: {:?}", twin);
+
+    Ok(())
+}

--- a/sdk/iothub/examples/updatetwin.rs
+++ b/sdk/iothub/examples/updatetwin.rs
@@ -1,0 +1,30 @@
+use iothub::service::ServiceClient;
+use serde_json;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let iothub_connection_string = std::env::var("IOTHUB_CONNECTION_STRING")
+        .expect("Set env variable IOTHUB_CONNECTION_STRING first!");
+
+    let device_id = std::env::args()
+        .nth(1)
+        .expect("Please pass the device id as the first parameter");
+
+    let payload = std::env::args()
+        .nth(2)
+        .expect("Please pass the payload as the second parameter");
+
+    println!("Updating device twin for device: {}", device_id);
+
+    let service_client = ServiceClient::from_connection_string(iothub_connection_string, 3600)?;
+    let updated_twin = service_client
+        .update_device_twin(device_id)
+        .properties(serde_json::from_str(&payload)?)
+        .execute()
+        .await?;
+
+    println!("Received device twin: {:?}", updated_twin);
+
+    Ok(())
+}

--- a/sdk/iothub/src/lib.rs
+++ b/sdk/iothub/src/lib.rs
@@ -1,1 +1,4 @@
+#[macro_use]
+extern crate serde_json;
+
 pub mod service;

--- a/sdk/iothub/src/lib.rs
+++ b/sdk/iothub/src/lib.rs
@@ -1,4 +1,1 @@
-#[macro_use]
-extern crate serde_json;
-
 pub mod service;

--- a/sdk/iothub/src/service/mod.rs
+++ b/sdk/iothub/src/service/mod.rs
@@ -4,8 +4,10 @@ use hmac::{Hmac, Mac, NewMac};
 use sha2::Sha256;
 
 pub mod directmethod;
+pub mod twin;
 
 use crate::service::directmethod::DirectMethod;
+use crate::service::twin::{get_device_twin, get_module_twin, DeviceTwin, ModuleTwin};
 
 pub const API_VERSION: &str = "2020-03-13";
 
@@ -267,6 +269,43 @@ impl ServiceClient {
             connect_time_out,
             response_time_out,
         )
+    }
+
+    /// Get the module twin of a given device and module
+    ///
+    /// ```
+    /// use iothub::service::ServiceClient;
+    ///
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// let iothub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let twin = iothub.get_module_twin("some-device", "some-module");
+    /// ```
+    pub async fn get_module_twin<S, T>(
+        &self,
+        device_id: S,
+        module_id: T,
+    ) -> Result<ModuleTwin, AzureError>
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        get_module_twin(&self, device_id.into(), module_id.into()).await
+    }
+
+    /// Get the device twin of a given device
+    ///
+    /// ```
+    /// use iothub::service::ServiceClient;
+    ///
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// let iothub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let twin = iothub.get_device_twin("some-device");
+    /// ```
+    pub async fn get_device_twin<S>(&self, device_id: S) -> Result<DeviceTwin, AzureError>
+    where
+        S: Into<String>,
+    {
+        get_device_twin(&self, device_id.into()).await
     }
 }
 

--- a/sdk/iothub/src/service/mod.rs
+++ b/sdk/iothub/src/service/mod.rs
@@ -1,13 +1,16 @@
 use azure_core::errors::AzureError;
 use base64::{decode, encode_config};
 use hmac::{Hmac, Mac, NewMac};
+use hyper::Method;
 use sha2::Sha256;
 
 pub mod directmethod;
 pub mod twin;
 
 use crate::service::directmethod::DirectMethod;
-use crate::service::twin::{get_device_twin, get_module_twin, DeviceTwin, ModuleTwin};
+use crate::service::twin::{
+    get_device_twin, get_module_twin, DesiredTwinBuilder, DeviceTwin, ModuleTwin,
+};
 
 pub const API_VERSION: &str = "2020-03-13";
 
@@ -307,10 +310,118 @@ impl ServiceClient {
     {
         get_device_twin(&self, device_id.into()).await
     }
+
+    /// Update the module twin of a given device or module
+    ///
+    /// ```
+    /// use iothub::service::ServiceClient;
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    ///
+    /// fn main() {
+    ///     # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    ///     let iothub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    ///     let twin = iothub.update_module_twin("some-device", "some-module")
+    ///                  .tag("TagName", "TagValue")
+    ///                  .properties(json!({"PropertyName": "PropertyValue"}))
+    ///                  .execute();
+    /// }
+    /// ```
+    pub fn update_module_twin<S, T>(
+        &self,
+        device_id: S,
+        module_id: T,
+    ) -> DesiredTwinBuilder<'_, ModuleTwin>
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        DesiredTwinBuilder::new(
+            &self,
+            device_id.into(),
+            Some(module_id.into()),
+            Method::PATCH,
+        )
+    }
+
+    /// Replace the module twin of a given device and module
+    ///
+    /// ```
+    /// use iothub::service::ServiceClient;
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    ///
+    /// fn main() {
+    ///     # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    ///     let iothub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    ///     let twin = iothub.replace_module_twin("some-device", "some-module")
+    ///                  .tag("TagName", "TagValue")
+    ///                  .properties(json!({"PropertyName": "PropertyValue"}))
+    ///                  .execute();
+    /// }
+    /// ```
+    pub fn replace_module_twin<S, T>(
+        &self,
+        device_id: S,
+        module_id: T,
+    ) -> DesiredTwinBuilder<'_, ModuleTwin>
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        DesiredTwinBuilder::new(&self, device_id.into(), Some(module_id.into()), Method::PUT)
+    }
+    /// Update the device twin of a given device
+    ///
+    /// ```
+    /// use iothub::service::ServiceClient;
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    ///
+    /// fn main() {
+    ///     # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    ///     let iothub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    ///     let twin = iothub.update_device_twin("some-device")
+    ///                  .tag("TagName", "TagValue")
+    ///                  .properties(json!({"PropertyName": "PropertyValue"}))
+    ///                  .execute();
+    /// }
+    /// ```
+    pub fn update_device_twin<S>(&self, device_id: S) -> DesiredTwinBuilder<'_, DeviceTwin>
+    where
+        S: Into<String>,
+    {
+        DesiredTwinBuilder::new(&self, device_id.into(), None, Method::PATCH)
+    }
+
+    /// Replace the device twin of a given device
+    ///
+    /// ```
+    /// use iothub::service::ServiceClient;
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    ///
+    /// fn main() {
+    ///     # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    ///     let iothub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    ///     let twin = iothub.replace_device_twin("some-device")
+    ///                  .tag("TagName", "TagValue")
+    ///                  .properties(json!({"PropertyName": "PropertyValue"}))
+    ///                  .execute();
+    /// }
+    /// ```
+    pub fn replace_device_twin<S>(&self, device_id: S) -> DesiredTwinBuilder<'_, DeviceTwin>
+    where
+        S: Into<String>,
+    {
+        DesiredTwinBuilder::new(&self, device_id.into(), None, Method::PUT)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use hyper::Method;
+
     #[test]
     fn from_connectionstring_success() -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
@@ -344,6 +455,62 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
         let _ = ServiceClient::from_connection_string("HostName=cool-iot-hub.azure-devices.net;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==", 3600).is_err();
+        Ok(())
+    }
+
+    #[test]
+    fn update_module_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::service::ServiceClient;
+        let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+        let service_client = ServiceClient::from_connection_string(connection_string, 3600)?;
+
+        let builder = service_client.update_module_twin("deviceid", "moduleid");
+        assert_eq!(builder.device_id, "deviceid".to_string());
+        assert_eq!(builder.module_id, Some("moduleid".to_string()));
+        assert_eq!(builder.method, Method::PATCH);
+
+        Ok(())
+    }
+
+    #[test]
+    fn replace_module_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::service::ServiceClient;
+        let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+        let service_client = ServiceClient::from_connection_string(connection_string, 3600)?;
+
+        let builder = service_client.replace_module_twin("deviceid", "moduleid");
+        assert_eq!(builder.device_id, "deviceid".to_string());
+        assert_eq!(builder.module_id, Some("moduleid".to_string()));
+        assert_eq!(builder.method, Method::PUT);
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_device_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::service::ServiceClient;
+        let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+        let service_client = ServiceClient::from_connection_string(connection_string, 3600)?;
+
+        let builder = service_client.update_device_twin("deviceid");
+        assert_eq!(builder.device_id, "deviceid".to_string());
+        assert_eq!(builder.module_id, None);
+        assert_eq!(builder.method, Method::PATCH);
+
+        Ok(())
+    }
+
+    #[test]
+    fn replace_device_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
+        use crate::service::ServiceClient;
+        let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iothubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+        let service_client = ServiceClient::from_connection_string(connection_string, 3600)?;
+
+        let builder = service_client.replace_device_twin("deviceid");
+        assert_eq!(builder.device_id, "deviceid".to_string());
+        assert_eq!(builder.module_id, None);
+        assert_eq!(builder.method, Method::PUT);
+
         Ok(())
     }
 }

--- a/sdk/iothub/src/service/mod.rs
+++ b/sdk/iothub/src/service/mod.rs
@@ -290,15 +290,7 @@ impl ServiceClient {
         S: Into<String>,
         T: Into<String>,
     {
-        let uri = format!(
-            "https://{}.azure-devices.net/twins/{}/modules/{}?api-version={}",
-            self.iothub_name,
-            device_id.into(),
-            module_id.into(),
-            API_VERSION
-        );
-
-        get_twin(self, uri).await
+        get_twin(self, device_id.into(), Some(module_id.into())).await
     }
 
     /// Get the device twin of a given device
@@ -314,14 +306,7 @@ impl ServiceClient {
     where
         S: Into<String>,
     {
-        let uri = format!(
-            "https://{}.azure-devices.net/twins/{}?api-version={}",
-            self.iothub_name,
-            device_id.into(),
-            API_VERSION
-        );
-
-        get_twin(self, uri).await
+        get_twin(self, device_id.into(), None).await
     }
 
     /// Update the module twin of a given device or module

--- a/sdk/iothub/src/service/twin.rs
+++ b/sdk/iothub/src/service/twin.rs
@@ -1,0 +1,213 @@
+use azure_core::errors::{extract_status_headers_and_body, AzureError, UnexpectedHTTPResult};
+use hyper::{Body, Client, Method, Request, StatusCode};
+use hyper_tls::HttpsConnector;
+use serde::de::{self};
+use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
+
+use crate::service::{ServiceClient, API_VERSION};
+
+/// AuthenticationType of a module or device
+#[derive(Debug)]
+pub enum AuthenticationType {
+    Certificate,
+    Authority,
+    None,
+    SAS,
+    SelfSigned,
+}
+
+impl<'de> Deserialize<'de> for AuthenticationType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "certificate" => Ok(AuthenticationType::Certificate),
+            "sas" => Ok(AuthenticationType::SAS),
+            "Authority" => Ok(AuthenticationType::Authority),
+            "selfSigned" => Ok(AuthenticationType::SelfSigned),
+            "none" => Ok(AuthenticationType::None),
+            _ => Err(de::Error::custom(format!("Expected status to be 'certificate','sas','Authority','selfSigned' or 'none' but received: {}", s))),
+        }
+    }
+}
+
+/// The connection state of a module or device
+#[derive(Debug)]
+pub enum ConnectionState {
+    Connected,
+    Disconnected,
+}
+
+impl std::fmt::Display for ConnectionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ConnectionState::Connected => write!(f, "connected"),
+            ConnectionState::Disconnected => write!(f, "disconnected"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ConnectionState {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "Connected" => Ok(ConnectionState::Connected),
+            "Disconnected" => Ok(ConnectionState::Disconnected),
+            _ => Err(de::Error::custom(format!(
+                "Expected status to be 'Connected' or 'Disconnected' but received: {}",
+                s
+            ))),
+        }
+    }
+}
+
+/// Device or module status
+#[derive(Debug)]
+pub enum Status {
+    Disabled,
+    Enabled,
+}
+
+impl<'de> Deserialize<'de> for Status {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "disabled" => Ok(Status::Disabled),
+            "enabled" => Ok(Status::Enabled),
+            _ => Err(de::Error::custom(format!(
+                "Expected status to be enabled or disabled but received: {}",
+                s
+            ))),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct DeviceCapabilities {
+    #[serde(rename = "iotEdge")]
+    pub iotedge: bool,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct X509ThumbPrint {
+    pub primary_thumbprint: Option<String>,
+    pub secondary_thumbprint: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct TwinProperties {
+    pub desired: serde_json::Value,
+    pub reported: serde_json::Value,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceTwin {
+    pub authentication_type: AuthenticationType,
+    pub capabilities: DeviceCapabilities,
+    pub cloud_to_device_message_count: i64,
+    pub connection_state: ConnectionState,
+    pub device_etag: String,
+    pub device_id: String,
+    pub device_scope: Option<String>,
+    pub etag: String,
+    pub last_activity_time: String,
+    pub parent_scopes: Option<Vec<String>>,
+    pub properties: TwinProperties,
+    pub status: Status,
+    pub status_reason: Option<String>,
+    pub status_update_time: String,
+    pub tags: HashMap<String, String>,
+    pub version: i64,
+    pub x509_thumbprint: X509ThumbPrint,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModuleTwin {
+    pub authentication_type: AuthenticationType,
+    pub cloud_to_device_message_count: i64,
+    pub connection_state: ConnectionState,
+    pub device_etag: String,
+    pub device_id: String,
+    pub etag: String,
+    pub last_activity_time: String,
+    pub module_id: String,
+    pub properties: TwinProperties,
+    pub status: Status,
+    pub status_update_time: String,
+    pub version: i64,
+    pub x509_thumbprint: X509ThumbPrint,
+}
+
+async fn get_twin<T>(service_client: &ServiceClient, uri: String) -> Result<T, AzureError>
+where
+    for<'de> T: Deserialize<'de>,
+{
+    let https = HttpsConnector::new();
+    let client = Client::builder().build::<_, hyper::Body>(https);
+    let request = Request::builder()
+        .uri(uri)
+        .method(Method::GET)
+        .header("Authorization", &service_client.sas_token)
+        .header("Content-Type", "application/json")
+        .body(Body::empty())?;
+
+    let (status_code, _, whole_body) =
+        extract_status_headers_and_body(client.request(request)).await?;
+    if !status_code.is_success() {
+        return Err(AzureError::UnexpectedHTTPResult(UnexpectedHTTPResult::new(
+            StatusCode::OK,
+            status_code,
+            std::str::from_utf8(&whole_body)?,
+        )));
+    }
+
+    Ok(serde_json::from_slice(&whole_body)?)
+}
+
+pub(crate) async fn get_module_twin<S, T>(
+    service_client: &ServiceClient,
+    device_id: S,
+    module_id: T,
+) -> Result<ModuleTwin, AzureError>
+where
+    S: Into<String>,
+    T: Into<String>,
+{
+    let uri = format!(
+        "https://{}.azure-devices.net/twins/{}/modules/{}?api-version={}",
+        service_client.iothub_name,
+        device_id.into(),
+        module_id.into(),
+        API_VERSION
+    );
+
+    get_twin(service_client, uri).await
+}
+
+pub(crate) async fn get_device_twin<T>(
+    service_client: &ServiceClient,
+    device_id: T,
+) -> Result<DeviceTwin, AzureError>
+where
+    T: Into<String>,
+{
+    let uri = format!(
+        "https://{}.azure-devices.net/twins/{}?api-version={}",
+        service_client.iothub_name,
+        device_id.into(),
+        API_VERSION
+    );
+
+    get_twin(service_client, uri).await
+}


### PR DESCRIPTION
This PR adds support for most twin related operations for the IoT Hub Service SDK.

## Added
- `get_module_twin`, `get_device_twin`, `update_module_twin`, `replace_module_twin`, `update_device_twin`, `replace_device_twin` functions to `iothub::ServiceClient`.
- Structs/Enums for common types found in the module twin or device twin.
- Examples for getting the device twin and updating the device twin.

## Discussion
- I've tried keeping `DesiredTwinBuilder` generic so it can be used for both updating module and device twins. As to hide some details for the user (mainly the return type of `execute` which returns the `ModuleTwin` when updating modules and `DeviceTwin` for updating the devices) I had to resort to using `std::marker::PhantomData` in the `DesiredTwinBuilder`. I'm not too sure about that in particular, but couldn't find another way of doing this neatly. 