### PR TITLE
Implemented Queue Delete Message

### DIFF
--- a/sdk/storage/examples/delete_message.rs
+++ b/sdk/storage/examples/delete_message.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             let delete_response = queue
                 .delete_message()
-                .with_message(&message)
+                .with_pop_receipt(message.into())
                 .execute()
                 .await?;
 

--- a/sdk/storage/examples/delete_message.rs
+++ b/sdk/storage/examples/delete_message.rs
@@ -23,14 +23,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     trace!("getting messages");
 
-    let response = queue
+    let get_response = queue
         .get_messages()
         .with_number_of_messages(2)
         .with_visibility_timeout(Duration::from_secs(5)) // the message will become visible again after 5 secs
         .execute()
         .await?;
 
-    println!("response == {:#?}", response);
+    println!("get_response == {:#?}", get_response);
+
+    if get_response.messages.is_empty() {
+        trace!("no message to delete");
+    } else {
+        for message in get_response.messages {
+            trace!("deleting message {}", message.message_id);
+
+            let delete_response = queue
+                .delete_message()
+                .with_message(&message)
+                .execute()
+                .await?;
+
+            println!("delete_response == {:#?}", delete_response);
+        }
+    }
 
     Ok(())
 }

--- a/sdk/storage/examples/put_message.rs
+++ b/sdk/storage/examples/put_message.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let client = client::with_access_key(&account, &master_key).into_queue_service_client();
 
-    trace!("enumerating queues");
+    trace!("putting message");
 
     let response = client
         .with_queue_name_client(&queue_name)

--- a/sdk/storage/src/queue/clients/queue_name_client.rs
+++ b/sdk/storage/src/queue/clients/queue_name_client.rs
@@ -76,7 +76,7 @@ where
         requests::GetMessagesBuilder::new(self)
     }
 
-    fn delete_message(&self) -> requests::DeleteMessageBuilder<'_, '_, Self::StorageClient> {
+    fn delete_message(&self) -> requests::DeleteMessageBuilder<'_, Self::StorageClient> {
         requests::DeleteMessageBuilder::new(self)
     }
 }

--- a/sdk/storage/src/queue/clients/queue_name_client.rs
+++ b/sdk/storage/src/queue/clients/queue_name_client.rs
@@ -75,4 +75,8 @@ where
     fn get_messages(&self) -> requests::GetMessagesBuilder<'_, Self::StorageClient> {
         requests::GetMessagesBuilder::new(self)
     }
+
+    fn delete_message(&self) -> requests::DeleteMessageBuilder<'_, '_, Self::StorageClient> {
+        requests::DeleteMessageBuilder::new(self)
+    }
 }

--- a/sdk/storage/src/queue/mod.rs
+++ b/sdk/storage/src/queue/mod.rs
@@ -4,7 +4,7 @@ pub mod requests;
 pub mod responses;
 
 use crate::core::Client;
-use crate::responses::Message;
+use crate::responses::PopReceipt;
 use azure_core::No;
 pub use clients::*;
 use std::borrow::Cow;
