### PR TITLE
Lockdown oauth2 crate version to unblock build

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -31,7 +31,7 @@ bytes = "1.0"
 hyper-rustls = "0.22"
 failure = "0.1"
 async-trait = "0.1"
-oauth2 = "4.0.0-alpha.3"
+oauth2 = "=4.0.0-alpha.3"
 reqwest = "0.11"
 
 [dev-dependencies]

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.1.0" }
-oauth2 = { version = "4.0.0-alpha.3" }
+oauth2 = "=4.0.0-alpha.3"
 url = "2.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/key_vault/Cargo.toml
+++ b/sdk/key_vault/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-oauth2 = { version = "4.0.0-alpha.3" }
+oauth2 = "=4.0.0-alpha.3"
 azure_core = { path = "../core", version = "0.1.0" }
 azure_identity = { version = "0.1", path = "../identity" }
 


### PR DESCRIPTION
Fixes: #134

version='a' has same semantic of '^a', which will auto pick version with same major version. This won't work for packages on alpha version, which can have breaking change.