### PR TITLE
Fix listing blobs when there are no blobs in a container

### DIFF
--- a/sdk/storage/examples/list_blobs_01.rs
+++ b/sdk/storage/examples/list_blobs_01.rs
@@ -45,6 +45,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .await?;
     println!("Container {} created", container_name);
 
+    println!("Checking that container is empty");
+
+    let iv = container
+        .list_blobs()
+        .max_results(NonZeroU32::new(100u32).unwrap())
+        .delimiter("/")
+        .execute()
+        .await?;
+
     println!("Adding blobs");
 
     // create 4 root blobs

--- a/sdk/storage/examples/list_blobs_01.rs
+++ b/sdk/storage/examples/list_blobs_01.rs
@@ -54,6 +54,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .execute()
         .await?;
 
+    assert!(iv.blobs.blobs.is_empty());
+
     println!("Adding blobs");
 
     // create 4 root blobs

--- a/sdk/storage/src/blob/blob/responses/list_blobs_response.rs
+++ b/sdk/storage/src/blob/blob/responses/list_blobs_response.rs
@@ -33,7 +33,7 @@ struct ListBlobsResponseInternal {
 #[serde(rename_all = "PascalCase")]
 pub struct Blobs {
     pub blob_prefix: Option<Vec<BlobPrefix>>,
-    #[serde(rename = "Blob")]
+    #[serde(rename = "Blob", default = "Vec::new")]
     pub blobs: Vec<Blob>,
 }
 


### PR DESCRIPTION
Hi, I was trying out the code added in https://github.com/Azure/azure-sdk-for-rust/pull/176, and if a container doesn't have any blobs in it, serde can't deserialize it. If I run the list_blobs_01 example as it is in my first commit, it panics with this error:

```
Error: SerdeXMLDeserializationError(Custom { field: "missing field `Blob`" })
```

The second commit in this PR fixes it by setting a default of an empty vector on the `blobs` field.