@@ -82,13 +82,13 @@ pub trait MessageBodyRequired {
 /// Sets both the message id and the pop receipt for deleting a message as per Azure specification.
 /// See
 /// [https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2](https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2)
-pub trait MessageSupport<'b> {
+pub trait PopReceiptSupport {
     type O;
-    fn with_message(self, message: &'b Message) -> Self::O;
+    fn with_pop_receipt(self, pop_receipt: Box<dyn PopReceipt>) -> Self::O;
 }
 
-pub trait MessageRequired {
-    fn message<'b>(&self) -> &Message;
+pub trait PopReceiptRequired {
+    fn pop_receipt(&self) -> &dyn PopReceipt;
 }
 
 //********* Queue service traits
@@ -119,7 +119,7 @@ pub trait QueueNameService: HasStorageClient {
 
     fn put_message(&self) -> requests::PutMessageBuilder<'_, '_, Self::StorageClient, No>;
     fn get_messages(&self) -> requests::GetMessagesBuilder<'_, Self::StorageClient>;
-    fn delete_message(&self) -> requests::DeleteMessageBuilder<'_, '_, Self::StorageClient>;
+    fn delete_message(&self) -> requests::DeleteMessageBuilder<'_, Self::StorageClient>;
 }
 
 pub trait WithQueueNameClient<'a, 'b>: Debug + Send + Sync {

--- a/sdk/storage/src/queue/mod.rs
+++ b/sdk/storage/src/queue/mod.rs
@@ -4,6 +4,7 @@ pub mod requests;
 pub mod responses;
 
 use crate::core::Client;
+use crate::responses::Message;
 use azure_core::No;
 pub use clients::*;
 use std::borrow::Cow;
@@ -78,6 +79,18 @@ pub trait MessageBodyRequired {
     fn message_body<'b>(&self) -> &str;
 }
 
+/// Sets both the message id and the pop receipt for deleting a message as per Azure specification.
+/// See
+/// [https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2](https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2)
+pub trait MessageSupport<'b> {
+    type O;
+    fn with_message(self, message: &'b Message) -> Self::O;
+}
+
+pub trait MessageRequired {
+    fn message<'b>(&self) -> &Message;
+}
+
 //********* Queue service traits
 pub trait HasStorageClient: Debug + Send + Sync {
     type StorageClient: Client;
@@ -106,6 +119,7 @@ pub trait QueueNameService: HasStorageClient {
 
     fn put_message(&self) -> requests::PutMessageBuilder<'_, '_, Self::StorageClient, No>;
     fn get_messages(&self) -> requests::GetMessagesBuilder<'_, Self::StorageClient>;
+    fn delete_message(&self) -> requests::DeleteMessageBuilder<'_, '_, Self::StorageClient>;
 }
 
 pub trait WithQueueNameClient<'a, 'b>: Debug + Send + Sync {

--- a/sdk/storage/src/queue/prelude.rs
+++ b/sdk/storage/src/queue/prelude.rs
@@ -1,6 +1,7 @@
 pub use crate::{
     IntoQueueNameClient, IntoQueueServiceClient, MessageBodyRequired, MessageBodySupport,
-    MessageTTLRequired, MessageTTLSupport, NumberOfMessagesOption, NumberOfMessagesSupport,
-    QueueNameService, QueueService, VisibilityTimeoutOption, VisibilityTimeoutRequired,
-    VisibilityTimeoutSupport, WithQueueNameClient, WithQueueServiceClient,
+    MessageRequired, MessageSupport, MessageTTLRequired, MessageTTLSupport, NumberOfMessagesOption,
+    NumberOfMessagesSupport, QueueNameService, QueueService, VisibilityTimeoutOption,
+    VisibilityTimeoutRequired, VisibilityTimeoutSupport, WithQueueNameClient,
+    WithQueueServiceClient,
 };

--- a/sdk/storage/src/queue/prelude.rs
+++ b/sdk/storage/src/queue/prelude.rs
@@ -1,7 +1,7 @@
 pub use crate::{
     IntoQueueNameClient, IntoQueueServiceClient, MessageBodyRequired, MessageBodySupport,
-    PopReceiptRequired, PopReceiptSupport, MessageTTLRequired, MessageTTLSupport, NumberOfMessagesOption,
-    NumberOfMessagesSupport, QueueNameService, QueueService, VisibilityTimeoutOption,
+    MessageTTLRequired, MessageTTLSupport, NumberOfMessagesOption, NumberOfMessagesSupport,
+    PopReceiptRequired, PopReceiptSupport, QueueNameService, QueueService, VisibilityTimeoutOption,
     VisibilityTimeoutRequired, VisibilityTimeoutSupport, WithQueueNameClient,
     WithQueueServiceClient,
 };

--- a/sdk/storage/src/queue/prelude.rs
+++ b/sdk/storage/src/queue/prelude.rs
@@ -1,6 +1,6 @@
 pub use crate::{
     IntoQueueNameClient, IntoQueueServiceClient, MessageBodyRequired, MessageBodySupport,
-    MessageRequired, MessageSupport, MessageTTLRequired, MessageTTLSupport, NumberOfMessagesOption,
+    PopReceiptRequired, PopReceiptSupport, MessageTTLRequired, MessageTTLSupport, NumberOfMessagesOption,
     NumberOfMessagesSupport, QueueNameService, QueueService, VisibilityTimeoutOption,
     VisibilityTimeoutRequired, VisibilityTimeoutSupport, WithQueueNameClient,
     WithQueueServiceClient,

--- a/sdk/storage/src/queue/requests/delete_message_builder.json
+++ b/sdk/storage/src/queue/requests/delete_message_builder.json
@@ -1,0 +1,52 @@
+{
+  "name": "DeleteMessageBuilder",
+  "derive": "Debug, Clone",
+  "uses": [
+    "use crate::core::prelude::*",
+    "use crate::queue::prelude::*",
+    "use crate::responses::*",
+    "use azure_core::errors::{check_status_extract_headers_and_body, AzureError}",
+    "use azure_core::prelude::*",
+    "use hyper::StatusCode",
+    "use std::convert::TryInto",
+    "use std::time::Duration"
+  ],
+  "inline": true,
+  "extra_types": [
+    "'a",
+    "C"
+  ],
+  "extra_wheres": [
+    "C: Client"
+  ],
+  "constructor_fields": [
+    {
+      "name": "queue_name_service",
+      "field_type": "&'a dyn QueueNameService<StorageClient = C>"
+    }
+  ],
+  "fields": [
+    {
+      "name": "message",
+      "field_type": "&'b Message",
+      "builder_type": "MessageSet",
+      "optional": false,
+      "trait_get": "MessageRequired",
+      "trait_set": "MessageSupport<'b>"
+    },
+    {
+      "name": "timeout",
+      "field_type": "u64",
+      "optional": true,
+      "trait_get": "TimeoutOption",
+      "trait_set": "TimeoutSupport"
+    },
+    {
+      "name": "client_request_id",
+      "field_type": "&'a str",
+      "optional": true,
+      "trait_get": "ClientRequestIdOption<'a>",
+      "trait_set": "ClientRequestIdSupport<'a>"
+    }
+  ]
+}

--- a/sdk/storage/src/queue/requests/delete_message_builder.rs
+++ b/sdk/storage/src/queue/requests/delete_message_builder.rs
@@ -5,29 +5,30 @@ use azure_core::errors::{check_status_extract_headers_and_body, AzureError};
 use azure_core::prelude::*;
 use hyper::StatusCode;
 use std::convert::TryInto;
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
-#[derive(Debug, Clone)]
-pub struct DeleteMessageBuilder<'a, 'b, C>
+#[derive(Debug)]
+pub struct DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
     queue_name_service: &'a dyn QueueNameService<StorageClient = C>,
-    message: Option<&'b Message>,
+    pop_receipt: Option<Box<dyn PopReceipt>>,
     timeout: Option<u64>,
     client_request_id: Option<&'a str>,
 }
 
-impl<'a, 'b, C> DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
     #[inline]
     pub(crate) fn new(
         queue_name_service: &'a dyn QueueNameService<StorageClient = C>,
-    ) -> DeleteMessageBuilder<'a, 'b, C> {
+    ) -> DeleteMessageBuilder<'a, C> {
         DeleteMessageBuilder {
             queue_name_service,
-            message: None,
+            pop_receipt: None,
             timeout: None,
             client_request_id: None,
         }
@@ -35,17 +36,17 @@ where
 }
 
 //set mandatory no traits methods
-impl<'a, 'b, C> MessageRequired for DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> PopReceiptRequired for DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
     #[inline]
-    fn message(&self) -> &Message {
-        self.message.as_ref().unwrap()
+    fn pop_receipt(&self) -> &dyn PopReceipt {
+        self.pop_receipt.as_deref().unwrap()
     }
 }
 
-impl<'a, 'b, C> TimeoutOption for DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> TimeoutOption for DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
@@ -55,7 +56,7 @@ where
     }
 }
 
-impl<'a, 'b, C> ClientRequestIdOption<'a> for DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> ClientRequestIdOption<'a> for DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
@@ -65,51 +66,51 @@ where
     }
 }
 
-impl<'a, 'b, C> MessageSupport<'b> for DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> PopReceiptSupport for DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
-    type O = DeleteMessageBuilder<'a, 'b, C>;
+    type O = DeleteMessageBuilder<'a, C>;
 
     #[inline]
-    fn with_message(self, message: &'b Message) -> Self::O {
+    fn with_pop_receipt(self, pop_receipt: Box<dyn PopReceipt>) -> Self::O {
         DeleteMessageBuilder {
             queue_name_service: self.queue_name_service,
-            message: Some(message),
+            pop_receipt: Some(pop_receipt),
             timeout: self.timeout,
             client_request_id: self.client_request_id,
         }
     }
 }
 
-impl<'a, 'b, C> TimeoutSupport for DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> TimeoutSupport for DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
-    type O = DeleteMessageBuilder<'a, 'b, C>;
+    type O = DeleteMessageBuilder<'a, C>;
 
     #[inline]
     fn with_timeout(self, timeout: u64) -> Self::O {
         DeleteMessageBuilder {
             queue_name_service: self.queue_name_service,
-            message: self.message,
+            pop_receipt: self.pop_receipt,
             timeout: Some(timeout),
             client_request_id: self.client_request_id,
         }
     }
 }
 
