### PR TITLE
Deny missing docs in cosmos

### DIFF
--- a/sdk/cosmos/src/clients/attachment_client.rs
+++ b/sdk/cosmos/src/clients/attachment_client.rs
@@ -13,6 +13,7 @@ pub struct AttachmentClient {
 }
 
 impl AttachmentClient {
+    /// Create a new client
     pub(crate) fn new<S: Into<ReadonlyString>>(
         document_client: DocumentClient,
         attachment_name: S,
@@ -41,11 +42,6 @@ impl AttachmentClient {
     /// Get a [`DocumentClient`].
     pub fn document_client(&self) -> &DocumentClient {
         &self.document_client
-    }
-
-    /// Get a raw [`HttpClient`].
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
     }
 
     /// Get the attachment name.
@@ -81,6 +77,11 @@ impl AttachmentClient {
     /// Initiate a request to replace an attachment.
     pub fn replace_reference(&self) -> requests::ReplaceReferenceAttachmentBuilder<'_, '_> {
         requests::ReplaceReferenceAttachmentBuilder::new(self)
+    }
+
+    /// Get a raw [`HttpClient`].
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 
     pub(crate) fn prepare_request(&self, method: http::Method) -> http::request::Builder {

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -23,42 +23,47 @@ impl CollectionClient {
         }
     }
 
+    /// Get a [`CosmosClient`].
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.database_client.cosmos_client()
     }
 
+    /// Get a [`DatabaseClient`].
     pub fn database_client(&self) -> &DatabaseClient {
         &self.database_client
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
-    }
-
+    /// Get the collection name
     pub fn collection_name(&self) -> &str {
         &self.collection_name
     }
 
+    /// Get a collection
     pub fn get_collection(&self) -> requests::GetCollectionBuilder<'_> {
         requests::GetCollectionBuilder::new(self)
     }
 
+    /// Delete a collection
     pub fn delete_collection(&self) -> requests::DeleteCollectionBuilder<'_> {
         requests::DeleteCollectionBuilder::new(self)
     }
 
+    /// Replace a collection
     pub fn replace_collection(&self) -> requests::ReplaceCollectionBuilder<'_, '_> {
         requests::ReplaceCollectionBuilder::new(self)
     }
 
+    /// list documents in a collection
     pub fn list_documents(&self) -> requests::ListDocumentsBuilder<'_, '_> {
         requests::ListDocumentsBuilder::new(self)
     }
 
+    /// create a document in a collection
     pub fn create_document(&self) -> requests::CreateDocumentBuilder<'_, '_> {
         requests::CreateDocumentBuilder::new(self)
     }
 
+    /// replace a document in a collection
     pub fn replace_document<'a>(
         &'a self,
         document_id: &'a str,
@@ -66,26 +71,32 @@ impl CollectionClient {
         requests::ReplaceDocumentBuilder::new(self, document_id)
     }
 
+    /// query documents in a collection
     pub fn query_documents(&self) -> requests::QueryDocumentsBuilder<'_, '_> {
         requests::QueryDocumentsBuilder::new(self)
     }
 
+    /// list stored procedures in a collection
     pub fn list_stored_procedures(&self) -> requests::ListStoredProceduresBuilder<'_, '_> {
         requests::ListStoredProceduresBuilder::new(self)
     }
 
+    /// list user defined functions in a collection
     pub fn list_user_defined_functions(&self) -> requests::ListUserDefinedFunctionsBuilder<'_, '_> {
         requests::ListUserDefinedFunctionsBuilder::new(self)
     }
 
+    /// list triggers in a collection
     pub fn list_triggers(&self) -> requests::ListTriggersBuilder<'_, '_> {
         requests::ListTriggersBuilder::new(self)
     }
 
+    /// list the partition key ranges in a collection
     pub fn get_partition_key_ranges(&self) -> requests::GetPartitionKeyRangesBuilder<'_, '_> {
         requests::GetPartitionKeyRangesBuilder::new(self)
     }
 
