### PR TITLE
Remove the various Name traits 

### DIFF
--- a/sdk/cosmos/examples/database_00.rs
+++ b/sdk/cosmos/examples/database_00.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             println!("collection == {:?}", collection);
             let collection_client = database.clone().into_collection_client(collection.id);
 
-            if collection_client.collection_name().name() == "democ" {
+            if collection_client.collection_name() == "democ" {
                 println!("democ!");
 
                 let data = r#"

--- a/sdk/cosmos/src/prelude.rs
+++ b/sdk/cosmos/src/prelude.rs
@@ -25,9 +25,5 @@ pub use crate::resources::*;
 
 // Traits
 pub use crate::traits::*;
-#[doc(inline)]
-pub use database::DatabaseName;
-#[doc(inline)]
-pub use user::UserName;
 
 pub use permission::AuthorizationToken;

--- a/sdk/cosmos/src/requests/create_collection_builder.rs
+++ b/sdk/cosmos/src/requests/create_collection_builder.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::resources::collection::{Collection, CollectionName, IndexingPolicy, PartitionKey};
+use crate::resources::collection::{Collection, IndexingPolicy, PartitionKey};
 use crate::resources::ResourceType;
 use crate::responses::CreateCollectionResponse;
 use azure_core::prelude::*;
@@ -27,7 +27,7 @@ pub struct CreateCollectionBuilder<
     p_indexing_policy: PhantomData<IndexingPolicySet>,
     p_partition_key: PhantomData<PartitionKeySet>,
     offer: Option<Offer>,
-    collection_name: Option<&'a dyn CollectionName>,
+    collection_name: Option<&'a str>,
     indexing_policy: Option<&'a IndexingPolicy>,
     partition_key: Option<&'a PartitionKey>,
     user_agent: Option<&'a str>,
@@ -89,7 +89,7 @@ where
     IndexingPolicySet: ToAssign,
     PartitionKeySet: ToAssign,
 {
-    fn collection_name(&self) -> &'a dyn CollectionName {
+    fn collection_name(&self) -> &'a str {
         self.collection_name.unwrap()
     }
 }
@@ -194,7 +194,7 @@ where
 {
     type O = CreateCollectionBuilder<'a, OfferSet, Yes, IndexingPolicySet, PartitionKeySet>;
 
-    fn with_collection_name(self, collection_name: &'a dyn CollectionName) -> Self::O {
+    fn with_collection_name(self, collection_name: &'a str) -> Self::O {
         CreateCollectionBuilder {
             database_client: self.database_client,
             p_offer: PhantomData {},
@@ -369,10 +369,8 @@ impl<'a> CreateCollectionBuilder<'a, Yes, Yes, Yes, Yes> {
         let req = ActivityIdOption::add_header(self, req);
         let req = ConsistencyLevelOption::add_header(self, req);
 
-        let mut collection = Collection::new(
-            self.collection_name().name(),
-            self.indexing_policy().to_owned(),
-        );
+        let mut collection =
+            Collection::new(self.collection_name(), self.indexing_policy().to_owned());
         collection.parition_key = self.partition_key().to_owned();
 
         let body = serde_json::to_string(&collection)?;

--- a/sdk/cosmos/src/requests/create_database_builder.rs
+++ b/sdk/cosmos/src/requests/create_database_builder.rs
@@ -14,7 +14,7 @@ where
 {
     cosmos_client: &'a CosmosClient,
     p_database_name: PhantomData<DatabaseNameSet>,
-    database_name: Option<&'a dyn DatabaseName>,
+    database_name: Option<&'a str>,
     user_agent: Option<&'a str>,
     activity_id: Option<&'a str>,
     consistency_level: Option<ConsistencyLevel>,
@@ -46,7 +46,7 @@ where
 
 //set mandatory no traits methods
 impl<'a> DatabaseNameRequired<'a> for CreateDatabaseBuilder<'a, Yes> {
-    fn database_name(&self) -> &'a dyn DatabaseName {
+    fn database_name(&self) -> &'a str {
         self.database_name.unwrap()
     }
 }
@@ -81,7 +81,7 @@ where
 impl<'a> DatabaseNameSupport<'a> for CreateDatabaseBuilder<'a, No> {
     type O = CreateDatabaseBuilder<'a, Yes>;
 
-    fn with_database_name(self, database_name: &'a dyn DatabaseName) -> Self::O {
+    fn with_database_name(self, database_name: &'a str) -> Self::O {
         CreateDatabaseBuilder {
             cosmos_client: self.cosmos_client,
             p_database_name: PhantomData {},
@@ -158,7 +158,7 @@ impl<'a> CreateDatabaseBuilder<'a, Yes> {
         }
 
         let req = serde_json::to_string(&CreateDatabaseRequest {
-            id: self.database_name().name(),
+            id: self.database_name(),
         })?;
 
         let request = self.cosmos_client().prepare_request(

--- a/sdk/cosmos/src/requests/create_permission_builder.rs
+++ b/sdk/cosmos/src/requests/create_permission_builder.rs
@@ -116,7 +116,7 @@ impl<'a, 'b> CreatePermissionBuilder<'a, 'b> {
             &format!(
                 "dbs/{}/users/{}/permissions",
                 self.permission_client.database_client().database_name(),
-                self.permission_client.user_client().user_name().id(),
+                self.permission_client.user_client().user_name(),
             ),
             http::Method::POST,
             ResourceType::Permissions,

--- a/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
@@ -220,7 +220,7 @@ impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b, Yes, Yes> {
         }
 
         let request = serde_json::to_string(&_Request {
-            id: self.attachment_client.attachment_name().name(),
+            id: self.attachment_client.attachment_name(),
             content_type: ContentTypeRequired::content_type(self),
             media: self.media(),
         })?;

--- a/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
@@ -241,7 +241,7 @@ impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b, Yes, Yes> {
 
         req = ContentTypeRequired::add_header(self, req);
 
-        req = req.header("Slug", self.attachment_client.attachment_name().name());
+        req = req.header("Slug", self.attachment_client.attachment_name());
         req = req.header(http::header::CONTENT_LENGTH, self.body().len());
 
         let req = req.body(self.body())?;

--- a/sdk/cosmos/src/requests/list_attachments_builder.rs
+++ b/sdk/cosmos/src/requests/list_attachments_builder.rs
@@ -164,7 +164,7 @@ impl<'a, 'b> ListAttachmentsBuilder<'a, 'b> {
                 "dbs/{}/colls/{}/docs/{}/attachments",
                 self.document_client.database_client().database_name(),
                 self.document_client.collection_client().collection_name(),
-                self.document_client.document_name().name()
+                self.document_client.document_name()
             ),
             http::Method::GET,
             ResourceType::Attachments,

--- a/sdk/cosmos/src/requests/list_collections_builder.rs
+++ b/sdk/cosmos/src/requests/list_collections_builder.rs
@@ -125,7 +125,7 @@ impl<'a> ListCollectionsBuilder<'a> {
     pub async fn execute(&self) -> Result<ListCollectionsResponse, CosmosError> {
         trace!("ListCollectionsBuilder::execute called");
         let request = self.database_client.cosmos_client().prepare_request(
-            &format!("dbs/{}/colls", self.database_client.database_name().name()),
+            &format!("dbs/{}/colls", self.database_client.database_name()),
             http::Method::GET,
             ResourceType::Collections,
         );

--- a/sdk/cosmos/src/requests/list_permissions_builder.rs
+++ b/sdk/cosmos/src/requests/list_permissions_builder.rs
@@ -129,7 +129,7 @@ impl<'a, 'b> ListPermissionsBuilder<'a, 'b> {
             &format!(
                 "dbs/{}/users/{}/permissions",
                 self.user_client.database_client().database_name(),
-                self.user_client.user_name().id(),
+                self.user_client.user_name()
             ),
             http::Method::GET,
             ResourceType::Permissions,

--- a/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
@@ -251,7 +251,7 @@ impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b, Yes, Yes> {
         }
 
         let request = serde_json::to_string(&_Request {
-            id: self.attachment_client.attachment_name().name(),
+            id: self.attachment_client.attachment_name(),
             content_type: ContentTypeRequired::content_type(self),
             media: self.media(),
         })?;

--- a/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
@@ -238,7 +238,7 @@ impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b, Yes, Yes> {
 
         req = ContentTypeRequired::add_header(self, req);
 
-        req = req.header("Slug", self.attachment_client.attachment_name().name());
+        req = req.header("Slug", self.attachment_client.attachment_name());
         req = req.header(http::header::CONTENT_LENGTH, self.body().len());
 
         let req = req.body(self.body())?;

--- a/sdk/cosmos/src/requests/replace_user_builder.rs
+++ b/sdk/cosmos/src/requests/replace_user_builder.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use crate::resources::user::UserName;
 use crate::responses::CreateUserResponse;
 use azure_core::prelude::*;
 use azure_core::{No, ToAssign, Yes};
@@ -14,7 +13,7 @@ where
 {
     user_client: &'a UserClient,
     p_user_name: PhantomData<UserNameSet>,
-    user_name: Option<&'a dyn UserName>,
+    user_name: Option<&'a str>,
     user_agent: Option<&'b str>,
     activity_id: Option<&'b str>,
     consistency_level: Option<ConsistencyLevel>,
@@ -43,7 +42,7 @@ where
 }
 
 impl<'a, 'b> UserNameRequired<'a> for ReplaceUserBuilder<'a, 'b, Yes> {
-    fn user_name(&self) -> &'a dyn UserName {
+    fn user_name(&self) -> &'a str {
         self.user_name.unwrap()
     }
 }
@@ -78,7 +77,7 @@ where
 impl<'a, 'b> UserNameSupport<'a> for ReplaceUserBuilder<'a, 'b, No> {
     type O = ReplaceUserBuilder<'a, 'b, Yes>;
 
-    fn with_user_name(self, user_name: &'a dyn UserName) -> Self::O {
+    fn with_user_name(self, user_name: &'a str) -> Self::O {
         ReplaceUserBuilder {
             user_client: self.user_client,
             p_user_name: PhantomData {},
@@ -150,7 +149,7 @@ impl<'a, 'b> ReplaceUserBuilder<'a, 'b, Yes> {
             id: &'x str,
         }
         let request_body = RequestBody {
-            id: self.user_name().id(),
+            id: self.user_name(),
         };
         let request_body = serde_json::to_string(&request_body)?;
 

--- a/sdk/cosmos/src/resources/collection/mod.rs
+++ b/sdk/cosmos/src/resources/collection/mod.rs
@@ -42,38 +42,16 @@ impl Collection {
             id: id.to_owned(),
             indexing_policy,
             parition_key: PartitionKey::default(),
-            rid: "".to_owned(),
+            rid: String::new(),
             ts: 0,
-            _self: "".to_owned(),
-            etag: "".to_owned(),
-            docs: "".to_owned(),
-            sprocs: "".to_owned(),
-            triggers: "".to_owned(),
-            udfs: "".to_owned(),
-            conflicts: "".to_owned(),
+            _self: String::new(),
+            etag: String::new(),
+            docs: String::new(),
+            sprocs: String::new(),
+            triggers: String::new(),
+            udfs: String::new(),
+            conflicts: String::new(),
         }
-    }
-}
-
-pub trait CollectionName: std::fmt::Debug {
-    fn name(&self) -> &str;
-}
-
-impl CollectionName for Collection {
-    fn name(&self) -> &str {
-        &self.id
-    }
-}
-
-impl CollectionName for &str {
-    fn name(&self) -> &str {
-        self
-    }
-}
-
-impl CollectionName for String {
-    fn name(&self) -> &str {
-        self.as_ref()
     }
 }
 
@@ -106,16 +84,14 @@ pub enum DataType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
+#[serde(rename_all = "lowercase")]
 pub enum IndexingMode {
-    #[serde(rename = "consistent")]
     Consistent,
-    #[serde(rename = "lazy")]
     Lazy,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
 pub struct IncludedPath {
-    #[serde(rename = "path")]
     pub path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "indexes")]
@@ -126,16 +102,13 @@ pub struct IncludedPath {
 pub struct IncludedPathIndex {
     #[serde(rename = "dataType")]
     pub data_type: DataType,
-    #[serde(rename = "precision")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub precision: Option<i8>,
-    #[serde(rename = "kind")]
     pub kind: KeyKind,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
 pub struct ExcludedPath {
-    #[serde(rename = "path")]
     pub path: String,
 }
 

--- a/sdk/cosmos/src/resources/database.rs
+++ b/sdk/cosmos/src/resources/database.rs
@@ -22,22 +22,10 @@ pub struct Database {
     pub users: String,
 }
 
-pub trait DatabaseName: std::fmt::Debug {
-    fn name(&self) -> &str;
-}
-
-impl DatabaseName for Database {
-    fn name(&self) -> &str {
+impl Database {
+    /// The name of the database
+    pub fn name(&self) -> &str {
         &self.id
-    }
-}
-
-impl<R> DatabaseName for R
-where
-    R: AsRef<str> + std::fmt::Debug,
-{
-    fn name(&self) -> &str {
-        self.as_ref()
     }
 }
 

--- a/sdk/cosmos/src/resources/document/mod.rs
+++ b/sdk/cosmos/src/resources/document/mod.rs
@@ -60,25 +60,3 @@ impl<T> Resource for &Document<T> {
         self.document_attributes._self()
     }
 }
-
-pub trait DocumentName: std::fmt::Debug {
-    fn name(&self) -> &str;
-}
-
-impl DocumentName for &str {
-    fn name(&self) -> &str {
-        self
-    }
-}
-
-impl DocumentName for String {
-    fn name(&self) -> &str {
-        self.as_ref()
-    }
-}
-
-impl DocumentName for std::borrow::Cow<'_, str> {
-    fn name(&self) -> &str {
-        self.as_ref()
-    }
-}

--- a/sdk/cosmos/src/resources/mod.rs
+++ b/sdk/cosmos/src/resources/mod.rs
@@ -2,14 +2,15 @@
 //!
 //! You can learn about the Cosmos DB resource model [here](https://docs.microsoft.com/en-us/azure/cosmos-db/account-databases-containers-items).
 
-mod attachment;
 pub mod collection;
-pub mod database;
 pub mod document;
 pub mod permission;
 pub mod stored_procedure;
 pub mod trigger;
-pub mod user;
+
+mod attachment;
+mod database;
+mod user;
 mod user_defined_function;
 
 #[doc(inline)]

--- a/sdk/cosmos/src/resources/stored_procedure.rs
+++ b/sdk/cosmos/src/resources/stored_procedure.rs
@@ -19,23 +19,9 @@ pub struct StoredProcedure {
     pub body: String,
 }
 
-impl StoredProcedureName for StoredProcedure {
-    fn name(&self) -> &str {
+impl StoredProcedure {
+    /// The name of the stored procedure
+    pub fn name(&self) -> &str {
         &self.id
-    }
-}
-pub trait StoredProcedureName: std::fmt::Debug {
-    fn name(&self) -> &str;
-}
-
-impl StoredProcedureName for &str {
-    fn name(&self) -> &str {
-        self
-    }
-}
-
-impl StoredProcedureName for String {
-    fn name(&self) -> &str {
-        self.as_ref()
     }
 }

--- a/sdk/cosmos/src/resources/user.rs
+++ b/sdk/cosmos/src/resources/user.rs
@@ -43,25 +43,3 @@ impl Resource for &User {
         &self._self
     }
 }
-
-pub trait UserName: std::fmt::Debug {
-    fn id(&self) -> &str;
-}
-
-impl UserName for User {
-    fn id(&self) -> &str {
-        &self.id
-    }
-}
-
-impl UserName for String {
-    fn id(&self) -> &str {
-        &self
-    }
-}
-
-impl UserName for &str {
-    fn id(&self) -> &str {
-        self
-    }
-}

--- a/sdk/cosmos/src/traits.rs
+++ b/sdk/cosmos/src/traits.rs
@@ -393,12 +393,12 @@ pub trait OfferSupport {
 }
 
 pub trait CollectionNameRequired<'a> {
-    fn collection_name(&self) -> &'a dyn CollectionName;
+    fn collection_name(&self) -> &'a str;
 }
 
 pub trait CollectionNameSupport<'a> {
     type O;
-    fn with_collection_name(self, collection_name: &'a dyn CollectionName) -> Self::O;
+    fn with_collection_name(self, collection_name: &'a str) -> Self::O;
 }
 
 pub trait CollectionRequired<'a> {
@@ -438,19 +438,19 @@ pub trait QuerySupport<'a> {
 }
 
 pub trait DatabaseNameRequired<'a> {
-    fn database_name(&'a self) -> &'a dyn database::DatabaseName;
+    fn database_name(&'a self) -> &'a str;
 }
 
 pub trait DatabaseNameSupport<'a> {
     type O;
-    fn with_database_name(self, database_name: &'a dyn database::DatabaseName) -> Self::O;
+    fn with_database_name(self, database_name: &'a str) -> Self::O;
 }
 
 pub trait UserNameRequired<'a> {
-    fn user_name(&self) -> &'a dyn user::UserName;
+    fn user_name(&self) -> &'a str;
 }
 
 pub trait UserNameSupport<'a> {
     type O;
-    fn with_user_name(self, user_name: &'a dyn user::UserName) -> Self::O;
+    fn with_user_name(self, user_name: &'a str) -> Self::O;
 }


### PR DESCRIPTION
This removes the various name traits like `DatabaseName`. This was adding extra boilerplate for now real benefit over just returning `&str` from the various methods that return names. 

I consider making wrapper types around `&str` or `String` to make this more type safe but I'm not convinced that we would gain too much from it...