### PR TITLE
Remove the various client traits

### DIFF
--- a/sdk/cosmos/src/requests/create_collection_builder.rs
+++ b/sdk/cosmos/src/requests/create_collection_builder.rs
@@ -54,22 +54,19 @@ impl<'a> CreateCollectionBuilder<'a, No, No, No, No> {
     }
 }
 
-impl<'a, OfferSet, CollectionNameSet, IndexingPolicySet, PartitionKeySet> DatabaseClientRequired<'a>
-    for CreateCollectionBuilder<'a, OfferSet, CollectionNameSet, IndexingPolicySet, PartitionKeySet>
+impl<'a, OfferSet, CollectionNameSet, IndexingPolicySet, PartitionKeySet>
+    CreateCollectionBuilder<'a, OfferSet, CollectionNameSet, IndexingPolicySet, PartitionKeySet>
 where
     OfferSet: ToAssign,
     CollectionNameSet: ToAssign,
     IndexingPolicySet: ToAssign,
     PartitionKeySet: ToAssign,
 {
-    fn database_client(&self) -> &'a DatabaseClient {
+    pub fn database_client(&self) -> &'a DatabaseClient {
         self.database_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, CollectionNameSet, IndexingPolicySet, PartitionKeySet> OfferRequired
     for CreateCollectionBuilder<'a, Yes, CollectionNameSet, IndexingPolicySet, PartitionKeySet>
 where

--- a/sdk/cosmos/src/requests/create_database_builder.rs
+++ b/sdk/cosmos/src/requests/create_database_builder.rs
@@ -33,18 +33,15 @@ impl<'a> CreateDatabaseBuilder<'a, No> {
     }
 }
 
-impl<'a, DatabaseNameSet> CosmosClientRequired<'a> for CreateDatabaseBuilder<'a, DatabaseNameSet>
+impl<'a, DatabaseNameSet> CreateDatabaseBuilder<'a, DatabaseNameSet>
 where
     DatabaseNameSet: ToAssign,
 {
-    fn cosmos_client(&self) -> &'a CosmosClient {
+    pub fn cosmos_client(&self) -> &'a CosmosClient {
         self.cosmos_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a> DatabaseNameRequired<'a> for CreateDatabaseBuilder<'a, Yes> {
     fn database_name(&self) -> &'a dyn DatabaseName {
         self.database_name.unwrap()

--- a/sdk/cosmos/src/requests/create_document_builder.rs
+++ b/sdk/cosmos/src/requests/create_document_builder.rs
@@ -46,19 +46,15 @@ impl<'a, 'b> CreateDocumentBuilder<'a, 'b, No> {
     }
 }
 
-impl<'a, 'b, PartitionKeysSet> CollectionClientRequired<'a>
-    for CreateDocumentBuilder<'a, 'b, PartitionKeysSet>
+impl<'a, 'b, PartitionKeysSet> CreateDocumentBuilder<'a, 'b, PartitionKeysSet>
 where
     PartitionKeysSet: ToAssign,
 {
-    fn collection_client(&self) -> &'a CollectionClient {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, 'b> PartitionKeysRequired<'b> for CreateDocumentBuilder<'a, 'b, Yes> {
     fn partition_keys(&self) -> &'b PartitionKeys {
         self.partition_keys.unwrap()

--- a/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
@@ -45,8 +45,8 @@ impl<'a> CreateOrReplaceTriggerBuilder<'a, No, No, No> {
     }
 }
 
-impl<'a, TriggerOperationSet, TriggerTypeSet, BodySet> TriggerClientRequired<'a>
-    for CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, BodySet>
+impl<'a, TriggerOperationSet, TriggerTypeSet, BodySet>
+    CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, BodySet>
 where
     TriggerOperationSet: ToAssign,
     TriggerTypeSet: ToAssign,

--- a/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
@@ -37,8 +37,7 @@ impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, No> {
     }
 }
 
