### PR TITLE
Cosmos Errors

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -35,6 +35,7 @@ oauth2 = "=4.0.0-alpha.3"
 reqwest = "0.11"
 paste = "1.0"
 md5 = "0.7"
+thiserror = "1.0"
 
 [dev-dependencies]
 tokio = "1.0"

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -33,8 +33,9 @@ impl HeaderError {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ParsingError {
+    #[error("Element not found: {}", 0)]
     ElementNotFound(String),
 }
 

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -9,6 +9,30 @@ use std::string;
 use url::ParseError as URLParseError;
 use xml::BuilderError as XMLError;
 
+#[derive(Debug, thiserror::Error)]
+pub enum HeaderError {
+    #[error("The header '{}' was not utf8: {}", name, 0)]
+    ValueNotUtf8 { name: String },
+    #[error("The header '{}' was expected but not found", name)]
+    NotFound { name: String },
+    #[error(
+        "An error was encountered when parsing the '{}' header: {}",
+        name,
+        error
+    )]
+    ParsingError {
+        name: String,
+        #[source]
+        error: Box<dyn std::error::Error + Send + Sync>,
+    },
+}
+
+impl HeaderError {
+    pub fn not_found(name: String) -> Self {
+        Self::NotFound { name }
+    }
+}
+
 #[derive(Debug)]
 pub enum ParsingError {
     ElementNotFound(String),

--- a/sdk/core/src/http_client.rs
+++ b/sdk/core/src/http_client.rs
@@ -123,7 +123,7 @@ impl HttpClient for reqwest::Client {
 }
 
 /// Serialize to json
-pub fn to_json<T>(value: &T) -> Result<Bytes, Box<dyn std::error::Error + Sync + Send>>
+pub fn to_json<T>(value: &T) -> Result<Bytes, serde_json::Error>
 where
     T: ?Sized + Serialize,
 {

--- a/sdk/core/src/prelude.rs
+++ b/sdk/core/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::errors::AzureError;
+pub use crate::errors::*;
 pub use crate::request_options::*;
 pub use crate::{
     AddAsHeader, AppendToUrlQuery, Consistency, HttpClient, RequestId, SessionToken,

--- a/sdk/cosmos/Cargo.toml
+++ b/sdk/cosmos/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 url = "2.2"
 uuid = { version = "0.8", features = ["v4"] }
-failure = "0.1"
+thiserror = "1.0"
 bytes = "1.0"
 
 [dev-dependencies]

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -1,59 +1,8 @@
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum TokenParsingError {
-    #[error(
-        "string has an unsupported starting token. Token: \"{}\", String: \"{}\"",
-        token,
-        s
-    )]
-    UnsupportedToken { token: String, s: String },
-    #[error(
-        "string has unsufficient number of tokens. Required {}, found {}. String: \"{}\"",
-        required,
-        found,
-        s
-    )]
-    InsufficientTokens {
-        s: String,
-        required: u32,
-        found: u32,
-    },
-    #[error(
-        "A required token is missing. Required: {}. String: \"{}\"",
-        missing_token,
-        s
-    )]
-    MissingToken { s: String, missing_token: String },
-    #[error(
-        "Replicated token found. Token: {}. Occurrences: {}. String: \"{}\"",
-        token,
-        occurrences,
-        s
-    )]
-    ReplicatedToken {
-        s: String,
-        token: String,
-        occurrences: u32,
-    },
-    #[error("Could not parse number: {}", error)]
-    NumberParseError {
-        #[from]
-        error: std::num::ParseIntError,
-    },
-    #[error("Wrong version provided: {}", provided_version)]
-    UnrecognizedVersionNumber { provided_version: String },
-    #[error("Wrong version provided: {}", provided_type)]
-    UnrecognizedPermissionType { provided_type: String },
-    #[error("The value was not properly base64 encoded: {}", error)]
-    WronglyEncodedValue {
-        #[from]
-        error: base64::DecodeError,
-    },
-}
-
-#[derive(Debug, Error)]
-pub enum ConversionToDocumentError {
-    #[error("Conversion to document failed because at lease one element is raw.")]
-    RawElementFound {},
+/// A general error having to do with Cosmos.
+#[derive(Debug, thiserror::Error)]
+pub enum CosmosError {
+    #[error("An error parsing json occured: {}", 0)]
+    JsonError(#[from] serde_json::Error),
+    #[error("An error in building a request occured: {}", 0)]
+    RequestBuilderError(#[from] http::Error),
 }

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -1,8 +1,36 @@
 /// A general error having to do with Cosmos.
 #[derive(Debug, thiserror::Error)]
 pub enum CosmosError {
-    #[error("An error parsing json occured: {}", 0)]
+    /// An error when parsing JSON
+    #[error("An error parsing JSON occured: {}", 0)]
     JsonError(#[from] serde_json::Error),
+    /// An error when building a request
     #[error("An error in building a request occured: {}", 0)]
     RequestBuilderError(#[from] http::Error),
+    /// An unexpected http result
+    #[error("An unexpected http error occured: {}", 0)]
+    UnexpectedHTTPResult(#[from] azure_core::errors::UnexpectedHTTPResult),
+    /// An header failed to parse
+    #[error("Failed to parse a header: {}", 0)]
+    HeaderError(#[from] azure_core::errors::HeaderError),
+    /// A generic catchall error
+    #[error("An error occurred: {}", 0)]
+    GenericError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl From<azure_core::errors::AzureError> for CosmosError {
+    fn from(error: azure_core::errors::AzureError) -> Self {
+        CosmosError::GenericError(error.into())
+    }
+}
+impl From<std::str::Utf8Error> for CosmosError {
+    fn from(error: std::str::Utf8Error) -> Self {
+        CosmosError::GenericError(error.into())
+    }
+}
+
+impl From<base64::DecodeError> for CosmosError {
+    fn from(error: base64::DecodeError) -> Self {
+        CosmosError::GenericError(error.into())
+    }
 }

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -7,6 +7,9 @@ pub enum CosmosError {
     /// An error when building a request
     #[error("An error in building a request occured: {}", 0)]
     RequestBuilderError(#[from] http::Error),
+    /// An http error occured
+    #[error("An error occurred when making an http request")]
+    HttpRequestError(#[from] azure_core::errors::HttpRequestError),
     /// An unexpected http result
     #[error("An unexpected http error occured: {}", 0)]
     UnexpectedHTTPResult(#[from] azure_core::errors::UnexpectedHTTPResult),

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -1,65 +1,59 @@
-#[derive(Debug, Fail)]
+use thiserror::Error;
+
+#[derive(Debug, Error)]
 pub enum TokenParsingError {
-    #[fail(
-        display = "string has an unsupported starting token. Token: \"{}\", String: \"{}\"",
-        token, s
+    #[error(
+        "string has an unsupported starting token. Token: \"{}\", String: \"{}\"",
+        token,
+        s
     )]
     UnsupportedToken { token: String, s: String },
-
-    #[fail(
-        display = "string has unsufficient number of tokens. Required {}, found {}. String: \"{}\"",
-        required, found, s
+    #[error(
+        "string has unsufficient number of tokens. Required {}, found {}. String: \"{}\"",
+        required,
+        found,
+        s
     )]
     InsufficientTokens {
         s: String,
         required: u32,
         found: u32,
     },
-    #[fail(
-        display = "A required token is missing. Required: {}. String: \"{}\"",
-        missing_token, s
+    #[error(
+        "A required token is missing. Required: {}. String: \"{}\"",
+        missing_token,
+        s
     )]
     MissingToken { s: String, missing_token: String },
-
-    #[fail(
-        display = "Replicated token found. Token: {}. Occurrencies: {}. String: \"{}\"",
-        token, occurrencies, s
+    #[error(
+        "Replicated token found. Token: {}. Occurrences: {}. String: \"{}\"",
+        token,
+        occurrences,
+        s
     )]
     ReplicatedToken {
         s: String,
         token: String,
-        occurrencies: u32,
+        occurrences: u32,
+    },
+    #[error("Could not parse number: {}", error)]
+    NumberParseError {
+        #[from]
+        error: std::num::ParseIntError,
+    },
+    #[error("Wrong version provided: {}", provided_version)]
+    UnrecognizedVersionNumber { provided_version: String },
+    #[error("Wrong version provided: {}", provided_type)]
+    UnrecognizedPermissionType { provided_type: String },
+    #[error("The value was not properly base64 encoded: {}", error)]
+    WronglyEncodedValue {
+        #[from]
+        error: base64::DecodeError,
     },
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum ConversionToDocumentError {
-    #[fail(display = "Conversion to document failed because at lease one element is raw.")]
+    #[error("Conversion to document failed because at lease one element is raw.")]
     RawElementFound {},
-}
-
-pub(crate) fn item_or_error<'a>(
-    s: &'a str,
-    tokens: &[&'a str],
-    token: &'a str,
-) -> Result<&'a str, TokenParsingError> {
-    let mut tokens = tokens.iter().filter(|t| t.starts_with(token));
-
-    match tokens.next() {
-        Some(t) => {
-            if tokens.next().is_some() {
-                return Err(TokenParsingError::ReplicatedToken {
-                    s: s.to_owned(),
-                    token: token.to_owned(),
-                    occurrencies: 2 + tokens.count() as u32,
-                });
-            }
-            // we checked for < 1 and > 1 so this is == 1
-            Ok(&t[token.len()..])
-        }
-        None => Err(TokenParsingError::MissingToken {
-            s: s.to_owned(),
-            missing_token: token.to_owned(),
-        }),
-    }
 }

--- a/sdk/cosmos/src/headers/from_headers.rs
+++ b/sdk/cosmos/src/headers/from_headers.rs
@@ -2,305 +2,208 @@ use crate::headers::*;
 use crate::resource_quota::resource_quotas_from_str;
 use crate::resources::document::IndexingDirective;
 use crate::ResourceQuota;
-use azure_core::errors::AzureError;
+use azure_core::errors::HeaderError;
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
-pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> Result<f64, AzureError> {
-    Ok(headers
-        .get(HEADER_REQUEST_CHARGE)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_REQUEST_CHARGE.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> Result<f64, HeaderError> {
+    parse(headers, HEADER_REQUEST_CHARGE)
 }
 
-pub(crate) fn item_count_from_headers(headers: &HeaderMap) -> Result<u32, AzureError> {
-    Ok(headers
-        .get(HEADER_ITEM_COUNT)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_ITEM_COUNT.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn item_count_from_headers(headers: &HeaderMap) -> Result<u32, HeaderError> {
+    parse(headers, HEADER_ITEM_COUNT)
 }
 
-pub(crate) fn role_from_headers(headers: &HeaderMap) -> Result<u32, AzureError> {
-    Ok(headers
-        .get(HEADER_ROLE)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_ROLE.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn role_from_headers(headers: &HeaderMap) -> Result<u32, HeaderError> {
+    parse(headers, HEADER_ROLE)
 }
 
-pub(crate) fn number_of_read_regions_from_headers(headers: &HeaderMap) -> Result<u32, AzureError> {
-    Ok(headers
-        .get(HEADER_NUMBER_OF_READ_REGIONS)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_NUMBER_OF_READ_REGIONS.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn number_of_read_regions_from_headers(headers: &HeaderMap) -> Result<u32, HeaderError> {
+    parse(headers, HEADER_NUMBER_OF_READ_REGIONS)
 }
 
-pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> Result<uuid::Uuid, AzureError> {
-    let s = headers
-        .get(HEADER_ACTIVITY_ID)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_ACTIVITY_ID.to_owned()))?
-        .to_str()?;
-    Ok(uuid::Uuid::parse_str(s)?)
+pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> Result<uuid::Uuid, HeaderError> {
+    extract_with_parse(headers, HEADER_ACTIVITY_ID, |s| {
+        uuid::Uuid::parse_str(s).map_err(|e| HeaderError::ParsingError {
+            name: HEADER_ACTIVITY_ID.to_owned(),
+            error: e.into(),
+        })
+    })
 }
 
-pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> Result<&str, AzureError> {
-    Ok(headers
-        .get(HEADER_CONTENT_PATH)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_CONTENT_PATH.to_owned()))?
-        .to_str()?)
+pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> Result<&str, HeaderError> {
+    extract(headers, HEADER_CONTENT_PATH)
 }
 
-pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> Result<&str, AzureError> {
-    Ok(headers
-        .get(HEADER_ALT_CONTENT_PATH)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_ALT_CONTENT_PATH.to_owned()))?
-        .to_str()?)
+pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> Result<&str, HeaderError> {
+    extract(headers, HEADER_ALT_CONTENT_PATH)
 }
 
 pub(crate) fn resource_quota_from_headers(
     headers: &HeaderMap,
-) -> Result<Vec<ResourceQuota>, AzureError> {
-    let s = headers
-        .get(HEADER_RESOURCE_QUOTA)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_RESOURCE_QUOTA.to_owned()))?
-        .to_str()?;
-    Ok(resource_quotas_from_str(s)?)
+) -> Result<Vec<ResourceQuota>, HeaderError> {
+    extract_with_parse(headers, HEADER_RESOURCE_QUOTA, |s| {
+        resource_quotas_from_str(s).map_err(|e| HeaderError::ParsingError {
+            name: HEADER_RESOURCE_QUOTA.to_owned(),
+            error: e.into(),
+        })
+    })
 }
 
 pub(crate) fn resource_usage_from_headers(
     headers: &HeaderMap,
-) -> Result<Vec<ResourceQuota>, AzureError> {
-    let s = headers
-        .get(HEADER_RESOURCE_USAGE)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_RESOURCE_USAGE.to_owned()))?
-        .to_str()?;
-    Ok(resource_quotas_from_str(s)?)
+) -> Result<Vec<ResourceQuota>, HeaderError> {
+    let s = extract(headers, HEADER_RESOURCE_USAGE)?;
+    resource_quotas_from_str(s).map_err(|e| HeaderError::ParsingError {
+        name: HEADER_RESOURCE_USAGE.to_owned(),
+        error: e.into(),
+    })
 }
 
-pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_QUORUM_ACKED_LSN)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_QUORUM_ACKED_LSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_QUORUM_ACKED_LSN)
 }
 
 pub(crate) fn quorum_acked_lsn_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, AzureError> {
-    Ok(match headers.get(HEADER_QUORUM_ACKED_LSN) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, HeaderError> {
+    parse_optional(headers, HEADER_QUORUM_ACKED_LSN)
 }
 
 pub(crate) fn cosmos_quorum_acked_llsn_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_COSMOS_QUORUM_ACKED_LLSN)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_COSMOS_QUORUM_ACKED_LLSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_COSMOS_QUORUM_ACKED_LLSN)
 }
 
 pub(crate) fn cosmos_quorum_acked_llsn_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, AzureError> {
-    Ok(match headers.get(HEADER_COSMOS_QUORUM_ACKED_LLSN) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, HeaderError> {
+    parse_optional(headers, HEADER_COSMOS_QUORUM_ACKED_LLSN)
 }
 
-pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_CURRENT_WRITE_QUORUM)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_CURRENT_WRITE_QUORUM.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_CURRENT_WRITE_QUORUM)
 }
 
 pub(crate) fn current_write_quorum_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, AzureError> {
-    Ok(match headers.get(HEADER_CURRENT_WRITE_QUORUM) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, HeaderError> {
+    parse_optional(headers, HEADER_CURRENT_WRITE_QUORUM)
 }
 
 pub(crate) fn collection_partition_index_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_COLLECTION_PARTITION_INDEX)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_COLLECTION_PARTITION_INDEX.to_owned()))?
