### PR TITLE
Expose azurite_workaround feature in storage crate and use endpoint URIs from connection string in storage KeyClient

### DIFF
--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -48,6 +48,7 @@ url = "2.1"
 default = ["account", "blob", "queue", "table"]
 test_e2e = ["adls_gen2", "account", "blob", "queue", "table"]
 account = []
+azurite_workaround = []
 blob = []
 queue = []
 table = []


### PR DESCRIPTION
This PR exposes the azurite_workaround feature and recognizes enpoint URIs from the storage connection string.

The azurite storage emulator requires specific configurations that are already available in the source code of the storage crate. The feature is not exposed, to be used though.

Endpoint URIs can be specified in the storage connection string. Currently they are ignored and replaced with hard-coded default values pointing to the azure blob storage. This is relevant when using the azurite storage emulator, where the account names can be modified (since version 3). The "with_emulator" method with hard coded value is no longer sufficient if account names are customized.