-impl<'a, 'b, BodySet> UserDefinedFunctionClientRequired<'a>
-    for CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, BodySet>
+impl<'a, 'b, BodySet> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, BodySet>
 where
     BodySet: ToAssign,
 {

--- a/sdk/cosmos/src/requests/create_permission_builder.rs
+++ b/sdk/cosmos/src/requests/create_permission_builder.rs
@@ -27,15 +27,12 @@ impl<'a, 'b> CreatePermissionBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> PermissionClientRequired<'a> for CreatePermissionBuilder<'a, 'b> {
-    fn permission_client(&self) -> &'a PermissionClient {
+impl<'a, 'b> CreatePermissionBuilder<'a, 'b> {
+    pub fn permission_client(&self) -> &'a PermissionClient {
         self.permission_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, 'b> ExpirySecondsOption for CreatePermissionBuilder<'a, 'b> {
     fn expiry_seconds(&self) -> u64 {
         self.expiry_seconds

--- a/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
@@ -36,20 +36,17 @@ impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, ContentTypeSet, MediaSet> AttachmentClientRequired<'a>
-    for CreateReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
+impl<'a, 'b, ContentTypeSet, MediaSet>
+    CreateReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
 where
     ContentTypeSet: ToAssign,
     MediaSet: ToAssign,
 {
-    fn attachment_client(&self) -> &'a AttachmentClient {
+    pub fn attachment_client(&self) -> &'a AttachmentClient {
         self.attachment_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, 'b, MediaSet> ContentTypeRequired<'b>
     for CreateReferenceAttachmentBuilder<'a, 'b, Yes, MediaSet>
 where

--- a/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
@@ -39,20 +39,16 @@ impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, BodySet, ContentTypeSet> AttachmentClientRequired<'a>
-    for CreateSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
+impl<'a, 'b, BodySet, ContentTypeSet> CreateSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
 where
     BodySet: ToAssign,
     ContentTypeSet: ToAssign,
 {
-    fn attachment_client(&self) -> &'a AttachmentClient {
+    pub fn attachment_client(&self) -> &'a AttachmentClient {
         self.attachment_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, 'b, ContentTypeSet> BodyRequired<'b>
     for CreateSlugAttachmentBuilder<'a, 'b, Yes, ContentTypeSet>
 where

--- a/sdk/cosmos/src/requests/create_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/create_stored_procedure_builder.rs
@@ -32,8 +32,7 @@ impl<'a, 'b> CreateStoredProcedureBuilder<'a, 'b, No> {
     }
 }
 
-impl<'a, 'b, BodySet> StoredProcedureClientRequired<'a>
-    for CreateStoredProcedureBuilder<'a, 'b, BodySet>
+impl<'a, 'b, BodySet> CreateStoredProcedureBuilder<'a, 'b, BodySet>
 where
     BodySet: ToAssign,
 {

--- a/sdk/cosmos/src/requests/create_user_builder.rs
+++ b/sdk/cosmos/src/requests/create_user_builder.rs
@@ -23,8 +23,8 @@ impl<'a, 'b> CreateUserBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> UserClientRequired<'a> for CreateUserBuilder<'a, 'b> {
-    fn user_client(&self) -> &'a UserClient {
+impl<'a, 'b> CreateUserBuilder<'a, 'b> {
+    pub fn user_client(&self) -> &'a UserClient {
         self.user_client
     }
 }

--- a/sdk/cosmos/src/requests/delete_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/delete_attachment_builder.rs
@@ -24,8 +24,8 @@ impl<'a, 'b> DeleteAttachmentBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> AttachmentClientRequired<'a> for DeleteAttachmentBuilder<'a, 'b> {
-    fn attachment_client(&self) -> &'a AttachmentClient {
+impl<'a, 'b> DeleteAttachmentBuilder<'a, 'b> {
+    pub fn attachment_client(&self) -> &'a AttachmentClient {
         self.attachment_client
     }
 }

--- a/sdk/cosmos/src/requests/delete_collection_builder.rs
+++ b/sdk/cosmos/src/requests/delete_collection_builder.rs
@@ -23,8 +23,8 @@ impl<'a> DeleteCollectionBuilder<'a> {
     }
 }
 
-impl<'a> CollectionClientRequired<'a> for DeleteCollectionBuilder<'a> {
-    fn collection_client(&self) -> &'a CollectionClient {
+impl<'a> DeleteCollectionBuilder<'a> {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/delete_database_builder.rs
+++ b/sdk/cosmos/src/requests/delete_database_builder.rs
@@ -23,8 +23,8 @@ impl<'a> DeleteDatabaseBuilder<'a> {
     }
 }
 
-impl<'a> DatabaseClientRequired<'a> for DeleteDatabaseBuilder<'a> {
-    fn database_client(&self) -> &'a DatabaseClient {
+impl<'a> DeleteDatabaseBuilder<'a> {
+    pub fn database_client(&self) -> &'a DatabaseClient {
         self.database_client
     }
 }

--- a/sdk/cosmos/src/requests/delete_document_builder.rs
+++ b/sdk/cosmos/src/requests/delete_document_builder.rs
@@ -32,8 +32,8 @@ impl<'a> DeleteDocumentBuilder<'a> {
     }
 }
 
