### PR TITLE
Change setter methods to take param as `Into<T>` instead of `T`

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -33,7 +33,6 @@ failure = "0.1"
 async-trait = "0.1"
 oauth2 = "4.0.0-alpha.3"
 reqwest = "0.11"
-paste = "1.0"
 
 [dev-dependencies]
 tokio = "1.0"

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -1127,7 +1127,3 @@ pub trait AddAsHeader {
 pub trait AppendToUrlQuery {
     fn append_to_url_query(&self, url: &mut url::Url);
 }
-
-#[doc(hidden)]
-/// Reexport paste for use in macros
-pub use paste;

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -26,12 +26,11 @@
 #[macro_export]
 macro_rules! setters {
     (@single $name:ident : $typ:ty => $transform:expr) => {
-        $crate::paste::paste! {
-            pub fn [<with_ $name>](self, $name: $typ) -> Self {
-                Self  {
-                    $name: $transform,
-                    ..self
-                }
+        pub fn $name<T: ::std::convert::Into<$typ>>(self, $name: T) -> Self {
+            let $name: $typ = $name.into();
+            Self  {
+                $name: $transform,
+                ..self
             }
         }
     };

--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // let's add an entity.
     match client
         .create_document()
-        .with_partition_keys([&doc.document.id])
+        .partition_keys([&doc.document.id])
         .execute_with_document(&doc)
         .await
     {
@@ -78,9 +78,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let attachment_client = document_client.clone().into_attachment_client("myref06");
     let resp = attachment_client
         .create_reference()
-        .with_consistency_level((&ret).into())
-        .with_content_type("image/jpeg")
-        .with_media(
+        .consistency_level(ret)
+        .content_type("image/jpeg")
+        .media(
             "https://cdn.pixabay.com/photo/2020/01/11/09/30/abstract-background-4756987__340.jpg",
         )
         .execute()
@@ -93,7 +93,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let resp = attachment_client
         .get()
-        .with_consistency_level(session_token)
+        .consistency_level(session_token)
         .execute()
         .await?;
 
@@ -104,9 +104,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let attachment_client = document_client.clone().into_attachment_client("myref06");
     let resp = attachment_client
         .replace_reference()
-        .with_consistency_level(session_token)
-        .with_content_type("image/jpeg")
-        .with_media(
+        .consistency_level(session_token)
+        .content_type("image/jpeg")
+        .media(
             "https://Adn.pixabay.com/photo/2020/01/11/09/30/abstract-background-4756987__340.jpg",
         )
         .execute()
@@ -116,7 +116,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("deleting");
     let resp_delete = attachment_client
         .delete()
-        .with_consistency_level((&resp).into())
+        .consistency_level(&resp)
         .execute()
         .await?;
     println!("delete attachment == {:#?}", resp_delete);
@@ -126,9 +126,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let attachment_client = document_client.into_attachment_client("slug00".to_owned());
     let resp = attachment_client
         .create_slug()
-        .with_consistency_level((&resp_delete).into())
-        .with_content_type("text/plain")
-        .with_body(b"FFFFF")
+        .consistency_level(&resp_delete)
+        .content_type("text/plain")
+        .body(b"FFFFF")
         .execute()
         .await?;
 
@@ -137,7 +137,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("deleting");
     let resp_delete = attachment_client
         .delete()
-        .with_consistency_level((&resp).into())
+        .consistency_level(&resp)
         .execute()
         .await?;
     println!("delete attachment == {:#?}", resp_delete);

--- a/sdk/cosmos/examples/create_delete_database.rs
+++ b/sdk/cosmos/examples/create_delete_database.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let db = client
         .create_database()
-        .with_database_name(&database_name)
+        .database_name(&database_name)
         .execute()
         .await?;
     println!("created database = {:#?}", db);
@@ -71,10 +71,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
         let create_collection_response = db_client
             .create_collection()
-            .with_collection_name(&"panzadoro")
-            .with_partition_key("/id")
-            .with_offer(Offer::Throughput(400))
-            .with_indexing_policy(&ip)
+            .collection_name(&"panzadoro")
+            .partition_key("/id")
+            .offer(Offer::Throughput(400))
+            .indexing_policy(&ip)
             .execute()
             .await?;
 

--- a/sdk/cosmos/examples/database_00.rs
+++ b/sdk/cosmos/examples/database_00.rs
@@ -56,8 +56,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 let document = Document::new(v);
                 let resp = collection_client
                     .create_document()
-                    .with_partition_keys([43u32])
-                    .with_is_upsert(true)
+                    .partition_keys([43u32])
+                    .is_upsert(true)
                     .execute_with_document(&document)
                     .await?;
 
@@ -72,8 +72,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 println!("\nReplacing collection");
                 let replace_collection_response = collection_client
                     .replace_collection()
-                    .with_partition_key("/age")
-                    .with_indexing_policy(&indexing_policy_new)
+                    .partition_key("/age")
+                    .indexing_policy(&indexing_policy_new)
                     .execute()
                     .await?;
                 println!(

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         None => {
             client
                 .create_database()
-                .with_database_name(&DATABASE)
+                .database_name(&DATABASE)
                 .execute()
                 .await?
                 .database
@@ -117,10 +117,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 .clone()
                 .into_database_client(database.id.clone())
                 .create_collection()
-                .with_collection_name(&COLLECTION)
-                .with_offer(Offer::Throughput(400))
-                .with_indexing_policy(&ip)
-                .with_partition_key("/id")
+                .collection_name(&COLLECTION)
+                .offer(Offer::Throughput(400))
+                .indexing_policy(&ip)
+                .partition_key("/id")
                 .execute()
                 .await?
                 .collection
@@ -150,7 +150,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // the document attributes.
     let create_document_response = collection_client
         .create_document()
-        .with_partition_keys([&doc.document.id])
+        .partition_keys([&doc.document.id])
         .execute_with_document(&doc)
         .await?;
     println!(
@@ -192,9 +192,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // CosmosDB it means something else updated the document before us!
         let replace_document_response = collection_client
             .replace_document()
-            .with_document_id(&doc.document.id)
-            .with_partition_keys([&doc.document.id])
-            .with_if_match_condition(IfMatchCondition::Match(&document.etag))
+            .document_id(&doc.document.id)
+            .partition_keys([&doc.document.id])
+            .if_match_condition(IfMatchCondition::Match(&document.etag))
             .execute_with_document(&doc)
             .await?;
         println!(

--- a/sdk/cosmos/examples/document_entries_01.rs
+++ b/sdk/cosmos/examples/document_entries_01.rs
@@ -46,8 +46,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // let's add an entity.
     let create_document_response = client
         .create_document()
-        .with_partition_keys(partition_keys.clone())
-        .with_is_upsert(true)
+        .partition_keys(partition_keys.clone())
+        .is_upsert(true)
         .execute_with_document(&doc)
         .await?;
 
@@ -62,7 +62,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let get_document_response = document_client
         .get_document()
-        .with_consistency_level((&create_document_response).into())
+        .consistency_level(&create_document_response)
         .execute::<serde_json::Value>()
         .await?;
     println!("get_document_response == {:#?}", get_document_response);
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let get_document_response = document_client
         .get_document()
-        .with_consistency_level((&get_document_response).into())
+        .consistency_level(&get_document_response)
         .execute::<serde_json::Value>()
         .await?;
     println!(
@@ -83,16 +83,16 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let list_documents_response = client
         .list_documents()
-        .with_consistency_level((&get_document_response).into())
+        .consistency_level(&get_document_response)
         .execute::<serde_json::Value>()
         .await?;
     println!("list_documents_response == {:#?}", list_documents_response);
 
     let query_documents_response = client
         .query_documents()
-        .with_query(&("SELECT * FROM c WHERE c.a_number = 600".into()))
-        .with_consistency_level((&list_documents_response).into())
-        .with_query_cross_partition(true)
+        .query(&("SELECT * FROM c WHERE c.a_number = 600".into()))
+        .consistency_level(&list_documents_response)
+        .query_cross_partition(true)
         .execute::<serde_json::Value>()
         .await?;
     println!(
@@ -104,9 +104,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let replace_document_response = client
         .replace_document()
-        .with_consistency_level((&query_documents_response).into())
-        .with_document_id(&doc.document.id)
-        .with_partition_keys(partition_keys)
+        .consistency_level(&query_documents_response)
+        .document_id(&doc.document.id)
+        .partition_keys(partition_keys)
         .execute_with_document(&doc)
         .await?;
     println!(

--- a/sdk/cosmos/examples/permission_00.rs
+++ b/sdk/cosmos/examples/permission_00.rs
@@ -59,8 +59,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_permission_response = permission_client
         .create_permission()
-        .with_consistency_level((&create_user_response).into())
-        .with_expiry_seconds(18000) // 5 hours, max!
+        .consistency_level(&create_user_response)
+        .expiry_seconds(18000u64) // 5 hours, max!
         .execute_with_permission(&permission_mode)
         .await?;
     println!(
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_permission2_response = permission_client
         .create_permission()
-        .with_consistency_level((&create_user_response).into())
+        .consistency_level(&create_user_response)
         .execute_with_permission(&permission_mode)
         .await?;
     println!(
@@ -85,7 +85,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let list_permissions_response = user_client
         .list_permissions()
-        .with_consistency_level(ConsistencyLevel::Session(
+        .consistency_level(ConsistencyLevel::Session(
             create_permission2_response.session_token,
         ))
         .execute()
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let get_permission_response = permission_client
         .get_permission()
-        .with_consistency_level(ConsistencyLevel::Session(
+        .consistency_level(ConsistencyLevel::Session(
             list_permissions_response.session_token,
         ))
         .execute()
@@ -110,8 +110,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // renew permission extending its validity for 60 seconds more.
     let replace_permission_response = permission_client
         .replace_permission()
-        .with_expiry_seconds(60)
-        .with_consistency_level(ConsistencyLevel::Session(
+        .expiry_seconds(60u64)
+        .consistency_level(ConsistencyLevel::Session(
             get_permission_response.session_token,
         ))
         .execute_with_permission(permission_mode)
@@ -123,7 +123,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let delete_permission_response = permission_client
         .delete_permission()
-        .with_consistency_level(ConsistencyLevel::Session(
+        .consistency_level(ConsistencyLevel::Session(
             replace_permission_response.session_token,
         ))
         .execute()
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let delete_user_response = user_client
         .delete_user()
-        .with_consistency_level(ConsistencyLevel::Session(
+        .consistency_level(ConsistencyLevel::Session(
             delete_permission_response.session_token,
         ))
         .execute()

--- a/sdk/cosmos/examples/query_document_00.rs
+++ b/sdk/cosmos/examples/query_document_00.rs
@@ -49,19 +49,19 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let respo: QueryDocumentsResponse<serde_json::Value> = client
         .query_documents()
-        .with_query(&query_obj)
-        .with_query_cross_partition(true)
-        .with_max_item_count(3)
+        .query(&query_obj)
+        .query_cross_partition(true)
+        .max_item_count(3)
         .execute()
         .await?;
     println!("as json == {:?}", respo);
 
     let respo: QueryDocumentsResponse<MySecondSampleStructOwned> = client
         .query_documents()
-        .with_query(&query_obj)
-        .with_query_cross_partition(true)
-        .with_parallelize_cross_partition_query(true)
-        .with_max_item_count(2)
+        .query(&query_obj)
+        .query_cross_partition(true)
+        .parallelize_cross_partition_query(true)
+        .max_item_count(2)
         .execute()
         .await?;
     println!("as items == {:?}", respo);

--- a/sdk/cosmos/examples/readme.rs
+++ b/sdk/cosmos/examples/readme.rs
@@ -70,8 +70,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         session_token = Some(
             collection_client
                 .create_document()
-                .with_partition_keys([&document_to_insert.document.a_number])
-                .with_is_upsert(true) // this option will overwrite a preexisting document (if any)
+                .partition_keys([&document_to_insert.document.a_number])
+                .is_upsert(true) // this option will overwrite a preexisting document (if any)
                 .execute_with_document(&document_to_insert)
                 .await?
                 .session_token, // get only the session token, if everything else was ok!
@@ -89,8 +89,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // you will use a more sensible number (or accept the Azure default).
         let stream = collection_client
             .list_documents()
-            .with_consistency_level(session_token.clone())
-            .with_max_item_count(3);
+            .consistency_level(session_token.clone())
+            .max_item_count(3);
         let mut stream = Box::pin(stream.stream::<MySampleStruct>());
         // TODO: As soon as the streaming functionality is stabilized
         // in Rust we can substitute this while let Some... into
@@ -106,9 +106,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("\nQuerying documents");
     let query_documents_response = collection_client
         .query_documents()
-        .with_query(&("SELECT * FROM A WHERE A.a_number < 600".into())) // there are other ways to construct a query, this is the simplest.
-        .with_query_cross_partition(true) // this will perform a cross partition query! notice how simple it is!
-        .with_consistency_level(session_token)
+        .query(&("SELECT * FROM A WHERE A.a_number < 600".into())) // there are other ways to construct a query, this is the simplest.
+        .query_cross_partition(true) // this will perform a cross partition query! notice how simple it is!
+        .consistency_level(session_token)
         .execute::<MySampleStruct>() // This will make sure the result is our custom struct!
         .await?
         .into_documents() // queries can return Documents or Raw json (ie without etag, _rid, etc...). Since our query return docs we convert with this function.
@@ -143,8 +143,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 [document.result.a_number],
             )
             .delete_document()
-            .with_consistency_level(session_token.clone())
-            .with_if_match_condition((&document.document_attributes).into())
+            .consistency_level(session_token.clone())
+            .if_match_condition(&document.document_attributes)
             .execute()
             .await?;
     }
@@ -153,7 +153,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // Now the list documents should return 4 documents!
     let list_documents_response = collection_client
         .list_documents()
-        .with_consistency_level(session_token)
+        .consistency_level(session_token)
         .execute::<serde_json::Value>() // you can use this if you don't know/care about the return type!
         .await?;
     assert_eq!(list_documents_response.documents.len(), 4);

--- a/sdk/cosmos/examples/stored_proc_00.rs
+++ b/sdk/cosmos/examples/stored_proc_00.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_collection_client(collection)
         .into_stored_procedure_client("test_proc")
         .execute_stored_procedure()
-        .with_parameters(["Robert"])
+        .parameters(["Robert"])
         .execute::<serde_json::Value>()
         .await?;
 

--- a/sdk/cosmos/examples/stored_proc_01.rs
+++ b/sdk/cosmos/examples/stored_proc_01.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_stored_procedure_response = stored_procedure_client
         .create_stored_procedure()
-        .with_body(&function_body)
+        .body(&function_body)
         .execute()
         .await?;
     println!(
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let execute_stored_procedure_response = stored_procedure_client
         .execute_stored_procedure()
-        .with_parameters(["Robert"])
+        .parameters(["Robert"])
         .execute::<serde_json::Value>()
         .await?;
 

--- a/sdk/cosmos/examples/trigger_00.rs
+++ b/sdk/cosmos/examples/trigger_00.rs
@@ -62,19 +62,19 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = trigger_client
         .create_trigger()
-        .with_trigger_type(TriggerType::Post)
-        .with_trigger_operation(TriggerOperation::All)
-        .with_body(&"something")
+        .trigger_type(TriggerType::Post)
+        .trigger_operation(TriggerOperation::All)
+        .body(&"something")
         .execute()
         .await?;
     println!("Creeate response object:\n{:#?}", ret);
 
     let ret = trigger_client
         .replace_trigger()
-        .with_consistency_level(ret.into())
-        .with_trigger_type(TriggerType::Post)
-        .with_trigger_operation(TriggerOperation::All)
-        .with_body(&TRIGGER_BODY)
+        .consistency_level(ret)
+        .trigger_type(TriggerType::Post)
+        .trigger_operation(TriggerOperation::All)
+        .body(&TRIGGER_BODY)
         .execute()
         .await?;
     println!("Replace response object:\n{:#?}", ret);
@@ -83,8 +83,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let stream = collection_client
         .list_triggers()
-        .with_max_item_count(3)
-        .with_consistency_level((&ret).into());
+        .max_item_count(3)
+        .consistency_level(&ret);
     let mut stream = Box::pin(stream.stream());
     while let Some(ret) = stream.next().await {
         let ret = ret.unwrap();
@@ -97,7 +97,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = trigger_client
         .delete_trigger()
-        .with_consistency_level(last_session_token.unwrap())
+        .consistency_level(last_session_token.unwrap())
         .execute()
         .await?;
     println!("Delete response object:\n{:#?}", ret);

--- a/sdk/cosmos/examples/user_00.rs
+++ b/sdk/cosmos/examples/user_00.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let replace_user_response = user_client
         .replace_user()
-        .with_user_name(&new_user)
+        .user_name(&new_user)
         .execute()
         .await?;
     println!("replace_user_response == {:#?}", replace_user_response);

--- a/sdk/cosmos/examples/user_defined_function_00.rs
+++ b/sdk/cosmos/examples/user_defined_function_00.rs
@@ -42,15 +42,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = user_defined_function_client
         .create_user_defined_function()
-        .with_body("body")
+        .body("body")
         .execute()
         .await?;
     println!("Creeate response object:\n{:#?}", ret);
 
     let stream = collection_client
         .list_user_defined_functions()
-        .with_max_item_count(3)
-        .with_consistency_level((&ret).into());
+        .max_item_count(3)
+        .consistency_level(&ret);
     let mut stream = Box::pin(stream.stream());
     while let Some(ret) = stream.next().await {
         let ret = ret.unwrap();
@@ -62,17 +62,17 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = user_defined_function_client
         .replace_user_defined_function()
-        .with_consistency_level((&ret).into())
-        .with_body(FN_BODY)
+        .consistency_level(&ret)
+        .body(FN_BODY)
         .execute()
         .await?;
     println!("Replace response object:\n{:#?}", ret);
 
     let ret = collection_client
         .query_documents()
-        .with_query(&"SELECT udf.test15(100)".into())
-        .with_consistency_level((&ret).into())
-        .with_max_item_count(2)
+        .query(&"SELECT udf.test15(100)".into())
+        .consistency_level(&ret)
+        .max_item_count(2)
         .execute::<serde_json::Value>()
         .await?
         .into_raw();
@@ -94,7 +94,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = user_defined_function_client
         .delete_user_defined_function()
-        .with_consistency_level((&ret).into())
+        .consistency_level(&ret)
         .execute()
         .await?;
 

--- a/sdk/cosmos/examples/user_permission_token.rs
+++ b/sdk/cosmos/examples/user_permission_token.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_permission_response = permission_client
         .create_permission()
-        .with_expiry_seconds(18000) // 5 hours, max!
+        .expiry_seconds(18000u64) // 5 hours, max!
         .execute_with_permission(&permission_mode)
         .await?;
     println!(
@@ -76,7 +76,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         new_authorization_token
     );
     let mut client = client.clone();
-    client.with_auth_token(new_authorization_token);
+    client.auth_token(new_authorization_token);
 
     // let's list the documents with the new auth token
     let list_documents_response = client
@@ -116,8 +116,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_database_client(database_name.clone())
         .into_collection_client(collection_name.clone())
         .create_document()
-        .with_is_upsert(true)
-        .with_partition_keys(["Gianluigi Bombatomica"])
+        .is_upsert(true)
+        .partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await
     {
@@ -131,7 +131,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let permission_mode = get_collection_response.collection.all_permission();
     let create_permission_response = permission_client
         .create_permission()
-        .with_expiry_seconds(18000) // 5 hours, max!
+        .expiry_seconds(18000u64) // 5 hours, max!
         .execute_with_permission(&permission_mode)
         .await?;
     println!(
@@ -148,7 +148,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         "Replacing authorization_token with {:?}.",
         new_authorization_token
     );
-    client.with_auth_token(new_authorization_token);
+    client.auth_token(new_authorization_token);
 
     // now we have an "All" authorization_token
     // so the create_document should succeed!
@@ -156,8 +156,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_database_client(database_name)
         .into_collection_client(collection_name)
         .create_document()
-        .with_is_upsert(true)
-        .with_partition_keys(["Gianluigi Bombatomica"])
+        .is_upsert(true)
+        .partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await?;
     println!(

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -86,7 +86,7 @@ impl CosmosClient {
         }
     }
 
-    pub fn with_auth_token(&mut self, auth_token: AuthorizationToken) {
+    pub fn auth_token(&mut self, auth_token: AuthorizationToken) {
         self.auth_token = auth_token;
     }
 

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -73,8 +73,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // insert it
         collection_client
             .create_document()
-            .with_partition_keys([&document_to_insert.document.a_number])
-            .with_is_upsert(true) // this option will overwrite a preexisting document (if any)
+            .partition_keys([&document_to_insert.document.a_number])
+            .is_upsert(true) // this option will overwrite a preexisting document (if any)
             .execute_with_document(&document_to_insert)
             .await?;
     }

--- a/sdk/cosmos/src/requests/create_collection_builder.rs
+++ b/sdk/cosmos/src/requests/create_collection_builder.rs
@@ -76,7 +76,7 @@ where
     IndexingPolicySet: ToAssign,
     PartitionKeySet: ToAssign,
 {
-    pub fn with_offer(
+    pub fn offer(
         self,
         offer: Offer,
     ) -> CreateCollectionBuilder<'a, Yes, CollectionNameSet, IndexingPolicySet, PartitionKeySet>
@@ -105,7 +105,7 @@ where
     IndexingPolicySet: ToAssign,
     PartitionKeySet: ToAssign,
 {
-    pub fn with_collection_name(
+    pub fn collection_name(
         self,
         collection_name: &'a str,
     ) -> CreateCollectionBuilder<'a, OfferSet, Yes, IndexingPolicySet, PartitionKeySet> {
@@ -133,7 +133,7 @@ where
     CollectionNameSet: ToAssign,
     PartitionKeySet: ToAssign,
 {
-    pub fn with_indexing_policy(
+    pub fn indexing_policy(
         self,
         indexing_policy: &'a IndexingPolicy,
     ) -> CreateCollectionBuilder<'a, OfferSet, CollectionNameSet, Yes, PartitionKeySet> {
@@ -161,7 +161,7 @@ where
     CollectionNameSet: ToAssign,
     IndexingPolicySet: ToAssign,
 {
-    pub fn with_partition_key<P: Into<PartitionKey>>(
+    pub fn partition_key<P: Into<PartitionKey>>(
         self,
         partition_key: P,
     ) -> CreateCollectionBuilder<'a, OfferSet, CollectionNameSet, IndexingPolicySet, Yes> {

--- a/sdk/cosmos/src/requests/create_database_builder.rs
+++ b/sdk/cosmos/src/requests/create_database_builder.rs
@@ -44,7 +44,7 @@ where
 }
 
 impl<'a> CreateDatabaseBuilder<'a, No> {
-    pub fn with_database_name(self, database_name: &'a str) -> CreateDatabaseBuilder<'a, Yes> {
+    pub fn database_name(self, database_name: &'a str) -> CreateDatabaseBuilder<'a, Yes> {
         CreateDatabaseBuilder {
             database_name: Some(database_name),
             cosmos_client: self.cosmos_client,

--- a/sdk/cosmos/src/requests/create_document_builder.rs
+++ b/sdk/cosmos/src/requests/create_document_builder.rs
@@ -63,7 +63,7 @@ where
 }
 
 impl<'a, 'b> CreateDocumentBuilder<'a, 'b, No> {
-    pub fn with_partition_keys<P: Into<PartitionKeys>>(
+    pub fn partition_keys<P: Into<PartitionKeys>>(
         self,
         partition_keys: P,
     ) -> CreateDocumentBuilder<'a, 'b, Yes> {

--- a/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
@@ -95,7 +95,7 @@ where
     TriggerTypeSet: ToAssign,
     BodySet: ToAssign,
 {
-    pub fn with_trigger_operation(
+    pub fn trigger_operation(
         self,
         trigger_operation: TriggerOperation,
     ) -> CreateOrReplaceTriggerBuilder<'a, Yes, TriggerTypeSet, BodySet> {
@@ -121,7 +121,7 @@ where
     TriggerOperationSet: ToAssign,
     BodySet: ToAssign,
 {
-    pub fn with_trigger_type(
+    pub fn trigger_type(
         self,
         trigger_type: TriggerType,
     ) -> CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, Yes, BodySet> {
@@ -147,7 +147,7 @@ where
     TriggerOperationSet: ToAssign,
     TriggerTypeSet: ToAssign,
 {
-    pub fn with_body(
+    pub fn body(
         self,
         body: &'a str,
     ) -> CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, Yes> {

--- a/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
@@ -54,10 +54,7 @@ impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
 }
 
 impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, No> {
-    pub fn with_body(
-        self,
-        body: &'b str,
-    ) -> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
+    pub fn body(self, body: &'b str) -> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
         CreateOrReplaceUserDefinedFunctionBuilder {
             body: Some(body),
             user_defined_function_client: self.user_defined_function_client,

--- a/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
@@ -53,7 +53,7 @@ impl<'a, 'b, MediaSet> CreateReferenceAttachmentBuilder<'a, 'b, No, MediaSet>
 where
     MediaSet: ToAssign,
 {
-    pub fn with_content_type(
+    pub fn content_type(
         self,
         content_type: &'b str,
     ) -> CreateReferenceAttachmentBuilder<'a, 'b, Yes, MediaSet> {
@@ -74,7 +74,7 @@ impl<'a, 'b, ContentTypeSet> CreateReferenceAttachmentBuilder<'a, 'b, ContentTyp
 where
     ContentTypeSet: ToAssign,
 {
-    pub fn with_media(
+    pub fn media(
         self,
         media: &'b str,
     ) -> CreateReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, Yes> {

--- a/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
@@ -56,10 +56,7 @@ impl<'a, 'b, ContentTypeSet> CreateSlugAttachmentBuilder<'a, 'b, No, ContentType
 where
     ContentTypeSet: ToAssign,
 {
-    pub fn with_body(
-        self,
-        body: &'b [u8],
-    ) -> CreateSlugAttachmentBuilder<'a, 'b, Yes, ContentTypeSet> {
+    pub fn body(self, body: &'b [u8]) -> CreateSlugAttachmentBuilder<'a, 'b, Yes, ContentTypeSet> {
         CreateSlugAttachmentBuilder {
             body: Some(body),
             attachment_client: self.attachment_client,
@@ -78,7 +75,7 @@ impl<'a, 'b, BodySet> CreateSlugAttachmentBuilder<'a, 'b, BodySet, No>
 where
     BodySet: ToAssign,
 {
-    pub fn with_content_type(
+    pub fn content_type(
         self,
         content_type: &'b str,
     ) -> CreateSlugAttachmentBuilder<'a, 'b, BodySet, Yes> {

--- a/sdk/cosmos/src/requests/create_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/create_stored_procedure_builder.rs
@@ -50,7 +50,7 @@ impl<'a, 'b> CreateStoredProcedureBuilder<'a, 'b, Yes> {
 }
 
 impl<'a, 'b> CreateStoredProcedureBuilder<'a, 'b, No> {
-    pub fn with_body(self, body: &'a str) -> CreateStoredProcedureBuilder<'a, 'b, Yes> {
+    pub fn body(self, body: &'a str) -> CreateStoredProcedureBuilder<'a, 'b, Yes> {
         CreateStoredProcedureBuilder {
             body: Some(body),
             stored_procedure_client: self.stored_procedure_client,

--- a/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
@@ -38,7 +38,7 @@ impl<'a, 'b> ExecuteStoredProcedureBuilder<'a, 'b> {
         partition_keys: &'b PartitionKeys => Some(partition_keys),
     }
 
-    pub fn with_parameters<P: Into<Parameters>>(self, p: P) -> Self {
+    pub fn parameters<P: Into<Parameters>>(self, p: P) -> Self {
         Self {
             parameters: Some(p.into()),
             ..self

--- a/sdk/cosmos/src/requests/list_attachments_builder.rs
+++ b/sdk/cosmos/src/requests/list_attachments_builder.rs
@@ -91,7 +91,7 @@ impl<'a, 'b> ListAttachmentsBuilder<'a, 'b> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_collections_builder.rs
+++ b/sdk/cosmos/src/requests/list_collections_builder.rs
@@ -78,7 +78,7 @@ impl<'a> ListCollectionsBuilder<'a> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_databases_builder.rs
+++ b/sdk/cosmos/src/requests/list_databases_builder.rs
@@ -75,7 +75,7 @@ impl<'a> ListDatabasesBuilder<'a> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_documents_builder.rs
+++ b/sdk/cosmos/src/requests/list_documents_builder.rs
@@ -101,7 +101,7 @@ impl<'a, 'b> ListDocumentsBuilder<'a, 'b> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_permissions_builder.rs
+++ b/sdk/cosmos/src/requests/list_permissions_builder.rs
@@ -84,7 +84,7 @@ impl<'a, 'b> ListPermissionsBuilder<'a, 'b> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_stored_procedures_builder.rs
+++ b/sdk/cosmos/src/requests/list_stored_procedures_builder.rs
@@ -84,7 +84,7 @@ impl<'a, 'b> ListStoredProceduresBuilder<'a, 'b> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_triggers_builder.rs
+++ b/sdk/cosmos/src/requests/list_triggers_builder.rs
@@ -86,7 +86,7 @@ impl<'a, 'b> ListTriggersBuilder<'a, 'b> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_user_defined_functions_builder.rs
+++ b/sdk/cosmos/src/requests/list_user_defined_functions_builder.rs
@@ -88,7 +88,7 @@ impl<'a, 'b> ListUserDefinedFunctionsBuilder<'a, 'b> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/list_users_builder.rs
+++ b/sdk/cosmos/src/requests/list_users_builder.rs
@@ -74,7 +74,7 @@ impl<'a, 'b> ListUsersBuilder<'a, 'b> {
                         Some(States::Init) => self.execute().await,
                         Some(States::Continuation(continuation_token)) => {
                             self.clone()
-                                .with_continuation(&continuation_token)
+                                .continuation(continuation_token.as_str())
                                 .execute()
                                 .await
                         }

--- a/sdk/cosmos/src/requests/query_documents_builder.rs
+++ b/sdk/cosmos/src/requests/query_documents_builder.rs
@@ -136,7 +136,7 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, Yes> {
                     Some(States::Init) => self.execute().await,
                     Some(States::Continuation(continuation_token)) => {
                         self.clone()
-                            .with_continuation(&continuation_token)
+                            .continuation(continuation_token.as_str())
                             .execute()
                             .await
                     }
@@ -160,7 +160,7 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, Yes> {
 }
 
 impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, No> {
-    pub fn with_query(self, query: &'b Query<'b>) -> QueryDocumentsBuilder<'a, 'b, Yes> {
+    pub fn query(self, query: &'b Query<'b>) -> QueryDocumentsBuilder<'a, 'b, Yes> {
         QueryDocumentsBuilder {
             query: Some(query),
             collection_client: self.collection_client,

--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -104,7 +104,7 @@ impl<'a, 'b, IndexingPolicySet> ReplaceCollectionBuilder<'a, 'b, No, IndexingPol
 where
     IndexingPolicySet: ToAssign,
 {
-    pub fn with_partition_key<P: Into<PartitionKey>>(
+    pub fn partition_key<P: Into<PartitionKey>>(
         self,
         partition_key: P,
     ) -> ReplaceCollectionBuilder<'a, 'b, Yes, IndexingPolicySet> {
@@ -125,7 +125,7 @@ impl<'a, 'b, PartitionKeysSet> ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet
 where
     PartitionKeysSet: ToAssign,
 {
-    pub fn with_indexing_policy(
+    pub fn indexing_policy(
         self,
         indexing_policy: &'a IndexingPolicy,
     ) -> ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet, Yes> {

--- a/sdk/cosmos/src/requests/replace_document_builder.rs
+++ b/sdk/cosmos/src/requests/replace_document_builder.rs
@@ -115,7 +115,7 @@ impl<'a, 'b, DocumentIdSet> ReplaceDocumentBuilder<'a, 'b, No, DocumentIdSet>
 where
     DocumentIdSet: ToAssign,
 {
-    pub fn with_partition_keys<P: Into<PartitionKeys>>(
+    pub fn partition_keys<P: Into<PartitionKeys>>(
         self,
         partition_keys: P,
     ) -> ReplaceDocumentBuilder<'a, 'b, Yes, DocumentIdSet> {
@@ -140,7 +140,7 @@ impl<'a, 'b, PartitionKeysSet> ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, 
 where
     PartitionKeysSet: ToAssign,
 {
-    pub fn with_document_id(
+    pub fn document_id(
         self,
         document_id: &'b str,
     ) -> ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, Yes> {

--- a/sdk/cosmos/src/requests/replace_permission_builder.rs
+++ b/sdk/cosmos/src/requests/replace_permission_builder.rs
@@ -33,11 +33,6 @@ impl<'a, 'b> ReplacePermissionBuilder<'a, 'b> {
         expiry_seconds: u64 => ExpirySeconds::new(expiry_seconds),
     }
 
-    #[allow(unused)]
-    fn expiry_seconds(&self) -> ExpirySeconds {
-        self.expiry_seconds
-    }
-
     pub async fn execute_with_permission(
         &self,
         permission_mode: &PermissionMode<'a>,

--- a/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
@@ -105,7 +105,7 @@ impl<'a, 'b, MediaSet> ReplaceReferenceAttachmentBuilder<'a, 'b, No, MediaSet>
 where
     MediaSet: ToAssign,
 {
-    pub fn with_content_type(
+    pub fn content_type(
         self,
         content_type: &'b str,
     ) -> ReplaceReferenceAttachmentBuilder<'a, 'b, Yes, MediaSet> {
@@ -127,7 +127,7 @@ impl<'a, 'b, ContentTypeSet> ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTy
 where
     ContentTypeSet: ToAssign,
 {
-    pub fn with_media(
+    pub fn media(
         self,
         media: &'b str,
     ) -> ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, Yes> {

--- a/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
@@ -90,10 +90,7 @@ impl<'a, 'b, ContentTypeSet> ReplaceSlugAttachmentBuilder<'a, 'b, No, ContentTyp
 where
     ContentTypeSet: ToAssign,
 {
-    pub fn with_body(
-        self,
-        body: &'b [u8],
-    ) -> ReplaceSlugAttachmentBuilder<'a, 'b, Yes, ContentTypeSet> {
+    pub fn body(self, body: &'b [u8]) -> ReplaceSlugAttachmentBuilder<'a, 'b, Yes, ContentTypeSet> {
         ReplaceSlugAttachmentBuilder {
             attachment_client: self.attachment_client,
             p_body: PhantomData,
@@ -112,7 +109,7 @@ impl<'a, 'b, BodySet> ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, No>
 where
     BodySet: ToAssign,
 {
-    pub fn with_content_type(
+    pub fn content_type(
         self,
         content_type: &'b str,
     ) -> ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, Yes> {

--- a/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
@@ -81,7 +81,7 @@ impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
 }
 
 impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, No> {
-    pub fn with_body(self, body: &'b str) -> ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
+    pub fn body(self, body: &'b str) -> ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
         ReplaceStoredProcedureBuilder {
             stored_procedure_client: self.stored_procedure_client,
             p_body: PhantomData,

--- a/sdk/cosmos/src/requests/replace_user_builder.rs
+++ b/sdk/cosmos/src/requests/replace_user_builder.rs
@@ -82,7 +82,7 @@ impl<'a, 'b> ReplaceUserBuilder<'a, 'b, Yes> {
 }
 
 impl<'a, 'b> ReplaceUserBuilder<'a, 'b, No> {
-    pub fn with_user_name(self, user_name: &'a str) -> ReplaceUserBuilder<'a, 'b, Yes> {
+    pub fn user_name(self, user_name: &'a str) -> ReplaceUserBuilder<'a, 'b, Yes> {
         ReplaceUserBuilder {
             user_name: Some(user_name),
             user_client: self.user_client,

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -55,7 +55,6 @@ pub enum QueryResult<T> {
 pub struct QueryDocumentsResponse<T> {
     pub query_response_meta: QueryResponseMeta,
     pub results: Vec<QueryResult<T>>,
-
     pub last_state_change: DateTime<Utc>,
     pub resource_quota: Vec<ResourceQuota>,
     pub resource_usage: Vec<ResourceQuota>,

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -29,7 +29,7 @@ async fn attachment() -> Result<(), CosmosError> {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -58,10 +58,10 @@ async fn attachment() -> Result<(), CosmosError> {
 
         database_client
             .create_collection()
-            .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key("/id")
-            .with_offer(Offer::Throughput(400))
-            .with_indexing_policy(&ip)
+            .collection_name(&COLLECTION_NAME)
+            .partition_key("/id")
+            .offer(Offer::Throughput(400))
+            .indexing_policy(&ip)
             .execute()
             .await
             .unwrap()
@@ -83,7 +83,7 @@ async fn attachment() -> Result<(), CosmosError> {
     // let's add an entity.
     let session_token: ConsistencyLevel = collection_client
         .create_document()
-        .with_partition_keys([&doc.document.id])
+        .partition_keys([&doc.document.id])
         .execute_with_document(&doc)
         .await?
         .into();
@@ -95,7 +95,7 @@ async fn attachment() -> Result<(), CosmosError> {
     // list attachments, there must be none.
     let ret = document_client
         .list_attachments()
-        .with_consistency_level(session_token.clone())
+        .consistency_level(session_token.clone())
         .execute()
         .await?;
     assert_eq!(0, ret.attachments.len());
@@ -104,18 +104,18 @@ async fn attachment() -> Result<(), CosmosError> {
     let attachment_client = document_client.clone().into_attachment_client("reference");
     let resp = attachment_client
         .create_reference()
-        .with_consistency_level((&ret).into())
-        .with_content_type("image/jpeg")
-        .with_media("https://www.bing.com")
+        .consistency_level(&ret)
+        .content_type("image/jpeg")
+        .media("https://www.bing.com")
         .execute()
         .await?;
 
     // replace reference attachment
     let resp = attachment_client
         .replace_reference()
-        .with_consistency_level((&resp).into())
-        .with_content_type("image/jpeg")
-        .with_media("https://www.microsoft.com")
+        .consistency_level(&resp)
+        .content_type("image/jpeg")
+        .media("https://www.microsoft.com")
         .execute()
         .await?;
 
@@ -123,16 +123,16 @@ async fn attachment() -> Result<(), CosmosError> {
     let attachment_client = document_client.clone().into_attachment_client("slug");
     let resp = attachment_client
         .create_slug()
-        .with_consistency_level((&resp).into())
-        .with_content_type("text/plain")
-        .with_body(b"something cool here")
+        .consistency_level(&resp)
+        .content_type("text/plain")
+        .body(b"something cool here")
         .execute()
         .await?;
 
     // list attachments, there must be two.
     let ret = document_client
         .list_attachments()
-        .with_consistency_level((&resp).into())
+        .consistency_level(&resp)
         .execute()
         .await?;
     assert_eq!(2, ret.attachments.len());
@@ -142,7 +142,7 @@ async fn attachment() -> Result<(), CosmosError> {
         .clone()
         .into_attachment_client("reference")
         .get()
-        .with_consistency_level((&ret).into())
+        .consistency_level(&ret)
         .execute()
         .await?;
     assert_eq!(
@@ -156,7 +156,7 @@ async fn attachment() -> Result<(), CosmosError> {
         .clone()
         .into_attachment_client("slug")
         .get()
-        .with_consistency_level((&reference_attachment).into())
+        .consistency_level(&reference_attachment)
         .execute()
         .await
         .unwrap();
@@ -165,14 +165,14 @@ async fn attachment() -> Result<(), CosmosError> {
     // delete slug attachment
     let resp_delete = attachment_client
         .delete()
-        .with_consistency_level((&slug_attachment).into())
+        .consistency_level(&slug_attachment)
         .execute()
         .await?;
 
     // list attachments, there must be one.
     let ret = document_client
         .list_attachments()
-        .with_consistency_level((&resp_delete).into())
+        .consistency_level(&resp_delete)
         .execute()
         .await?;
     assert_eq!(1, ret.attachments.len());

--- a/sdk/cosmos/tests/cosmos_collection.rs
+++ b/sdk/cosmos/tests/cosmos_collection.rs
@@ -13,7 +13,7 @@ async fn create_and_delete_collection() {
 
     client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -29,10 +29,10 @@ async fn create_and_delete_collection() {
     };
     let collection = database_client
         .create_collection()
-        .with_collection_name(&COLLECTION_NAME)
-        .with_offer(Offer::S2)
-        .with_partition_key("/id")
-        .with_indexing_policy(&indexing_policy)
+        .collection_name(&COLLECTION_NAME)
+        .offer(Offer::S2)
+        .partition_key("/id")
+        .indexing_policy(&indexing_policy)
         .execute()
         .await
         .unwrap();
@@ -74,7 +74,7 @@ async fn replace_collection() {
 
     client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -90,10 +90,10 @@ async fn replace_collection() {
     };
     let collection = database_client
         .create_collection()
-        .with_collection_name(&COLLECTION_NAME)
-        .with_offer(Offer::S2)
-        .with_partition_key("/id")
-        .with_indexing_policy(&indexing_policy)
+        .collection_name(&COLLECTION_NAME)
+        .offer(Offer::S2)
+        .partition_key("/id")
+        .indexing_policy(&indexing_policy)
         .execute()
         .await
         .unwrap();
@@ -134,8 +134,8 @@ async fn replace_collection() {
 
     let _replace_collection_reponse = collection_client
         .replace_collection()
-        .with_indexing_policy(&new_ip)
-        .with_partition_key("/id")
+        .indexing_policy(&new_ip)
+        .partition_key("/id")
         .execute()
         .await
         .unwrap();

--- a/sdk/cosmos/tests/cosmos_database.rs
+++ b/sdk/cosmos/tests/cosmos_database.rs
@@ -15,7 +15,7 @@ async fn create_and_delete_database() {
     // create a new database and check if the number of DBs increased
     let database = client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -24,7 +24,7 @@ async fn create_and_delete_document() {
 
     client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -41,10 +41,10 @@ async fn create_and_delete_document() {
 
     database_client
         .create_collection()
-        .with_collection_name(&COLLECTION_NAME)
-        .with_offer(Offer::Throughput(400))
-        .with_partition_key("/id")
-        .with_indexing_policy(&indexing_policy)
+        .collection_name(&COLLECTION_NAME)
+        .offer(Offer::Throughput(400))
+        .partition_key("/id")
+        .indexing_policy(&indexing_policy)
         .execute()
         .await
         .unwrap();
@@ -60,7 +60,7 @@ async fn create_and_delete_document() {
     });
     collection_client
         .create_document()
-        .with_partition_keys([&DOCUMENT_NAME])
+        .partition_keys([&DOCUMENT_NAME])
         .execute_with_document(&document_data)
         .await
         .unwrap();
@@ -115,7 +115,7 @@ async fn query_documents() {
 
     client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -131,10 +131,10 @@ async fn query_documents() {
 
     database_client
         .create_collection()
-        .with_collection_name(&COLLECTION_NAME)
-        .with_offer(Offer::S2)
-        .with_partition_key("/id")
-        .with_indexing_policy(&indexing_policy)
+        .collection_name(&COLLECTION_NAME)
+        .offer(Offer::S2)
+        .partition_key("/id")
+        .indexing_policy(&indexing_policy)
         .execute()
         .await
         .unwrap();
@@ -150,7 +150,7 @@ async fn query_documents() {
     });
     collection_client
         .create_document()
-        .with_partition_keys([&document_data.document.id])
+        .partition_keys([&document_data.document.id])
         .execute_with_document(&document_data)
         .await
         .unwrap();
@@ -166,8 +166,8 @@ async fn query_documents() {
     // now query all documents and see if we get the correct result
     let query_result = collection_client
         .query_documents()
-        .with_query(&Query::new("SELECT * FROM c"))
-        .with_query_cross_partition(true)
+        .query(&Query::new("SELECT * FROM c"))
+        .query_cross_partition(true)
         .execute::<MyDocument>()
         .await
         .unwrap()
@@ -192,7 +192,7 @@ async fn replace_document() {
 
     client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -208,10 +208,10 @@ async fn replace_document() {
 
     database_client
         .create_collection()
-        .with_collection_name(&COLLECTION_NAME)
-        .with_offer(Offer::S2)
-        .with_partition_key("/id")
-        .with_indexing_policy(&indexing_policy)
+        .collection_name(&COLLECTION_NAME)
+        .offer(Offer::S2)
+        .partition_key("/id")
+        .indexing_policy(&indexing_policy)
         .execute()
         .await
         .unwrap();
@@ -227,7 +227,7 @@ async fn replace_document() {
     });
     collection_client
         .create_document()
-        .with_partition_keys([&document_data.document.id])
+        .partition_keys([&document_data.document.id])
         .execute_with_document(&document_data)
         .await
         .unwrap();
@@ -243,10 +243,10 @@ async fn replace_document() {
     document_data.document.hello = 190;
     collection_client
         .replace_document()
-        .with_document_id(&document_data.document.id)
-        .with_partition_keys([&document_data.document.id])
-        .with_consistency_level(ConsistencyLevel::from(&documents))
-        .with_if_match_condition(IfMatchCondition::Match(
+        .document_id(&document_data.document.id)
+        .partition_keys([&document_data.document.id])
+        .consistency_level(ConsistencyLevel::from(&documents))
+        .if_match_condition(IfMatchCondition::Match(
             &documents.documents[0].document_attributes.etag(),
         ))
         .execute_with_document(&document_data)

--- a/sdk/cosmos/tests/permission.rs
+++ b/sdk/cosmos/tests/permission.rs
@@ -18,7 +18,7 @@ async fn permissions() {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -53,10 +53,10 @@ async fn permissions() {
 
         database_client
             .create_collection()
-            .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key("/id")
-            .with_offer(Offer::Throughput(400))
-            .with_indexing_policy(&ip)
+            .collection_name(&COLLECTION_NAME)
+            .partition_key("/id")
+            .offer(Offer::Throughput(400))
+            .indexing_policy(&ip)
             .execute()
             .await
             .unwrap()
@@ -68,14 +68,14 @@ async fn permissions() {
 
     let _create_permission_user1_response = permission_client_user1
         .create_permission()
-        .with_expiry_seconds(18000) // 5 hours, max!
+        .expiry_seconds(18000u64) // 5 hours, max!
         .execute_with_permission(&create_collection_response.collection.all_permission())
         .await
         .unwrap();
 
     let _create_permission_user2_response = permission_client_user2
         .create_permission()
-        .with_expiry_seconds(18000) // 5 hours, max!
+        .expiry_seconds(18000u64) // 5 hours, max!
         .execute_with_permission(&create_collection_response.collection.read_permission())
         .await
         .unwrap();

--- a/sdk/cosmos/tests/permission_token_usage.rs
+++ b/sdk/cosmos/tests/permission_token_usage.rs
@@ -16,7 +16,7 @@ async fn permission_token_usage() {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -33,10 +33,10 @@ async fn permission_token_usage() {
 
     let create_collection_response = database_client
         .create_collection()
-        .with_collection_name(&COLLECTION_NAME)
-        .with_offer(Offer::Throughput(400))
-        .with_partition_key("/id")
-        .with_indexing_policy(&indexing_policy)
+        .collection_name(&COLLECTION_NAME)
+        .offer(Offer::Throughput(400))
+        .partition_key("/id")
+        .indexing_policy(&indexing_policy)
         .execute()
         .await
         .unwrap();
@@ -50,7 +50,7 @@ async fn permission_token_usage() {
 
     let create_permission_response = permission_client
         .create_permission()
-        .with_expiry_seconds(18000) // 5 hours, max!
+        .expiry_seconds(18000u64) // 5 hours, max!
         .execute_with_permission(&permission_mode)
         .await
         .unwrap();
@@ -61,7 +61,7 @@ async fn permission_token_usage() {
         .permission
         .permission_token
         .into();
-    client.with_auth_token(new_authorization_token);
+    client.auth_token(new_authorization_token);
     let new_database_client = client.clone().into_database_client(DATABASE_NAME);
 
     // let's list the collection content.
@@ -90,8 +90,8 @@ async fn permission_token_usage() {
     let document = Document::new(serde_json::from_str::<serde_json::Value>(data).unwrap());
     new_collection_client
         .create_document()
-        .with_is_upsert(true)
-        .with_partition_keys(["Gianluigi Bombatomica"])
+        .is_upsert(true)
+        .partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await
         .unwrap_err();
@@ -106,7 +106,7 @@ async fn permission_token_usage() {
     let permission_mode = create_collection_response.collection.all_permission();
     let create_permission_response = permission_client
         .create_permission()
-        .with_expiry_seconds(18000) // 5 hours, max!
+        .expiry_seconds(18000u64) // 5 hours, max!
         .execute_with_permission(&permission_mode)
         .await
         .unwrap();
@@ -115,7 +115,7 @@ async fn permission_token_usage() {
         .permission
         .permission_token
         .into();
-    client.with_auth_token(new_authorization_token);
+    client.auth_token(new_authorization_token);
     let new_database_client = client.into_database_client(DATABASE_NAME);
     let new_collection_client = new_database_client.into_collection_client(COLLECTION_NAME);
 
@@ -123,8 +123,8 @@ async fn permission_token_usage() {
     // so the create_document should succeed!
     let create_document_response = new_collection_client
         .create_document()
-        .with_is_upsert(true)
-        .with_partition_keys(["Gianluigi Bombatomica"])
+        .is_upsert(true)
+        .partition_keys(["Gianluigi Bombatomica"])
         .execute_with_document(&document)
         .await
         .unwrap();

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -45,7 +45,7 @@ async fn trigger() -> Result<(), CosmosError> {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -74,10 +74,10 @@ async fn trigger() -> Result<(), CosmosError> {
 
         database_client
             .create_collection()
-            .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key("/id")
-            .with_offer(Offer::Throughput(400))
-            .with_indexing_policy(&ip)
+            .collection_name(&COLLECTION_NAME)
+            .partition_key("/id")
+            .offer(Offer::Throughput(400))
+            .indexing_policy(&ip)
             .execute()
             .await
             .unwrap()
@@ -90,18 +90,18 @@ async fn trigger() -> Result<(), CosmosError> {
 
     let ret = trigger_client
         .create_trigger()
-        .with_trigger_type(trigger::TriggerType::Post)
-        .with_trigger_operation(trigger::TriggerOperation::All)
-        .with_body(&"something")
+        .trigger_type(trigger::TriggerType::Post)
+        .trigger_operation(trigger::TriggerOperation::All)
+        .body(&"something")
         .execute()
         .await?;
 
     let ret = trigger_client
         .replace_trigger()
-        .with_consistency_level(ret.into())
-        .with_trigger_type(trigger::TriggerType::Post)
-        .with_trigger_operation(trigger::TriggerOperation::All)
-        .with_body(&TRIGGER_BODY)
+        .consistency_level(ret)
+        .trigger_type(trigger::TriggerType::Post)
+        .trigger_operation(trigger::TriggerOperation::All)
+        .body(&TRIGGER_BODY)
         .execute()
         .await?;
 
@@ -109,8 +109,8 @@ async fn trigger() -> Result<(), CosmosError> {
 
     let stream = collection_client
         .list_triggers()
-        .with_max_item_count(3)
-        .with_consistency_level((&ret).into());
+        .max_item_count(3)
+        .consistency_level(&ret);
     let mut stream = Box::pin(stream.stream());
     while let Some(ret) = stream.next().await {
         let ret = ret.unwrap();
@@ -119,7 +119,7 @@ async fn trigger() -> Result<(), CosmosError> {
 
     let _ret = trigger_client
         .delete_trigger()
-        .with_consistency_level(last_session_token.unwrap())
+        .consistency_level(last_session_token.unwrap())
         .execute()
         .await?;
 

--- a/sdk/cosmos/tests/user.rs
+++ b/sdk/cosmos/tests/user.rs
@@ -13,7 +13,7 @@ async fn users() {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -33,7 +33,7 @@ async fn users() {
 
     let _replace_user_response = user_client
         .replace_user()
-        .with_user_name(&USER_NAME_REPLACED)
+        .user_name(&USER_NAME_REPLACED)
         .execute()
         .await
         .unwrap();

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -29,7 +29,7 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .with_database_name(&DATABASE_NAME)
+        .database_name(&DATABASE_NAME)
         .execute()
         .await
         .unwrap();
@@ -58,10 +58,10 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
 
         database_client
             .create_collection()
-            .with_collection_name(&COLLECTION_NAME)
-            .with_partition_key("/id")
-            .with_offer(Offer::Throughput(400))
-            .with_indexing_policy(&ip)
+            .collection_name(&COLLECTION_NAME)
+            .partition_key("/id")
+            .offer(Offer::Throughput(400))
+            .indexing_policy(&ip)
             .execute()
             .await
             .unwrap()
@@ -76,14 +76,14 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
 
     let ret = user_defined_function_client
         .create_user_defined_function()
-        .with_body("body")
+        .body("body")
         .execute()
         .await?;
 
     let stream = collection_client
         .list_user_defined_functions()
-        .with_max_item_count(3)
-        .with_consistency_level((&ret).into());
+        .max_item_count(3)
+        .consistency_level(&ret);
     let mut stream = Box::pin(stream.stream());
     while let Some(ret) = stream.next().await {
         let ret = ret.unwrap();
@@ -92,17 +92,17 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
 
     let ret = user_defined_function_client
         .replace_user_defined_function()
-        .with_consistency_level((&ret).into())
-        .with_body(FN_BODY)
+        .consistency_level(&ret)
+        .body(FN_BODY)
         .execute()
         .await?;
 
     let query_stmt = format!("SELECT udf.{}(100)", USER_DEFINED_FUNCTION_NAME);
     let ret: QueryDocumentsResponseRaw<serde_json::Value> = collection_client
         .query_documents()
-        .with_query(&(&query_stmt as &str).into())
-        .with_consistency_level((&ret).into())
-        .with_max_item_count(2)
+        .query(&(&query_stmt as &str).into())
+        .consistency_level(&ret)
+        .max_item_count(2)
         .execute()
         .await?
         .into_raw();
@@ -116,9 +116,9 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
     let query_stmt = format!("SELECT udf.{}(10000)", USER_DEFINED_FUNCTION_NAME);
     let ret: QueryDocumentsResponseRaw<serde_json::Value> = collection_client
         .query_documents()
-        .with_query(&(&query_stmt as &str).into())
-        .with_consistency_level((&ret).into())
-        .with_max_item_count(2)
+        .query(&(&query_stmt as &str).into())
+        .consistency_level(&ret)
+        .max_item_count(2)
         .execute()
         .await?
         .into_raw();
@@ -138,7 +138,7 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
 
     let _ret = user_defined_function_client
         .delete_user_defined_function()
-        .with_consistency_level((&ret).into())
+        .consistency_level(&ret)
         .execute()
         .await?;
 


### PR DESCRIPTION
Fixes #139 

Additionally this renames the setters such that they no longer have `with_` before them as discussed in #129.

Not every setter has been changed as some setters cannot follow this pattern. For instance one setter takes a `&'a Query<'a>`. We could change that to be be `T: Into<&'a Query<'a>>` but most implementations we care about won't work. For instance, there's no way to turn a `&'a str` into a `&'a Query<'a>`.