### PR TITLE
Request builders updates

### DIFF
--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     match client
         .create_document()
         .partition_keys([&doc.document.id])
-        .execute_with_document(&doc)
+        .execute(&doc)
         .await
     {
         Ok(_) => {

--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -105,11 +105,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let resp = attachment_client
         .replace_reference()
         .consistency_level(session_token)
-        .content_type("image/jpeg")
-        .media(
+        .execute(
             "https://Adn.pixabay.com/photo/2020/01/11/09/30/abstract-background-4756987__340.jpg",
+            "image/jpeg",
         )
-        .execute()
         .await?;
     println!("replace reference == {:#?}", resp);
 

--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -80,11 +80,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let resp = attachment_client
         .create_reference()
         .consistency_level(ret)
-        .content_type("image/jpeg")
-        .media(
+        .execute(
             "https://cdn.pixabay.com/photo/2020/01/11/09/30/abstract-background-4756987__340.jpg",
+            "image/jpeg",
         )
-        .execute()
         .await?;
     println!("create reference == {:#?}", resp);
 

--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -128,8 +128,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .create_slug()
         .consistency_level(&resp_delete)
         .content_type("text/plain")
-        .body(Bytes::from_static(b"FFFFF"))
-        .execute()
+        .execute(b"FFFFF")
         .await?;
 
     println!("create slug == {:#?}", resp);

--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -1,6 +1,5 @@
 use azure_core::HttpClient;
 use azure_cosmos::prelude::*;
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::error::Error;
@@ -127,7 +126,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .create_slug()
         .consistency_level(&resp_delete)
         .content_type("text/plain")
-        .execute(b"FFFFF")
+        .execute("FFFFF")
         .await?;
 
     println!("create slug == {:#?}", resp);

--- a/sdk/cosmos/examples/create_delete_database.rs
+++ b/sdk/cosmos/examples/create_delete_database.rs
@@ -40,11 +40,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let list_databases_response = client.list_databases().execute().await?;
     println!("list_databases_response = {:#?}", list_databases_response);
 
-    let db = client
-        .create_database()
-        .database_name(&database_name)
-        .execute()
-        .await?;
+    let db = client.create_database().execute(&database_name).await?;
     println!("created database = {:#?}", db);
 
     // create collection!

--- a/sdk/cosmos/examples/database_00.rs
+++ b/sdk/cosmos/examples/database_00.rs
@@ -72,9 +72,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 println!("\nReplacing collection");
                 let replace_collection_response = collection_client
                     .replace_collection()
-                    .partition_key("/age")
                     .indexing_policy(&indexing_policy_new)
-                    .execute()
+                    .execute("/age")
                     .await?;
                 println!(
                     "replace_collection_response == {:#?}",

--- a/sdk/cosmos/examples/database_00.rs
+++ b/sdk/cosmos/examples/database_00.rs
@@ -58,7 +58,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                     .create_document()
                     .partition_keys([43u32])
                     .is_upsert(true)
-                    .execute_with_document(&document)
+                    .execute(&document)
                     .await?;
 
                 println!("resp == {:?}", resp);

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -182,10 +182,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // changes every time the document is updated. If the passed etag is different in
         // CosmosDB it means something else updated the document before us!
         let replace_document_response = collection_client
-            .replace_document()
+            .replace_document(&doc.document.id)
             .partition_keys([&doc.document.id])
             .if_match_condition(IfMatchCondition::Match(&document.etag))
-            .execute(&doc.document.id, &doc)
+            .execute(&doc)
             .await?;
         println!(
             "replace_document_response == {:#?}",

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -142,7 +142,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let create_document_response = collection_client
         .create_document()
         .partition_keys([&doc.document.id])
-        .execute_with_document(&doc)
+        .execute(&doc)
         .await?;
     println!(
         "create_document_response == {:#?}",
@@ -186,7 +186,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             .document_id(&doc.document.id)
             .partition_keys([&doc.document.id])
             .if_match_condition(IfMatchCondition::Match(&document.etag))
-            .execute_with_document(&doc)
+            .execute(&doc)
             .await?;
         println!(
             "replace_document_response == {:#?}",

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -60,14 +60,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // If the requested database is not found we create it.
     let database = match db {
         Some(db) => db,
-        None => {
-            client
-                .create_database()
-                .database_name(&DATABASE)
-                .execute()
-                .await?
-                .database
-        }
+        None => client.create_database().execute(DATABASE).await?.database,
     };
     println!("database == {:?}", database);
 

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -183,10 +183,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // CosmosDB it means something else updated the document before us!
         let replace_document_response = collection_client
             .replace_document()
-            .document_id(&doc.document.id)
             .partition_keys([&doc.document.id])
             .if_match_condition(IfMatchCondition::Match(&document.etag))
-            .execute(&doc)
+            .execute(&doc.document.id, &doc)
             .await?;
         println!(
             "replace_document_response == {:#?}",

--- a/sdk/cosmos/examples/document_entries_00.rs
+++ b/sdk/cosmos/examples/document_entries_00.rs
@@ -146,10 +146,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let replace_document_response = client
         .replace_document()
         .partition_keys(partition_keys)
-        .document_id(&id)
         .consistency_level(ConsistencyLevel::from(&response))
         .if_match_condition(IfMatchCondition::Match(&doc.etag)) // use optimistic concurrency check
-        .execute(&doc.document)
+        .execute(&id, &doc.document)
         .await?;
 
     println!(

--- a/sdk/cosmos/examples/document_entries_00.rs
+++ b/sdk/cosmos/examples/document_entries_00.rs
@@ -144,11 +144,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("\n\nReplacing document");
     let replace_document_response = client
-        .replace_document()
+        .replace_document(&id)
         .partition_keys(partition_keys)
         .consistency_level(ConsistencyLevel::from(&response))
         .if_match_condition(IfMatchCondition::Match(&doc.etag)) // use optimistic concurrency check
-        .execute(&id, &doc.document)
+        .execute(&doc.document)
         .await?;
 
     println!(

--- a/sdk/cosmos/examples/document_entries_00.rs
+++ b/sdk/cosmos/examples/document_entries_00.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             client
                 .create_document()
                 .partition_keys([&doc.document.id])
-                .execute_with_document(&doc)
+                .execute(&doc)
                 .await?,
         );
     }
@@ -149,7 +149,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .document_id(&id)
         .consistency_level(ConsistencyLevel::from(&response))
         .if_match_condition(IfMatchCondition::Match(&doc.etag)) // use optimistic concurrency check
-        .execute_with_document(&doc.document)
+        .execute(&doc.document)
         .await?;
 
     println!(

--- a/sdk/cosmos/examples/document_entries_01.rs
+++ b/sdk/cosmos/examples/document_entries_01.rs
@@ -105,9 +105,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let replace_document_response = client
         .replace_document()
         .consistency_level(&query_documents_response)
-        .document_id(&doc.document.id)
         .partition_keys(partition_keys)
-        .execute(&doc)
+        .execute(&doc.document.id, &doc)
         .await?;
     println!(
         "replace_document_response == {:#?}",

--- a/sdk/cosmos/examples/document_entries_01.rs
+++ b/sdk/cosmos/examples/document_entries_01.rs
@@ -90,10 +90,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let query_documents_response = client
         .query_documents()
-        .query(&("SELECT * FROM c WHERE c.a_number = 600".into()))
         .consistency_level(&list_documents_response)
         .query_cross_partition(true)
-        .execute::<serde_json::Value>()
+        .execute::<serde_json::Value, _>("SELECT * FROM c WHERE c.a_number = 600")
         .await?;
     println!(
         "query_documents_response == {:#?}",

--- a/sdk/cosmos/examples/document_entries_01.rs
+++ b/sdk/cosmos/examples/document_entries_01.rs
@@ -102,10 +102,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     doc.document.a_number = 43;
 
     let replace_document_response = client
-        .replace_document()
+        .replace_document(&doc.document.id)
         .consistency_level(&query_documents_response)
         .partition_keys(partition_keys)
-        .execute(&doc.document.id, &doc)
+        .execute(&doc)
         .await?;
     println!(
         "replace_document_response == {:#?}",

--- a/sdk/cosmos/examples/document_entries_01.rs
+++ b/sdk/cosmos/examples/document_entries_01.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .create_document()
         .partition_keys(partition_keys.clone())
         .is_upsert(true)
-        .execute_with_document(&doc)
+        .execute(&doc)
         .await?;
 
     println!(
@@ -107,7 +107,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .consistency_level(&query_documents_response)
         .document_id(&doc.document.id)
         .partition_keys(partition_keys)
-        .execute_with_document(&doc)
+        .execute(&doc)
         .await?;
     println!(
         "replace_document_response == {:#?}",

--- a/sdk/cosmos/examples/permission_00.rs
+++ b/sdk/cosmos/examples/permission_00.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .create_permission()
         .consistency_level(&create_user_response)
         .expiry_seconds(18000u64) // 5 hours, max!
-        .execute_with_permission(&permission_mode)
+        .execute(&permission_mode)
         .await?;
     println!(
         "create_permission_response == {:#?}",
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let create_permission2_response = permission_client
         .create_permission()
         .consistency_level(&create_user_response)
-        .execute_with_permission(&permission_mode)
+        .execute(&permission_mode)
         .await?;
     println!(
         "create_permission2_response == {:#?}",
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .consistency_level(ConsistencyLevel::Session(
             get_permission_response.session_token,
         ))
-        .execute_with_permission(permission_mode)
+        .execute(permission_mode)
         .await?;
     println!(
         "replace_permission_response == {:#?}",

--- a/sdk/cosmos/examples/query_document_00.rs
+++ b/sdk/cosmos/examples/query_document_00.rs
@@ -49,20 +49,18 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let respo: QueryDocumentsResponse<serde_json::Value> = client
         .query_documents()
-        .query(&query_obj)
         .query_cross_partition(true)
-        .max_item_count(3)
-        .execute()
+        .max_item_count(3i32)
+        .execute(&query_obj)
         .await?;
     println!("as json == {:?}", respo);
 
     let respo: QueryDocumentsResponse<MySecondSampleStructOwned> = client
         .query_documents()
-        .query(&query_obj)
         .query_cross_partition(true)
         .parallelize_cross_partition_query(true)
         .max_item_count(2)
-        .execute()
+        .execute(&query_obj)
         .await?;
     println!("as items == {:?}", respo);
 

--- a/sdk/cosmos/examples/readme.rs
+++ b/sdk/cosmos/examples/readme.rs
@@ -106,10 +106,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("\nQuerying documents");
     let query_documents_response = collection_client
         .query_documents()
-        .query(&("SELECT * FROM A WHERE A.a_number < 600".into())) // there are other ways to construct a query, this is the simplest.
         .query_cross_partition(true) // this will perform a cross partition query! notice how simple it is!
         .consistency_level(session_token)
-        .execute::<MySampleStruct>() // This will make sure the result is our custom struct!
+        .execute::<MySampleStruct, _>("SELECT * FROM A WHERE A.a_number < 600") // there are other ways to construct a query, this is the simplest.
         .await?
         .into_documents() // queries can return Documents or Raw json (ie without etag, _rid, etc...). Since our query return docs we convert with this function.
         .unwrap(); // we know in advance that the conversion to Document will not fail since we SELECT'ed * FROM table

--- a/sdk/cosmos/examples/readme.rs
+++ b/sdk/cosmos/examples/readme.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 .create_document()
                 .partition_keys([&document_to_insert.document.a_number])
                 .is_upsert(true) // this option will overwrite a preexisting document (if any)
-                .execute_with_document(&document_to_insert)
+                .execute(&document_to_insert)
                 .await?
                 .session_token, // get only the session token, if everything else was ok!
         );

--- a/sdk/cosmos/examples/stored_proc_01.rs
+++ b/sdk/cosmos/examples/stored_proc_01.rs
@@ -54,8 +54,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_stored_procedure_response = stored_procedure_client
         .create_stored_procedure()
-        .body(&function_body)
-        .execute()
+        .execute(function_body)
         .await?;
     println!(
         "create_stored_procedure_response == {:#?}",

--- a/sdk/cosmos/examples/trigger_00.rs
+++ b/sdk/cosmos/examples/trigger_00.rs
@@ -62,20 +62,14 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = trigger_client
         .create_trigger()
-        .trigger_type(TriggerType::Post)
-        .trigger_operation(TriggerOperation::All)
-        .body(&"something")
-        .execute()
+        .execute("something", TriggerType::Post, TriggerOperation::All)
         .await?;
     println!("Creeate response object:\n{:#?}", ret);
 
     let ret = trigger_client
         .replace_trigger()
         .consistency_level(ret)
-        .trigger_type(TriggerType::Post)
-        .trigger_operation(TriggerOperation::All)
-        .body(&TRIGGER_BODY)
-        .execute()
+        .execute(TRIGGER_BODY, TriggerType::Post, TriggerOperation::All)
         .await?;
     println!("Replace response object:\n{:#?}", ret);
 

--- a/sdk/cosmos/examples/user_00.rs
+++ b/sdk/cosmos/examples/user_00.rs
@@ -37,11 +37,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let new_user = format!("{}replaced", user_name);
 
-    let replace_user_response = user_client
-        .replace_user()
-        .user_name(&new_user)
-        .execute()
-        .await?;
+    let replace_user_response = user_client.replace_user().execute(&new_user).await?;
     println!("replace_user_response == {:#?}", replace_user_response);
 
     let user_client = database_client.into_user_client(new_user);

--- a/sdk/cosmos/examples/user_defined_function_00.rs
+++ b/sdk/cosmos/examples/user_defined_function_00.rs
@@ -42,8 +42,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = user_defined_function_client
         .create_user_defined_function()
-        .body("body")
-        .execute()
+        .execute("body")
         .await?;
     println!("Creeate response object:\n{:#?}", ret);
 
@@ -63,8 +62,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let ret = user_defined_function_client
         .replace_user_defined_function()
         .consistency_level(&ret)
-        .body(FN_BODY)
-        .execute()
+        .execute(FN_BODY)
         .await?;
     println!("Replace response object:\n{:#?}", ret);
 

--- a/sdk/cosmos/examples/user_defined_function_00.rs
+++ b/sdk/cosmos/examples/user_defined_function_00.rs
@@ -68,10 +68,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let ret = collection_client
         .query_documents()
-        .query(&"SELECT udf.test15(100)".into())
         .consistency_level(&ret)
-        .max_item_count(2)
-        .execute::<serde_json::Value>()
+        .max_item_count(2i32)
+        .execute::<serde_json::Value, _>("SELECT udf.test15(100)")
         .await?
         .into_raw();
     println!("Query response object:\n{:#?}", ret);

--- a/sdk/cosmos/examples/user_permission_token.rs
+++ b/sdk/cosmos/examples/user_permission_token.rs
@@ -118,7 +118,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .create_document()
         .is_upsert(true)
         .partition_keys(["Gianluigi Bombatomica"])
-        .execute_with_document(&document)
+        .execute(&document)
         .await
     {
         Ok(_) => panic!("this should not happen!"),
@@ -158,7 +158,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .create_document()
         .is_upsert(true)
         .partition_keys(["Gianluigi Bombatomica"])
-        .execute_with_document(&document)
+        .execute(&document)
         .await?;
     println!(
         "create_document_response == {:#?}",

--- a/sdk/cosmos/examples/user_permission_token.rs
+++ b/sdk/cosmos/examples/user_permission_token.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let create_permission_response = permission_client
         .create_permission()
         .expiry_seconds(18000u64) // 5 hours, max!
-        .execute_with_permission(&permission_mode)
+        .execute(&permission_mode)
         .await?;
     println!(
         "create_permission_response == {:#?}",
@@ -132,7 +132,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let create_permission_response = permission_client
         .create_permission()
         .expiry_seconds(18000u64) // 5 hours, max!
-        .execute_with_permission(&permission_mode)
+        .execute(&permission_mode)
         .await?;
     println!(
         "create_permission_response == {:#?}",

--- a/sdk/cosmos/src/clients/attachment_client.rs
+++ b/sdk/cosmos/src/clients/attachment_client.rs
@@ -74,7 +74,7 @@ impl AttachmentClient {
     }
 
     /// Initiate a request to create an attachment.
-    pub fn create_reference(&self) -> requests::CreateReferenceAttachmentBuilder<'_, '_, No, No> {
+    pub fn create_reference(&self) -> requests::CreateReferenceAttachmentBuilder<'_, '_> {
         requests::CreateReferenceAttachmentBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/attachment_client.rs
+++ b/sdk/cosmos/src/clients/attachment_client.rs
@@ -64,7 +64,7 @@ impl AttachmentClient {
     }
 
     /// Initiate a request to create an attachment with a slug.
-    pub fn create_slug(&self) -> requests::CreateSlugAttachmentBuilder<'_, '_, No, No> {
+    pub fn create_slug(&self) -> requests::CreateSlugAttachmentBuilder<'_, '_> {
         requests::CreateSlugAttachmentBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/attachment_client.rs
+++ b/sdk/cosmos/src/clients/attachment_client.rs
@@ -1,7 +1,7 @@
 use crate::requests;
 use crate::resources::ResourceType;
 use crate::ReadonlyString;
-use azure_core::{HttpClient, No};
+use azure_core::HttpClient;
 
 use super::*;
 
@@ -69,7 +69,7 @@ impl AttachmentClient {
     }
 
     /// Initiate a request to replace an attachment.
-    pub fn replace_slug(&self) -> requests::ReplaceSlugAttachmentBuilder<'_, '_, No, No> {
+    pub fn replace_slug(&self) -> requests::ReplaceSlugAttachmentBuilder<'_, '_> {
         requests::ReplaceSlugAttachmentBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/attachment_client.rs
+++ b/sdk/cosmos/src/clients/attachment_client.rs
@@ -79,7 +79,7 @@ impl AttachmentClient {
     }
 
     /// Initiate a request to replace an attachment.
-    pub fn replace_reference(&self) -> requests::ReplaceReferenceAttachmentBuilder<'_, '_, No, No> {
+    pub fn replace_reference(&self) -> requests::ReplaceReferenceAttachmentBuilder<'_, '_> {
         requests::ReplaceReferenceAttachmentBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -59,8 +59,11 @@ impl CollectionClient {
         requests::CreateDocumentBuilder::new(self)
     }
 
-    pub fn replace_document(&self) -> requests::ReplaceDocumentBuilder<'_, '_> {
-        requests::ReplaceDocumentBuilder::new(self)
+    pub fn replace_document<'a>(
+        &'a self,
+        document_id: &'a str,
+    ) -> requests::ReplaceDocumentBuilder<'a, '_> {
+        requests::ReplaceDocumentBuilder::new(self, document_id)
     }
 
     pub fn query_documents(&self) -> requests::QueryDocumentsBuilder<'_, '_> {

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -55,7 +55,7 @@ impl CollectionClient {
         requests::ListDocumentsBuilder::new(self)
     }
 
-    pub fn create_document(&self) -> requests::CreateDocumentBuilder<'_, '_, No> {
+    pub fn create_document(&self) -> requests::CreateDocumentBuilder<'_, '_> {
         requests::CreateDocumentBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -47,7 +47,7 @@ impl CollectionClient {
         requests::DeleteCollectionBuilder::new(self)
     }
 
-    pub fn replace_collection(&self) -> requests::ReplaceCollectionBuilder<'_, '_, No, No> {
+    pub fn replace_collection(&self) -> requests::ReplaceCollectionBuilder<'_, '_> {
         requests::ReplaceCollectionBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -59,7 +59,7 @@ impl CollectionClient {
         requests::CreateDocumentBuilder::new(self)
     }
 
-    pub fn replace_document(&self) -> requests::ReplaceDocumentBuilder<'_, '_, No, No> {
+    pub fn replace_document(&self) -> requests::ReplaceDocumentBuilder<'_, '_> {
         requests::ReplaceDocumentBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -3,7 +3,7 @@ use crate::clients::*;
 use crate::requests;
 use crate::resources::ResourceType;
 use crate::{PartitionKeys, ReadonlyString};
-use azure_core::{HttpClient, No};
+use azure_core::HttpClient;
 
 /// A client for Cosmos collection resources.
 #[derive(Debug, Clone)]
@@ -63,7 +63,7 @@ impl CollectionClient {
         requests::ReplaceDocumentBuilder::new(self)
     }
 
-    pub fn query_documents(&self) -> requests::QueryDocumentsBuilder<'_, '_, No> {
+    pub fn query_documents(&self) -> requests::QueryDocumentsBuilder<'_, '_> {
         requests::QueryDocumentsBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -4,7 +4,7 @@ use crate::resources::permission::AuthorizationToken;
 use crate::resources::ResourceType;
 use crate::{requests, ReadonlyString};
 
-use azure_core::{HttpClient, No};
+use azure_core::HttpClient;
 use http::request::Builder as RequestBuilder;
 use http::{header, HeaderValue};
 use ring::hmac;
@@ -112,7 +112,7 @@ impl CosmosClient {
             .header(header::AUTHORIZATION, signature)
     }
 
-    pub fn create_database(&self) -> requests::CreateDatabaseBuilder<'_, No> {
+    pub fn create_database(&self) -> requests::CreateDatabaseBuilder<'_> {
         requests::CreateDatabaseBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/stored_procedure_client.rs
+++ b/sdk/cosmos/src/clients/stored_procedure_client.rs
@@ -41,7 +41,7 @@ impl StoredProcedureClient {
         &self.stored_procedure_name
     }
 
-    pub fn create_stored_procedure(&self) -> requests::CreateStoredProcedureBuilder<'_, '_, No> {
+    pub fn create_stored_procedure(&self) -> requests::CreateStoredProcedureBuilder<'_, '_> {
         requests::CreateStoredProcedureBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/stored_procedure_client.rs
+++ b/sdk/cosmos/src/clients/stored_procedure_client.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::resources::ResourceType;
 use crate::{requests, ReadonlyString};
-use azure_core::{HttpClient, No};
+use azure_core::HttpClient;
 
 /// A client for Cosmos stored procedure resources.
 #[derive(Debug, Clone)]
@@ -45,7 +45,7 @@ impl StoredProcedureClient {
         requests::CreateStoredProcedureBuilder::new(self)
     }
 
-    pub fn replace_stored_procedure(&self) -> requests::ReplaceStoredProcedureBuilder<'_, '_, No> {
+    pub fn replace_stored_procedure(&self) -> requests::ReplaceStoredProcedureBuilder<'_, '_> {
         requests::ReplaceStoredProcedureBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/trigger_client.rs
+++ b/sdk/cosmos/src/clients/trigger_client.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::resources::ResourceType;
 use crate::{requests, ReadonlyString};
-use azure_core::{HttpClient, No};
+use azure_core::HttpClient;
 
 /// A client for Cosmos trigger resources.
 #[derive(Debug, Clone)]
@@ -69,11 +69,11 @@ impl TriggerClient {
         &self.trigger_name
     }
 
-    pub fn create_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_, No, No, No> {
+    pub fn create_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_> {
         requests::CreateOrReplaceTriggerBuilder::new(self, true)
     }
 
-    pub fn replace_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_, No, No, No> {
+    pub fn replace_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_> {
         requests::CreateOrReplaceTriggerBuilder::new(self, false)
     }
 

--- a/sdk/cosmos/src/clients/user_client.rs
+++ b/sdk/cosmos/src/clients/user_client.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::resources::ResourceType;
 use crate::{requests, ReadonlyString};
-use azure_core::{HttpClient, No};
+use azure_core::HttpClient;
 
 /// A client for Cosmos user resources.
 #[derive(Debug, Clone)]
@@ -45,7 +45,7 @@ impl UserClient {
         requests::GetUserBuilder::new(self)
     }
 
-    pub fn replace_user(&self) -> requests::ReplaceUserBuilder<'_, '_, No> {
+    pub fn replace_user(&self) -> requests::ReplaceUserBuilder<'_, '_> {
         requests::ReplaceUserBuilder::new(self)
     }
 

--- a/sdk/cosmos/src/clients/user_defined_function_client.rs
+++ b/sdk/cosmos/src/clients/user_defined_function_client.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::resources::ResourceType;
 use crate::{requests, ReadonlyString};
-use azure_core::{HttpClient, No};
+use azure_core::HttpClient;
 
 /// A client for Cosmos user defined function resources.
 #[derive(Debug, Clone)]
@@ -43,13 +43,13 @@ impl UserDefinedFunctionClient {
 
     pub fn create_user_defined_function(
         &self,
-    ) -> requests::CreateOrReplaceUserDefinedFunctionBuilder<'_, '_, No> {
+    ) -> requests::CreateOrReplaceUserDefinedFunctionBuilder<'_, '_> {
         requests::CreateOrReplaceUserDefinedFunctionBuilder::new(self, true)
     }
 
     pub fn replace_user_defined_function(
         &self,
-    ) -> requests::CreateOrReplaceUserDefinedFunctionBuilder<'_, '_, No> {
+    ) -> requests::CreateOrReplaceUserDefinedFunctionBuilder<'_, '_> {
         requests::CreateOrReplaceUserDefinedFunctionBuilder::new(self, false)
     }
 

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             .create_document()
             .partition_keys([&document_to_insert.document.a_number])
             .is_upsert(true) // this option will overwrite a preexisting document (if any)
-            .execute_with_document(&document_to_insert)
+            .execute(&document_to_insert)
             .await?;
     }
     // wow that was easy and fast, wasn't it? :)

--- a/sdk/cosmos/src/requests/create_database_builder.rs
+++ b/sdk/cosmos/src/requests/create_database_builder.rs
@@ -44,7 +44,7 @@ impl<'a> CreateDatabaseBuilder<'a> {
             pub id: &'a str,
         }
 
-        let req = serde_json::to_string(&CreateDatabaseRequest {
+        let req = azure_core::to_json(&CreateDatabaseRequest {
             id: database_name.as_ref(),
         })?;
 

--- a/sdk/cosmos/src/requests/create_database_builder.rs
+++ b/sdk/cosmos/src/requests/create_database_builder.rs
@@ -1,41 +1,30 @@
 use crate::prelude::*;
 use crate::resources::ResourceType;
 use crate::responses::CreateDatabaseResponse;
-use azure_core::{ActivityId, No, ToAssign, UserAgent, Yes};
+use azure_core::{ActivityId, UserAgent};
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct CreateDatabaseBuilder<'a, DatabaseNameSet>
-where
-    DatabaseNameSet: ToAssign,
-{
+pub struct CreateDatabaseBuilder<'a> {
     cosmos_client: &'a CosmosClient,
-    database_name: Option<&'a str>,
     user_agent: Option<UserAgent<'a>>,
     activity_id: Option<ActivityId<'a>>,
     consistency_level: Option<ConsistencyLevel>,
-    p_database_name: PhantomData<DatabaseNameSet>,
 }
 
-impl<'a> CreateDatabaseBuilder<'a, No> {
+impl<'a> CreateDatabaseBuilder<'a> {
     pub(crate) fn new(cosmos_client: &'a CosmosClient) -> Self {
         Self {
             cosmos_client,
-            database_name: None,
             user_agent: None,
             activity_id: None,
             consistency_level: None,
-            p_database_name: PhantomData,
         }
     }
 }
 
-impl<'a, DatabaseNameSet> CreateDatabaseBuilder<'a, DatabaseNameSet>
-where
-    DatabaseNameSet: ToAssign,
-{
+impl<'a> CreateDatabaseBuilder<'a> {
     setters! {
         user_agent: &'a str => Some(UserAgent::new(user_agent)),
         activity_id: &'a str => Some(ActivityId::new(activity_id)),
@@ -43,21 +32,11 @@ where
     }
 }
 
-impl<'a> CreateDatabaseBuilder<'a, No> {
-    pub fn database_name(self, database_name: &'a str) -> CreateDatabaseBuilder<'a, Yes> {
-        CreateDatabaseBuilder {
-            database_name: Some(database_name),
-            cosmos_client: self.cosmos_client,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_database_name: PhantomData,
-        }
-    }
-}
-
-impl<'a> CreateDatabaseBuilder<'a, Yes> {
-    pub async fn execute(&self) -> Result<CreateDatabaseResponse, CosmosError> {
+impl<'a> CreateDatabaseBuilder<'a> {
+    pub async fn execute<D: AsRef<str>>(
+        &self,
+        database_name: D,
+    ) -> Result<CreateDatabaseResponse, CosmosError> {
         trace!("CreateDatabaseBuilder::execute called");
 
         #[derive(Serialize, Debug)]
@@ -65,8 +44,8 @@ impl<'a> CreateDatabaseBuilder<'a, Yes> {
             pub id: &'a str,
         }
 
-        let req = azure_core::to_json(&CreateDatabaseRequest {
-            id: self.database_name.unwrap(),
+        let req = serde_json::to_string(&CreateDatabaseRequest {
+            id: database_name.as_ref(),
         })?;
 
         let request =

--- a/sdk/cosmos/src/requests/create_document_builder.rs
+++ b/sdk/cosmos/src/requests/create_document_builder.rs
@@ -3,18 +3,14 @@ use crate::resources::ResourceType;
 use crate::responses::CreateDocumentResponse;
 use azure_core::errors::UnexpectedHTTPResult;
 use azure_core::prelude::*;
-use azure_core::{ActivityId, No, ToAssign, UserAgent, Yes};
+use azure_core::{ActivityId, UserAgent};
 use chrono::{DateTime, Utc};
 use http::StatusCode;
 use serde::Serialize;
 use std::convert::TryFrom;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct CreateDocumentBuilder<'a, 'b, PartitionKeysSet>
-where
-    PartitionKeysSet: ToAssign,
-{
+pub struct CreateDocumentBuilder<'a, 'b> {
     collection_client: &'a CollectionClient,
     partition_keys: Option<PartitionKeys>,
     is_upsert: IsUpsert,
@@ -25,10 +21,9 @@ where
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
     allow_tentative_writes: TenativeWritesAllowance,
-    p_partition_keys: PhantomData<PartitionKeysSet>,
 }
 
-impl<'a, 'b> CreateDocumentBuilder<'a, 'b, No> {
+impl<'a, 'b> CreateDocumentBuilder<'a, 'b> {
     pub(crate) fn new(collection_client: &'a CollectionClient) -> Self {
         Self {
             collection_client,
@@ -41,15 +36,11 @@ impl<'a, 'b> CreateDocumentBuilder<'a, 'b, No> {
             activity_id: None,
             consistency_level: None,
             allow_tentative_writes: TenativeWritesAllowance::Deny,
-            p_partition_keys: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, PartitionKeysSet> CreateDocumentBuilder<'a, 'b, PartitionKeysSet>
-where
-    PartitionKeysSet: ToAssign,
-{
+impl<'a, 'b> CreateDocumentBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
@@ -59,38 +50,15 @@ where
         allow_tentative_writes: TenativeWritesAllowance,
         is_upsert: bool => if is_upsert { IsUpsert::Yes } else { IsUpsert::No },
         indexing_directive: IndexingDirective,
+        partition_keys: PartitionKeys => Some(partition_keys),
     }
 }
 
-impl<'a, 'b> CreateDocumentBuilder<'a, 'b, No> {
-    pub fn partition_keys<P: Into<PartitionKeys>>(
-        self,
-        partition_keys: P,
-    ) -> CreateDocumentBuilder<'a, 'b, Yes> {
-        CreateDocumentBuilder {
-            partition_keys: Some(partition_keys.into()),
-            collection_client: self.collection_client,
-            is_upsert: self.is_upsert,
-            indexing_directive: self.indexing_directive,
-            if_match_condition: self.if_match_condition,
-            if_modified_since: self.if_modified_since,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            allow_tentative_writes: self.allow_tentative_writes,
-            p_partition_keys: PhantomData,
-        }
-    }
-}
-
-impl<'a, 'b> CreateDocumentBuilder<'a, 'b, Yes> {
-    pub async fn execute_with_document<T>(
+impl<'a, 'b> CreateDocumentBuilder<'a, 'b> {
+    pub async fn execute<T: Serialize>(
         &self,
         document: &T,
-    ) -> Result<CreateDocumentResponse, CosmosError>
-    where
-        T: Serialize,
-    {
+    ) -> Result<CreateDocumentResponse, CosmosError> {
         let mut req = self.collection_client.cosmos_client().prepare_request(
             &format!(
                 "dbs/{}/colls/{}/docs",
@@ -101,14 +69,12 @@ impl<'a, 'b> CreateDocumentBuilder<'a, 'b, Yes> {
             ResourceType::Documents,
         );
 
-        // add trait headers
         req = azure_core::headers::add_optional_header(&self.if_match_condition, req);
         req = azure_core::headers::add_optional_header(&self.if_modified_since, req);
         req = azure_core::headers::add_optional_header(&self.user_agent, req);
         req = azure_core::headers::add_optional_header(&self.activity_id, req);
         req = azure_core::headers::add_optional_header(&self.consistency_level, req);
-        req =
-            azure_core::headers::add_mandatory_header(&self.partition_keys.as_ref().unwrap(), req);
+        req = azure_core::headers::add_optional_header(&self.partition_keys.as_ref(), req);
         req = azure_core::headers::add_mandatory_header(&self.is_upsert, req);
         req = azure_core::headers::add_mandatory_header(&self.indexing_directive, req);
         req = azure_core::headers::add_mandatory_header(&self.allow_tentative_writes, req);
@@ -126,8 +92,6 @@ impl<'a, 'b> CreateDocumentBuilder<'a, 'b, Yes> {
         debug!("headers == {:?}", response.headers());
         debug!("whole body == {:#?}", response.body());
 
-        // expect CREATED is IsUpsert is off. Otherwise either
-        // CREATED or OK means success.
         if self.is_upsert == IsUpsert::No && response.status() != StatusCode::CREATED {
             return Err(UnexpectedHTTPResult::new(
                 StatusCode::CREATED,

--- a/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
@@ -1,42 +1,24 @@
 use crate::prelude::*;
 use crate::resources::trigger::*;
 use crate::responses::CreateTriggerResponse;
-use azure_core::{ActivityId, No, ToAssign, UserAgent, Yes};
+use azure_core::{ActivityId, UserAgent};
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, BodySet>
-where
-    TriggerOperationSet: ToAssign,
-    TriggerTypeSet: ToAssign,
-    BodySet: ToAssign,
-{
+pub struct CreateOrReplaceTriggerBuilder<'a> {
     trigger_client: &'a TriggerClient,
     is_create: bool,
-    p_trigger_operation: PhantomData<TriggerOperationSet>,
-    p_trigger_type: PhantomData<TriggerTypeSet>,
-    p_body: PhantomData<BodySet>,
-    trigger_operation: TriggerOperation,
-    trigger_type: TriggerType,
-    body: Option<&'a str>,
     user_agent: Option<UserAgent<'a>>,
     activity_id: Option<ActivityId<'a>>,
     consistency_level: Option<ConsistencyLevel>,
 }
 
-impl<'a> CreateOrReplaceTriggerBuilder<'a, No, No, No> {
+impl<'a> CreateOrReplaceTriggerBuilder<'a> {
     pub(crate) fn new(trigger_client: &'a TriggerClient, is_create: bool) -> Self {
         Self {
             trigger_client,
             is_create,
-            p_trigger_operation: PhantomData,
-            trigger_operation: TriggerOperation::All,
-            p_trigger_type: PhantomData,
-            trigger_type: TriggerType::Pre,
-            p_body: PhantomData,
-            body: None,
             user_agent: None,
             activity_id: None,
             consistency_level: None,
@@ -44,13 +26,7 @@ impl<'a> CreateOrReplaceTriggerBuilder<'a, No, No, No> {
     }
 }
 
-impl<'a, TriggerOperationSet, TriggerTypeSet, BodySet>
-    CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, BodySet>
-where
-    TriggerOperationSet: ToAssign,
-    TriggerTypeSet: ToAssign,
-    BodySet: ToAssign,
-{
+impl<'a> CreateOrReplaceTriggerBuilder<'a> {
     setters! {
         user_agent: &'a str => Some(UserAgent::new(user_agent)),
         activity_id: &'a str => Some(ActivityId::new(activity_id)),
@@ -58,117 +34,18 @@ where
     }
 }
 
-impl<'a, TriggerTypeSet, BodySet> CreateOrReplaceTriggerBuilder<'a, Yes, TriggerTypeSet, BodySet>
-where
-    TriggerTypeSet: ToAssign,
-    BodySet: ToAssign,
-{
-    fn trigger_operation(&self) -> TriggerOperation {
-        self.trigger_operation
-    }
-}
-
-impl<'a, TriggerOperationSet, BodySet>
-    CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, Yes, BodySet>
-where
-    TriggerOperationSet: ToAssign,
-    BodySet: ToAssign,
-{
-    fn trigger_type(&self) -> TriggerType {
-        self.trigger_type
-    }
-}
-
-impl<'a, TriggerOperationSet, TriggerTypeSet>
-    CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, Yes>
-where
-    TriggerOperationSet: ToAssign,
-    TriggerTypeSet: ToAssign,
-{
-    fn body(&self) -> &'a str {
-        self.body.unwrap()
-    }
-}
-
-impl<'a, TriggerTypeSet, BodySet> CreateOrReplaceTriggerBuilder<'a, No, TriggerTypeSet, BodySet>
-where
-    TriggerTypeSet: ToAssign,
-    BodySet: ToAssign,
-{
-    pub fn trigger_operation(
-        self,
-        trigger_operation: TriggerOperation,
-    ) -> CreateOrReplaceTriggerBuilder<'a, Yes, TriggerTypeSet, BodySet> {
-        CreateOrReplaceTriggerBuilder {
-            trigger_operation,
-            trigger_client: self.trigger_client,
-            is_create: self.is_create,
-            trigger_type: self.trigger_type,
-            body: self.body,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_trigger_operation: PhantomData,
-            p_trigger_type: PhantomData,
-            p_body: PhantomData,
-        }
-    }
-}
-
-impl<'a, TriggerOperationSet, BodySet>
-    CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, No, BodySet>
-where
-    TriggerOperationSet: ToAssign,
-    BodySet: ToAssign,
-{
-    pub fn trigger_type(
-        self,
-        trigger_type: TriggerType,
-    ) -> CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, Yes, BodySet> {
-        CreateOrReplaceTriggerBuilder {
-            trigger_type,
-            trigger_client: self.trigger_client,
-            is_create: self.is_create,
-            trigger_operation: self.trigger_operation,
-            body: self.body,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_trigger_operation: PhantomData,
-            p_trigger_type: PhantomData,
-            p_body: PhantomData,
-        }
-    }
-}
-
-impl<'a, TriggerOperationSet, TriggerTypeSet>
-    CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, No>
-where
-    TriggerOperationSet: ToAssign,
-    TriggerTypeSet: ToAssign,
-{
-    pub fn body(
-        self,
-        body: &'a str,
-    ) -> CreateOrReplaceTriggerBuilder<'a, TriggerOperationSet, TriggerTypeSet, Yes> {
-        CreateOrReplaceTriggerBuilder {
-            body: Some(body),
-            trigger_client: self.trigger_client,
-            is_create: self.is_create,
-            trigger_operation: self.trigger_operation,
-            trigger_type: self.trigger_type,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_trigger_operation: PhantomData,
-            p_trigger_type: PhantomData,
-            p_body: PhantomData,
-        }
-    }
-}
-
-impl<'a> CreateOrReplaceTriggerBuilder<'a, Yes, Yes, Yes> {
-    pub async fn execute(&self) -> Result<CreateTriggerResponse, CosmosError> {
+impl<'a> CreateOrReplaceTriggerBuilder<'a> {
+    pub async fn execute<B, T, O>(
+        &self,
+        body: B,
+        trigger_type: T,
+        trigger_operation: O,
+    ) -> Result<CreateTriggerResponse, CosmosError>
+    where
+        B: AsRef<str>,
+        T: Into<TriggerType>,
+        O: Into<TriggerOperation>,
+    {
         trace!("CreateOrReplaceTriggerBuilder::execute called");
 
         let req = self.trigger_client;
@@ -178,15 +55,14 @@ impl<'a> CreateOrReplaceTriggerBuilder<'a, Yes, Yes, Yes> {
             req.prepare_request_with_trigger_name(http::Method::PUT)
         };
 
-        // add trait headers
         let req = azure_core::headers::add_optional_header(&self.user_agent, req);
         let req = azure_core::headers::add_optional_header(&self.activity_id, req);
         let req = azure_core::headers::add_optional_header(&self.consistency_level, req);
 
         let req = req.header(http::header::CONTENT_TYPE, "application/json");
 
-        #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-        struct _Request<'a> {
+        #[derive(Debug, Deserialize, Serialize)]
+        struct Request<'a> {
             pub id: &'a str,
             #[serde(rename = "triggerOperation")]
             pub trigger_operation: TriggerOperation,
@@ -195,11 +71,11 @@ impl<'a> CreateOrReplaceTriggerBuilder<'a, Yes, Yes, Yes> {
             pub body: &'a str,
         }
 
-        let request = _Request {
+        let request = Request {
             id: self.trigger_client.trigger_name(),
-            trigger_operation: self.trigger_operation(),
-            trigger_type: self.trigger_type(),
-            body: self.body(),
+            trigger_operation: trigger_operation.into(),
+            trigger_type: trigger_type.into(),
+            body: body.as_ref(),
         };
 
         let request = azure_core::to_json(&request)?;

--- a/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
@@ -1,25 +1,19 @@
 use crate::prelude::*;
 use crate::responses::CreateUserDefinedFunctionResponse;
-use azure_core::{ActivityId, No, ToAssign, UserAgent, Yes};
+use azure_core::{ActivityId, UserAgent};
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, BodySet>
-where
-    BodySet: ToAssign,
-{
+pub struct CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b> {
     user_defined_function_client: &'a UserDefinedFunctionClient,
     is_create: bool,
-    body: Option<&'b str>,
     user_agent: Option<UserAgent<'b>>,
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
-    p_body: PhantomData<BodySet>,
 }
 
-impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, No> {
+impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b> {
     pub(crate) fn new(
         user_defined_function_client: &'a UserDefinedFunctionClient,
         is_create: bool,
@@ -27,19 +21,14 @@ impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, No> {
         Self {
             user_defined_function_client,
             is_create,
-            body: None,
             user_agent: None,
             activity_id: None,
             consistency_level: None,
-            p_body: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, BodySet> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, BodySet>
-where
-    BodySet: ToAssign,
-{
+impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
@@ -47,28 +36,11 @@ where
     }
 }
 
-impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
-    fn body(&self) -> &'b str {
-        self.body.unwrap()
-    }
-}
-
-impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, No> {
-    pub fn body(self, body: &'b str) -> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
-        CreateOrReplaceUserDefinedFunctionBuilder {
-            body: Some(body),
-            user_defined_function_client: self.user_defined_function_client,
-            is_create: self.is_create,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_body: PhantomData,
-        }
-    }
-}
-
-impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
-    pub async fn execute(&self) -> Result<CreateUserDefinedFunctionResponse, CosmosError> {
+impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b> {
+    pub async fn execute<B: AsRef<str>>(
+        &self,
+        body: B,
+    ) -> Result<CreateUserDefinedFunctionResponse, CosmosError> {
         trace!("CreateOrReplaceUserDefinedFunctionBuilder::execute called");
 
         // Create is POST with no name in the URL. Expected return is CREATED.
@@ -97,7 +69,7 @@ impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
             id: &'a str,
         }
         let request = Request {
-            body: self.body(),
+            body: body.as_ref(),
             id: self
                 .user_defined_function_client
                 .user_defined_function_name(),
@@ -106,18 +78,17 @@ impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b, Yes> {
         let request = azure_core::to_json(&request)?;
         let request = req.body(request)?;
 
-        Ok(if self.is_create {
+        let result = if self.is_create {
             self.user_defined_function_client
                 .http_client()
                 .execute_request_check_status(request, StatusCode::CREATED)
                 .await?
-                .try_into()?
         } else {
             self.user_defined_function_client
                 .http_client()
                 .execute_request_check_status(request, StatusCode::OK)
                 .await?
-                .try_into()?
-        })
+        };
+        Ok(result.try_into()?)
     }
 }

--- a/sdk/cosmos/src/requests/create_permission_builder.rs
+++ b/sdk/cosmos/src/requests/create_permission_builder.rs
@@ -39,7 +39,7 @@ impl<'a, 'b> CreatePermissionBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> CreatePermissionBuilder<'a, 'b> {
-    pub async fn execute_with_permission(
+    pub async fn execute(
         &self,
         permission_mode: &PermissionMode<'a>,
     ) -> Result<CreatePermissionResponse<'a>, CosmosError> {

--- a/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
@@ -1,47 +1,28 @@
 use crate::prelude::*;
-use azure_core::prelude::*;
-use azure_core::{ActivityId, No, ToAssign, UserAgent, Yes};
+use azure_core::{ActivityId, UserAgent};
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct CreateReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
-where
-    ContentTypeSet: ToAssign,
-    MediaSet: ToAssign,
-{
+pub struct CreateReferenceAttachmentBuilder<'a, 'b> {
     attachment_client: &'a AttachmentClient,
-    p_content_type: PhantomData<ContentTypeSet>,
-    p_media: PhantomData<MediaSet>,
-    content_type: Option<ContentType<'b>>,
-    media: Option<&'b str>,
     user_agent: Option<UserAgent<'b>>,
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
 }
 
-impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b, No, No> {
+impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b> {
     pub(crate) fn new(attachment_client: &'a AttachmentClient) -> Self {
         Self {
             attachment_client,
-            content_type: None,
-            media: None,
             user_agent: None,
             activity_id: None,
             consistency_level: None,
-            p_content_type: PhantomData,
-            p_media: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, ContentTypeSet, MediaSet>
-    CreateReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
-where
-    ContentTypeSet: ToAssign,
-    MediaSet: ToAssign,
-{
+impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
@@ -49,55 +30,18 @@ where
     }
 }
 
-impl<'a, 'b, MediaSet> CreateReferenceAttachmentBuilder<'a, 'b, No, MediaSet>
-where
-    MediaSet: ToAssign,
-{
-    pub fn content_type(
-        self,
-        content_type: &'b str,
-    ) -> CreateReferenceAttachmentBuilder<'a, 'b, Yes, MediaSet> {
-        CreateReferenceAttachmentBuilder {
-            content_type: Some(ContentType::new(content_type)),
-            attachment_client: self.attachment_client,
-            media: self.media,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_content_type: PhantomData,
-            p_media: PhantomData,
-        }
-    }
-}
-
-impl<'a, 'b, ContentTypeSet> CreateReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, No>
-where
-    ContentTypeSet: ToAssign,
-{
-    pub fn media(
-        self,
-        media: &'b str,
-    ) -> CreateReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, Yes> {
-        CreateReferenceAttachmentBuilder {
-            media: Some(media),
-            attachment_client: self.attachment_client,
-            content_type: self.content_type,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_content_type: PhantomData,
-            p_media: PhantomData,
-        }
-    }
-}
-
-impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b, Yes, Yes> {
-    pub async fn execute(
+impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b> {
+    pub async fn execute<M, C>(
         &self,
-    ) -> Result<crate::responses::CreateReferenceAttachmentResponse, CosmosError> {
+        media: M,
+        content_type: C,
+    ) -> Result<crate::responses::CreateReferenceAttachmentResponse, CosmosError>
+    where
+        M: AsRef<str>,
+        C: AsRef<str>,
+    {
         let mut req = self.attachment_client.prepare_request(http::Method::POST);
 
-        // add trait headers
         req = azure_core::headers::add_optional_header(&self.user_agent, req);
         req = azure_core::headers::add_optional_header(&self.activity_id, req);
         req = azure_core::headers::add_optional_header(&self.consistency_level, req);
@@ -107,19 +51,18 @@ impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b, Yes, Yes> {
             req,
         );
 
-        // create serialized request
-        #[derive(Debug, Clone, Serialize)]
-        struct _Request<'r> {
+        #[derive(Debug, Serialize)]
+        struct Request<'r> {
             pub id: &'r str,
             #[serde(rename = "contentType")]
             pub content_type: &'r str,
             pub media: &'r str,
         }
 
-        let request = azure_core::to_json(&_Request {
+        let request = azure_core::to_json(&Request {
             id: self.attachment_client.attachment_name(),
-            content_type: self.content_type.unwrap().as_str(),
-            media: self.media.unwrap(),
+            content_type: content_type.as_ref(),
+            media: media.as_ref(),
         })?;
 
         req = req.header(http::header::CONTENT_TYPE, "application/json");

--- a/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
@@ -43,7 +43,7 @@ impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b> {
         &self,
         body: B,
     ) -> Result<CreateSlugAttachmentResponse, CosmosError> {
-        let body = body.as_ref();
+        let body = body.into();
         let mut req = self.attachment_client.prepare_request(http::Method::POST);
 
         req = azure_core::headers::add_optional_header(&self.if_match_condition, req);

--- a/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
@@ -1,121 +1,63 @@
 use crate::prelude::*;
 use crate::responses::CreateSlugAttachmentResponse;
 use azure_core::prelude::*;
-use azure_core::{No, ToAssign, Yes};
 use bytes::Bytes;
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct CreateSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
-where
-    BodySet: ToAssign,
-    ContentTypeSet: ToAssign,
-{
+pub struct CreateSlugAttachmentBuilder<'a, 'b> {
     attachment_client: &'a AttachmentClient,
-    body: Option<Bytes>,
     content_type: Option<ContentType<'b>>,
     if_match_condition: Option<IfMatchCondition<'b>>,
     user_agent: Option<UserAgent<'b>>,
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
-    p_body: PhantomData<BodySet>,
-    p_content_type: PhantomData<ContentTypeSet>,
 }
 
-impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b, No, No> {
+impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b> {
     pub(crate) fn new(attachment_client: &'a AttachmentClient) -> Self {
         Self {
             attachment_client,
-            body: None,
             content_type: None,
             if_match_condition: None,
             user_agent: None,
             activity_id: None,
             consistency_level: None,
-            p_content_type: PhantomData,
-            p_body: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, BodySet, ContentTypeSet> CreateSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
-where
-    BodySet: ToAssign,
-    ContentTypeSet: ToAssign,
-{
+impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
         consistency_level: ConsistencyLevel => Some(consistency_level),
         if_match_condition: IfMatchCondition<'b> => Some(if_match_condition),
+        content_type: ContentType<'b> => Some(content_type),
     }
 }
 
-impl<'a, 'b, ContentTypeSet> CreateSlugAttachmentBuilder<'a, 'b, No, ContentTypeSet>
-where
-    ContentTypeSet: ToAssign,
-{
-    pub fn body(
-        self,
-        body: impl Into<Bytes>,
-    ) -> CreateSlugAttachmentBuilder<'a, 'b, Yes, ContentTypeSet> {
-        CreateSlugAttachmentBuilder {
-            body: Some(body.into()),
-            attachment_client: self.attachment_client,
-            content_type: self.content_type,
-            if_match_condition: self.if_match_condition,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_body: PhantomData,
-            p_content_type: PhantomData,
-        }
-    }
-}
-
-impl<'a, 'b, BodySet> CreateSlugAttachmentBuilder<'a, 'b, BodySet, No>
-where
-    BodySet: ToAssign,
-{
-    pub fn content_type(
-        self,
-        content_type: &'b str,
-    ) -> CreateSlugAttachmentBuilder<'a, 'b, BodySet, Yes> {
-        CreateSlugAttachmentBuilder {
-            content_type: Some(ContentType::new(content_type)),
-            attachment_client: self.attachment_client,
-            body: self.body,
-            if_match_condition: self.if_match_condition,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_body: PhantomData,
-            p_content_type: PhantomData,
-        }
-    }
-}
-
-impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b, Yes, Yes> {
-    pub async fn execute(&self) -> Result<CreateSlugAttachmentResponse, CosmosError> {
+impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b> {
+    pub async fn execute<B: Into<Bytes>>(
+        &self,
+        body: B,
+    ) -> Result<CreateSlugAttachmentResponse, CosmosError> {
+        let body = body.as_ref();
         let mut req = self.attachment_client.prepare_request(http::Method::POST);
 
-        // add trait headers
         req = azure_core::headers::add_optional_header(&self.if_match_condition, req);
         req = azure_core::headers::add_optional_header(&self.user_agent, req);
         req = azure_core::headers::add_optional_header(&self.activity_id, req);
         req = azure_core::headers::add_optional_header(&self.consistency_level, req);
+        req = azure_core::headers::add_optional_header(&self.content_type, req);
 
         req = crate::headers::add_partition_keys_header(
             self.attachment_client.document_client().partition_keys(),
             req,
         );
 
-        req = azure_core::headers::add_mandatory_header(&self.content_type.unwrap(), req);
-
         req = req.header("Slug", self.attachment_client.attachment_name());
-        let body = self.body.clone().unwrap();
         req = req.header(http::header::CONTENT_LENGTH, body.len());
 
         let req = req.body(body)?;

--- a/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
@@ -39,13 +39,7 @@ impl<'a, 'b> ExecuteStoredProcedureBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
         allow_tentative_writes: TenativeWritesAllowance,
         partition_keys: &'b PartitionKeys => Some(partition_keys),
-    }
-
-    pub fn parameters<P: Into<Parameters>>(self, p: P) -> Self {
-        Self {
-            parameters: Some(p.into()),
-            ..self
-        }
+        parameters: Parameters => Some(parameters),
     }
 
     pub async fn execute<T>(&self) -> Result<ExecuteStoredProcedureResponse<T>, CosmosError>
@@ -58,7 +52,6 @@ impl<'a, 'b> ExecuteStoredProcedureBuilder<'a, 'b> {
             .stored_procedure_client
             .prepare_request_with_stored_procedure_name(http::Method::POST);
 
-        // add trait headers
         let request = azure_core::headers::add_optional_header(&self.user_agent, request);
         let request = azure_core::headers::add_optional_header(&self.activity_id, request);
         let request = azure_core::headers::add_optional_header(&self.consistency_level, request);

--- a/sdk/cosmos/src/requests/query_documents_builder.rs
+++ b/sdk/cosmos/src/requests/query_documents_builder.rs
@@ -3,21 +3,15 @@ use crate::resources::document::Query;
 use crate::resources::ResourceType;
 use crate::responses::QueryDocumentsResponse;
 use azure_core::prelude::*;
-use azure_core::{No, ToAssign, Yes};
 use chrono::{DateTime, Utc};
 use futures::stream::{unfold, Stream};
 use http::StatusCode;
 use serde::de::DeserializeOwned;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct QueryDocumentsBuilder<'a, 'b, QuerySet>
-where
-    QuerySet: ToAssign,
-{
+pub struct QueryDocumentsBuilder<'a, 'b> {
     collection_client: &'a CollectionClient,
-    query: Option<&'b Query<'b>>,
     if_match_condition: Option<IfMatchCondition<'b>>,
     if_modified_since: Option<IfModifiedSince<'b>>,
     user_agent: Option<UserAgent<'b>>,
@@ -28,14 +22,12 @@ where
     partition_keys: Option<&'b PartitionKeys>,
     query_cross_partition: QueryCrossPartition,
     parallelize_cross_partition_query: ParallelizeCrossPartition,
-    p_query: PhantomData<QuerySet>,
 }
 
-impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, No> {
+impl<'a, 'b> QueryDocumentsBuilder<'a, 'b> {
     pub(crate) fn new(collection_client: &'a CollectionClient) -> Self {
         Self {
             collection_client,
-            query: None,
             if_match_condition: None,
             if_modified_since: None,
             user_agent: None,
@@ -47,15 +39,11 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, No> {
             query_cross_partition: QueryCrossPartition::No,
             // TODO: use this in request
             parallelize_cross_partition_query: ParallelizeCrossPartition::No,
-            p_query: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, QuerySet> QueryDocumentsBuilder<'a, 'b, QuerySet>
-where
-    QuerySet: ToAssign,
-{
+impl<'a, 'b> QueryDocumentsBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
@@ -70,10 +58,11 @@ where
     }
 }
 
-impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, Yes> {
-    pub async fn execute<T>(&self) -> Result<QueryDocumentsResponse<T>, CosmosError>
+impl<'a, 'b> QueryDocumentsBuilder<'a, 'b> {
+    pub async fn execute<T, Q>(&self, query: Q) -> Result<QueryDocumentsResponse<T>, CosmosError>
     where
         T: DeserializeOwned,
+        Q: Into<Query<'a>>,
     {
         trace!("QueryDocumentBuilder::execute called");
 
@@ -102,7 +91,7 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, Yes> {
         let req = azure_core::headers::add_optional_header(&self.partition_keys, req);
         let req = azure_core::headers::add_mandatory_header(&self.query_cross_partition, req);
 
-        let body = azure_core::to_json(self.query.unwrap())?;
+        let body = serde_json::to_string(&query.into())?;
         debug!("body == {:?}", body);
 
         let req = req.body(body)?;
@@ -116,11 +105,13 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, Yes> {
             .try_into()?)
     }
 
-    pub fn stream<T>(
-        &self,
-    ) -> impl Stream<Item = Result<QueryDocumentsResponse<T>, CosmosError>> + '_
+    pub fn stream<T, Q>(
+        &'a self,
+        query: Q,
+    ) -> impl Stream<Item = Result<QueryDocumentsResponse<T>, CosmosError>> + 'a
     where
         T: DeserializeOwned,
+        Q: Into<Query<'a>> + 'a + Copy,
     {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
@@ -133,11 +124,11 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, Yes> {
             move |continuation_token: Option<States>| async move {
                 debug!("continuation_token == {:?}", &continuation_token);
                 let response = match continuation_token {
-                    Some(States::Init) => self.execute().await,
+                    Some(States::Init) => self.execute(query).await,
                     Some(States::Continuation(continuation_token)) => {
                         self.clone()
                             .continuation(continuation_token.as_str())
-                            .execute()
+                            .execute(query)
                             .await
                     }
                     None => return None,
@@ -156,25 +147,5 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, Yes> {
                 Some((Ok(response), continuation_token))
             },
         )
-    }
-}
-
-impl<'a, 'b> QueryDocumentsBuilder<'a, 'b, No> {
-    pub fn query(self, query: &'b Query<'b>) -> QueryDocumentsBuilder<'a, 'b, Yes> {
-        QueryDocumentsBuilder {
-            query: Some(query),
-            collection_client: self.collection_client,
-            if_match_condition: self.if_match_condition,
-            if_modified_since: self.if_modified_since,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            continuation: self.continuation,
-            max_item_count: self.max_item_count,
-            partition_keys: self.partition_keys,
-            query_cross_partition: self.query_cross_partition,
-            parallelize_cross_partition_query: self.parallelize_cross_partition_query,
-            p_query: PhantomData,
-        }
     }
 }

--- a/sdk/cosmos/src/requests/query_documents_builder.rs
+++ b/sdk/cosmos/src/requests/query_documents_builder.rs
@@ -91,7 +91,7 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b> {
         let req = azure_core::headers::add_optional_header(&self.partition_keys, req);
         let req = azure_core::headers::add_mandatory_header(&self.query_cross_partition, req);
 
-        let body = serde_json::to_string(&query.into())?;
+        let body = azure_core::to_json(&query.into())?;
         debug!("body == {:?}", body);
 
         let req = req.body(body)?;

--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -55,11 +55,11 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b> {
         let req = req.header(http::header::CONTENT_TYPE, "application/json");
 
         #[derive(Debug, Clone, Serialize)]
+        #[serde(rename_all = "camelCase")]
         struct Request<'k> {
             id: &'k str,
-            #[serde(rename = "indexingPolicy", skip_serializing_if = "Option::is_none")]
+            #[serde(skip_serializing_if = "Option::is_none")]
             indexing_policy: Option<&'k IndexingPolicy>,
-            #[serde(rename = "partitionKey")]
             partition_key: PartitionKey,
         };
 

--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -2,28 +2,20 @@ use crate::prelude::*;
 use crate::resources::collection::{IndexingPolicy, PartitionKey};
 use crate::responses::CreateCollectionResponse;
 use azure_core::prelude::*;
-use azure_core::{No, ToAssign, Yes};
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet, IndexingPolicySet>
-where
-    PartitionKeysSet: ToAssign,
-    IndexingPolicySet: ToAssign,
-{
+pub struct ReplaceCollectionBuilder<'a, 'b> {
     collection_client: &'a CollectionClient,
     partition_key: Option<PartitionKey>,
     indexing_policy: Option<&'a IndexingPolicy>,
     user_agent: Option<UserAgent<'b>>,
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
-    p_partition_key: PhantomData<PartitionKeysSet>,
-    p_indexing_policy: PhantomData<IndexingPolicySet>,
 }
 
-impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b, No, No> {
+impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b> {
     pub(crate) fn new(collection_client: &'a CollectionClient) -> Self {
         Self {
             collection_client,
@@ -32,28 +24,24 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b, No, No> {
             user_agent: None,
             activity_id: None,
             consistency_level: None,
-            p_partition_key: PhantomData,
-            p_indexing_policy: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, PartitionKeysSet, IndexingPolicySet>
-    ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet, IndexingPolicySet>
-where
-    PartitionKeysSet: ToAssign,
-    IndexingPolicySet: ToAssign,
-{
+impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
         consistency_level: ConsistencyLevel => Some(consistency_level),
+        indexing_policy: &'a IndexingPolicy => Some(indexing_policy),
     }
 }
 
-// methods callable only when every mandatory field has been filled
-impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b, Yes, Yes> {
-    pub async fn execute(&self) -> Result<CreateCollectionResponse, CosmosError> {
+impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b> {
+    pub async fn execute<P: Into<PartitionKey>>(
+        &self,
+        partition_key: P,
+    ) -> Result<CreateCollectionResponse, CosmosError> {
         trace!("ReplaceCollectionBuilder::execute called");
 
         let req = self
@@ -69,16 +57,16 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b, Yes, Yes> {
         #[derive(Debug, Clone, Serialize)]
         struct Request<'k> {
             id: &'k str,
-            #[serde(rename = "indexingPolicy")]
-            indexing_policy: &'k IndexingPolicy,
+            #[serde(rename = "indexingPolicy", skip_serializing_if = "Option::is_none")]
+            indexing_policy: Option<&'k IndexingPolicy>,
             #[serde(rename = "partitionKey")]
-            partition_key: &'k PartitionKey,
-        }
+            partition_key: PartitionKey,
+        };
 
         let request = Request {
             id: self.collection_client.collection_name(),
-            indexing_policy: self.indexing_policy.unwrap(),
-            partition_key: self.partition_key.as_ref().unwrap(),
+            indexing_policy: self.indexing_policy,
+            partition_key: partition_key.into(),
         };
 
         let body = azure_core::to_json(&request)?;
@@ -97,47 +85,5 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b, Yes, Yes> {
             .execute_request_check_status(req, StatusCode::OK)
             .await?
             .try_into()?)
-    }
-}
-
-impl<'a, 'b, IndexingPolicySet> ReplaceCollectionBuilder<'a, 'b, No, IndexingPolicySet>
-where
-    IndexingPolicySet: ToAssign,
-{
-    pub fn partition_key<P: Into<PartitionKey>>(
-        self,
-        partition_key: P,
-    ) -> ReplaceCollectionBuilder<'a, 'b, Yes, IndexingPolicySet> {
-        ReplaceCollectionBuilder {
-            collection_client: self.collection_client,
-            p_partition_key: PhantomData,
-            p_indexing_policy: PhantomData,
-            partition_key: Some(partition_key.into()),
-            indexing_policy: self.indexing_policy,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-        }
-    }
-}
-
-impl<'a, 'b, PartitionKeysSet> ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet, No>
-where
-    PartitionKeysSet: ToAssign,
-{
-    pub fn indexing_policy(
-        self,
-        indexing_policy: &'a IndexingPolicy,
-    ) -> ReplaceCollectionBuilder<'a, 'b, PartitionKeysSet, Yes> {
-        ReplaceCollectionBuilder {
-            collection_client: self.collection_client,
-            p_partition_key: PhantomData,
-            p_indexing_policy: PhantomData,
-            partition_key: self.partition_key,
-            indexing_policy: Some(indexing_policy),
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-        }
     }
 }

--- a/sdk/cosmos/src/requests/replace_document_builder.rs
+++ b/sdk/cosmos/src/requests/replace_document_builder.rs
@@ -66,10 +66,7 @@ where
 }
 
 impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, Yes, Yes> {
-    pub async fn execute_with_document<T>(
-        &self,
-        document: &T,
-    ) -> Result<ReplaceDocumentResponse, CosmosError>
+    pub async fn execute<T>(&self, document: &T) -> Result<ReplaceDocumentResponse, CosmosError>
     where
         T: Serialize,
     {

--- a/sdk/cosmos/src/requests/replace_document_builder.rs
+++ b/sdk/cosmos/src/requests/replace_document_builder.rs
@@ -2,22 +2,15 @@ use crate::prelude::*;
 use crate::resources::ResourceType;
 use crate::responses::ReplaceDocumentResponse;
 use azure_core::prelude::*;
-use azure_core::{No, ToAssign, Yes};
 use chrono::{DateTime, Utc};
 use http::StatusCode;
 use serde::Serialize;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, DocumentIdSet>
-where
-    PartitionKeysSet: ToAssign,
-    DocumentIdSet: ToAssign,
-{
+pub struct ReplaceDocumentBuilder<'a, 'b> {
     collection_client: &'a CollectionClient,
     partition_keys: Option<PartitionKeys>,
-    document_id: Option<&'b str>,
     indexing_directive: IndexingDirective,
     if_match_condition: Option<IfMatchCondition<'b>>,
     if_modified_since: Option<IfModifiedSince<'b>>,
@@ -25,15 +18,12 @@ where
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
     allow_tentative_writes: TenativeWritesAllowance,
-    p_partition_keys: PhantomData<PartitionKeysSet>,
-    p_document_id: PhantomData<DocumentIdSet>,
 }
 
-impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, No, No> {
+impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
     pub(crate) fn new(collection_client: &'a CollectionClient) -> Self {
         Self {
             collection_client,
-            document_id: None,
             partition_keys: None,
             indexing_directive: IndexingDirective::Default,
             if_match_condition: None,
@@ -42,18 +32,11 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, No, No> {
             activity_id: None,
             consistency_level: None,
             allow_tentative_writes: TenativeWritesAllowance::Deny,
-            p_document_id: PhantomData,
-            p_partition_keys: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, PartitionKeysSet, DocumentIdSet>
-    ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, DocumentIdSet>
-where
-    PartitionKeysSet: ToAssign,
-    DocumentIdSet: ToAssign,
-{
+impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
@@ -62,11 +45,16 @@ where
         if_modified_since: &'b DateTime<Utc> => Some(IfModifiedSince::new(if_modified_since)),
         allow_tentative_writes: TenativeWritesAllowance,
         indexing_directive: IndexingDirective,
+        partition_keys: PartitionKeys => Some(partition_keys),
     }
 }
 
-impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, Yes, Yes> {
-    pub async fn execute<T>(&self, document: &T) -> Result<ReplaceDocumentResponse, CosmosError>
+impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
+    pub async fn execute<T>(
+        &self,
+        document_id: &str,
+        document: &T,
+    ) -> Result<ReplaceDocumentResponse, CosmosError>
     where
         T: Serialize,
     {
@@ -77,21 +65,19 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, Yes, Yes> {
                 "dbs/{}/colls/{}/docs/{}",
                 self.collection_client.database_client().database_name(),
                 self.collection_client.collection_name(),
-                self.document_id.unwrap()
+                document_id
             ),
             http::Method::PUT,
             ResourceType::Documents,
         );
 
-        // add trait headers
         let req = azure_core::headers::add_mandatory_header(&self.indexing_directive, req);
         let req = azure_core::headers::add_optional_header(&self.if_match_condition, req);
         let req = azure_core::headers::add_optional_header(&self.if_modified_since, req);
         let req = azure_core::headers::add_optional_header(&self.user_agent, req);
         let req = azure_core::headers::add_optional_header(&self.activity_id, req);
         let req = azure_core::headers::add_optional_header(&self.consistency_level, req);
-        let req =
-            azure_core::headers::add_mandatory_header(&self.partition_keys.as_ref().unwrap(), req);
+        let req = azure_core::headers::add_optional_header(&self.partition_keys.as_ref(), req);
         let req = azure_core::headers::add_mandatory_header(&self.allow_tentative_writes, req);
 
         let serialized = azure_core::to_json(document)?;
@@ -105,55 +91,5 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b, Yes, Yes> {
             .execute_request_check_status(req, StatusCode::OK)
             .await?
             .try_into()?)
-    }
-}
-
-impl<'a, 'b, DocumentIdSet> ReplaceDocumentBuilder<'a, 'b, No, DocumentIdSet>
-where
-    DocumentIdSet: ToAssign,
-{
-    pub fn partition_keys<P: Into<PartitionKeys>>(
-        self,
-        partition_keys: P,
-    ) -> ReplaceDocumentBuilder<'a, 'b, Yes, DocumentIdSet> {
-        ReplaceDocumentBuilder {
-            partition_keys: Some(partition_keys.into()),
-            collection_client: self.collection_client,
-            document_id: self.document_id,
-            indexing_directive: self.indexing_directive,
-            if_match_condition: self.if_match_condition,
-            if_modified_since: self.if_modified_since,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            allow_tentative_writes: self.allow_tentative_writes,
-            p_partition_keys: PhantomData,
-            p_document_id: PhantomData,
-        }
-    }
-}
-
-impl<'a, 'b, PartitionKeysSet> ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, No>
-where
-    PartitionKeysSet: ToAssign,
-{
-    pub fn document_id(
-        self,
-        document_id: &'b str,
-    ) -> ReplaceDocumentBuilder<'a, 'b, PartitionKeysSet, Yes> {
-        ReplaceDocumentBuilder {
-            collection_client: self.collection_client,
-            p_partition_keys: PhantomData,
-            p_document_id: PhantomData,
-            partition_keys: self.partition_keys,
-            document_id: Some(document_id),
-            indexing_directive: self.indexing_directive,
-            if_match_condition: self.if_match_condition,
-            if_modified_since: self.if_modified_since,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            allow_tentative_writes: self.allow_tentative_writes,
-        }
     }
 }

--- a/sdk/cosmos/src/requests/replace_document_builder.rs
+++ b/sdk/cosmos/src/requests/replace_document_builder.rs
@@ -10,6 +10,7 @@ use std::convert::TryInto;
 #[derive(Debug, Clone)]
 pub struct ReplaceDocumentBuilder<'a, 'b> {
     collection_client: &'a CollectionClient,
+    document_id: &'a str,
     partition_keys: Option<PartitionKeys>,
     indexing_directive: IndexingDirective,
     if_match_condition: Option<IfMatchCondition<'b>>,
@@ -21,9 +22,10 @@ pub struct ReplaceDocumentBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
-    pub(crate) fn new(collection_client: &'a CollectionClient) -> Self {
+    pub(crate) fn new(collection_client: &'a CollectionClient, document_id: &'a str) -> Self {
         Self {
             collection_client,
+            document_id,
             partition_keys: None,
             indexing_directive: IndexingDirective::Default,
             if_match_condition: None,
@@ -50,11 +52,7 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
-    pub async fn execute<T>(
-        &self,
-        document_id: &str,
-        document: &T,
-    ) -> Result<ReplaceDocumentResponse, CosmosError>
+    pub async fn execute<T>(&self, document: &T) -> Result<ReplaceDocumentResponse, CosmosError>
     where
         T: Serialize,
     {
@@ -65,7 +63,7 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
                 "dbs/{}/colls/{}/docs/{}",
                 self.collection_client.database_client().database_name(),
                 self.collection_client.collection_name(),
-                document_id
+                self.document_id
             ),
             http::Method::PUT,
             ResourceType::Documents,

--- a/sdk/cosmos/src/requests/replace_permission_builder.rs
+++ b/sdk/cosmos/src/requests/replace_permission_builder.rs
@@ -33,7 +33,7 @@ impl<'a, 'b> ReplacePermissionBuilder<'a, 'b> {
         expiry_seconds: u64 => ExpirySeconds::new(expiry_seconds),
     }
 
-    pub async fn execute_with_permission(
+    pub async fn execute(
         &self,
         permission_mode: &PermissionMode<'a>,
     ) -> Result<ReplacePermissionResponse<'a>, CosmosError> {

--- a/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
@@ -1,35 +1,21 @@
 use crate::prelude::*;
 use azure_core::prelude::*;
-use azure_core::{No, ToAssign, Yes};
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
-where
-    ContentTypeSet: ToAssign,
-    MediaSet: ToAssign,
-{
+pub struct ReplaceReferenceAttachmentBuilder<'a, 'b> {
     attachment_client: &'a AttachmentClient,
-    p_content_type: PhantomData<ContentTypeSet>,
-    p_media: PhantomData<MediaSet>,
-    content_type: Option<ContentType<'b>>,
     if_match_condition: Option<IfMatchCondition<'b>>,
-    media: Option<&'b str>,
     user_agent: Option<UserAgent<'b>>,
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
 }
 
-impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b, No, No> {
+impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b> {
     pub(crate) fn new(attachment_client: &'a AttachmentClient) -> Self {
         Self {
             attachment_client,
-            p_content_type: PhantomData,
-            content_type: None,
-            p_media: PhantomData,
-            media: None,
             if_match_condition: None,
             user_agent: None,
             activity_id: None,
@@ -38,12 +24,7 @@ impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, ContentTypeSet, MediaSet>
-    ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, MediaSet>
-where
-    ContentTypeSet: ToAssign,
-    MediaSet: ToAssign,
-{
+impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
@@ -53,10 +34,16 @@ where
 }
 
 // methods callable only when every mandatory field has been filled
-impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b, Yes, Yes> {
-    pub async fn execute(
+impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b> {
+    pub async fn execute<M, C>(
         &self,
-    ) -> Result<crate::responses::ReplaceReferenceAttachmentResponse, CosmosError> {
+        media: M,
+        content_type: C,
+    ) -> Result<crate::responses::ReplaceReferenceAttachmentResponse, CosmosError>
+    where
+        M: AsRef<str>,
+        C: Into<ContentType<'b>>,
+    {
         let mut req = self
             .attachment_client
             .prepare_request_with_attachment_name(http::Method::PUT);
@@ -83,8 +70,8 @@ impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b, Yes, Yes> {
 
         let request = azure_core::to_json(&_Request {
             id: self.attachment_client.attachment_name(),
-            content_type: self.content_type.unwrap().as_str(),
-            media: self.media.unwrap(),
+            content_type: content_type.into().as_str(),
+            media: media.as_ref(),
         })?;
 
         req = req.header(http::header::CONTENT_TYPE, "application/json");
@@ -98,49 +85,5 @@ impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b, Yes, Yes> {
             .execute_request_check_status(req, StatusCode::OK)
             .await?
             .try_into()?)
-    }
-}
-
-impl<'a, 'b, MediaSet> ReplaceReferenceAttachmentBuilder<'a, 'b, No, MediaSet>
-where
-    MediaSet: ToAssign,
-{
-    pub fn content_type(
-        self,
-        content_type: &'b str,
-    ) -> ReplaceReferenceAttachmentBuilder<'a, 'b, Yes, MediaSet> {
-        ReplaceReferenceAttachmentBuilder {
-            attachment_client: self.attachment_client,
-            p_content_type: PhantomData,
-            p_media: PhantomData,
-            content_type: Some(ContentType::new(content_type)),
-            if_match_condition: self.if_match_condition,
-            media: self.media,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-        }
-    }
-}
-
-impl<'a, 'b, ContentTypeSet> ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, No>
-where
-    ContentTypeSet: ToAssign,
-{
-    pub fn media(
-        self,
-        media: &'b str,
-    ) -> ReplaceReferenceAttachmentBuilder<'a, 'b, ContentTypeSet, Yes> {
-        ReplaceReferenceAttachmentBuilder {
-            media: Some(media),
-            attachment_client: self.attachment_client,
-            content_type: self.content_type,
-            if_match_condition: self.if_match_condition,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-            p_content_type: PhantomData,
-            p_media: PhantomData,
-        }
     }
 }

--- a/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
@@ -39,11 +39,11 @@ impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b> {
 }
 
 impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b> {
-    pub async fn execute<B: AsRef<[u8]>>(
+    pub async fn execute<B: Into<Bytes>>(
         &self,
         body: B,
     ) -> Result<CreateSlugAttachmentResponse, CosmosError> {
-        let body = body.as_ref();
+        let body = body.into();
         let mut req = self.attachment_client.prepare_request(http::Method::PUT);
 
         req = azure_core::headers::add_optional_header(&self.if_match_condition, req);

--- a/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
@@ -1,22 +1,13 @@
 use crate::prelude::*;
 use crate::responses::CreateSlugAttachmentResponse;
 use azure_core::prelude::*;
-use azure_core::{No, ToAssign, Yes};
 use bytes::Bytes;
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
-where
-    BodySet: ToAssign,
-    ContentTypeSet: ToAssign,
-{
+pub struct ReplaceSlugAttachmentBuilder<'a, 'b> {
     attachment_client: &'a AttachmentClient,
-    p_body: PhantomData<BodySet>,
-    p_content_type: PhantomData<ContentTypeSet>,
-    body: Option<Bytes>,
     content_type: Option<ContentType<'b>>,
     if_match_condition: Option<IfMatchCondition<'b>>,
     user_agent: Option<UserAgent<'b>>,
@@ -24,13 +15,10 @@ where
     consistency_level: Option<ConsistencyLevel>,
 }
 
-impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b, No, No> {
+impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b> {
     pub(crate) fn new(attachment_client: &'a AttachmentClient) -> Self {
         Self {
             attachment_client,
-            p_body: PhantomData,
-            body: None,
-            p_content_type: PhantomData,
             content_type: None,
             if_match_condition: None,
             user_agent: None,
@@ -40,25 +28,24 @@ impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b, No, No> {
     }
 }
 
-impl<'a, 'b, BodySet, ContentTypeSet> ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, ContentTypeSet>
-where
-    BodySet: ToAssign,
-    ContentTypeSet: ToAssign,
-{
+impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
         consistency_level: ConsistencyLevel => Some(consistency_level),
         if_match_condition: IfMatchCondition<'b> => Some(if_match_condition),
+        content_type: ContentType<'b> => Some(content_type),
     }
 }
 
-// methods callable only when every mandatory field has been filled
-impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b, Yes, Yes> {
-    pub async fn execute(&self) -> Result<CreateSlugAttachmentResponse, CosmosError> {
+impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b> {
+    pub async fn execute<B: AsRef<[u8]>>(
+        &self,
+        body: B,
+    ) -> Result<CreateSlugAttachmentResponse, CosmosError> {
+        let body = body.as_ref();
         let mut req = self.attachment_client.prepare_request(http::Method::PUT);
 
-        // add trait headers
         req = azure_core::headers::add_optional_header(&self.if_match_condition, req);
         req = azure_core::headers::add_optional_header(&self.user_agent, req);
         req = azure_core::headers::add_optional_header(&self.activity_id, req);
@@ -69,10 +56,9 @@ impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b, Yes, Yes> {
             req,
         );
 
-        req = azure_core::headers::add_mandatory_header(&self.content_type.unwrap(), req);
+        req = azure_core::headers::add_optional_header(&self.content_type, req);
 
         req = req.header("Slug", self.attachment_client.attachment_name());
-        let body = self.body.clone().unwrap();
         req = req.header(http::header::CONTENT_LENGTH, body.len());
 
         let req = req.body(body)?;
@@ -85,50 +71,5 @@ impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b, Yes, Yes> {
             .execute_request_check_status(req, StatusCode::OK)
             .await?
             .try_into()?)
-    }
-}
-
-impl<'a, 'b, ContentTypeSet> ReplaceSlugAttachmentBuilder<'a, 'b, No, ContentTypeSet>
-where
-    ContentTypeSet: ToAssign,
-{
-    pub fn body(
-        self,
-        body: impl Into<Bytes>,
-    ) -> ReplaceSlugAttachmentBuilder<'a, 'b, Yes, ContentTypeSet> {
-        ReplaceSlugAttachmentBuilder {
-            attachment_client: self.attachment_client,
-            p_body: PhantomData,
-            p_content_type: PhantomData,
-            body: Some(body.into()),
-            content_type: self.content_type,
-            if_match_condition: self.if_match_condition,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-        }
-    }
-}
-
-impl<'a, 'b, BodySet> ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, No>
-where
-    BodySet: ToAssign,
-{
-    pub fn content_type(
-        self,
-        content_type: &'b str,
-    ) -> ReplaceSlugAttachmentBuilder<'a, 'b, BodySet, Yes> {
-        ReplaceSlugAttachmentBuilder {
-            attachment_client: self.attachment_client,
-            p_body: PhantomData,
-            p_content_type: PhantomData,
-            body: self.body,
-
-            content_type: Some(ContentType::new(content_type)),
-            if_match_condition: self.if_match_condition,
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-        }
     }
 }

--- a/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
@@ -1,41 +1,29 @@
 use crate::prelude::*;
 use crate::responses::ReplaceStoredProcedureResponse;
 use azure_core::prelude::*;
-use azure_core::{No, ToAssign, Yes};
 use http::StatusCode;
 use std::convert::TryInto;
-use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
-pub struct ReplaceStoredProcedureBuilder<'a, 'b, BodySet>
-where
-    BodySet: ToAssign,
-{
+pub struct ReplaceStoredProcedureBuilder<'a, 'b> {
     stored_procedure_client: &'a StoredProcedureClient,
-    body: Option<&'b str>,
     user_agent: Option<UserAgent<'b>>,
     activity_id: Option<ActivityId<'b>>,
     consistency_level: Option<ConsistencyLevel>,
-    p_body: PhantomData<BodySet>,
 }
 
-impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, No> {
+impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b> {
     pub(crate) fn new(stored_procedure_client: &'a StoredProcedureClient) -> Self {
         Self {
             stored_procedure_client,
-            body: None,
             user_agent: None,
             activity_id: None,
             consistency_level: None,
-            p_body: PhantomData,
         }
     }
 }
 
-impl<'a, 'b, BodySet> ReplaceStoredProcedureBuilder<'a, 'b, BodySet>
-where
-    BodySet: ToAssign,
-{
+impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b> {
     setters! {
         user_agent: &'b str => Some(UserAgent::new(user_agent)),
         activity_id: &'b str => Some(ActivityId::new(activity_id)),
@@ -43,15 +31,17 @@ where
     }
 }
 
-impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
-    pub async fn execute(&self) -> Result<ReplaceStoredProcedureResponse, CosmosError> {
+impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b> {
+    pub async fn execute<B: AsRef<str>>(
+        &self,
+        body: B,
+    ) -> Result<ReplaceStoredProcedureResponse, CosmosError> {
         trace!("ReplaceStoredProcedureBuilder::execute called");
 
         let req = self
             .stored_procedure_client
             .prepare_request_with_stored_procedure_name(http::Method::PUT);
 
-        // add trait headers
         let req = azure_core::headers::add_optional_header(&self.user_agent, req);
         let req = azure_core::headers::add_optional_header(&self.activity_id, req);
         let req = azure_core::headers::add_optional_header(&self.consistency_level, req);
@@ -64,7 +54,7 @@ impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
             id: &'a str,
         }
         let request = Request {
-            body: self.body.unwrap(),
+            body: body.as_ref(),
             id: self.stored_procedure_client.stored_procedure_name(),
         };
 
@@ -77,18 +67,5 @@ impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
             .execute_request_check_status(request, StatusCode::OK)
             .await?
             .try_into()?)
-    }
-}
-
-impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b, No> {
-    pub fn body(self, body: &'b str) -> ReplaceStoredProcedureBuilder<'a, 'b, Yes> {
-        ReplaceStoredProcedureBuilder {
-            stored_procedure_client: self.stored_procedure_client,
-            p_body: PhantomData,
-            body: Some(body),
-            user_agent: self.user_agent,
-            activity_id: self.activity_id,
-            consistency_level: self.consistency_level,
-        }
     }
 }

--- a/sdk/cosmos/src/resources/document/query.rs
+++ b/sdk/cosmos/src/resources/document/query.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 /// A SQL Query
 ///
 /// You can learn more about how SQL queries work in Cosmos [here](https://docs.microsoft.com/en-us/azure/cosmos-db/sql-query-getting-started).
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct Query<'a> {
     query: &'a str,
     parameters: Vec<Param<'a>>,
@@ -40,9 +40,15 @@ impl<'a> From<&'a str> for Query<'a> {
     }
 }
 
-impl<'a> AsRef<Query<'a>> for Query<'a> {
-    fn as_ref(&self) -> &Query<'a> {
-        &self
+impl<'a> From<&'a Query<'a>> for Query<'a> {
+    fn from(query: &'a Query<'a>) -> Query<'a> {
+        query.clone()
+    }
+}
+
+impl<'a> From<&'a String> for Query<'a> {
+    fn from(query: &'a String) -> Query<'a> {
+        query.as_str().into()
     }
 }
 

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -30,8 +30,7 @@ async fn attachment() -> Result<(), CosmosError> {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -110,9 +110,7 @@ async fn attachment() -> Result<(), CosmosError> {
     let resp = attachment_client
         .replace_reference()
         .consistency_level(&resp)
-        .content_type("image/jpeg")
-        .media("https://www.microsoft.com")
-        .execute()
+        .execute("https://www.microsoft.com", "image/jpeg")
         .await?;
 
     // create slug attachment

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -82,7 +82,7 @@ async fn attachment() -> Result<(), CosmosError> {
     let session_token: ConsistencyLevel = collection_client
         .create_document()
         .partition_keys([&doc.document.id])
-        .execute_with_document(&doc)
+        .execute(&doc)
         .await?
         .into();
 

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -121,8 +121,7 @@ async fn attachment() -> Result<(), CosmosError> {
         .create_slug()
         .consistency_level(&resp)
         .content_type("text/plain")
-        .body(Bytes::from_static(b"something cool here"))
-        .execute()
+        .execute(b"something cool here")
         .await?;
 
     // list attachments, there must be two.

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -1,6 +1,5 @@
 #![cfg(all(test, feature = "test_e2e"))]
 use azure_cosmos::prelude::*;
-use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -119,7 +118,7 @@ async fn attachment() -> Result<(), CosmosError> {
         .create_slug()
         .consistency_level(&resp)
         .content_type("text/plain")
-        .execute(b"something cool here")
+        .execute("something cool here")
         .await?;
 
     // list attachments, there must be two.

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -103,9 +103,7 @@ async fn attachment() -> Result<(), CosmosError> {
     let resp = attachment_client
         .create_reference()
         .consistency_level(&ret)
-        .content_type("image/jpeg")
-        .media("https://www.bing.com")
-        .execute()
+        .execute("https://www.bing.com", "image/jpeg")
         .await?;
 
     // replace reference attachment

--- a/sdk/cosmos/tests/cosmos_collection.rs
+++ b/sdk/cosmos/tests/cosmos_collection.rs
@@ -13,8 +13,7 @@ async fn create_and_delete_collection() {
 
     client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 
@@ -64,8 +63,7 @@ async fn replace_collection() {
 
     client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_collection.rs
+++ b/sdk/cosmos/tests/cosmos_collection.rs
@@ -121,8 +121,7 @@ async fn replace_collection() {
     let _replace_collection_reponse = collection_client
         .replace_collection()
         .indexing_policy(&new_ip)
-        .partition_key("/id")
-        .execute()
+        .execute("/id")
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_database.rs
+++ b/sdk/cosmos/tests/cosmos_database.rs
@@ -15,8 +15,7 @@ async fn create_and_delete_database() {
     // create a new database and check if the number of DBs increased
     let database = client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
     let databases = client.list_databases().execute().await.unwrap();

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -234,13 +234,12 @@ async fn replace_document() {
     document_data.document.hello = 190;
     collection_client
         .replace_document()
-        .document_id(&document_data.document.id)
         .partition_keys([&document_data.document.id])
         .consistency_level(ConsistencyLevel::from(&documents))
         .if_match_condition(IfMatchCondition::Match(
             &documents.documents[0].document_attributes.etag(),
         ))
-        .execute(&document_data)
+        .execute(&document_data.document.id, &document_data)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -58,7 +58,7 @@ async fn create_and_delete_document() {
     collection_client
         .create_document()
         .partition_keys([&DOCUMENT_NAME])
-        .execute_with_document(&document_data)
+        .execute(&document_data)
         .await
         .unwrap();
 
@@ -145,7 +145,7 @@ async fn query_documents() {
     collection_client
         .create_document()
         .partition_keys([&document_data.document.id])
-        .execute_with_document(&document_data)
+        .execute(&document_data)
         .await
         .unwrap();
 
@@ -219,7 +219,7 @@ async fn replace_document() {
     collection_client
         .create_document()
         .partition_keys([&document_data.document.id])
-        .execute_with_document(&document_data)
+        .execute(&document_data)
         .await
         .unwrap();
 
@@ -240,7 +240,7 @@ async fn replace_document() {
         .if_match_condition(IfMatchCondition::Match(
             &documents.documents[0].document_attributes.etag(),
         ))
-        .execute_with_document(&document_data)
+        .execute(&document_data)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -232,13 +232,13 @@ async fn replace_document() {
     // replace document with optimistic concurrency and session token
     document_data.document.hello = 190;
     collection_client
-        .replace_document()
+        .replace_document(&document_data.document.id)
         .partition_keys([&document_data.document.id])
         .consistency_level(ConsistencyLevel::from(&documents))
         .if_match_condition(IfMatchCondition::Match(
             &documents.documents[0].document_attributes.etag(),
         ))
-        .execute(&document_data.document.id, &document_data)
+        .execute(&document_data)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -160,9 +160,8 @@ async fn query_documents() {
     // now query all documents and see if we get the correct result
     let query_result = collection_client
         .query_documents()
-        .query(&Query::new("SELECT * FROM c"))
         .query_cross_partition(true)
-        .execute::<MyDocument>()
+        .execute::<MyDocument, _>("SELECT * FROM c")
         .await
         .unwrap()
         .into_documents()

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -24,8 +24,7 @@ async fn create_and_delete_document() {
 
     client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 
@@ -113,8 +112,7 @@ async fn query_documents() {
 
     client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
     let database_client = client.into_database_client(DATABASE_NAME);
@@ -188,8 +186,7 @@ async fn replace_document() {
 
     client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
     let database_client = client.into_database_client(DATABASE_NAME);

--- a/sdk/cosmos/tests/permission.rs
+++ b/sdk/cosmos/tests/permission.rs
@@ -43,14 +43,14 @@ async fn permissions() {
     let _create_permission_user1_response = permission_client_user1
         .create_permission()
         .expiry_seconds(18000u64) // 5 hours, max!
-        .execute_with_permission(&create_collection_response.collection.all_permission())
+        .execute(&create_collection_response.collection.all_permission())
         .await
         .unwrap();
 
     let _create_permission_user2_response = permission_client_user2
         .create_permission()
         .expiry_seconds(18000u64) // 5 hours, max!
-        .execute_with_permission(&create_collection_response.collection.read_permission())
+        .execute(&create_collection_response.collection.read_permission())
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/permission.rs
+++ b/sdk/cosmos/tests/permission.rs
@@ -17,8 +17,7 @@ async fn permissions() {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/permission_token_usage.rs
+++ b/sdk/cosmos/tests/permission_token_usage.rs
@@ -89,7 +89,7 @@ async fn permission_token_usage() {
         .create_document()
         .is_upsert(true)
         .partition_keys(["Gianluigi Bombatomica"])
-        .execute_with_document(&document)
+        .execute(&document)
         .await
         .unwrap_err();
 
@@ -122,7 +122,7 @@ async fn permission_token_usage() {
         .create_document()
         .is_upsert(true)
         .partition_keys(["Gianluigi Bombatomica"])
-        .execute_with_document(&document)
+        .execute(&document)
         .await
         .unwrap();
     println!(

--- a/sdk/cosmos/tests/permission_token_usage.rs
+++ b/sdk/cosmos/tests/permission_token_usage.rs
@@ -16,8 +16,7 @@ async fn permission_token_usage() {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/permission_token_usage.rs
+++ b/sdk/cosmos/tests/permission_token_usage.rs
@@ -48,7 +48,7 @@ async fn permission_token_usage() {
     let create_permission_response = permission_client
         .create_permission()
         .expiry_seconds(18000u64) // 5 hours, max!
-        .execute_with_permission(&permission_mode)
+        .execute(&permission_mode)
         .await
         .unwrap();
 
@@ -104,7 +104,7 @@ async fn permission_token_usage() {
     let create_permission_response = permission_client
         .create_permission()
         .expiry_seconds(18000u64) // 5 hours, max!
-        .execute_with_permission(&permission_mode)
+        .execute(&permission_mode)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -45,8 +45,7 @@ async fn trigger() -> Result<(), CosmosError> {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -87,19 +87,21 @@ async fn trigger() -> Result<(), CosmosError> {
 
     let ret = trigger_client
         .create_trigger()
-        .trigger_type(trigger::TriggerType::Post)
-        .trigger_operation(trigger::TriggerOperation::All)
-        .body(&"something")
-        .execute()
+        .execute(
+            "something",
+            trigger::TriggerType::Post,
+            trigger::TriggerOperation::All,
+        )
         .await?;
 
     let ret = trigger_client
         .replace_trigger()
         .consistency_level(ret)
-        .trigger_type(trigger::TriggerType::Post)
-        .trigger_operation(trigger::TriggerOperation::All)
-        .body(&TRIGGER_BODY)
-        .execute()
+        .execute(
+            TRIGGER_BODY,
+            trigger::TriggerType::Post,
+            trigger::TriggerOperation::All,
+        )
         .await?;
 
     let mut last_session_token: Option<ConsistencyLevel> = None;

--- a/sdk/cosmos/tests/user.rs
+++ b/sdk/cosmos/tests/user.rs
@@ -32,8 +32,7 @@ async fn users() {
 
     let _replace_user_response = user_client
         .replace_user()
-        .user_name(&USER_NAME_REPLACED)
-        .execute()
+        .execute(USER_NAME_REPLACED)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/user.rs
+++ b/sdk/cosmos/tests/user.rs
@@ -13,8 +13,7 @@ async fn users() {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -95,10 +95,9 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
     let query_stmt = format!("SELECT udf.{}(100)", USER_DEFINED_FUNCTION_NAME);
     let ret: QueryDocumentsResponseRaw<serde_json::Value> = collection_client
         .query_documents()
-        .query(&Query::new(&query_stmt))
         .consistency_level(&ret)
         .max_item_count(2i32)
-        .execute()
+        .execute(&query_stmt)
         .await?
         .into_raw();
 
@@ -111,10 +110,9 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
     let query_stmt = format!("SELECT udf.{}(10000)", USER_DEFINED_FUNCTION_NAME);
     let ret: QueryDocumentsResponseRaw<serde_json::Value> = collection_client
         .query_documents()
-        .query(&(&query_stmt as &str).into())
         .consistency_level(&ret)
         .max_item_count(2i32)
-        .execute()
+        .execute(&query_stmt)
         .await?
         .into_raw();
 

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -29,8 +29,7 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
     // create a temp database
     let _create_database_response = client
         .create_database()
-        .database_name(&DATABASE_NAME)
-        .execute()
+        .execute(DATABASE_NAME)
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -73,8 +73,7 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
 
     let ret = user_defined_function_client
         .create_user_defined_function()
-        .body("body")
-        .execute()
+        .execute("body")
         .await?;
 
     let stream = collection_client
@@ -90,8 +89,7 @@ async fn user_defined_function00() -> Result<(), CosmosError> {
     let ret = user_defined_function_client
         .replace_user_defined_function()
         .consistency_level(&ret)
-        .body(FN_BODY)
-        .execute()
+        .execute(FN_BODY)
         .await?;
 
     let query_stmt = format!("SELECT udf.{}(100)", USER_DEFINED_FUNCTION_NAME);


### PR DESCRIPTION
A continuation of #141 doing basically the same for almost all the rest of the builders.

Take note of the `QueryDocumentBuilder` which now requires two generic params which makes the API a bit more awkward.