-        .to_str()?
-        .parse()?)
+) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_COLLECTION_PARTITION_INDEX)
 }
 
 pub(crate) fn indexing_directive_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<IndexingDirective>, AzureError> {
-    match headers.get(HEADER_INDEXING_DIRECTIVE) {
-        Some(header) => Ok(Some(header.to_str()?.parse()?)),
-        None => Ok(None),
-    }
+) -> Result<Option<IndexingDirective>, HeaderError> {
+    parse_optional(headers, HEADER_INDEXING_DIRECTIVE)
 }
 
 pub(crate) fn collection_service_index_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_COLLECTION_SERVICE_INDEX)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_COLLECTION_SERVICE_INDEX.to_owned()))?
-        .to_str()?
-        .parse()?)
+) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_COLLECTION_SERVICE_INDEX)
 }
 
-pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_LSN)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_LSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_LSN)
 }
 
-pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_ITEM_LSN)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_ITEM_LSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_ITEM_LSN)
 }
 
-pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_TRANSPORT_REQUEST_ID)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_TRANSPORT_REQUEST_ID.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_TRANSPORT_REQUEST_ID)
 }
 
-pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    let s = headers
-        .get(HEADER_GLOBAL_COMMITTED_LSN)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_GLOBAL_COMMITTED_LSN.to_owned()))?
-        .to_str()?;
-    Ok(if s == "-1" { 0 } else { s.parse()? })
+pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    extract_with_parse(headers, HEADER_GLOBAL_COMMITTED_LSN, |s| {
+        if s == "-1" {
+            Ok(0)
+        } else {
+            s.parse()
+                .map_err(|e: std::num::ParseIntError| HeaderError::ParsingError {
+                    name: HEADER_GLOBAL_COMMITTED_LSN.to_owned(),
+                    error: e.into(),
+                })
+        }
+    })
 }
 
-pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_COSMOS_LLSN)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_COSMOS_LLSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_COSMOS_LLSN)
 }
 
-pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_COSMOS_ITEM_LLSN)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_COSMOS_ITEM_LLSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_COSMOS_ITEM_LLSN)
 }
 
 pub(crate) fn current_replica_set_size_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_CURRENT_REPLICA_SET_SIZE)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_CURRENT_REPLICA_SET_SIZE.to_owned()))?
-        .to_str()?
-        .parse()?)
+) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_CURRENT_REPLICA_SET_SIZE)
 }
 
 pub(crate) fn current_replica_set_size_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, AzureError> {
-    Ok(match headers.get(HEADER_CURRENT_REPLICA_SET_SIZE) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, HeaderError> {
+    parse_optional(headers, HEADER_CURRENT_REPLICA_SET_SIZE)
 }
 
-pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> Result<&str, AzureError> {
-    Ok(headers
-        .get(HEADER_SCHEMA_VERSION)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_SCHEMA_VERSION.to_owned()))?
-        .to_str()?)
+pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> Result<&str, HeaderError> {
+    extract(headers, HEADER_SCHEMA_VERSION)
 }
 
-pub(crate) fn server_from_headers(headers: &HeaderMap) -> Result<&str, AzureError> {
-    let header_server = http::header::SERVER;
-
-    Ok(headers
-        .get(http::header::SERVER)
-        .ok_or_else(|| AzureError::HeaderNotFound(header_server.to_string()))?
-        .to_str()?)
+pub(crate) fn server_from_headers(headers: &HeaderMap) -> Result<&str, HeaderError> {
+    extract(headers, http::header::SERVER.as_str())
 }
 
-pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> Result<&str, AzureError> {
-    Ok(headers
-        .get(HEADER_SERVICE_VERSION)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_SERVICE_VERSION.to_owned()))?
-        .to_str()?)
+pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> Result<&str, HeaderError> {
+    extract(headers, HEADER_SERVICE_VERSION)
 }
 
-pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> Result<&str, AzureError> {
-    Ok(headers
-        .get(http::header::CONTENT_LOCATION)
-        .ok_or_else(|| {
-            let header = http::header::CONTENT_LOCATION;
-            AzureError::HeaderNotFound(header.as_str().to_owned())
-        })?
-        .to_str()?)
+pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> Result<&str, HeaderError> {
+    extract(headers, http::header::CONTENT_LOCATION.as_str())
 }
 
-pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> Result<&str, AzureError> {
-    Ok(headers
-        .get(HEADER_GATEWAY_VERSION)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_GATEWAY_VERSION.to_owned()))?
-        .to_str()?)
+pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> Result<&str, HeaderError> {
+    extract(headers, HEADER_GATEWAY_VERSION)
 }
 
 pub(crate) fn max_media_storage_usage_mb_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_MAX_MEDIA_STORAGE_USAGE_MB)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_MAX_MEDIA_STORAGE_USAGE_MB.to_owned()))?
