### PR TITLE
Make APIs that take partition keys more flexible

### DIFF
--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // let's add an entity.
     match client
         .create_document()
-        .with_partition_keys(PartitionKeys::new().push(&doc.document.id)?)
+        .with_partition_keys([&doc.document.id])
         .execute_with_document(&doc)
         .await
     {

--- a/sdk/cosmos/examples/create_delete_database.rs
+++ b/sdk/cosmos/examples/create_delete_database.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let create_collection_response = db_client
             .create_collection()
             .with_collection_name(&"panzadoro")
-            .with_partition_key(&("/id".into()))
+            .with_partition_key("/id")
             .with_offer(Offer::Throughput(400))
             .with_indexing_policy(&ip)
             .execute()

--- a/sdk/cosmos/examples/database_00.rs
+++ b/sdk/cosmos/examples/database_00.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 let document = Document::new(v);
                 let resp = collection_client
                     .create_document()
-                    .with_partition_keys(PartitionKeys::new().push(&43u32)?)
+                    .with_partition_keys([43u32])
                     .with_is_upsert(true)
                     .execute_with_document(&document)
                     .await?;
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 println!("\nReplacing collection");
                 let replace_collection_response = collection_client
                     .replace_collection()
-                    .with_partition_key(&("/age".into()))
+                    .with_partition_key("/age")
                     .with_indexing_policy(&indexing_policy_new)
                     .execute()
                     .await?;

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -120,7 +120,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 .with_collection_name(&COLLECTION)
                 .with_offer(Offer::Throughput(400))
                 .with_indexing_policy(&ip)
-                .with_partition_key(&("/id".into()))
+                .with_partition_key("/id")
                 .execute()
                 .await?
                 .collection
@@ -150,7 +150,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // the document attributes.
     let create_document_response = collection_client
         .create_document()
-        .with_partition_keys(&(&doc.document.id).into())
+        .with_partition_keys([&doc.document.id])
         .execute_with_document(&doc)
         .await?;
     println!(
@@ -174,10 +174,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("getting document by id {}", &doc.document.id);
     let get_document_response = collection_client
         .clone()
-        .into_document_client(
-            doc.document.id.clone().into_owned(),
-            (&doc.document.id).into(),
-        )
+        .into_document_client(doc.document.id.clone().into_owned(), [&doc.document.id])
         .get_document()
         .execute::<MySampleStruct>()
         .await?;
@@ -196,7 +193,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let replace_document_response = collection_client
             .replace_document()
             .with_document_id(&doc.document.id)
-            .with_partition_keys(&(&doc.document.id).into())
+            .with_partition_keys([&doc.document.id])
             .with_if_match_condition(IfMatchCondition::Match(&document.etag))
             .execute_with_document(&doc)
             .await?;

--- a/sdk/cosmos/examples/document_entries_00.rs
+++ b/sdk/cosmos/examples/document_entries_00.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         response = Some(
             client
                 .create_document()
-                .with_partition_keys(PartitionKeys::new().push(&doc.document.id)?)
+                .with_partition_keys([&doc.document.id])
                 .execute_with_document(&doc)
                 .await?,
         );
@@ -121,7 +121,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("\n\nLooking for a specific item");
     let id = format!("unique_id{}", 3);
-    let partition_keys: PartitionKeys = (&id).into();
+    let partition_keys = PartitionKeys::from([&id]);
 
     let response = client
         .clone()
@@ -146,7 +146,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("\n\nReplacing document");
     let replace_document_response = client
         .replace_document()
-        .with_partition_keys(&partition_keys)
+        .with_partition_keys(partition_keys)
         .with_document_id(&id)
         .with_consistency_level(ConsistencyLevel::from(&response))
         .with_if_match_condition(IfMatchCondition::Match(&doc.etag)) // use optimistic concurrency check
@@ -162,7 +162,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // has_been_found == false
     println!("\n\nLooking for non-existing item");
     let id = format!("unique_id{}", 100);
-    let partition_keys: PartitionKeys = (&id).into();
+    let partition_keys = PartitionKeys::from([&id]);
 
     let response = client
         .clone()
@@ -180,7 +180,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     for i in 0u64..5 {
         let id = format!("unique_id{}", i);
-        let partition_keys: PartitionKeys = (&id).into();
+        let partition_keys = PartitionKeys::from([&id]);
         client
             .clone()
             .into_document_client(id, partition_keys)

--- a/sdk/cosmos/examples/document_entries_01.rs
+++ b/sdk/cosmos/examples/document_entries_01.rs
@@ -42,13 +42,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         a_timestamp: chrono::Utc::now().timestamp(),
     });
 
-    let mut partition_keys = PartitionKeys::new();
-    partition_keys.push(&doc.document.id)?;
-
+    let partition_keys = PartitionKeys::from([&doc.document.id]);
     // let's add an entity.
     let create_document_response = client
         .create_document()
-        .with_partition_keys(&partition_keys)
+        .with_partition_keys(partition_keys.clone())
         .with_is_upsert(true)
         .execute_with_document(&doc)
         .await?;
@@ -108,7 +106,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .replace_document()
         .with_consistency_level((&query_documents_response).into())
         .with_document_id(&doc.document.id)
-        .with_partition_keys(&partition_keys)
+        .with_partition_keys(partition_keys)
         .execute_with_document(&doc)
         .await?;
     println!(

--- a/sdk/cosmos/examples/readme.rs
+++ b/sdk/cosmos/examples/readme.rs
@@ -70,9 +70,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         session_token = Some(
             collection_client
                 .create_document()
-                .with_partition_keys(
-                    PartitionKeys::new().push(&document_to_insert.document.a_number)?,
-                )
+                .with_partition_keys([&document_to_insert.document.a_number])
                 .with_is_upsert(true) // this option will overwrite a preexisting document (if any)
                 .execute_with_document(&document_to_insert)
                 .await?
@@ -142,7 +140,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             .clone()
             .into_document_client(
                 document.result.id.clone().into_owned(),
-                document.result.a_number.into(),
+                [document.result.a_number],
             )
             .delete_document()
             .with_consistency_level(session_token.clone())

--- a/sdk/cosmos/examples/remove_all_documents.rs
+++ b/sdk/cosmos/examples/remove_all_documents.rs
@@ -54,11 +54,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             _ => panic!("cannot find id field as string"),
         };
         let partition_key: PartitionKeys = match &doc_as_obj[&partition_key_name] {
-            Value::String(id) => id.into(),
-            Value::Number(num) => num
-                .as_i64()
-                .expect("only numbers up to i64 are supported")
-                .into(),
+            Value::String(id) => [id].into(),
+            Value::Number(num) => {
+                [num.as_i64().expect("only numbers up to i64 are supported")].into()
+            }
             _ => panic!("cannot find supplied partition key as string"),
         };
 

--- a/sdk/cosmos/examples/stored_proc_00.rs
+++ b/sdk/cosmos/examples/stored_proc_00.rs
@@ -7,7 +7,6 @@ use azure_core::HttpClient;
 ///     response.setBody("Hello, " + personToGreet);
 /// }
 use azure_cosmos::prelude::*;
-use azure_cosmos::resources::stored_procedure::Parameters;
 use std::error::Error;
 use std::sync::Arc;
 
@@ -34,7 +33,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_collection_client(collection)
         .into_stored_procedure_client("test_proc")
         .execute_stored_procedure()
-        .with_parameters(Parameters::new().push("Robert")?)
+        .with_parameters(["Robert"])
         .execute::<serde_json::Value>()
         .await?;
 

--- a/sdk/cosmos/examples/stored_proc_01.rs
+++ b/sdk/cosmos/examples/stored_proc_01.rs
@@ -7,7 +7,6 @@ use azure_core::HttpClient;
 ///     response.setBody("Hello, " + personToGreet);
 /// }
 use azure_cosmos::prelude::*;
-use azure_cosmos::resources::stored_procedure::Parameters;
 use std::error::Error;
 use std::sync::Arc;
 
@@ -65,7 +64,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let execute_stored_procedure_response = stored_procedure_client
         .execute_stored_procedure()
-        .with_parameters(Parameters::new().push("Robert")?)
+        .with_parameters(["Robert"])
         .execute::<serde_json::Value>()
         .await?;
 

--- a/sdk/cosmos/examples/user_permission_token.rs
+++ b/sdk/cosmos/examples/user_permission_token.rs
@@ -117,7 +117,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_collection_client(collection_name.clone())
         .create_document()
         .with_is_upsert(true)
-        .with_partition_keys(PartitionKeys::new().push("Gianluigi Bombatomica")?)
+        .with_partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await
     {
@@ -157,7 +157,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_collection_client(collection_name)
         .create_document()
         .with_is_upsert(true)
-        .with_partition_keys(PartitionKeys::new().push("Gianluigi Bombatomica")?)
+        .with_partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await?;
     println!(

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -83,12 +83,12 @@ impl CollectionClient {
         requests::GetPartitionKeyRangesBuilder::new(self)
     }
 
-    pub fn into_document_client<S: Into<ReadonlyString>>(
+    pub fn into_document_client<S: Into<ReadonlyString>, P: Into<PartitionKeys>>(
         self,
         document_name: S,
-        partition_keys: PartitionKeys,
+        partition_keys: P,
     ) -> DocumentClient {
-        DocumentClient::new(self, document_name, partition_keys)
+        DocumentClient::new(self, document_name, partition_keys.into())
     }
 
     pub fn into_trigger_client<S: Into<ReadonlyString>>(self, trigger_name: S) -> TriggerClient {

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -73,9 +73,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // insert it
         collection_client
             .create_document()
-            .with_partition_keys(
-                PartitionKeys::new().push(&document_to_insert.document.a_number)?,
-            )
+            .with_partition_keys([&document_to_insert.document.a_number])
             .with_is_upsert(true) // this option will overwrite a preexisting document (if any)
             .execute_with_document(&document_to_insert)
             .await?;

--- a/sdk/cosmos/src/partition_keys.rs
+++ b/sdk/cosmos/src/partition_keys.rs
@@ -1,11 +1,60 @@
 use crate::headers;
+use crate::to_json_vector::ToJsonVector;
 use azure_core::AddAsHeader;
 use http::request::Builder;
+use serde::Serialize;
 
 /// A collection of keys to partition on
 ///
 /// You can learn more about partitioning [here](https://docs.microsoft.com/en-us/azure/cosmos-db/partitioning-overview)
-pub type PartitionKeys = crate::to_json_vector::ToJsonVector;
+#[derive(Debug, Clone)]
+pub struct PartitionKeys(ToJsonVector);
+
+impl PartitionKeys {
+    /// New partition keys
+    pub fn new() -> Self {
+        Self(ToJsonVector::new())
+    }
+
+    /// Push a serialized object into the collection
+    pub fn push<T: Serialize>(&mut self, item: T) -> serde_json::Result<()> {
+        self.0.push(item)
+    }
+
+    /// Convert into a JSON formatted string
+    pub fn to_json(&self) -> String {
+        self.0.to_json()
+    }
+}
+
+macro_rules! delegate_from_impl {
+    ($($t:ty),*) => {
+        $(
+            delegate_from_impl!(@imp &$t);
+            delegate_from_impl!(@imp $t);
+        )*
+    };
+    (@imp $t:ty) => {
+        impl<T: Serialize> From<$t> for PartitionKeys {
+            fn from(s: $t) -> Self {
+                Self(ToJsonVector::from(s))
+            }
+        }
+    }
+}
+
+delegate_from_impl! {
+    Vec<T>,
+    [T; 0],
+    [T; 1],
+    [T; 2],
+    [T; 3],
+    [T; 4],
+    [T; 5],
+    [T; 6],
+    [T; 7],
+    [T; 8]
+}
 
 impl AddAsHeader for &'_ PartitionKeys {
     fn add_as_header(&self, builder: Builder) -> Builder {

--- a/sdk/cosmos/src/requests/create_collection_builder.rs
+++ b/sdk/cosmos/src/requests/create_collection_builder.rs
@@ -25,7 +25,7 @@ pub struct CreateCollectionBuilder<
     offer: Option<Offer>,
     collection_name: Option<&'a str>,
     indexing_policy: Option<&'a IndexingPolicy>,
-    partition_key: Option<&'a PartitionKey>,
+    partition_key: Option<PartitionKey>,
     user_agent: Option<UserAgent<'a>>,
     activity_id: Option<ActivityId<'a>>,
     consistency_level: Option<ConsistencyLevel>,
@@ -161,12 +161,12 @@ where
     CollectionNameSet: ToAssign,
     IndexingPolicySet: ToAssign,
 {
-    pub fn with_partition_key(
+    pub fn with_partition_key<P: Into<PartitionKey>>(
         self,
-        partition_key: &'a PartitionKey,
+        partition_key: P,
     ) -> CreateCollectionBuilder<'a, OfferSet, CollectionNameSet, IndexingPolicySet, Yes> {
         CreateCollectionBuilder {
-            partition_key: Some(partition_key),
+            partition_key: Some(partition_key.into()),
             database_client: self.database_client,
             offer: self.offer,
             collection_name: self.collection_name,
@@ -205,7 +205,7 @@ impl<'a> CreateCollectionBuilder<'a, Yes, Yes, Yes, Yes> {
             self.collection_name.unwrap(),
             self.indexing_policy.unwrap().to_owned(),
         );
-        collection.parition_key = self.partition_key.unwrap().to_owned();
+        collection.parition_key = self.partition_key.as_ref().unwrap().clone();
 
         let body = serde_json::to_string(&collection)?;
         debug!("body == {}", body);

--- a/sdk/cosmos/src/requests/create_document_builder.rs
+++ b/sdk/cosmos/src/requests/create_document_builder.rs
@@ -16,7 +16,7 @@ where
     PartitionKeysSet: ToAssign,
 {
     collection_client: &'a CollectionClient,
-    partition_keys: Option<&'b PartitionKeys>,
+    partition_keys: Option<PartitionKeys>,
     is_upsert: IsUpsert,
     indexing_directive: IndexingDirective,
     if_match_condition: Option<IfMatchCondition<'b>>,
@@ -63,12 +63,12 @@ where
 }
 
 impl<'a, 'b> CreateDocumentBuilder<'a, 'b, No> {
-    pub fn with_partition_keys(
+    pub fn with_partition_keys<P: Into<PartitionKeys>>(
         self,
-        partition_keys: &'b PartitionKeys,
+        partition_keys: P,
     ) -> CreateDocumentBuilder<'a, 'b, Yes> {
         CreateDocumentBuilder {
-            partition_keys: Some(partition_keys),
+            partition_keys: Some(partition_keys.into()),
             collection_client: self.collection_client,
             is_upsert: self.is_upsert,
             indexing_directive: self.indexing_directive,
@@ -107,7 +107,8 @@ impl<'a, 'b> CreateDocumentBuilder<'a, 'b, Yes> {
         req = azure_core::headers::add_optional_header(&self.user_agent, req);
         req = azure_core::headers::add_optional_header(&self.activity_id, req);
         req = azure_core::headers::add_optional_header(&self.consistency_level, req);
-        req = azure_core::headers::add_mandatory_header(&self.partition_keys.unwrap(), req);
+        req =
+            azure_core::headers::add_mandatory_header(&self.partition_keys.as_ref().unwrap(), req);
         req = azure_core::headers::add_mandatory_header(&self.is_upsert, req);
         req = azure_core::headers::add_mandatory_header(&self.indexing_directive, req);
         req = azure_core::headers::add_mandatory_header(&self.allow_tentative_writes, req);

--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -14,7 +14,7 @@ where
     IndexingPolicySet: ToAssign,
 {
     collection_client: &'a CollectionClient,
-    partition_key: Option<&'a PartitionKey>,
+    partition_key: Option<PartitionKey>,
     indexing_policy: Option<&'a IndexingPolicy>,
     user_agent: Option<UserAgent<'b>>,
     activity_id: Option<ActivityId<'b>>,
@@ -78,7 +78,7 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b, Yes, Yes> {
         let request = Request {
             id: self.collection_client.collection_name(),
             indexing_policy: self.indexing_policy.unwrap(),
-            partition_key: self.partition_key.unwrap(),
+            partition_key: self.partition_key.as_ref().unwrap(),
         };
 
         let body = serde_json::to_string(&request)?;
@@ -104,15 +104,15 @@ impl<'a, 'b, IndexingPolicySet> ReplaceCollectionBuilder<'a, 'b, No, IndexingPol
 where
     IndexingPolicySet: ToAssign,
 {
-    pub fn with_partition_key(
+    pub fn with_partition_key<P: Into<PartitionKey>>(
         self,
-        partition_key: &'a PartitionKey,
+        partition_key: P,
     ) -> ReplaceCollectionBuilder<'a, 'b, Yes, IndexingPolicySet> {
         ReplaceCollectionBuilder {
             collection_client: self.collection_client,
             p_partition_key: PhantomData,
             p_indexing_policy: PhantomData,
-            partition_key: Some(partition_key),
+            partition_key: Some(partition_key.into()),
             indexing_policy: self.indexing_policy,
             user_agent: self.user_agent,
             activity_id: self.activity_id,

--- a/sdk/cosmos/src/requests/replace_document_builder.rs
+++ b/sdk/cosmos/src/requests/replace_document_builder.rs
@@ -16,7 +16,7 @@ where
     DocumentIdSet: ToAssign,
 {
     collection_client: &'a CollectionClient,
-    partition_keys: Option<&'b PartitionKeys>,
+    partition_keys: Option<PartitionKeys>,
     document_id: Option<&'b str>,
     indexing_directive: IndexingDirective,
     if_match_condition: Option<IfMatchCondition<'b>>,
@@ -93,7 +93,8 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, Yes, Yes> {
         let req = azure_core::headers::add_optional_header(&self.user_agent, req);
         let req = azure_core::headers::add_optional_header(&self.activity_id, req);
         let req = azure_core::headers::add_optional_header(&self.consistency_level, req);
-        let req = azure_core::headers::add_mandatory_header(&self.partition_keys.unwrap(), req);
+        let req =
+            azure_core::headers::add_mandatory_header(&self.partition_keys.as_ref().unwrap(), req);
         let req = azure_core::headers::add_mandatory_header(&self.allow_tentative_writes, req);
 
         let serialized = serde_json::to_string(document)?;
@@ -114,12 +115,12 @@ impl<'a, 'b, DocumentIdSet> ReplaceDocumentBuilder<'a, 'b, No, DocumentIdSet>
 where
     DocumentIdSet: ToAssign,
 {
-    pub fn with_partition_keys(
+    pub fn with_partition_keys<P: Into<PartitionKeys>>(
         self,
-        partition_keys: &'b PartitionKeys,
+        partition_keys: P,
     ) -> ReplaceDocumentBuilder<'a, 'b, Yes, DocumentIdSet> {
         ReplaceDocumentBuilder {
-            partition_keys: Some(partition_keys),
+            partition_keys: Some(partition_keys.into()),
             collection_client: self.collection_client,
             document_id: self.document_id,
             indexing_directive: self.indexing_directive,

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -59,7 +59,7 @@ async fn attachment() -> Result<(), CosmosError> {
         database_client
             .create_collection()
             .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key(&("/id".into()))
+            .with_partition_key("/id")
             .with_offer(Offer::Throughput(400))
             .with_indexing_policy(&ip)
             .execute()
@@ -83,7 +83,7 @@ async fn attachment() -> Result<(), CosmosError> {
     // let's add an entity.
     let session_token: ConsistencyLevel = collection_client
         .create_document()
-        .with_partition_keys(PartitionKeys::new().push(&doc.document.id)?)
+        .with_partition_keys([&doc.document.id])
         .execute_with_document(&doc)
         .await?
         .into();

--- a/sdk/cosmos/tests/cosmos_collection.rs
+++ b/sdk/cosmos/tests/cosmos_collection.rs
@@ -31,7 +31,7 @@ async fn create_and_delete_collection() {
         .create_collection()
         .with_collection_name(&COLLECTION_NAME)
         .with_offer(Offer::S2)
-        .with_partition_key(&("/id".into()))
+        .with_partition_key("/id")
         .with_indexing_policy(&indexing_policy)
         .execute()
         .await
@@ -92,7 +92,7 @@ async fn replace_collection() {
         .create_collection()
         .with_collection_name(&COLLECTION_NAME)
         .with_offer(Offer::S2)
-        .with_partition_key(&("/id".into()))
+        .with_partition_key("/id")
         .with_indexing_policy(&indexing_policy)
         .execute()
         .await
@@ -135,7 +135,7 @@ async fn replace_collection() {
     let _replace_collection_reponse = collection_client
         .replace_collection()
         .with_indexing_policy(&new_ip)
-        .with_partition_key(&("/id".into()))
+        .with_partition_key("/id")
         .execute()
         .await
         .unwrap();

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -43,7 +43,7 @@ async fn create_and_delete_document() {
         .create_collection()
         .with_collection_name(&COLLECTION_NAME)
         .with_offer(Offer::Throughput(400))
-        .with_partition_key(&("/id".into()))
+        .with_partition_key("/id")
         .with_indexing_policy(&indexing_policy)
         .execute()
         .await
@@ -60,7 +60,7 @@ async fn create_and_delete_document() {
     });
     collection_client
         .create_document()
-        .with_partition_keys(&DOCUMENT_NAME.into())
+        .with_partition_keys([&DOCUMENT_NAME])
         .execute_with_document(&document_data)
         .await
         .unwrap();
@@ -74,10 +74,10 @@ async fn create_and_delete_document() {
     assert!(documents.len() == 1);
 
     // try to get the contents of the previously created document
-    let partition_keys = DOCUMENT_NAME.into();
+    let partition_keys = DOCUMENT_NAME;
     let document_client = collection_client
         .clone()
-        .into_document_client(DOCUMENT_NAME, partition_keys);
+        .into_document_client(DOCUMENT_NAME, [partition_keys]);
 
     let document_after_get = document_client
         .get_document()
@@ -133,7 +133,7 @@ async fn query_documents() {
         .create_collection()
         .with_collection_name(&COLLECTION_NAME)
         .with_offer(Offer::S2)
-        .with_partition_key(&("/id".into()))
+        .with_partition_key("/id")
         .with_indexing_policy(&indexing_policy)
         .execute()
         .await
@@ -150,7 +150,7 @@ async fn query_documents() {
     });
     collection_client
         .create_document()
-        .with_partition_keys(&(&document_data.document.id).into())
+        .with_partition_keys([&document_data.document.id])
         .execute_with_document(&document_data)
         .await
         .unwrap();
@@ -210,7 +210,7 @@ async fn replace_document() {
         .create_collection()
         .with_collection_name(&COLLECTION_NAME)
         .with_offer(Offer::S2)
-        .with_partition_key(&("/id".into()))
+        .with_partition_key("/id")
         .with_indexing_policy(&indexing_policy)
         .execute()
         .await
@@ -227,7 +227,7 @@ async fn replace_document() {
     });
     collection_client
         .create_document()
-        .with_partition_keys(&(&document_data.document.id).into())
+        .with_partition_keys([&document_data.document.id])
         .execute_with_document(&document_data)
         .await
         .unwrap();
@@ -244,7 +244,7 @@ async fn replace_document() {
     collection_client
         .replace_document()
         .with_document_id(&document_data.document.id)
-        .with_partition_keys(&(&document_data.document.id).into())
+        .with_partition_keys([&document_data.document.id])
         .with_consistency_level(ConsistencyLevel::from(&documents))
         .with_if_match_condition(IfMatchCondition::Match(
             &documents.documents[0].document_attributes.etag,
@@ -254,8 +254,8 @@ async fn replace_document() {
         .unwrap();
 
     // now get the replaced document
-    let partition_keys = DOCUMENT_NAME.into();
-    let document_client = collection_client.into_document_client(DOCUMENT_NAME, partition_keys);
+    let partition_keys = DOCUMENT_NAME;
+    let document_client = collection_client.into_document_client(DOCUMENT_NAME, [partition_keys]);
     let document_after_get = document_client
         .get_document()
         .execute::<MyDocument>()

--- a/sdk/cosmos/tests/permission.rs
+++ b/sdk/cosmos/tests/permission.rs
@@ -54,7 +54,7 @@ async fn permissions() {
         database_client
             .create_collection()
             .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key(&("/id".into()))
+            .with_partition_key("/id")
             .with_offer(Offer::Throughput(400))
             .with_indexing_policy(&ip)
             .execute()

--- a/sdk/cosmos/tests/permission_token_usage.rs
+++ b/sdk/cosmos/tests/permission_token_usage.rs
@@ -35,7 +35,7 @@ async fn permission_token_usage() {
         .create_collection()
         .with_collection_name(&COLLECTION_NAME)
         .with_offer(Offer::Throughput(400))
-        .with_partition_key(&("/id".into()))
+        .with_partition_key("/id")
         .with_indexing_policy(&indexing_policy)
         .execute()
         .await
@@ -91,7 +91,7 @@ async fn permission_token_usage() {
     new_collection_client
         .create_document()
         .with_is_upsert(true)
-        .with_partition_keys(PartitionKeys::new().push(&"Gianluigi Bombatomica").unwrap())
+        .with_partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await
         .unwrap_err();
@@ -124,7 +124,7 @@ async fn permission_token_usage() {
     let create_document_response = new_collection_client
         .create_document()
         .with_is_upsert(true)
-        .with_partition_keys(PartitionKeys::new().push(&"Gianluigi Bombatomica").unwrap())
+        .with_partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await
         .unwrap();

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -75,7 +75,7 @@ async fn trigger() -> Result<(), CosmosError> {
         database_client
             .create_collection()
             .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key(&("/id".into()))
+            .with_partition_key("/id")
             .with_offer(Offer::Throughput(400))
             .with_indexing_policy(&ip)
             .execute()

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -59,7 +59,7 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
         database_client
             .create_collection()
             .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key(&("/id".into()))
+            .with_partition_key("/id")
             .with_offer(Offer::Throughput(400))
             .with_indexing_policy(&ip)
             .execute()


### PR DESCRIPTION
Fixes #127  

This changes APIs that took `PartitionKeys` to take `Into<PartitionKeys>` instead. Additionally, it changes the conversions to `PartitionKeys` such that collections are the only thing that convert to `PartitionKeys` which is more logical than turning single elements into `PartitionKeys` (which is logically plural). This does mean that users will have to wrap their partition keys in `[]` but I think this makes sense.

In general calls will normally look like:

```rust
with_partition_keys(["key1", "key2"])
```