-impl<'a, 'b, C> ClientRequestIdSupport<'a> for DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> ClientRequestIdSupport<'a> for DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
-    type O = DeleteMessageBuilder<'a, 'b, C>;
+    type O = DeleteMessageBuilder<'a, C>;
 
     #[inline]
     fn with_client_request_id(self, client_request_id: &'a str) -> Self::O {
         DeleteMessageBuilder {
             queue_name_service: self.queue_name_service,
-            message: self.message,
+            pop_receipt: self.pop_receipt,
             timeout: self.timeout,
             client_request_id: Some(client_request_id),
         }
@@ -117,7 +118,7 @@ where
 }
 
 // methods callable regardless
-impl<'a, 'b, C> DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
@@ -127,19 +128,19 @@ where
 }
 
 // methods callable only when every mandatory field has been filled
-impl<'a, 'b, C> DeleteMessageBuilder<'a, 'b, C>
+impl<'a, C> DeleteMessageBuilder<'a, C>
 where
     C: Client,
 {
     pub async fn execute(self) -> Result<DeleteMessageResponse, AzureError> {
-        let message = self.message();
+        let pop_receipt = self.pop_receipt();
 
         let mut uri = format!(
             "{}/{}/messages/{}?popreceipt={}",
             self.queue_name_service.storage_client().queue_uri(),
             self.queue_name_service.queue_name(),
-            message.message_id,
-            message.pop_receipt
+            pop_receipt.message_id(),
+            utf8_percent_encode(pop_receipt.pop_receipt(), NON_ALPHANUMERIC)
         );
 
         if let Some(nm) = TimeoutOption::to_uri_parameter(&self) {

--- a/sdk/storage/src/queue/requests/delete_message_builder.rs
+++ b/sdk/storage/src/queue/requests/delete_message_builder.rs
@@ -4,8 +4,8 @@ use crate::responses::*;
 use azure_core::errors::{check_status_extract_headers_and_body, AzureError};
 use azure_core::prelude::*;
 use hyper::StatusCode;
-use std::convert::TryInto;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use std::convert::TryInto;
 
 #[derive(Debug)]
 pub struct DeleteMessageBuilder<'a, C>

--- a/sdk/storage/src/queue/requests/delete_message_builder.rs
+++ b/sdk/storage/src/queue/requests/delete_message_builder.rs
@@ -1,0 +1,166 @@
+use crate::core::prelude::*;
+use crate::queue::prelude::*;
+use crate::responses::*;
+use azure_core::errors::{check_status_extract_headers_and_body, AzureError};
+use azure_core::prelude::*;
+use hyper::StatusCode;
+use std::convert::TryInto;
+
+#[derive(Debug, Clone)]
+pub struct DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    queue_name_service: &'a dyn QueueNameService<StorageClient = C>,
+    message: Option<&'b Message>,
+    timeout: Option<u64>,
+    client_request_id: Option<&'a str>,
+}
+
+impl<'a, 'b, C> DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    #[inline]
+    pub(crate) fn new(
+        queue_name_service: &'a dyn QueueNameService<StorageClient = C>,
+    ) -> DeleteMessageBuilder<'a, 'b, C> {
+        DeleteMessageBuilder {
+            queue_name_service,
+            message: None,
+            timeout: None,
+            client_request_id: None,
+        }
+    }
+}
+
+//set mandatory no traits methods
+impl<'a, 'b, C> MessageRequired for DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    #[inline]
+    fn message(&self) -> &Message {
+        self.message.as_ref().unwrap()
+    }
+}
+
+impl<'a, 'b, C> TimeoutOption for DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    #[inline]
+    fn timeout(&self) -> Option<u64> {
+        self.timeout
+    }
+}
+
+impl<'a, 'b, C> ClientRequestIdOption<'a> for DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    #[inline]
+    fn client_request_id(&self) -> Option<&'a str> {
+        self.client_request_id
+    }
+}
+
+impl<'a, 'b, C> MessageSupport<'b> for DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    type O = DeleteMessageBuilder<'a, 'b, C>;
+
+    #[inline]
+    fn with_message(self, message: &'b Message) -> Self::O {
+        DeleteMessageBuilder {
+            queue_name_service: self.queue_name_service,
+            message: Some(message),
+            timeout: self.timeout,
+            client_request_id: self.client_request_id,
+        }
+    }
+}
+
+impl<'a, 'b, C> TimeoutSupport for DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    type O = DeleteMessageBuilder<'a, 'b, C>;
+
+    #[inline]
+    fn with_timeout(self, timeout: u64) -> Self::O {
+        DeleteMessageBuilder {
+            queue_name_service: self.queue_name_service,
+            message: self.message,
+            timeout: Some(timeout),
+            client_request_id: self.client_request_id,
+        }
+    }
+}
+
+impl<'a, 'b, C> ClientRequestIdSupport<'a> for DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    type O = DeleteMessageBuilder<'a, 'b, C>;
+
+    #[inline]
+    fn with_client_request_id(self, client_request_id: &'a str) -> Self::O {
+        DeleteMessageBuilder {
+            queue_name_service: self.queue_name_service,
+            message: self.message,
+            timeout: self.timeout,
+            client_request_id: Some(client_request_id),
+        }
+    }
+}
+
+// methods callable regardless
+impl<'a, 'b, C> DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    pub fn queue_name_service(&self) -> &'a dyn QueueNameService<StorageClient = C> {
+        self.queue_name_service
+    }
+}
+
+// methods callable only when every mandatory field has been filled
+impl<'a, 'b, C> DeleteMessageBuilder<'a, 'b, C>
+where
+    C: Client,
+{
+    pub async fn execute(self) -> Result<DeleteMessageResponse, AzureError> {
+        let message = self.message();
+
+        let mut uri = format!(
+            "{}/{}/messages/{}?popreceipt={}",
+            self.queue_name_service.storage_client().queue_uri(),
+            self.queue_name_service.queue_name(),
+            message.message_id,
+            message.pop_receipt
+        );
+
+        if let Some(nm) = TimeoutOption::to_uri_parameter(&self) {
+            uri = format!("{}{}{}", uri, '&', nm);
+        }
+
+        debug!("uri == {}", uri);
+
+        let future_response = self.queue_name_service.storage_client().perform_request(
+            &uri,
+            &http::Method::DELETE,
+            &|mut request| {
+                request = ClientRequestIdOption::add_header(&self, request);
+                request
+            },
+            Some(&[]),
+        )?;
+
+        let (headers, _) =
+            check_status_extract_headers_and_body(future_response, StatusCode::NO_CONTENT).await?;
+
+        (&headers).try_into()
+    }
+}