-impl<'a> DocumentClientRequired<'a> for DeleteDocumentBuilder<'a> {
-    fn document_client(&self) -> &'a DocumentClient {
+impl<'a> DeleteDocumentBuilder<'a> {
+    pub fn document_client(&self) -> &'a DocumentClient {
         self.document_client
     }
 }

--- a/sdk/cosmos/src/requests/delete_permission_builder.rs
+++ b/sdk/cosmos/src/requests/delete_permission_builder.rs
@@ -23,8 +23,8 @@ impl<'a, 'b> DeletePermissionsBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> PermissionClientRequired<'a> for DeletePermissionsBuilder<'a, 'b> {
-    fn permission_client(&self) -> &'a PermissionClient {
+impl<'a, 'b> DeletePermissionsBuilder<'a, 'b> {
+    pub fn permission_client(&self) -> &'a PermissionClient {
         self.permission_client
     }
 }

--- a/sdk/cosmos/src/requests/delete_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/delete_stored_procedure_builder.rs
@@ -23,7 +23,7 @@ impl<'a, 'b> DeleteStoredProcedureBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> StoredProcedureClientRequired<'a> for DeleteStoredProcedureBuilder<'a, 'b> {
+impl<'a, 'b> DeleteStoredProcedureBuilder<'a, 'b> {
     fn stored_procedure_client(&self) -> &'a StoredProcedureClient {
         self.stored_procedure_client
     }

--- a/sdk/cosmos/src/requests/delete_trigger_builder.rs
+++ b/sdk/cosmos/src/requests/delete_trigger_builder.rs
@@ -23,7 +23,7 @@ impl<'a, 'b> DeleteTriggerBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> TriggerClientRequired<'a> for DeleteTriggerBuilder<'a, 'b> {
+impl<'a, 'b> DeleteTriggerBuilder<'a, 'b> {
     fn trigger_client(&self) -> &'a TriggerClient {
         self.trigger_client
     }

--- a/sdk/cosmos/src/requests/delete_user_builder.rs
+++ b/sdk/cosmos/src/requests/delete_user_builder.rs
@@ -23,8 +23,8 @@ impl<'a, 'b> DeleteUserBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> UserClientRequired<'a> for DeleteUserBuilder<'a, 'b> {
-    fn user_client(&self) -> &'a UserClient {
+impl<'a, 'b> DeleteUserBuilder<'a, 'b> {
+    pub fn user_client(&self) -> &'a UserClient {
         self.user_client
     }
 }

--- a/sdk/cosmos/src/requests/delete_user_defined_function_builder.rs
+++ b/sdk/cosmos/src/requests/delete_user_defined_function_builder.rs
@@ -23,7 +23,7 @@ impl<'a, 'b> DeleteUserDefinedFunctionBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> UserDefinedFunctionClientRequired<'a> for DeleteUserDefinedFunctionBuilder<'a, 'b> {
+impl<'a, 'b> DeleteUserDefinedFunctionBuilder<'a, 'b> {
     fn user_defined_function_client(&self) -> &'a UserDefinedFunctionClient {
         self.user_defined_function_client
     }

--- a/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
@@ -31,7 +31,7 @@ impl<'a, 'b> ExecuteStoredProcedureBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> StoredProcedureClientRequired<'a> for ExecuteStoredProcedureBuilder<'a, 'b> {
+impl<'a, 'b> ExecuteStoredProcedureBuilder<'a, 'b> {
     fn stored_procedure_client(&self) -> &'a StoredProcedureClient {
         self.stored_procedure_client
     }