+    /// convert into a [`DocumentClient`]
     pub fn into_document_client<S: Into<ReadonlyString>, P: Into<PartitionKeys>>(
         self,
         document_name: S,
@@ -94,10 +105,12 @@ impl CollectionClient {
         DocumentClient::new(self, document_name, partition_keys.into())
     }
 
+    /// convert into a [`TriggerClient`]
     pub fn into_trigger_client<S: Into<ReadonlyString>>(self, trigger_name: S) -> TriggerClient {
         TriggerClient::new(self, trigger_name)
     }
 
+    /// convert into a [`UserDefinedFunctionClient`]
     pub fn into_user_defined_function_client<S: Into<ReadonlyString>>(
         self,
         user_defined_function_name: S,
@@ -105,6 +118,7 @@ impl CollectionClient {
         UserDefinedFunctionClient::new(self, user_defined_function_name)
     }
 
+    /// convert into a [`StoredProcedureClient`]
     pub fn into_stored_procedure_client<S: Into<ReadonlyString>>(
         self,
         stored_procedure_name: S,
@@ -112,15 +126,7 @@ impl CollectionClient {
         StoredProcedureClient::new(self, stored_procedure_name)
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
-        self.cosmos_client().prepare_request(
-            &format!("dbs/{}/colls", self.database_client().database_name()),
-            method,
-            ResourceType::Collections,
-        )
-    }
-
-    pub fn prepare_request_with_collection_name(
+    pub(crate) fn prepare_request_with_collection_name(
         &self,
         method: http::Method,
     ) -> http::request::Builder {
@@ -133,5 +139,9 @@ impl CollectionClient {
             method,
             ResourceType::Collections,
         )
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 }

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -23,30 +23,32 @@ impl DatabaseClient {
         }
     }
 
+    /// Get a [`CosmosClient`].
     pub fn cosmos_client(&self) -> &CosmosClient {
         &self.cosmos_client
     }
 
+    /// Get the database's name
     pub fn database_name(&self) -> &str {
         &self.database_name
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
-    }
-
-    pub fn list_collections(&self) -> requests::ListCollectionsBuilder<'_> {
-        requests::ListCollectionsBuilder::new(self)
-    }
-
+    /// Get the database
     pub fn get_database(&self) -> requests::GetDatabaseBuilder<'_, '_> {
         requests::GetDatabaseBuilder::new(self)
     }
 
+    /// List collections in the database
+    pub fn list_collections(&self) -> requests::ListCollectionsBuilder<'_> {
+        requests::ListCollectionsBuilder::new(self)
+    }
+
+    /// Delete the database
     pub fn delete_database(&self) -> requests::DeleteDatabaseBuilder<'_> {
         requests::DeleteDatabaseBuilder::new(self)
     }
 
+    /// Create a collection
     pub fn create_collection<'a, P: Into<PartitionKey>>(
         &'a self,
         partition_key: P,
@@ -54,10 +56,12 @@ impl DatabaseClient {
         requests::CreateCollectionBuilder::new(self, partition_key.into())
     }
 
+    /// List users
     pub fn list_users(&self) -> requests::ListUsersBuilder<'_, '_> {
         requests::ListUsersBuilder::new(self)
     }
 
+    /// Convert into a [`CollectionClient`]
     pub fn into_collection_client<S: Into<ReadonlyString>>(
         self,
         collection_name: S,
@@ -65,16 +69,12 @@ impl DatabaseClient {
         CollectionClient::new(self, collection_name)
     }
 
+    /// Convert into a [`UserClient`]
     pub fn into_user_client<S: Into<ReadonlyString>>(self, user_name: S) -> UserClient {
         UserClient::new(self, user_name)
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
-        self.cosmos_client()
-            .prepare_request("dbs", method, ResourceType::Databases)
-    }
-
-    pub fn prepare_request_with_database_name(
+    pub(crate) fn prepare_request_with_database_name(
         &self,
         method: http::Method,
     ) -> http::request::Builder {
@@ -83,5 +83,9 @@ impl DatabaseClient {
             method,
             ResourceType::Databases,
         )
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 }

--- a/sdk/cosmos/src/clients/document_client.rs
+++ b/sdk/cosmos/src/clients/document_client.rs
@@ -24,42 +24,47 @@ impl DocumentClient {
         }
     }
 
+    /// Get a [`CosmosClient`]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection_client().cosmos_client()
     }
 
+    /// Get a [`DatabaseClient`]
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection_client().database_client()
     }
 
+    /// Get a [`CollectionClient`]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection_client
     }
 
+    /// Get the document's name
     pub fn document_name(&self) -> &str {
         &self.document_name
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
-    }
-
+    /// Get the partition keys
     pub fn partition_keys(&self) -> &PartitionKeys {
         &self.partition_keys
     }
 
+    /// Get a document
     pub fn get_document(&self) -> requests::GetDocumentBuilder<'_, '_> {
         requests::GetDocumentBuilder::new(self)
     }
 
+    /// Delete a document
     pub fn delete_document(&self) -> requests::DeleteDocumentBuilder<'_> {
         requests::DeleteDocumentBuilder::new(self)
     }
 
+    /// List all attachments for a document
     pub fn list_attachments(&self) -> requests::ListAttachmentsBuilder<'_, '_> {
         requests::ListAttachmentsBuilder::new(self)
     }
 