--- a/sdk/storage/src/queue/requests/mod.rs
+++ b/sdk/storage/src/queue/requests/mod.rs
@@ -4,3 +4,5 @@ mod list_queues_builder;
 pub use list_queues_builder::ListQueuesBuilder;
 mod get_messages_builder;
 pub use get_messages_builder::GetMessagesBuilder;
+mod delete_message_builder;
+pub use delete_message_builder::DeleteMessageBuilder;

--- a/sdk/storage/src/queue/responses/delete_message_response.rs
+++ b/sdk/storage/src/queue/responses/delete_message_response.rs
@@ -1,0 +1,20 @@
+use azure_core::errors::AzureError;
+use azure_core::headers::CommonStorageResponseHeaders;
+use hyper::header::HeaderMap;
+use std::convert::TryInto;
+
+#[derive(Debug, Clone)]
+pub struct DeleteMessageResponse {
+    pub common_storage_response_headers: CommonStorageResponseHeaders,
+}
+
+impl std::convert::TryFrom<&HeaderMap> for DeleteMessageResponse {
+    type Error = AzureError;
+    fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
+        debug!("headers == {:?}", headers);
+
+        Ok(DeleteMessageResponse {
+            common_storage_response_headers: headers.try_into()?,
+        })
+    }
+}