--- a/sdk/cosmos/src/requests/get_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/get_attachment_builder.rs
@@ -24,8 +24,8 @@ impl<'a, 'b> GetAttachmentBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> AttachmentClientRequired<'a> for GetAttachmentBuilder<'a, 'b> {
-    fn attachment_client(&self) -> &'a AttachmentClient {
+impl<'a, 'b> GetAttachmentBuilder<'a, 'b> {
+    pub fn attachment_client(&self) -> &'a AttachmentClient {
         self.attachment_client
     }
 }

--- a/sdk/cosmos/src/requests/get_collection_builder.rs
+++ b/sdk/cosmos/src/requests/get_collection_builder.rs
@@ -23,8 +23,8 @@ impl<'a> GetCollectionBuilder<'a> {
     }
 }
 
-impl<'a> CollectionClientRequired<'a> for GetCollectionBuilder<'a> {
-    fn collection_client(&self) -> &'a CollectionClient {
+impl<'a> GetCollectionBuilder<'a> {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/get_database_builder.rs
+++ b/sdk/cosmos/src/requests/get_database_builder.rs
@@ -22,15 +22,12 @@ impl<'a, 'b> GetDatabaseBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> DatabaseClientRequired<'a> for GetDatabaseBuilder<'a, 'b> {
-    fn database_client(&self) -> &'a DatabaseClient {
+impl<'a, 'b> GetDatabaseBuilder<'a, 'b> {
+    pub fn database_client(&self) -> &'a DatabaseClient {
         self.database_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, 'b> UserAgentOption<'b> for GetDatabaseBuilder<'a, 'b> {
     fn user_agent(&self) -> Option<&'b str> {
         self.user_agent

--- a/sdk/cosmos/src/requests/get_document_builder.rs
+++ b/sdk/cosmos/src/requests/get_document_builder.rs
@@ -31,8 +31,8 @@ impl<'a, 'b> GetDocumentBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> DocumentClientRequired<'a> for GetDocumentBuilder<'a, 'b> {
-    fn document_client(&self) -> &'a DocumentClient {
+impl<'a, 'b> GetDocumentBuilder<'a, 'b> {
+    pub fn document_client(&self) -> &'a DocumentClient {
         self.document_client
     }
 }

--- a/sdk/cosmos/src/requests/get_partition_key_ranges_builder.rs
+++ b/sdk/cosmos/src/requests/get_partition_key_ranges_builder.rs
@@ -29,8 +29,8 @@ impl<'a, 'b> GetPartitionKeyRangesBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> CollectionClientRequired<'a> for GetPartitionKeyRangesBuilder<'a, 'b> {
-    fn collection_client(&self) -> &'a CollectionClient {
+impl<'a, 'b> GetPartitionKeyRangesBuilder<'a, 'b> {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/get_permission_builer.rs
+++ b/sdk/cosmos/src/requests/get_permission_builer.rs
@@ -23,8 +23,8 @@ impl<'a, 'b> GetPermissionBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> PermissionClientRequired<'a> for GetPermissionBuilder<'a, 'b> {
-    fn permission_client(&self) -> &'a PermissionClient {
+impl<'a, 'b> GetPermissionBuilder<'a, 'b> {
+    pub fn permission_client(&self) -> &'a PermissionClient {
         self.permission_client
     }
 }

--- a/sdk/cosmos/src/requests/get_user_builder.rs
+++ b/sdk/cosmos/src/requests/get_user_builder.rs
@@ -23,8 +23,8 @@ impl<'a, 'b> GetUserBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> UserClientRequired<'a> for GetUserBuilder<'a, 'b> {
-    fn user_client(&self) -> &'a UserClient {
+impl<'a, 'b> GetUserBuilder<'a, 'b> {
+    pub fn user_client(&self) -> &'a UserClient {
         self.user_client
     }
 }

--- a/sdk/cosmos/src/requests/list_attachments_builder.rs
+++ b/sdk/cosmos/src/requests/list_attachments_builder.rs
@@ -33,9 +33,9 @@ impl<'a, 'b> ListAttachmentsBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> DocumentClientRequired<'a> for ListAttachmentsBuilder<'a, 'b> {
+impl<'a, 'b> ListAttachmentsBuilder<'a, 'b> {
     #[inline]
-    fn document_client(&self) -> &'a DocumentClient {
+    pub fn document_client(&self) -> &'a DocumentClient {
         self.document_client
     }
 }