+    /// Convert into an [`AttachmentClient`]
     pub fn into_attachment_client<S: Into<ReadonlyString>>(
         self,
         attachment_name: S,
@@ -67,19 +72,7 @@ impl DocumentClient {
         AttachmentClient::new(self, attachment_name)
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
-        self.cosmos_client().prepare_request(
-            &format!(
-                "dbs/{}/colls/{}/docs",
-                self.database_client().database_name(),
-                self.collection_client().collection_name()
-            ),
-            method,
-            ResourceType::Documents,
-        )
-    }
-
-    pub fn prepare_request_with_document_name(
+    pub(crate) fn prepare_request_with_document_name(
         &self,
         method: http::Method,
     ) -> http::request::Builder {
@@ -93,5 +86,9 @@ impl DocumentClient {
             method,
             ResourceType::Documents,
         )
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 }

--- a/sdk/cosmos/src/clients/permission_client.rs
+++ b/sdk/cosmos/src/clients/permission_client.rs
@@ -21,55 +21,47 @@ impl PermissionClient {
         }
     }
 
+    /// Get a [`CosmosClient`
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.user_client.cosmos_client()
     }
 
+    /// Get a [`DatabaseClient`]
     pub fn database_client(&self) -> &DatabaseClient {
         self.user_client.database_client()
     }
 
+    /// Get the [`UserClient`]
     pub fn user_client(&self) -> &UserClient {
         &self.user_client
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
-    }
-
+    /// Get the permission's name
     pub fn permission_name(&self) -> &str {
         &self.permission_name
     }
 
+    /// Create the permission
     pub fn create_permission(&self) -> requests::CreatePermissionBuilder<'_, '_> {
         requests::CreatePermissionBuilder::new(self)
     }
 
+    /// Replace the permission
     pub fn replace_permission(&self) -> requests::ReplacePermissionBuilder<'_, '_> {
         requests::ReplacePermissionBuilder::new(self)
     }
 
+    /// Get the permission
     pub fn get_permission(&self) -> requests::GetPermissionBuilder<'_, '_> {
         requests::GetPermissionBuilder::new(self)
     }
 
+    /// Delete the permission
     pub fn delete_permission(&self) -> requests::DeletePermissionsBuilder<'_, '_> {
         requests::DeletePermissionsBuilder::new(self)
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
-        self.cosmos_client().prepare_request(
-            &format!(
-                "dbs/{}/users/{}/permissions",
-                self.database_client().database_name(),
-                self.user_client().user_name()
-            ),
-            method,
-            ResourceType::Permissions,
-        )
-    }
-
-    pub fn prepare_request_with_permission_name(
+    pub(crate) fn prepare_request_with_permission_name(
         &self,
         method: http::Method,
     ) -> http::request::Builder {
@@ -83,5 +75,9 @@ impl PermissionClient {
             method,
             ResourceType::Permissions,
         )
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 }

--- a/sdk/cosmos/src/clients/stored_procedure_client.rs
+++ b/sdk/cosmos/src/clients/stored_procedure_client.rs
@@ -21,43 +21,47 @@ impl StoredProcedureClient {
         }
     }
 
+    /// Get a [`CosmosClient`]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection_client.cosmos_client()
     }
 
+    /// Get a [`DatabaseClient`
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection_client.database_client()
     }
 
+    /// Get the [`CollectionClient`]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection_client
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
-    }
-
+    /// Get the stored procedure's name
     pub fn stored_procedure_name(&self) -> &str {
         &self.stored_procedure_name
     }
 
+    /// Create the stored procedure
     pub fn create_stored_procedure(&self) -> requests::CreateStoredProcedureBuilder<'_, '_> {
         requests::CreateStoredProcedureBuilder::new(self)
     }
 
+    /// Replace the stored procedure
     pub fn replace_stored_procedure(&self) -> requests::ReplaceStoredProcedureBuilder<'_, '_> {
         requests::ReplaceStoredProcedureBuilder::new(self)
     }
 
+    /// Execute the stored procedure
     pub fn execute_stored_procedure(&self) -> requests::ExecuteStoredProcedureBuilder<'_, '_> {
         requests::ExecuteStoredProcedureBuilder::new(self)
     }
 