--- a/sdk/storage/src/queue/responses/delete_message_response.rs
+++ b/sdk/storage/src/queue/responses/delete_message_response.rs
@@ -3,6 +3,35 @@ use azure_core::headers::CommonStorageResponseHeaders;
 use hyper::header::HeaderMap;
 use std::convert::TryInto;
 
+use super::get_messages_response::Message;
+
+pub trait PopReceipt {
+    fn message_id(&self) -> &str;
+    fn pop_receipt(&self) -> &str;
+}
+
+impl PopReceipt for Message {
+    fn message_id(&self) -> &str {
+        &self.message_id
+    }
+
+    fn pop_receipt(&self) -> &str {
+        &self.pop_receipt
+    }
+}
+
+impl From<Message> for Box<dyn PopReceipt> {
+    fn from(message: Message) -> Box<dyn PopReceipt> {
+        Box::new(message)
+    }
+}
+
+impl std::fmt::Debug for dyn PopReceipt {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "PopReceipt {{ message_id: {}, pop_receipt: {} }}", self.message_id(), self.pop_receipt())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DeleteMessageResponse {
     pub common_storage_response_headers: CommonStorageResponseHeaders,

--- a/sdk/storage/src/queue/responses/delete_message_response.rs
+++ b/sdk/storage/src/queue/responses/delete_message_response.rs
@@ -28,7 +28,12 @@ impl From<Message> for Box<dyn PopReceipt> {
 
 impl std::fmt::Debug for dyn PopReceipt {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "PopReceipt {{ message_id: {}, pop_receipt: {} }}", self.message_id(), self.pop_receipt())
+        write!(
+            f,
+            "PopReceipt {{ message_id: {}, pop_receipt: {} }}",
+            self.message_id(),
+            self.pop_receipt()
+        )
     }
 }
 

