### PR TITLE
Assign perform_request to intermediate variable in get_blob_properties_builder

### DIFF
--- a/sdk/storage/src/blob/blob/requests/get_blob_properties_builder.rs
+++ b/sdk/storage/src/blob/blob/requests/get_blob_properties_builder.rs
@@ -311,18 +311,17 @@ where
 
         trace!("uri == {:?}", uri);
 
-        let (headers, _) = self
-            .client()
-            .perform_request(
-                &uri,
-                &Method::HEAD,
-                &|mut request| {
-                    request = ClientRequestIdOption::add_header(&self, request);
-                    request = LeaseIdOption::add_header(&self, request);
-                    request
-                },
-                None,
-            )?
+        let perform_request_response = self.client().perform_request(
+            &uri,
+            &Method::HEAD,
+            &|mut request| {
+                request = ClientRequestIdOption::add_header(&self, request);
+                request = LeaseIdOption::add_header(&self, request);
+                request
+            },
+            None,
+        )?;
+        let (headers, _) = perform_request_response
             .check_status_extract_headers_and_body(StatusCode::OK)
             .await?;
         let blob = Blob::from_headers(&blob_name, &container_name, snapshot_time, &headers)?;

--- a/sdk/storage/tests/blob.rs
+++ b/sdk/storage/tests/blob.rs
@@ -398,6 +398,13 @@ async fn copy_blob() {
         .unwrap();
 }
 
+async fn requires_send_future<F, O>(fut: F) -> O
+where
+    F: std::future::Future<Output = O> + Send,
+{
+    fut.await
+}
+
 #[tokio::test]
 async fn put_block_blob_and_get_properties() {
     let client = initialize();
@@ -450,6 +457,14 @@ async fn put_block_blob_and_get_properties() {
         .unwrap();
 
     assert_eq!(blob_properties.blob.content_length, 6);
+
+    let _ = requires_send_future(
+        client
+            .get_blob_properties()
+            .with_container_name(&container_name)
+            .with_blob_name(&blob_name)
+            .finalize(),
+    );
 }
 
 fn initialize() -> Box<dyn Client> {


### PR DESCRIPTION
Without this, the compiler thinks we're trying to share the closure between threads (see example below), and this appears to fix it! This does seem to be a common pattern in other `finalize` methods; I'm not sure why the tests don't catch this case?

https://github.com/delta-io/delta.rs/pull/35/checks?check_run_id=1495733210