+    /// Delete the stored procedure
     pub fn delete_stored_procedure(&self) -> requests::DeleteStoredProcedureBuilder<'_, '_> {
         requests::DeleteStoredProcedureBuilder::new(self)
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
+    pub(crate) fn prepare_request(&self, method: http::Method) -> http::request::Builder {
         self.cosmos_client().prepare_request(
             &format!(
                 "dbs/{}/colls/{}/sprocs",
@@ -69,7 +73,7 @@ impl StoredProcedureClient {
         )
     }
 
-    pub fn prepare_request_with_stored_procedure_name(
+    pub(crate) fn prepare_request_with_stored_procedure_name(
         &self,
         method: http::Method,
     ) -> http::request::Builder {
@@ -83,5 +87,9 @@ impl StoredProcedureClient {
             method,
             ResourceType::StoredProcedures,
         )
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 }

--- a/sdk/cosmos/src/clients/trigger_client.rs
+++ b/sdk/cosmos/src/clients/trigger_client.rs
@@ -11,6 +11,7 @@ pub struct TriggerClient {
 }
 
 impl TriggerClient {
+    /// Create a new trigger client
     pub(crate) fn new<S: Into<ReadonlyString>>(
         collection_client: CollectionClient,
         trigger_name: S,
@@ -21,35 +22,46 @@ impl TriggerClient {
         }
     }
 
+    /// Get a [`CosmosClient`]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection_client.cosmos_client()
     }
 
+    /// Get a [`DatabaseClient`]
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection_client.database_client()
     }
 
+    /// Get a [`CollectionClient`]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection_client
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
+    /// Get the trigger name
+    pub fn trigger_name(&self) -> &str {
+        &self.trigger_name
+    }
+
+    /// Create a trigger
+    pub fn create_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_> {
+        requests::CreateOrReplaceTriggerBuilder::new(self, true)
+    }
+
+    /// Replace a trigger
+    pub fn replace_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_> {
+        requests::CreateOrReplaceTriggerBuilder::new(self, false)
+    }
+
+    /// Delete a trigger
+    pub fn delete_trigger(&self) -> requests::DeleteTriggerBuilder<'_, '_> {
+        requests::DeleteTriggerBuilder::new(self)
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
         self.cosmos_client().http_client()
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
-        self.cosmos_client().prepare_request(
-            &format!(
-                "dbs/{}/colls/{}/triggers",
-                self.database_client().database_name(),
-                self.collection_client().collection_name(),
-            ),
-            method,
-            ResourceType::Triggers,
-        )
-    }
-
-    pub fn prepare_request_with_trigger_name(
+    pub(crate) fn prepare_request_with_trigger_name(
         &self,
         method: http::Method,
     ) -> http::request::Builder {
@@ -65,19 +77,15 @@ impl TriggerClient {
         )
     }
 
-    pub fn trigger_name(&self) -> &str {
-        &self.trigger_name
-    }
-
-    pub fn create_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_> {
-        requests::CreateOrReplaceTriggerBuilder::new(self, true)
-    }
-
-    pub fn replace_trigger(&self) -> requests::CreateOrReplaceTriggerBuilder<'_> {
-        requests::CreateOrReplaceTriggerBuilder::new(self, false)
-    }
-
-    pub fn delete_trigger(&self) -> requests::DeleteTriggerBuilder<'_, '_> {
-        requests::DeleteTriggerBuilder::new(self)
+    pub(crate) fn prepare_request(&self, method: http::Method) -> http::request::Builder {
+        self.cosmos_client().prepare_request(
+            &format!(
+                "dbs/{}/colls/{}/triggers",
+                self.database_client().database_name(),
+                self.collection_client().collection_name(),
+            ),
+            method,
+            ResourceType::Triggers,
+        )
     }
 }

--- a/sdk/cosmos/src/clients/user_client.rs
+++ b/sdk/cosmos/src/clients/user_client.rs
@@ -21,42 +21,47 @@ impl UserClient {
         }
     }
 
+    /// Get a [`CosmosClient`]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.database_client().cosmos_client()
     }
 
+    /// Get a [`DatabaseClient`]
     pub fn database_client(&self) -> &DatabaseClient {
         &self.database_client
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
-    }
-
+    /// Get the user name
     pub fn user_name(&self) -> &str {
         &self.user_name
     }
 
+    /// Create the user
     pub fn create_user(&self) -> requests::CreateUserBuilder<'_, '_> {
         requests::CreateUserBuilder::new(self)
     }
 
+    /// Get the user
     pub fn get_user(&self) -> requests::GetUserBuilder<'_, '_> {
         requests::GetUserBuilder::new(self)
     }
 
+    /// Replace the user
     pub fn replace_user(&self) -> requests::ReplaceUserBuilder<'_, '_> {
         requests::ReplaceUserBuilder::new(self)
     }
 
+    /// Delete the user
     pub fn delete_user(&self) -> requests::DeleteUserBuilder<'_, '_> {
         requests::DeleteUserBuilder::new(self)
     }
 
+    /// List the user's permissions
     pub fn list_permissions(&self) -> requests::ListPermissionsBuilder<'_, '_> {
         requests::ListPermissionsBuilder::new(self)
     }
 
+    /// Convert into a [`PermissionClient`]
     pub fn into_permission_client<S: Into<ReadonlyString>>(
         self,
         permission_name: S,
@@ -64,7 +69,7 @@ impl UserClient {
         PermissionClient::new(self, permission_name)
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
+    pub(crate) fn prepare_request(&self, method: http::Method) -> http::request::Builder {
         self.cosmos_client().prepare_request(
             &format!("dbs/{}/users", self.database_client().database_name()),
             method,
@@ -72,7 +77,10 @@ impl UserClient {
         )
     }
 
-    pub fn prepare_request_with_user_name(&self, method: http::Method) -> http::request::Builder {
+    pub(crate) fn prepare_request_with_user_name(
+        &self,
+        method: http::Method,
+    ) -> http::request::Builder {
         self.cosmos_client().prepare_request(
             &format!(
                 "dbs/{}/users/{}",
@@ -82,5 +90,9 @@ impl UserClient {
             method,
             ResourceType::Users,
         )
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 }

--- a/sdk/cosmos/src/clients/user_defined_function_client.rs
+++ b/sdk/cosmos/src/clients/user_defined_function_client.rs
@@ -21,45 +21,48 @@ impl UserDefinedFunctionClient {
         }
     }
 
+    /// Get a [`CosmosClient`]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection_client.cosmos_client()
     }
 
+    /// Get a [`DatabaseClient`]
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection_client.database_client()
     }
 
+    /// Get a [`CollectionClient`]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection_client
     }
 
-    pub fn http_client(&self) -> &dyn HttpClient {
-        self.cosmos_client().http_client()
-    }
-
+    /// Get the user defined function's name
     pub fn user_defined_function_name(&self) -> &str {
         &self.user_defined_function_name
     }
 
+    /// Create the user defined function
     pub fn create_user_defined_function(
         &self,
     ) -> requests::CreateOrReplaceUserDefinedFunctionBuilder<'_, '_> {
         requests::CreateOrReplaceUserDefinedFunctionBuilder::new(self, true)
     }
 
+    /// Replace the user defined function
     pub fn replace_user_defined_function(
         &self,
     ) -> requests::CreateOrReplaceUserDefinedFunctionBuilder<'_, '_> {
         requests::CreateOrReplaceUserDefinedFunctionBuilder::new(self, false)
     }
 
+    /// Delete the user defined function
     pub fn delete_user_defined_function(
         &self,
     ) -> requests::DeleteUserDefinedFunctionBuilder<'_, '_> {
         requests::DeleteUserDefinedFunctionBuilder::new(self)
     }
 
-    pub fn prepare_request(&self, method: http::Method) -> http::request::Builder {
+    pub(crate) fn prepare_request(&self, method: http::Method) -> http::request::Builder {
         self.cosmos_client().prepare_request(
             &format!(
                 "dbs/{}/colls/{}/udfs",
@@ -71,7 +74,7 @@ impl UserDefinedFunctionClient {
         )
     }
 
-    pub fn prepare_request_with_user_defined_function_name(
+    pub(crate) fn prepare_request_with_user_defined_function_name(
         &self,
         method: http::Method,
     ) -> http::request::Builder {
@@ -85,5 +88,9 @@ impl UserDefinedFunctionClient {
             method,
             ResourceType::UserDefinedFunctions,
         )
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.cosmos_client().http_client()
     }
 }

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -87,6 +87,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 !*/
 
 #![warn(unused_extern_crates)]
+#![deny(missing_docs)]
 #![recursion_limit = "256"]
 #[macro_use]
 extern crate log;

--- a/sdk/cosmos/src/requests/mod.rs
+++ b/sdk/cosmos/src/requests/mod.rs
@@ -4,6 +4,8 @@
 //! then give you the ability to modify your request with certain options and finally
 //! execute the request with the `execute` method.
 
+#![allow(missing_docs)]
+
 mod create_collection_builder;
 mod create_database_builder;
 mod create_document_builder;

--- a/sdk/cosmos/src/resource_quota.rs
+++ b/sdk/cosmos/src/resource_quota.rs
@@ -4,6 +4,7 @@ use crate::errors::TokenParsingError;
 ///
 /// A collection of this type is often returned in responses allowing you to
 /// know how much of a given resource you can use.
+#[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 pub enum ResourceQuota {
     Databases(u64),

--- a/sdk/cosmos/src/resources/attachment.rs
+++ b/sdk/cosmos/src/resources/attachment.rs
@@ -3,16 +3,23 @@
 /// You can find more information about attachments in Cosmos [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/attachments)
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct Attachment {
+    /// The attachment id
     pub id: String,
+    /// The content type
     #[serde(rename = "contentType")]
     pub content_type: String,
+    /// The media url
     pub media: String,
+    /// The resource id
     #[serde(rename = "_rid")]
     rid: String,
+    /// The last updated timestamp
     #[serde(rename = "_ts")]
     pub timestamp: u64,
+    /// The resource's url
     #[serde(rename = "_self")]
     pub url: String,
+    /// The resource's etag used for concurrency control
     #[serde(rename = "_etag")]
     pub etag: String,
 }

--- a/sdk/cosmos/src/resources/collection/mod.rs
+++ b/sdk/cosmos/src/resources/collection/mod.rs
@@ -10,27 +10,39 @@ pub use offer::Offer;
 /// You can learn more about Collections [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/collections).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
 pub struct Collection {
+    /// The collection id
     pub id: String,
+    /// The indexing policy
     #[serde(rename = "indexingPolicy")]
     pub indexing_policy: IndexingPolicy,
+    /// The partition key
     #[serde(rename = "partitionKey")]
     pub parition_key: PartitionKey,
+    /// The resource id
     #[serde(rename = "_rid")]
     pub rid: String,
+    /// The last updated timestamp
     #[serde(rename = "_ts")]
     pub ts: u64,
+    /// The resource's uri
     #[serde(rename = "_self")]
     pub _self: String,
+    /// The resource's etag used for concurrency control
     #[serde(rename = "_etag")]
     pub etag: String,
+    /// the addressable path of the documents resource
     #[serde(rename = "_docs")]
     pub docs: String,
+    /// the addressable path of the stored procedures resource
     #[serde(rename = "_sprocs")]
     pub sprocs: String,
+    /// the addressable path of the triggers resource
     #[serde(rename = "_triggers")]
     pub triggers: String,
+    /// the addressable path of the user-defined functions (udfs) resource
     #[serde(rename = "_udfs")]
     pub udfs: String,
+    /// the addressable path of the conflicts resource
     #[serde(rename = "_conflicts")]
     pub conflicts: String,
 }
@@ -48,13 +60,19 @@ impl Resource for &Collection {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
+/// The type of index
 pub enum KeyKind {
+    /// useful for equality comparisons
     Hash,
+    /// seful for equality, range comparisons and sorting
     Range,
+    /// useful for spatial queries
     Spatial,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
+/// The datatype for which the indexing behavior is applied to
+#[allow(missing_docs)]
 pub enum DataType {
     String,
     Number,
@@ -63,13 +81,18 @@ pub enum DataType {
     LineString,
 }
 
+/// The indexing mode
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum IndexingMode {
+    /// indexing occurs synchronously during insertion, replacment or deletion of documents
     Consistent,
+    /// indexing occurs asynchronously during insertion, replacment or deletion of documents
     Lazy,
 }
 
+/// Path to be indexed
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
 pub struct IncludedPath {
     pub path: String,
@@ -78,17 +101,23 @@ pub struct IncludedPath {
     pub indexes: Option<Vec<IncludedPathIndex>>,
 }
 
+/// An indexed description
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
 pub struct IncludedPathIndex {
+    /// The datatype for which the indexing behavior is applied to
     #[serde(rename = "dataType")]
     pub data_type: DataType,
+    /// The precision of the index
     #[serde(skip_serializing_if = "Option::is_none")]
     pub precision: Option<i8>,
+    /// The type of index
     pub kind: KeyKind,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
+/// Path that is excluded from indexing
 pub struct ExcludedPath {
+    #[allow(missing_docs)]
     pub path: String,
 }
 
@@ -99,8 +128,11 @@ impl From<String> for ExcludedPath {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
+/// The partitioning configuration settings for collection
 pub struct PartitionKey {
+    /// An array of paths using which data within the collection can be partitioned
     pub paths: Vec<String>,
+    /// The algorithm used for partitioning
     pub kind: KeyKind,
 }
 
@@ -126,10 +158,15 @@ where
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
+/// The indexing policy for a collection
 #[serde(rename_all = "camelCase")]
 pub struct IndexingPolicy {
+    /// Whether automatic indexing is on or off
     pub automatic: bool,
+    /// The mode of indexing
     pub indexing_mode: IndexingMode,
+    /// Array containing document paths to be indexed
     pub included_paths: Vec<IncludedPath>,
+    /// Array containing document paths to be excluded from indexing
     pub excluded_paths: Vec<ExcludedPath>,
 }

--- a/sdk/cosmos/src/resources/collection/offer.rs
+++ b/sdk/cosmos/src/resources/collection/offer.rs
@@ -7,9 +7,13 @@ use http::request::Builder;
 /// It can either be custom or fixed. You can find more details [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/create-a-collection).
 #[derive(Debug, Clone, PartialEq, Copy)]
 pub enum Offer {
+    /// A Custom level of throughput
     Throughput(u64),
+    /// Legacy throughput level 1
     S1,
+    /// Legacy throughput level 2
     S2,
+    /// Legacy throughput level 3
     S3,
 }
 

--- a/sdk/cosmos/src/resources/database.rs
+++ b/sdk/cosmos/src/resources/database.rs
@@ -7,17 +7,24 @@ use super::Resource;
 /// You can learn more about Databases [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/databases).
 #[derive(Serialize, Clone, PartialEq, PartialOrd, Deserialize, Debug)]
 pub struct Database {
+    /// The database id
     pub id: String,
     #[serde(rename = "_rid")]
+    /// The resource id
     pub rid: String,
+    /// The last updated timestamp
     #[serde(rename = "_ts")]
     pub ts: u64,
+    /// The resource's uri
     #[serde(rename = "_self")]
     pub _self: String,
+    /// The resource's etag used for concurrency control
     #[serde(rename = "_etag")]
     pub etag: String,
+    /// The path to the database collections resource
     #[serde(rename = "_colls")]
     pub colls: String,
+    /// The path to the database users resource
     #[serde(rename = "_users")]
     pub users: String,
 }

--- a/sdk/cosmos/src/resources/document/mod.rs
+++ b/sdk/cosmos/src/resources/document/mod.rs
@@ -20,6 +20,7 @@ use serde::de::DeserializeOwned;
 ///
 /// You can learn more about Documents [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/documents).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[allow(missing_docs)]
 pub struct Document<T> {
     #[serde(flatten)]
     pub document_attributes: DocumentAttributes,
@@ -28,6 +29,7 @@ pub struct Document<T> {
 }
 
 impl<T> Document<T> {
+    /// Create a new document
     pub fn new(document: T) -> Self {
         let document_attributes = DocumentAttributes::default();
 
@@ -65,6 +67,7 @@ impl<T> Resource for &Document<T> {
 
 /// Whether to query across partitions
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(missing_docs)]
 pub enum QueryCrossPartition {
     Yes,
     No,
@@ -89,6 +92,7 @@ impl AddAsHeader for QueryCrossPartition {
 }
 
 /// Whether to parallelize across partitions
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ParallelizeCrossPartition {
     Yes,
@@ -115,6 +119,7 @@ impl AddAsHeader for ParallelizeCrossPartition {
 
 /// Whether the operation is an upsert
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[allow(missing_docs)]
 pub enum IsUpsert {
     Yes,
     No,
@@ -136,6 +141,7 @@ impl AddAsHeader for IsUpsert {
 }
 
 /// Whether to use an incremental change feed
+#[allow(missing_docs)]
 #[derive(Debug, Clone, Copy)]
 pub enum ChangeFeed {
     Incremental,
@@ -153,6 +159,7 @@ impl AddAsHeader for ChangeFeed {
 
 /// Whether to allow tenative writes allowance
 #[derive(Debug, Clone, Copy)]
+#[allow(missing_docs)]
 pub enum TenativeWritesAllowance {
     Allow,
     Deny,

--- a/sdk/cosmos/src/resources/mod.rs
+++ b/sdk/cosmos/src/resources/mod.rs
@@ -36,12 +36,15 @@ use permission::PermissionMode;
 
 /// A Cosmos resource such as databases, documents, collections, users, etc.
 pub trait Resource {
+    /// Get the uri for a resource
     fn uri(&self) -> &str;
 
+    /// Get the read permissions for the resource
     fn read_permission(&self) -> PermissionMode<'_> {
         PermissionMode::read(self)
     }
 
+    /// Get all permissions for the resource
     fn all_permission(&self) -> PermissionMode<'_> {
         PermissionMode::all(self)
     }

--- a/sdk/cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/cosmos/src/resources/permission/authorization_token.rs
@@ -6,7 +6,9 @@ use std::fmt;
 /// Learn more about the different types of tokens [here](https://docs.microsoft.com/en-us/azure/cosmos-db/secure-access-to-data).
 #[derive(PartialEq, Clone)]
 pub enum AuthorizationToken {
+    /// Used for administrative resources: database accounts, databases, users, and permissions
     Primary(Vec<u8>),
+    /// Used for application resources: containers, documents, attachments, stored procedures, triggers, and UDFs
     Resource(String),
 }
 

--- a/sdk/cosmos/src/resources/permission/mod.rs
+++ b/sdk/cosmos/src/resources/permission/mod.rs
@@ -13,10 +13,12 @@ use crate::headers;
 use azure_core::AddAsHeader;
 use http::request::Builder;
 
+/// The amount of time before authorization expires
 #[derive(Debug, Clone, Copy)]
 pub struct ExpirySeconds(u64);
 
 impl ExpirySeconds {
+    /// Create an `ExpirySeconds` from a `u64`
     pub fn new(secs: u64) -> Self {
         Self(secs)
     }

--- a/sdk/cosmos/src/resources/stored_procedure.rs
+++ b/sdk/cosmos/src/resources/stored_procedure.rs
@@ -1,5 +1,6 @@
 //! Utilities for interacting with [`StoredProcedure`]s.
 
+/// Stored procedure's parameters
 pub type Parameters = crate::to_json_vector::ToJsonVector;
 
 /// A piece of application logic that is registered and executed against a collection as a single transaction
@@ -7,15 +8,21 @@ pub type Parameters = crate::to_json_vector::ToJsonVector;
 /// You can learn more about stored procedures [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/stored-procedures).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StoredProcedure {
+    /// The procedure id
     pub id: String,
     #[serde(rename = "_rid")]
+    /// The resource id
     pub rid: String,
+    /// The last updated timestamp
     #[serde(rename = "_ts")]
     pub ts: u64,
+    /// The resource's uri
     #[serde(rename = "_self")]
     pub _self: String,
+    /// The resource's etag used for concurrency control
     #[serde(rename = "_etag")]
     pub etag: String,
+    /// The body
     pub body: String,
 }
 

--- a/sdk/cosmos/src/resources/trigger.rs
+++ b/sdk/cosmos/src/resources/trigger.rs
@@ -1,23 +1,32 @@
 //! Utilities for interacting with [`Trigger`]s.
 
+#![allow(missing_docs)]
+
 /// A piece of logic that can be executed before or after creating, deleting, & replacing a document.
 ///
 /// You can learn more about triggers [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/triggers).
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Trigger {
+    /// The trigger id
+    pub id: String,
+    /// The resource id
     #[serde(rename = "_rid")]
     pub rid: String,
     #[serde(rename = "_ts")]
+    /// The last updated timestamp
     pub ts: u64,
+    /// The resource's uri
     pub _self: String,
+    /// The resource's etag used for concurrency control
     #[serde(rename = "_etag")]
     pub etag: String,
-
-    pub id: String,
+    /// The trigger operation
     #[serde(rename = "triggerOperation")]
     pub trigger_operation: TriggerOperation,
     #[serde(rename = "triggerType")]
+    /// The trigger type
     pub trigger_type: TriggerType,
+    /// The trigger body
     pub body: String,
 }
 

--- a/sdk/cosmos/src/resources/user.rs
+++ b/sdk/cosmos/src/resources/user.rs
@@ -7,19 +7,25 @@ use super::Resource;
 /// You can learn more about users [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/users).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialOrd, PartialEq)]
 pub struct User {
+    /// The user's id
     pub id: String,
+    /// The resource id for a user
     #[serde(skip_serializing)]
     #[serde(rename = "_rid")]
     pub rid: String,
+    /// The last updated timestamp
     #[serde(skip_serializing)]
     #[serde(rename = "_ts")]
     pub ts: u64,
+    /// The url for this user resource
     #[serde(skip_serializing)]
     #[serde(rename = "_self")]
     pub _self: String,
+    /// The user's etag used for concurrency control
     #[serde(skip_serializing)]
     #[serde(rename = "_etag")]
     pub etag: String,
+    /// The user's permissions
     #[serde(skip_serializing)]
     #[serde(rename = "_permissions")]
     pub permissions: String,
@@ -33,12 +39,6 @@ impl std::convert::TryFrom<&[u8]> for User {
 }
 
 impl Resource for User {
-    fn uri(&self) -> &str {
-        &self._self
-    }
-}
-
-impl Resource for &User {
     fn uri(&self) -> &str {
         &self._self
     }

--- a/sdk/cosmos/src/resources/user_defined_function.rs
+++ b/sdk/cosmos/src/resources/user_defined_function.rs
@@ -3,14 +3,20 @@
 /// You can learn more about user defined functions [here](https://docs.microsoft.com/en-us/rest/api/cosmos-db/user-defined-functions).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct UserDefinedFunction {
+    /// The function id
     pub id: String,
+    /// The resource id
     #[serde(rename = "_rid")]
     pub rid: String,
+    /// The last updated timestamp
     #[serde(rename = "_ts")]
     pub ts: u64,
+    /// The unique uri for this resource
     #[serde(rename = "_self")]
     pub _self: String,
     #[serde(rename = "_etag")]
+    /// The function's etag used for concurrency control
     pub etag: String,
+    /// The function's body
     pub body: String,
 }

--- a/sdk/cosmos/src/responses/mod.rs
+++ b/sdk/cosmos/src/responses/mod.rs
@@ -1,5 +1,7 @@
 //! Responses from any call to the Cosmos API.
 
+#![allow(missing_docs)]
+
 mod create_collection_response;
 mod create_database_response;
 mod create_document_response;


### PR DESCRIPTION
Some missing docs are still permitted but now when adding new items, documentation or an explicit `#[allow(missing_docs)]` will be required. 