--- a/sdk/storage/src/queue/responses/mod.rs
+++ b/sdk/storage/src/queue/responses/mod.rs
@@ -4,3 +4,6 @@ mod put_message_response;
 pub use put_message_response::PutMessageResponse;
 mod get_messages_response;
 pub use get_messages_response::GetMessagesResponse;
+pub use get_messages_response::Message;
+mod delete_message_response;
+pub use delete_message_response::DeleteMessageResponse;

--- a/sdk/storage/src/queue/responses/mod.rs
+++ b/sdk/storage/src/queue/responses/mod.rs
@@ -4,6 +4,6 @@ mod put_message_response;
 pub use put_message_response::PutMessageResponse;
 mod get_messages_response;
 pub use get_messages_response::GetMessagesResponse;
-pub use get_messages_response::Message;
 mod delete_message_response;
 pub use delete_message_response::DeleteMessageResponse;
+pub use delete_message_response::PopReceipt;


### PR DESCRIPTION
PR to address #21 

To complete the message lifecycle for Azure Storage Queue we need the ability to delete messages.
To enable this, I have made the `Message` struct public, and used it as the required parameter to the new `DeleteMessageBuilder` request's method `with_message`. This sets the `messageid` URL path parameter, as well as the `popreceipt` query parameter.
I have added an example to show how the API can be used.