### PR TITLE
Support for question mark in SAS tokens

### DIFF
--- a/sdk/storage/examples/blob_00.rs
+++ b/sdk/storage/examples/blob_00.rs
@@ -26,9 +26,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let storage_account_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &master_key);
 
-    // this is how you use the SAS token
+    // this is how you would use the SAS token:
     // let storage_account_client = StorageAccountClient::new_sas_token(http_client.clone(), &account,
-    //     "sv=2018-11-09&ss=b&srt=o&se=2021-01-15T11%3A28%3A42Z&sp=r&st=2021-01-15T10%3A28%3A42Z&spr=http,https&sig=some_signature");
+    //      "sv=2018-11-09&ss=b&srt=o&se=2021-01-15T12%3A09%3A01Z&sp=r&st=2021-01-15T11%3A09%3A01Z&spr=http,https&sig=some_signature")?;
 
     let storage_client = storage_account_client.as_storage_client();
     let blob_client = storage_client

--- a/sdk/storage/examples/blob_00.rs
+++ b/sdk/storage/examples/blob_00.rs
@@ -25,6 +25,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let storage_account_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &master_key);
+
+    // this is how you use the SAS token
+    // let storage_account_client = StorageAccountClient::new_sas_token(http_client.clone(), &account,
+    //     "sv=2018-11-09&ss=b&srt=o&se=2021-01-15T11%3A28%3A42Z&sp=r&st=2021-01-15T10%3A28%3A42Z&spr=http,https&sig=some_signature");
+
     let storage_client = storage_account_client.as_storage_client();
     let blob_client = storage_client
         .as_container_client(&container)

--- a/sdk/storage/examples/list_containers2.rs
+++ b/sdk/storage/examples/list_containers2.rs
@@ -65,7 +65,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // the code is identical
     // once instantiated
     let sas_token = "?sv=2019-12-12&ss=bfqt&srt=sco&sp=rwdlacupx&se=2020-12-05T20:20:58Z&st=2020-12-05T12:20:58Z&spr=https&sig=vxUuKjQW4%2FmB884f%2BdqCp4h3O%2BYuYgIJN8RVGHFVFpY%3D";
-    let client = StorageAccountClient::new_sas_token(http_client.clone(), &account, sas_token)
+    let client = StorageAccountClient::new_sas_token(http_client.clone(), &account, sas_token)?
         .as_storage_client();
     let response = client.list_containers().execute().await?;
     println!("sas response = {:#?}", response);

--- a/sdk/storage/src/clients/storage_account_client.rs
+++ b/sdk/storage/src/clients/storage_account_client.rs
@@ -47,7 +47,7 @@ fn get_sas_token_parms(sas_token: &str) -> Vec<(String, String)> {
         // Any base url will do: we just need to parse the SAS token
         // to get its query pairs.
         .base_url(Some(&Url::parse("https://blob.core.windows.net").unwrap()))
-        .parse(sas_token)
+        .parse(&format!("?{}", sas_token))
         .unwrap()
         .query_pairs()
         .map(|p| (String::from(p.0), String::from(p.1)))

--- a/sdk/storage/src/clients/storage_account_client.rs
+++ b/sdk/storage/src/clients/storage_account_client.rs
@@ -42,16 +42,25 @@ pub struct StorageAccountClient {
     filesystem_url: Url,
 }
 
-fn get_sas_token_parms(sas_token: &str) -> Vec<(String, String)> {
-    Url::options()
-        // Any base url will do: we just need to parse the SAS token
-        // to get its query pairs.
-        .base_url(Some(&Url::parse("https://blob.core.windows.net").unwrap()))
-        .parse(&format!("?{}", sas_token))
-        .unwrap()
+fn get_sas_token_parms(sas_token: &str) -> Result<Vec<(String, String)>, url::ParseError> {
+    // Any base url will do: we just need to parse the SAS token
+    // to get its query pairs.
+    let base_url = Url::parse("https://blob.core.windows.net").unwrap();
+
+    let url = Url::options().base_url(Some(&base_url));
+
+    // this code handles the leading ?
+    // we support both with or without
+    let url = if sas_token.starts_with('?') {
+        url.parse(sas_token)
+    } else {
+        url.parse(&format!("?{}", sas_token))
+    }?;
+
+    Ok(url
         .query_pairs()
         .map(|p| (String::from(p.0), String::from(p.1)))
-        .collect()
+        .collect())
 }
 
 impl StorageAccountClient {
@@ -111,14 +120,14 @@ impl StorageAccountClient {
         http_client: Arc<Box<dyn HttpClient>>,
         account: A,
         sas_token: S,
-    ) -> Arc<Self>
+    ) -> Result<Arc<Self>, url::ParseError>
     where
         A: Into<String>,
         S: AsRef<str>,
     {
         let account = account.into();
 
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             blob_storage_url: Url::parse(&format!("https://{}.blob.core.windows.net", &account))
                 .unwrap(),
             table_storage_url: Url::parse(&format!("https://{}.table.core.windows.net", &account))
@@ -129,9 +138,9 @@ impl StorageAccountClient {
                 .unwrap(),
             storage_credentials: StorageCredentials::SASToken(get_sas_token_parms(
                 sas_token.as_ref(),
-            )),
+            )?),
             http_client,
-        })
+        }))
     }
 
     pub fn new_bearer_token<A, BT>(
@@ -179,7 +188,7 @@ impl StorageAccountClient {
                 Ok(Arc::new(Self {
                     storage_credentials: StorageCredentials::SASToken(get_sas_token_parms(
                         sas_token,
-                    )),
+                    )?),
                     blob_storage_url: get_endpoint_uri(blob_endpoint, account, "blob")?,
                     table_storage_url: get_endpoint_uri(table_endpoint, account, "table")?,
                     queue_storage_url: get_endpoint_uri(queue_endpoint, account, "queue")?,
@@ -196,7 +205,7 @@ impl StorageAccountClient {
                 file_endpoint,
                 ..
             } => Ok(Arc::new(Self {
-                storage_credentials: StorageCredentials::SASToken(get_sas_token_parms(sas_token)),
+                storage_credentials: StorageCredentials::SASToken(get_sas_token_parms(sas_token)?),
                 blob_storage_url: get_endpoint_uri(blob_endpoint, account, "blob")?,
                 table_storage_url: get_endpoint_uri(table_endpoint, account, "table")?,
                 queue_storage_url: get_endpoint_uri(queue_endpoint, account, "queue")?,


### PR DESCRIPTION
Fixes #123.

* This SDK now supports both SAS with or without leading question marks (as it's source of debate and we don't want to make a stand here).
* Now the SDK correctly surfaces the parser error in case of malformed SAS tokens (malformed in the sense of invalid query pairs, the crate does not validate the token itself).

