### PR TITLE
response Bytes

### DIFF
--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -61,7 +61,7 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b> {
             #[serde(skip_serializing_if = "Option::is_none")]
             indexing_policy: Option<&'k IndexingPolicy>,
             partition_key: PartitionKey,
-        };
+        }
 
         let request = Request {
             id: self.collection_client.collection_name(),

--- a/sdk/cosmos/src/resources/document/document_attributes.rs
+++ b/sdk/cosmos/src/resources/document/document_attributes.rs
@@ -44,10 +44,10 @@ impl DocumentAttributes {
     }
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DocumentAttributes {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DocumentAttributes {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(response.body())?)
     }
 }

--- a/sdk/cosmos/src/responses/create_collection_response.rs
+++ b/sdk/cosmos/src/responses/create_collection_response.rs
@@ -22,10 +22,10 @@ pub struct CreateCollectionResponse {
     pub current_replica_set_size: u64,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateCollectionResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateCollectionResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/create_database_response.rs
+++ b/sdk/cosmos/src/responses/create_database_response.rs
@@ -23,10 +23,10 @@ pub struct CreateDatabaseResponse {
     pub gateway_version: String,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateDatabaseResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateDatabaseResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/create_document_response.rs
+++ b/sdk/cosmos/src/responses/create_document_response.rs
@@ -35,10 +35,10 @@ pub struct CreateDocumentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateDocumentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateDocumentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let status_code = response.status();
         let headers = response.headers();
         let body = response.body();

--- a/sdk/cosmos/src/responses/create_permission_response.rs
+++ b/sdk/cosmos/src/responses/create_permission_response.rs
@@ -16,10 +16,10 @@ pub struct CreatePermissionResponse<'a> {
     pub alt_content_path: String,
 }
 
-impl<'a> std::convert::TryFrom<Response<Vec<u8>>> for CreatePermissionResponse<'a> {
+impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for CreatePermissionResponse<'a> {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body: &[u8] = response.body();
 

--- a/sdk/cosmos/src/responses/create_reference_attachment_response.rs
+++ b/sdk/cosmos/src/responses/create_reference_attachment_response.rs
@@ -34,10 +34,10 @@ pub struct CreateReferenceAttachmentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateReferenceAttachmentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateReferenceAttachmentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/create_slug_attachment_response.rs
+++ b/sdk/cosmos/src/responses/create_slug_attachment_response.rs
@@ -33,10 +33,10 @@ pub struct CreateSlugAttachmentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateSlugAttachmentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateSlugAttachmentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/create_stored_procedure_response.rs
+++ b/sdk/cosmos/src/responses/create_stored_procedure_response.rs
@@ -21,10 +21,10 @@ pub struct CreateStoredProcedureResponse {
     pub current_replica_set_size: u64,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateStoredProcedureResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateStoredProcedureResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/create_trigger_response.rs
+++ b/sdk/cosmos/src/responses/create_trigger_response.rs
@@ -35,10 +35,10 @@ pub struct CreateTriggerResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateTriggerResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateTriggerResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/create_user_defined_function_response.rs
+++ b/sdk/cosmos/src/responses/create_user_defined_function_response.rs
@@ -35,10 +35,10 @@ pub struct CreateUserDefinedFunctionResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateUserDefinedFunctionResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateUserDefinedFunctionResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/create_user_response.rs
+++ b/sdk/cosmos/src/responses/create_user_response.rs
@@ -14,10 +14,10 @@ pub struct CreateUserResponse {
     pub session_token: String,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for CreateUserResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateUserResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body: &[u8] = response.body();
 

--- a/sdk/cosmos/src/responses/delete_attachment_response.rs
+++ b/sdk/cosmos/src/responses/delete_attachment_response.rs
@@ -32,10 +32,10 @@ pub struct DeleteAttachmentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteAttachmentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteAttachmentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/delete_collection_response.rs
+++ b/sdk/cosmos/src/responses/delete_collection_response.rs
@@ -8,9 +8,9 @@ pub struct DeleteCollectionResponse {
     pub activity_id: uuid::Uuid,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteCollectionResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteCollectionResponse {
     type Error = CosmosError;
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
 
         let charge = request_charge_from_headers(headers)?;

--- a/sdk/cosmos/src/responses/delete_database_response.rs
+++ b/sdk/cosmos/src/responses/delete_database_response.rs
@@ -13,10 +13,10 @@ pub struct DeleteDatabaseResponse {
     pub resource_usage: Vec<ResourceQuota>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteDatabaseResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteDatabaseResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
 
         let charge = request_charge_from_headers(headers)?;

--- a/sdk/cosmos/src/responses/delete_document_response.rs
+++ b/sdk/cosmos/src/responses/delete_document_response.rs
@@ -10,10 +10,10 @@ pub struct DeleteDocumentResponse {
     pub session_token: String,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteDocumentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteDocumentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
 
         let charge = request_charge_from_headers(headers)?;

--- a/sdk/cosmos/src/responses/delete_permission_response.rs
+++ b/sdk/cosmos/src/responses/delete_permission_response.rs
@@ -12,10 +12,10 @@ pub struct DeletePermissionResponse {
     pub alt_content_path: String,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeletePermissionResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeletePermissionResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/delete_stored_procedure_response.rs
+++ b/sdk/cosmos/src/responses/delete_stored_procedure_response.rs
@@ -15,10 +15,10 @@ pub struct DeleteStoredProcedureResponse {
     pub resource_usage: Vec<ResourceQuota>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteStoredProcedureResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteStoredProcedureResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/cosmos/src/responses/delete_trigger_response.rs
+++ b/sdk/cosmos/src/responses/delete_trigger_response.rs
@@ -33,10 +33,10 @@ pub struct DeleteTriggerResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteTriggerResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteTriggerResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/delete_user_defined_function_response.rs
+++ b/sdk/cosmos/src/responses/delete_user_defined_function_response.rs
@@ -33,10 +33,10 @@ pub struct DeleteUserDefinedFunctionResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteUserDefinedFunctionResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteUserDefinedFunctionResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/delete_user_response.rs
+++ b/sdk/cosmos/src/responses/delete_user_response.rs
@@ -8,10 +8,10 @@ pub struct DeleteUserResponse {
     pub activity_id: uuid::Uuid,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for DeleteUserResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteUserResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/cosmos/src/responses/execute_stored_procedure_response.rs
+++ b/sdk/cosmos/src/responses/execute_stored_procedure_response.rs
@@ -34,13 +34,13 @@ where
     pub date: DateTime<Utc>,
 }
 
-impl<T> std::convert::TryFrom<Response<Vec<u8>>> for ExecuteStoredProcedureResponse<T>
+impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for ExecuteStoredProcedureResponse<T>
 where
     T: DeserializeOwned,
 {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/get_attachment_response.rs
+++ b/sdk/cosmos/src/responses/get_attachment_response.rs
@@ -37,10 +37,10 @@ pub struct GetAttachmentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for GetAttachmentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for GetAttachmentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/get_collection_response.rs
+++ b/sdk/cosmos/src/responses/get_collection_response.rs
@@ -29,10 +29,10 @@ pub struct GetCollectionResponse {
     pub gateway_version: String,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for GetCollectionResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for GetCollectionResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/get_database_response.rs
+++ b/sdk/cosmos/src/responses/get_database_response.rs
@@ -20,10 +20,10 @@ pub struct GetDatabaseResponse {
     pub gateway_version: String,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for GetDatabaseResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for GetDatabaseResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/get_document_response.rs
+++ b/sdk/cosmos/src/responses/get_document_response.rs
@@ -15,13 +15,13 @@ pub enum GetDocumentResponse<T> {
     NotFound(Box<NotFoundDocumentResponse>),
 }
 
-impl<T> std::convert::TryFrom<Response<Vec<u8>>> for GetDocumentResponse<T>
+impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for GetDocumentResponse<T>
 where
     T: DeserializeOwned,
 {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let status_code = response.status();
         let headers = response.headers();
         let body: &[u8] = response.body();
@@ -72,13 +72,13 @@ pub struct FoundDocumentResponse<T> {
     pub date: DateTime<Utc>,
 }
 
-impl<T> std::convert::TryFrom<Response<Vec<u8>>> for FoundDocumentResponse<T>
+impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for FoundDocumentResponse<T>
 where
     T: DeserializeOwned,
 {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body: &[u8] = response.body();
 
@@ -133,10 +133,10 @@ pub struct NotFoundDocumentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for NotFoundDocumentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for NotFoundDocumentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/cosmos/src/responses/get_partition_key_ranges_response.rs
+++ b/sdk/cosmos/src/responses/get_partition_key_ranges_response.rs
@@ -28,10 +28,10 @@ pub struct GetPartitionKeyRangesResponse {
     pub partition_key_ranges: Vec<PartitionKeyRange>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for GetPartitionKeyRangesResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for GetPartitionKeyRangesResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/get_permission_response.rs
+++ b/sdk/cosmos/src/responses/get_permission_response.rs
@@ -15,10 +15,10 @@ pub struct GetPermissionResponse<'a> {
     pub alt_content_path: String,
 }
 
-impl<'a> std::convert::TryFrom<Response<Vec<u8>>> for GetPermissionResponse<'a> {
+impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for GetPermissionResponse<'a> {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_attachments_response.rs
+++ b/sdk/cosmos/src/responses/list_attachments_response.rs
@@ -44,10 +44,10 @@ pub struct ListAttachmentsResponse {
     pub continuation_token: Option<String>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ListAttachmentsResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ListAttachmentsResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_collections_response.rs
+++ b/sdk/cosmos/src/responses/list_collections_response.rs
@@ -25,10 +25,10 @@ pub struct ListCollectionsResponse {
     pub continuation_token: Option<String>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ListCollectionsResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ListCollectionsResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_databases_response.rs
+++ b/sdk/cosmos/src/responses/list_databases_response.rs
@@ -23,10 +23,10 @@ pub struct ListDatabasesResponse {
     pub gateway_version: String,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ListDatabasesResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ListDatabasesResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_documents_response.rs
+++ b/sdk/cosmos/src/responses/list_documents_response.rs
@@ -73,13 +73,13 @@ where
     }
 }
 
-impl<T> std::convert::TryFrom<Response<Vec<u8>>> for ListDocumentsResponse<T>
+impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for ListDocumentsResponse<T>
 where
     T: DeserializeOwned,
 {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body: &[u8] = response.body();
 

--- a/sdk/cosmos/src/responses/list_permissions_response.rs
+++ b/sdk/cosmos/src/responses/list_permissions_response.rs
@@ -15,10 +15,10 @@ pub struct ListPermissionsResponse<'a> {
     pub continuation_token: Option<String>,
 }
 
-impl<'a> std::convert::TryFrom<Response<Vec<u8>>> for ListPermissionsResponse<'a> {
+impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for ListPermissionsResponse<'a> {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_stored_procedures_response.rs
+++ b/sdk/cosmos/src/responses/list_stored_procedures_response.rs
@@ -19,10 +19,10 @@ pub struct ListStoredProceduresResponse {
     pub continuation_token: Option<String>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ListStoredProceduresResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ListStoredProceduresResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_triggers_response.rs
+++ b/sdk/cosmos/src/responses/list_triggers_response.rs
@@ -34,10 +34,10 @@ pub struct ListTriggersResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ListTriggersResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ListTriggersResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_user_defined_functions_response.rs
+++ b/sdk/cosmos/src/responses/list_user_defined_functions_response.rs
@@ -34,10 +34,10 @@ pub struct ListUserDefinedFunctionsResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ListUserDefinedFunctionsResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ListUserDefinedFunctionsResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/list_users_response.rs
+++ b/sdk/cosmos/src/responses/list_users_response.rs
@@ -25,10 +25,10 @@ pub struct ListUsersResponse {
     pub continuation_token: Option<String>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ListUsersResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ListUsersResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -18,13 +18,13 @@ pub struct DocumentQueryResult<T> {
     pub result: T,
 }
 
-impl<T> std::convert::TryFrom<Response<Vec<u8>>> for DocumentQueryResult<T>
+impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for DocumentQueryResult<T>
 where
     T: DeserializeOwned,
 {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(response.body())?)
     }
 }
@@ -37,10 +37,10 @@ pub struct QueryResponseMeta {
     pub count: u64,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for QueryResponseMeta {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for QueryResponseMeta {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(response.body())?)
     }
 }
@@ -93,13 +93,13 @@ impl<T> QueryDocumentsResponse<T> {
     }
 }
 
-impl<T> std::convert::TryFrom<Response<Vec<u8>>> for QueryDocumentsResponse<T>
+impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for QueryDocumentsResponse<T>
 where
     T: DeserializeOwned,
 {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/replace_document_response.rs
+++ b/sdk/cosmos/src/responses/replace_document_response.rs
@@ -37,10 +37,10 @@ pub struct ReplaceDocumentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ReplaceDocumentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ReplaceDocumentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/cosmos/src/responses/replace_permission_response.rs
+++ b/sdk/cosmos/src/responses/replace_permission_response.rs
@@ -16,10 +16,10 @@ pub struct ReplacePermissionResponse<'a> {
     pub alt_content_path: String,
 }
 
-impl<'a> std::convert::TryFrom<Response<Vec<u8>>> for ReplacePermissionResponse<'a> {
+impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for ReplacePermissionResponse<'a> {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body: &[u8] = response.body();
 

--- a/sdk/cosmos/src/responses/replace_reference_attachment_response.rs
+++ b/sdk/cosmos/src/responses/replace_reference_attachment_response.rs
@@ -32,10 +32,10 @@ pub struct ReplaceReferenceAttachmentResponse {
     pub date: DateTime<Utc>,
 }
 
-impl std::convert::TryFrom<Response<Vec<u8>>> for ReplaceReferenceAttachmentResponse {
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ReplaceReferenceAttachmentResponse {
     type Error = CosmosError;
 
-    fn try_from(response: Response<Vec<u8>>) -> Result<Self, Self::Error> {
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();
 


### PR DESCRIPTION
#145 was for Bytes in the http request. This one is for the response to skip the `to_vec`.

https://docs.rs/bytes/1.0.1/bytes/struct.Bytes.html#method.to_vec
Copies self into a new Vec.