-        .to_str()?
-        .parse()?)
+) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_MAX_MEDIA_STORAGE_USAGE_MB)
 }
 
-pub(crate) fn media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result<u64, AzureError> {
-    Ok(headers
-        .get(HEADER_MEDIA_STORAGE_USAGE_MB)
-        .ok_or_else(|| AzureError::HeaderNotFound(HEADER_MEDIA_STORAGE_USAGE_MB.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result<u64, HeaderError> {
+    parse(headers, HEADER_MEDIA_STORAGE_USAGE_MB)
 }
 
-fn _date_from_headers(headers: &HeaderMap, header_name: &str) -> Result<DateTime<Utc>, AzureError> {
-    let date = headers
-        .get(header_name)
-        .ok_or_else(|| AzureError::HeaderNotFound(header_name.to_owned()))?
-        .to_str()?;
+fn _date_from_headers(
+    headers: &HeaderMap,
+    header_name: &str,
+) -> Result<DateTime<Utc>, HeaderError> {
+    let date = extract(headers, header_name)?;
     debug!("date == {:#}", date);
 
-    // since Azure returns "GMT" instead of +0000 as timezone we replace it
-    // ourselves.
+    // since Azure returns "GMT" instead of +0000 as timezone we replace it ourselves.
     // For example: Wed, 15 Jan 2020 23:39:44.369 GMT
     let date = date.replace("GMT", "+0000");
     debug!("date == {:#}", date);
 
-    let date = DateTime::parse_from_str(&date, "%a, %e %h %Y %H:%M:%S%.f %z")?;
+    let date = DateTime::parse_from_str(&date, "%a, %e %h %Y %H:%M:%S%.f %z").map_err(|e| {
+        HeaderError::ParsingError {
+            name: header_name.to_owned(),
+            error: e.into(),
+        }
+    })?;
     debug!("date == {:#}", date);
 
     let date = DateTime::from_utc(date.naive_utc(), Utc);
@@ -311,11 +214,78 @@ fn _date_from_headers(headers: &HeaderMap, header_name: &str) -> Result<DateTime
 
 pub(crate) fn last_state_change_from_headers(
     headers: &HeaderMap,
-) -> Result<DateTime<Utc>, AzureError> {
+) -> Result<DateTime<Utc>, HeaderError> {
     _date_from_headers(headers, HEADER_LAST_STATE_CHANGE_UTC)
 }
 
-pub(crate) fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>, AzureError> {
-    let header = http::header::DATE;
-    _date_from_headers(headers, header.as_str())
+pub(crate) fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>, HeaderError> {
+    _date_from_headers(headers, http::header::DATE.as_str())
+}
+
+fn extract_with_parse<'a, F, T>(
+    headers: &'a HeaderMap,
+    name: &str,
+    parse: F,
+) -> Result<T, HeaderError>
+where
+    F: Fn(&'a str) -> Result<T, HeaderError>,
+{
+    parse(
+        headers
+            .get(name)
+            .ok_or_else(|| HeaderError::not_found(name.to_owned()))?
+            .to_str()
+            .map_err(|e| HeaderError::ValueNotUtf8 {
+                name: name.to_owned(),
+            })?,
+    )
+}
+
+fn extract_optional_with_parse<'a, F, T>(
+    headers: &'a HeaderMap,
+    name: &str,
+    parse: F,
+) -> Result<Option<T>, HeaderError>
+where
+    F: Fn(&'a str) -> Result<T, HeaderError>,
+{
+    let val = headers
+        .get(name)
+        .map(|v| {
+            v.to_str().map_err(|e| HeaderError::ValueNotUtf8 {
+                name: name.to_owned(),
+            })
+        })
+        .transpose()?;
+    val.map(parse).transpose()
+}
+
+fn extract<'a>(headers: &'a HeaderMap, name: &str) -> Result<&'a str, HeaderError> {
+    extract_with_parse(headers, name, |val| Ok(val))
+}
+
+fn parse<T>(headers: &HeaderMap, name: &str) -> Result<T, HeaderError>
+where
+    T: std::str::FromStr,
+    T::Err: Send + Sync + std::error::Error + 'static,
+{
+    extract_with_parse(headers, name, |val| {
+        val.parse().map_err(|e: T::Err| HeaderError::ParsingError {
+            name: name.to_owned(),
+            error: e.into(),
+        })
+    })
+}
+
+fn parse_optional<T>(headers: &HeaderMap, name: &str) -> Result<Option<T>, HeaderError>
+where
+    T: std::str::FromStr,
+    T::Err: Send + Sync + std::error::Error + 'static,
+{
+    extract_optional_with_parse(headers, name, |val| {
+        val.parse().map_err(|e: T::Err| HeaderError::ParsingError {
+            name: name.to_owned(),
+            error: e.into(),
+        })
+    })
 }

--- a/sdk/cosmos/src/headers/from_headers.rs
+++ b/sdk/cosmos/src/headers/from_headers.rs
@@ -267,7 +267,7 @@ fn extract_optional<'a>(
     headers
         .get(name)
         .map(|v| {
-            v.to_str().map_err(|e| HeaderError::ValueNotUtf8 {
+            v.to_str().map_err(|_| HeaderError::ValueNotUtf8 {
                 name: name.to_owned(),
             })
         })

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -94,8 +94,6 @@ extern crate log;
 #[macro_use]
 extern crate serde;
 #[macro_use]
-extern crate failure;
-#[macro_use]
 extern crate azure_core;
 
 pub mod clients;
@@ -118,6 +116,12 @@ pub use partition_keys::PartitionKeys;
 pub use resource_quota::ResourceQuota;
 
 /// A general error having to do with Cosmos.
-pub type CosmosError = Box<dyn std::error::Error + Sync + Send>;
+#[derive(Debug, thiserror::Error)]
+pub enum CosmosError {
+    #[error("An error parsing json occured: {}", 0)]
+    JsonError(#[from] serde_json::Error),
+    #[error("An error in building a request occured: {}", 0)]
+    RequestBuilderError(#[from] http::Error),
+}
 
 type ReadonlyString = std::borrow::Cow<'static, str>;

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -115,13 +115,6 @@ pub use max_item_count::MaxItemCount;
 pub use partition_keys::PartitionKeys;
 pub use resource_quota::ResourceQuota;
 
-/// A general error having to do with Cosmos.
-#[derive(Debug, thiserror::Error)]
-pub enum CosmosError {
-    #[error("An error parsing json occured: {}", 0)]
-    JsonError(#[from] serde_json::Error),
-    #[error("An error in building a request occured: {}", 0)]
-    RequestBuilderError(#[from] http::Error),
-}
+pub use errors::CosmosError;
 
 type ReadonlyString = std::borrow::Cow<'static, str>;

--- a/sdk/cosmos/src/requests/create_document_builder.rs
+++ b/sdk/cosmos/src/requests/create_document_builder.rs
@@ -95,14 +95,18 @@ impl<'a, 'b> CreateDocumentBuilder<'a, 'b> {
             return Err(UnexpectedHTTPResult::new(
                 StatusCode::CREATED,
                 response.status(),
-                std::str::from_utf8(response.body())?,
+                std::str::from_utf8(response.body()).map_err(|e| {
+                    Box::new(e) as Box<dyn std::error::Error + Sync + Send + 'static>
+                })?,
             )
             .into());
         } else if response.status() != StatusCode::CREATED && response.status() != StatusCode::OK {
             return Err(UnexpectedHTTPResult::new_multiple(
                 vec![StatusCode::CREATED, StatusCode::OK],
                 response.status(),
-                std::str::from_utf8(response.body())?,
+                std::str::from_utf8(response.body()).map_err(|e| {
+                    Box::new(e) as Box<dyn std::error::Error + Sync + Send + 'static>
+                })?,
             )
             .into());
         }

--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -84,6 +84,7 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b> {
             .http_client()
             .execute_request_check_status(req, StatusCode::OK)
             .await?
-            .try_into()?)
+            .try_into()
+            .map_err(HttpRequestError::ResponseDeserializationError)?)
     }
 }

--- a/sdk/cosmos/src/resource_quota.rs
+++ b/sdk/cosmos/src/resource_quota.rs
@@ -1,5 +1,3 @@
-use crate::errors::TokenParsingError;
-
 /// A resource quota for the given resource kind
 ///
 /// A collection of this type is often returned in responses allowing you to
@@ -35,42 +33,57 @@ const FUNCTIONS: &str = "functions=";
 const CLIENT_ENCRYPTION_KEYS: &str = "clientEncryptionKeys=";
 
 /// Parse a collection of [`ResourceQuota`] from a string
-pub(crate) fn resource_quotas_from_str(s: &str) -> Result<Vec<ResourceQuota>, TokenParsingError> {
+pub(crate) fn resource_quotas_from_str(
+    s: &str,
+) -> Result<Vec<ResourceQuota>, ResourceQuotaParsingError> {
     debug!("resource_quotas_from_str(\"{}\") called", s);
     let tokens: Vec<&str> = s.split(';').collect();
     let mut v = Vec::with_capacity(tokens.len());
+
+    let parseu64 = |s| {
+        str::parse(s).map_err(|e| ResourceQuotaParsingError::NumberParseError {
+            string: s.to_owned(),
+            error: e,
+        })
+    };
+    let parsei64 = |s| {
+        str::parse(s).map_err(|e| ResourceQuotaParsingError::NumberParseError {
+            string: s.to_owned(),
+            error: e,
+        })
+    };
 
     for token in tokens.into_iter().filter(|token| !token.is_empty()) {
         debug!("processing token == {}", token);
 
         if let Some(stripped) = token.strip_prefix(DATABASES) {
-            v.push(ResourceQuota::Databases(str::parse(stripped)?));
+            v.push(ResourceQuota::Databases(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(STORED_PROCEDURES) {
-            v.push(ResourceQuota::StoredProcedures(str::parse(stripped)?));
+            v.push(ResourceQuota::StoredProcedures(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(COLLECTIONS) {
-            v.push(ResourceQuota::Collections(str::parse(stripped)?));
+            v.push(ResourceQuota::Collections(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(DOCUMENT_SIZE) {
-            v.push(ResourceQuota::DocumentSize(str::parse(stripped)?));
+            v.push(ResourceQuota::DocumentSize(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(DOCUMENTS_SIZE) {
-            v.push(ResourceQuota::DocumentsSize(str::parse(stripped)?));
+            v.push(ResourceQuota::DocumentsSize(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(DOCUMENTS_COUNT) {
-            v.push(ResourceQuota::DocumentsCount(str::parse(stripped)?));
+            v.push(ResourceQuota::DocumentsCount(parsei64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(COLLECTION_SIZE) {
-            v.push(ResourceQuota::CollectionSize(str::parse(stripped)?));
+            v.push(ResourceQuota::CollectionSize(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(USERS) {
-            v.push(ResourceQuota::Users(str::parse(stripped)?));
+            v.push(ResourceQuota::Users(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(PERMISSIONS) {
-            v.push(ResourceQuota::Permissions(str::parse(stripped)?));
+            v.push(ResourceQuota::Permissions(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(TRIGGERS) {
-            v.push(ResourceQuota::Triggers(str::parse(stripped)?));
+            v.push(ResourceQuota::Triggers(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(FUNCTIONS) {
-            v.push(ResourceQuota::Functions(str::parse(stripped)?));
+            v.push(ResourceQuota::Functions(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(CLIENT_ENCRYPTION_KEYS) {
-            v.push(ResourceQuota::ClientEncryptionKeys(str::parse(stripped)?));
+            v.push(ResourceQuota::ClientEncryptionKeys(parseu64(stripped)?));
         } else {
-            return Err(TokenParsingError::UnsupportedToken {
-                token: token.to_string(),
-                s: s.to_owned(),
+            return Err(ResourceQuotaParsingError::UnrecognizedPart {
+                part: token.to_string(),
+                full_string: s.to_owned(),
             });
         }
 
@@ -78,6 +91,26 @@ pub(crate) fn resource_quotas_from_str(s: &str) -> Result<Vec<ResourceQuota>, To
     }
 
     Ok(v)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ResourceQuotaParsingError {
+    #[error(
+        "String has an unrecognized part. Part: \"{}\", Full string: \"{}\"",
+        part,
+        full_string
+    )]
+    UnrecognizedPart { part: String, full_string: String },
+    #[error(
+        "Failed to parse resource quota string '{}' as number: {}",
+        string,
+        error
+    )]
+    NumberParseError {
+        string: String,
+        #[source]
+        error: std::num::ParseIntError,
+    },
 }
 
 #[cfg(test)]

--- a/sdk/cosmos/src/resource_quota.rs
+++ b/sdk/cosmos/src/resource_quota.rs
@@ -35,7 +35,7 @@ const FUNCTIONS: &str = "functions=";
 const CLIENT_ENCRYPTION_KEYS: &str = "clientEncryptionKeys=";
 
 /// Parse a collection of [`ResourceQuota`] from a string
-pub(crate) fn resource_quotas_from_str(s: &str) -> Result<Vec<ResourceQuota>, failure::Error> {
+pub(crate) fn resource_quotas_from_str(s: &str) -> Result<Vec<ResourceQuota>, TokenParsingError> {
     debug!("resource_quotas_from_str(\"{}\") called", s);
     let tokens: Vec<&str> = s.split(';').collect();
     let mut v = Vec::with_capacity(tokens.len());
@@ -71,8 +71,7 @@ pub(crate) fn resource_quotas_from_str(s: &str) -> Result<Vec<ResourceQuota>, fa
             return Err(TokenParsingError::UnsupportedToken {
                 token: token.to_string(),
                 s: s.to_owned(),
-            }
-            .into());
+            });
         }
 
         debug!("v == {:#?}", v);

--- a/sdk/cosmos/src/resources/permission/permission.rs
+++ b/sdk/cosmos/src/resources/permission/permission.rs
@@ -1,5 +1,5 @@
 use super::PermissionToken;
-use crate::{resources::Resource, CosmosError};
+use crate::resources::Resource;
 
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -87,7 +87,7 @@ impl<'a> PermissionMode<'a> {
 }
 
 impl<'a> std::convert::TryFrom<&[u8]> for Permission<'a> {
-    type Error = CosmosError;
+    type Error = serde_json::Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(slice)?)

--- a/sdk/cosmos/src/resources/permission/permission_token.rs
+++ b/sdk/cosmos/src/resources/permission/permission_token.rs
@@ -91,7 +91,7 @@ fn get_item<'a>(
     let mut tokens = parts.iter().filter(|t| t.starts_with(name));
 
     match tokens.next() {
-        Some(t) if tokens.next().is_some() => Err(PermissionTokenParsingError::DuplicatePart {
+        Some(_t) if tokens.next().is_some() => Err(PermissionTokenParsingError::DuplicatePart {
             token_string: token_string.to_owned(),
             part: name.to_owned(),
             // Add 2 since we've already called `next` twice

--- a/sdk/cosmos/src/resources/permission/permission_token.rs
+++ b/sdk/cosmos/src/resources/permission/permission_token.rs
@@ -1,5 +1,4 @@
 use super::AuthorizationToken;
-use crate::errors::TokenParsingError;
 
 const PERMISSION_TYPE_PREFIX: &str = "type=";
 const VERSION_PREFIX: &str = "ver=";
@@ -40,41 +39,42 @@ impl std::fmt::Display for PermissionToken {
 }
 
 impl std::convert::TryFrom<String> for PermissionToken {
-    type Error = TokenParsingError;
+    type Error = PermissionTokenParsingError;
     fn try_from(s: String) -> Result<Self, Self::Error> {
         Self::try_from(s.as_str())
     }
 }
 
+const MIN_REQUIRED_PARTS_COUNT: usize = 3;
+
 impl std::convert::TryFrom<&str> for PermissionToken {
-    type Error = TokenParsingError;
+    type Error = PermissionTokenParsingError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
         trace!("converting {} into PermissionToken", s);
 
-        let tokens: Vec<&str> = s.split('&').collect();
+        let parts: Vec<&str> = s.split('&').collect();
 
-        if tokens.len() < 3 {
-            return Err(TokenParsingError::InsufficientTokens {
-                s: s.to_owned(),
-                required: 3,
-                found: tokens.len() as u32,
+        if parts.len() < MIN_REQUIRED_PARTS_COUNT {
+            return Err(PermissionTokenParsingError::InsufficientParts {
+                token_string: s.to_owned(),
+                found: parts.len() as u32,
             }
             .into());
         }
-        let version = get_item(s, &tokens, VERSION_PREFIX)?;
+        let version = get_item(s, &parts, VERSION_PREFIX)?;
         if version != "1.0" && version != "1" {
-            return Err(TokenParsingError::UnrecognizedVersionNumber {
+            return Err(PermissionTokenParsingError::UnrecognizedVersionNumber {
                 provided_version: version.to_owned(),
             });
         }
 
-        let permission_type = get_item(s, &tokens, PERMISSION_TYPE_PREFIX)?;
-        let signature = get_item(s, &tokens, SIGNATURE_PREFIX)?.to_owned();
+        let permission_type = get_item(s, &parts, PERMISSION_TYPE_PREFIX)?;
+        let signature = get_item(s, &parts, SIGNATURE_PREFIX)?.to_owned();
         let token = match permission_type {
             "master" => AuthorizationToken::Primary(base64::decode(signature)?),
             "resource" => AuthorizationToken::Resource(signature),
             _ => {
-                return Err(TokenParsingError::UnrecognizedPermissionType {
+                return Err(PermissionTokenParsingError::UnrecognizedPermissionType {
                     provided_type: permission_type.to_owned(),
                 })
             }
@@ -83,22 +83,27 @@ impl std::convert::TryFrom<&str> for PermissionToken {
     }
 }
 
-fn get_item<'a>(s: &'a str, tokens: &[&'a str], token: &str) -> Result<&'a str, TokenParsingError> {
-    let mut tokens = tokens.iter().filter(|t| t.starts_with(token));
+fn get_item<'a>(
+    token_string: &'a str,
+    parts: &[&'a str],
+    name: &str,
+) -> Result<&'a str, PermissionTokenParsingError> {
+    let mut tokens = parts.iter().filter(|t| t.starts_with(name));
 
     match tokens.next() {
-        Some(t) if tokens.next().is_some() => Err(TokenParsingError::ReplicatedToken {
-            s: s.to_owned(),
-            token: token.to_owned(),
+        Some(t) if tokens.next().is_some() => Err(PermissionTokenParsingError::DuplicatePart {
+            token_string: token_string.to_owned(),
+            part: name.to_owned(),
+            // Add 2 since we've already called `next` twice
             occurrences: 2 + tokens.count() as u32,
         }),
         Some(t) => {
             // we checked for < 1 and > 1 so this is == 1
-            Ok(&t[token.len()..])
+            Ok(&t[name.len()..])
         }
-        None => Err(TokenParsingError::MissingToken {
-            s: s.to_owned(),
-            missing_token: token.to_owned(),
+        None => Err(PermissionTokenParsingError::MissingPart {
+            token_string: token_string.to_owned(),
+            missing_part: name.to_owned(),
         }),
     }
 }
@@ -107,6 +112,52 @@ impl std::convert::From<AuthorizationToken> for PermissionToken {
     fn from(token: AuthorizationToken) -> Self {
         Self { token }
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum PermissionTokenParsingError {
+    #[error(
+        "Permission token string has an insufficient number of ';' separated parts. Required number is {}, but found {}. Full string: \"{}\"",
+        MIN_REQUIRED_PARTS_COUNT,
+        found,
+        token_string
+    )]
+    InsufficientParts { token_string: String, found: u32 },
+    #[error(
+        "A required part of permission token is missing: {}. Full string: \"{}\"",
+        missing_part,
+        token_string
+    )]
+    MissingPart {
+        token_string: String,
+        missing_part: String,
+    },
+    #[error(
+        "Duplicate part found in permission token. Part: {}. Occurrences: {}. Full string: \"{}\"",
+        part,
+        occurrences,
+        token_string
+    )]
+    DuplicatePart {
+        token_string: String,
+        part: String,
+        occurrences: u32,
+    },
+    #[error(
+        "Unrecognized version number provided in permission token: {}",
+        provided_version
+    )]
+    UnrecognizedVersionNumber { provided_version: String },
+    #[error(
+        "Unrecognized permission type provided in permission token: {}",
+        provided_type
+    )]
+    UnrecognizedPermissionType { provided_type: String },
+    #[error("The authorization token was not properly base64 encoded: {}", error)]
+    InvalidBase64Encoding {
+        #[from]
+        error: base64::DecodeError,
+    },
 }
 
 #[cfg(test)]

--- a/sdk/cosmos/src/responses/create_collection_response.rs
+++ b/sdk/cosmos/src/responses/create_collection_response.rs
@@ -1,7 +1,7 @@
 use crate::headers::from_headers::*;
 use crate::resources::Collection;
-use crate::CosmosError;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
+use azure_core::prelude::*;
 use chrono::{DateTime, Utc};
 use http::response::Response;
 
@@ -23,7 +23,7 @@ pub struct CreateCollectionResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateCollectionResponse {
-    type Error = CosmosError;
+    type Error = ResponseDeserializationError;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -1,4 +1,3 @@
-use crate::errors::ConversionToDocumentError;
 use crate::headers::from_headers::*;
 use crate::resources::document::DocumentAttributes;
 use crate::{CosmosError, ResourceQuota};
@@ -277,7 +276,7 @@ impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsRespo
                 .into_iter()
                 .map(|r| match r {
                     QueryResult::Document(document) => Ok(document),
-                    QueryResult::Raw(_) => Err(ConversionToDocumentError::RawElementFound {}),
+                    QueryResult::Raw(_) => Err(ConversionToDocumentError::RawElementFound),
                 })
                 .collect::<Result<Vec<_>, _>>()?,
             last_state_change: q.last_state_change,
@@ -306,4 +305,10 @@ impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsRespo
             date: q.date,
         })
     }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConversionToDocumentError {
+    #[error("Conversion to document failed because at lease one element is raw.")]
+    RawElementFound,
 }


### PR DESCRIPTION
This PR makes several large changes to how error propogation is done in the `cosmos` crate:

* Make `CosmosError` an enum with all errors that are possible to get from using a cosmos API. Some of these will be simple wrappers around generic errors from other crates (e.g., `serde_json::Error` and `azure_core::HeaderError`)
* Use `thiserror` for declaring errors. Previously, `cosmos` used `failure` which has been deprecated in favor of `thiserror`. 