--- a/sdk/cosmos/src/requests/list_collections_builder.rs
+++ b/sdk/cosmos/src/requests/list_collections_builder.rs
@@ -29,8 +29,8 @@ impl<'a> ListCollectionsBuilder<'a> {
     }
 }
 
-impl<'a> DatabaseClientRequired<'a> for ListCollectionsBuilder<'a> {
-    fn database_client(&self) -> &'a DatabaseClient {
+impl<'a> ListCollectionsBuilder<'a> {
+    pub fn database_client(&self) -> &'a DatabaseClient {
         self.database_client
     }
 }

--- a/sdk/cosmos/src/requests/list_databases_builder.rs
+++ b/sdk/cosmos/src/requests/list_databases_builder.rs
@@ -29,8 +29,8 @@ impl<'a> ListDatabasesBuilder<'a> {
     }
 }
 
-impl<'a> CosmosClientRequired<'a> for ListDatabasesBuilder<'a> {
-    fn cosmos_client(&self) -> &'a CosmosClient {
+impl<'a> ListDatabasesBuilder<'a> {
+    pub fn cosmos_client(&self) -> &'a CosmosClient {
         self.cosmos_client
     }
 }

--- a/sdk/cosmos/src/requests/list_documents_builder.rs
+++ b/sdk/cosmos/src/requests/list_documents_builder.rs
@@ -36,8 +36,8 @@ impl<'a, 'b> ListDocumentsBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> CollectionClientRequired<'a> for ListDocumentsBuilder<'a, 'b> {
-    fn collection_client(&self) -> &'a CollectionClient {
+impl<'a, 'b> ListDocumentsBuilder<'a, 'b> {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/list_permissions_builder.rs
+++ b/sdk/cosmos/src/requests/list_permissions_builder.rs
@@ -29,8 +29,8 @@ impl<'a, 'b> ListPermissionsBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> UserClientRequired<'a> for ListPermissionsBuilder<'a, 'b> {
-    fn user_client(&self) -> &'a UserClient {
+impl<'a, 'b> ListPermissionsBuilder<'a, 'b> {
+    pub fn user_client(&self) -> &'a UserClient {
         self.user_client
     }
 }

--- a/sdk/cosmos/src/requests/list_stored_procedures_builder.rs
+++ b/sdk/cosmos/src/requests/list_stored_procedures_builder.rs
@@ -29,8 +29,8 @@ impl<'a, 'b> ListStoredProceduresBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> CollectionClientRequired<'a> for ListStoredProceduresBuilder<'a, 'b> {
-    fn collection_client(&self) -> &'a CollectionClient {
+impl<'a, 'b> ListStoredProceduresBuilder<'a, 'b> {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/list_triggers_builder.rs
+++ b/sdk/cosmos/src/requests/list_triggers_builder.rs
@@ -31,8 +31,8 @@ impl<'a, 'b> ListTriggersBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> CollectionClientRequired<'a> for ListTriggersBuilder<'a, 'b> {
-    fn collection_client(&self) -> &'a CollectionClient {
+impl<'a, 'b> ListTriggersBuilder<'a, 'b> {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/list_user_defined_functions_builder.rs
+++ b/sdk/cosmos/src/requests/list_user_defined_functions_builder.rs
@@ -31,8 +31,8 @@ impl<'a, 'b> ListUserDefinedFunctionsBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> CollectionClientRequired<'a> for ListUserDefinedFunctionsBuilder<'a, 'b> {
-    fn collection_client(&self) -> &'a CollectionClient {
+impl<'a, 'b> ListUserDefinedFunctionsBuilder<'a, 'b> {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/list_users_builder.rs
+++ b/sdk/cosmos/src/requests/list_users_builder.rs
@@ -29,8 +29,8 @@ impl<'a, 'b> ListUsersBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> DatabaseClientRequired<'a> for ListUsersBuilder<'a, 'b> {
-    fn database_client(&self) -> &'a DatabaseClient {
+impl<'a, 'b> ListUsersBuilder<'a, 'b> {
+    pub fn database_client(&self) -> &'a DatabaseClient {
         self.database_client
     }
 }

--- a/sdk/cosmos/src/requests/query_documents_builder.rs
+++ b/sdk/cosmos/src/requests/query_documents_builder.rs
@@ -74,11 +74,11 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, No> {
     }
 }
 
-impl<'a, 'b, QuerySet> CollectionClientRequired<'a> for QueryDocumentsBuilder<'a, 'b, QuerySet>
+impl<'a, 'b, QuerySet> QueryDocumentsBuilder<'a, 'b, QuerySet>
 where
     QuerySet: ToAssign,
 {
-    fn collection_client(&self) -> &'a CollectionClient {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -38,13 +38,13 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, PartitionKeysSet, IndexingPolicySet> CollectionClientRequired<'a>
-    for ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet, IndexingPolicySet>
+impl<'a, 'b, PartitionKeysSet, IndexingPolicySet>
+    ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet, IndexingPolicySet>
 where
     PartitionKeysSet: ToAssign,
     IndexingPolicySet: ToAssign,
 {
-    fn collection_client(&self) -> &'a CollectionClient {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }

--- a/sdk/cosmos/src/requests/replace_document_builder.rs
+++ b/sdk/cosmos/src/requests/replace_document_builder.rs
@@ -48,21 +48,18 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, PartitionKeysSet, DocumentIdSet> CollectionClientRequired<'a>
-    for ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, DocumentIdSet>
+impl<'a, 'b, PartitionKeysSet, DocumentIdSet>
+    ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, DocumentIdSet>
 where
     PartitionKeysSet: ToAssign,
     DocumentIdSet: ToAssign,
 {
     #[inline]
-    fn collection_client(&self) -> &'a CollectionClient {
+    pub fn collection_client(&self) -> &'a CollectionClient {
         self.collection_client
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, 'b, DocumentIdSet> PartitionKeysRequired<'b>
     for ReplaceDocumentBuilder<'a, 'b, Yes, DocumentIdSet>
 where

--- a/sdk/cosmos/src/requests/replace_permission_builder.rs
+++ b/sdk/cosmos/src/requests/replace_permission_builder.rs
@@ -26,8 +26,8 @@ impl<'a, 'b> ReplacePermissionBuilder<'a, 'b> {
     }
 }
 
-impl<'a, 'b> PermissionClientRequired<'a> for ReplacePermissionBuilder<'a, 'b> {
-    fn permission_client(&self) -> &'a PermissionClient {
+impl<'a, 'b> ReplacePermissionBuilder<'a, 'b> {
+    pub fn permission_client(&self) -> &'a PermissionClient {
         self.permission_client
     }
 }

--- a/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
@@ -38,13 +38,13 @@ impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, ContentTypeSet, MediaSet> AttachmentClientRequired<'a>
-    for ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
+impl<'a, 'b, ContentTypeSet, MediaSet>
+    ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
 where
     ContentTypeSet: ToAssign,
     MediaSet: ToAssign,
 {
-    fn attachment_client(&self) -> &'a AttachmentClient {
+    pub fn attachment_client(&self) -> &'a AttachmentClient {
         self.attachment_client
     }
 }

--- a/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
@@ -39,13 +39,12 @@ impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, BodySet, ContentTypeSet> AttachmentClientRequired<'a>
-    for ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
+impl<'a, 'b, BodySet, ContentTypeSet> ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
 where
     BodySet: ToAssign,
     ContentTypeSet: ToAssign,
 {
-    fn attachment_client(&self) -> &'a AttachmentClient {
+    pub fn attachment_client(&self) -> &'a AttachmentClient {
         self.attachment_client
     }
 }

--- a/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
@@ -32,8 +32,7 @@ impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, No> {
     }
 }
 
-impl<'a, 'b, BodySet> StoredProcedureClientRequired<'a>
-    for ReplaceStoredProcedureBuilder<'a, 'b, BodySet>
+impl<'a, 'b, BodySet> ReplaceStoredProcedureBuilder<'a, 'b, BodySet>
 where
     BodySet: ToAssign,
 {
@@ -42,9 +41,6 @@ where
     }
 }
 
-//get mandatory no traits methods
-
-//set mandatory no traits methods
 impl<'a, 'b> StoredProcedureBodyRequired<'b> for ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
     fn body(&self) -> &'b str {
         self.body.unwrap()

--- a/sdk/cosmos/src/requests/replace_user_builder.rs
+++ b/sdk/cosmos/src/requests/replace_user_builder.rs
@@ -33,11 +33,11 @@ impl<'a, 'b> ReplaceUserBuilder<'a, 'b, No> {
     }
 }
 
-impl<'a, 'b, UserNameSet> UserClientRequired<'a> for ReplaceUserBuilder<'a, 'b, UserNameSet>
+impl<'a, 'b, UserNameSet> ReplaceUserBuilder<'a, 'b, UserNameSet>
 where
     UserNameSet: ToAssign,
 {
-    fn user_client(&self) -> &'a UserClient {
+    pub fn user_client(&self) -> &'a UserClient {
         self.user_client
     }
 }

--- a/sdk/cosmos/src/traits.rs
+++ b/sdk/cosmos/src/traits.rs
@@ -1,13 +1,8 @@
-use crate::clients::*;
 use crate::resources::*;
 use crate::{headers, ConsistencyLevel, PartitionKeys};
 use collection::*;
 use document::{IndexingDirective, Query};
 use http::request::Builder;
-
-pub trait CosmosClientRequired<'a> {
-    fn cosmos_client(&'a self) -> &'a CosmosClient;
-}
 
 pub trait DatabaseRequired<'a> {
     fn database(&self) -> &'a str;
@@ -321,37 +316,9 @@ pub trait ExpirySecondsSupport {
     fn with_expiry_seconds(self, expiry_seconds: u64) -> Self::O;
 }
 
-pub trait DatabaseClientRequired<'a> {
-    fn database_client(&self) -> &'a DatabaseClient;
-}
-
 pub trait DatabaseSupport<'a> {
     type O;
     fn with_database(self, database: &'a str) -> Self::O;
-}
-
-pub trait CollectionClientRequired<'a> {
-    fn collection_client(&self) -> &'a CollectionClient;
-}
-
-pub trait AttachmentClientRequired<'a> {
-    fn attachment_client(&self) -> &'a AttachmentClient;
-}
-
-pub trait StoredProcedureClientRequired<'a> {
-    fn stored_procedure_client(&self) -> &'a StoredProcedureClient;
-}
-
-pub trait UserDefinedFunctionClientRequired<'a> {
-    fn user_defined_function_client(&self) -> &'a UserDefinedFunctionClient;
-}
-
-pub trait TriggerClientRequired<'a> {
-    fn trigger_client(&'a self) -> &'a TriggerClient;
-}
-
-pub trait UserClientRequired<'a> {
-    fn user_client(&'a self) -> &'a UserClient;
 }
 
 pub trait StoredProcedureNameRequired<'a> {
@@ -361,14 +328,6 @@ pub trait StoredProcedureNameRequired<'a> {
 pub trait StoredProcedureNameSupport<'a> {
     type O;
     fn with_stored_procedure_name(self, stored_procedure_name: &'a str) -> Self::O;
-}
-
-pub trait DocumentClientRequired<'a> {
-    fn document_client(&'a self) -> &'a DocumentClient;
-}
-
-pub trait PermissionClientRequired<'a> {
-    fn permission_client(&self) -> &'a PermissionClient;
 }
 
 pub trait OfferRequired {


### PR DESCRIPTION
This is the first in (I hope) many PRs to remove most of the traits we use internally in Cosmos. 

This removes all traits which seek to require client getter methods. I don't see any advantage to these being a part of a trait instead of being on the struct itself. I believe the thought originally behind this was consistent naming, but I think it's easier to manually keep track of that rather than relying on traits (after all, the user could just choose to not implement the trait at all). 

I believe we should remove all traits which exist only to enforce naming conventions. I believe this will most likely result in removing the entire `traits.rs` file in Cosmos DB. 