### PR TITLE
Changed GetBlob return type from Vec<u8> to bytes::Bytes

### DIFF
--- a/sdk/storage/examples/blob_00.rs
+++ b/sdk/storage/examples/blob_00.rs
@@ -47,10 +47,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let mut stream = Box::pin(blob_client.get().stream(128));
     while let Some(value) = stream.next().await {
-        println!("received {:?} bytes", value?.len());
+        println!("received {:?} bytes", value?.data.len());
     }
 
-    let s_content = String::from_utf8(response.data)?;
+    let s_content = String::from_utf8(response.data.to_vec())?;
     println!("blob == {:?}", blob);
     println!("s_content == {}", s_content);
 

--- a/sdk/storage/examples/blob_02_bearer_token.rs
+++ b/sdk/storage/examples/blob_02_bearer_token.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let response = blob.get().execute().await?;
 
-    let s_content = String::from_utf8(response.data)?;
+    let s_content = String::from_utf8(response.data.to_vec())?;
     println!("blob == {:?}", blob);
     println!("s_content == {}", s_content);
 

--- a/sdk/storage/examples/blob_04.rs
+++ b/sdk/storage/examples/blob_04.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let retrieved_blob = blob.get().execute().await?;
     println!("retrieved_blob == {:?}", retrieved_blob);
 
-    let s = String::from_utf8(retrieved_blob.data)?;
+    let s = String::from_utf8(retrieved_blob.data.to_vec())?;
     println!("retrieved contents == {}", s);
 
     Ok(())

--- a/sdk/storage/examples/blob_05_default_credential.rs
+++ b/sdk/storage/examples/blob_05_default_credential.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let response = blob.get().execute().await?;
 
-    let s_content = String::from_utf8(response.data)?;
+    let s_content = String::from_utf8(response.data.to_vec())?;
     println!("blob == {:?}", blob);
     println!("s_content == {}", s_content);
 

--- a/sdk/storage/examples/blob_range.rs
+++ b/sdk/storage/examples/blob_range.rs
@@ -72,7 +72,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("\nStreaming");
     let mut chunk: usize = 0;
     while let Some(value) = stream.next().await {
-        let value = value?;
+        let value = value?.data;
         println!("received {:?} bytes", value.len());
         println!("received {}", std::str::from_utf8(&value)?);
 

--- a/sdk/storage/examples/stream_blob_00.rs
+++ b/sdk/storage/examples/stream_blob_00.rs
@@ -2,6 +2,8 @@ use azure_core::prelude::*;
 use azure_storage::blob::prelude::*;
 use azure_storage::core::prelude::*;
 use futures::stream::StreamExt;
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 // This example shows how to stream data from a blob. We will create a simple blob first, the we
@@ -51,12 +53,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // just to make sure to loop at least twice.
     let mut stream = Box::pin(blob.get().stream(128));
 
-    let result = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+    let result = Rc::new(RefCell::new(Vec::new()));
 
     {
         let mut res_closure = result.borrow_mut();
         while let Some(value) = stream.next().await {
-            let mut value = value?;
+            let mut value = value?.data.to_vec();
             println!("received {:?} bytes", value.len());
             res_closure.append(&mut value);
         }

--- a/sdk/storage/examples/stream_blob_01.rs
+++ b/sdk/storage/examples/stream_blob_01.rs
@@ -1,4 +1,5 @@
 use azure_core::prelude::*;
+use azure_storage::blob::blob::responses::GetBlobResponse;
 use azure_storage::core::prelude::*;
 use futures::stream::StreamExt;
 use std::sync::Arc;
@@ -43,7 +44,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 fn get_blob_stream<'a>(
     blob: &'a BlobClient,
-) -> impl futures::Stream<Item = Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>> + 'a {
+) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>> + 'a
+{
     let stream = blob.get().stream(1024);
     stream
 }

--- a/sdk/storage/src/blob/blob/requests/get_blob_builder.rs
+++ b/sdk/storage/src/blob/blob/requests/get_blob_builder.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use crate::blob::blob::responses::GetBlobResponse;
 use crate::blob::prelude::*;
 use crate::clients::BlobClient;
@@ -80,17 +82,15 @@ impl<'a> GetBlobBuilder<'a> {
         debug!("response.headers() == {:#?}", response.headers());
 
         let blob = Blob::from_headers(self.blob_client.blob_name(), response.headers())?;
-        Ok(GetBlobResponse::from_response(
-            response.headers(),
-            blob,
-            response.body(),
-        )?)
+
+        Ok(response.try_into()?)
     }
 
     pub fn stream(
         self,
         chunk_size: u64,
-    ) -> impl Stream<Item = Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>> + 'a {
+    ) -> impl Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>> + 'a
+    {
         enum States {
             Init,
             Progress(Range),
@@ -119,31 +119,30 @@ impl<'a> GetBlobBuilder<'a> {
                 Err(err) => return Some((Err(err), States::End)),
             };
 
-            Some((
-                Ok(response.data),
-                if remaining.end > range.end {
-                    if self.range.is_some() {
-                        States::Progress(Range::new(range.end, remaining.end))
-                    } else {
-                        // if we are here it means the user have not specified a
-                        // range and we didn't get the whole blob in one passing.
-                        // We specified u64::MAX as the first range but now
-                        // we need to find the correct size to avoid requesting data
-                        // outside the valid range.
-                        debug!("content-range == {:?}", response.content_range);
-                        // this unwrap should always be safe since we did not
-                        // get the whole blob in the previous call.
-                        let content_range = response.content_range.unwrap();
-                        let ridx =
-                            match content_range.find('/') {
-                                Some(ridx) => ridx,
-                                None => return Some((
-                                    Err("The returned content-range is invalid: / is not present"
-                                        .into()),
-                                    States::End,
-                                )),
-                            };
-                        let total =
+            let next_state = if remaining.end > range.end {
+                if self.range.is_some() {
+                    States::Progress(Range::new(range.end, remaining.end))
+                } else {
+                    // if we are here it means the user have not specified a
+                    // range and we didn't get the whole blob in one passing.
+                    // We specified u64::MAX as the first range but now
+                    // we need to find the correct size to avoid requesting data
+                    // outside the valid range.
+                    debug!("content-range == {:?}", response.content_range);
+                    // this unwrap should always be safe since we did not
+                    // get the whole blob in the previous call.
+                    let content_range = response.content_range.clone().unwrap();
+                    let ridx = match content_range.find('/') {
+                        Some(ridx) => ridx,
+                        None => {
+                            return Some((
+                                Err("The returned content-range is invalid: / is not present"
+                                    .into()),
+                                States::End,
+                            ))
+                        }
+                    };
+                    let total =
                             match str::parse(&content_range[ridx + 1..]) {
                                 Ok(total) => total,
                                 Err(_err) => return Some((
@@ -153,12 +152,13 @@ impl<'a> GetBlobBuilder<'a> {
                                 )),
                             };
 
-                        States::Progress(Range::new(range.end, total))
-                    }
-                } else {
-                    States::End
-                },
-            ))
+                    States::Progress(Range::new(range.end, total))
+                }
+            } else {
+                States::End
+            };
+
+            Some((Ok(response), next_state))
         })
     }
 }

--- a/sdk/storage/src/blob/blob/requests/get_blob_builder.rs
+++ b/sdk/storage/src/blob/blob/requests/get_blob_builder.rs
@@ -79,11 +79,7 @@ impl<'a> GetBlobBuilder<'a> {
             .execute_request_check_status(request, expected_status_code)
             .await?;
 
-        debug!("response.headers() == {:#?}", response.headers());
-
-        let blob = Blob::from_headers(self.blob_client.blob_name(), response.headers())?;
-
-        Ok(response.try_into()?)
+        Ok((self.blob_client.blob_name(), response).try_into()?)
     }
 
     pub fn stream(

--- a/sdk/storage/src/blob/blob/responses/get_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_blob_response.rs
@@ -10,15 +10,16 @@ use std::convert::TryFrom;
 #[derive(Debug, Clone)]
 pub struct GetBlobResponse {
     pub request_id: RequestId,
+    pub blob: Blob,
     pub data: Bytes,
     pub date: DateTime<Utc>,
     pub content_range: Option<String>,
 }
 
-impl TryFrom<Response<Bytes>> for GetBlobResponse {
+impl TryFrom<(&str, Response<Bytes>)> for GetBlobResponse {
     type Error = AzureError;
-    fn try_from(response: Response<Bytes>) -> Result<Self, Self::Error> {
-        println!("response.headers() == {:#?}", response.headers());
+    fn try_from((blob_name, response): (&str, Response<Bytes>)) -> Result<Self, Self::Error> {
+        debug!("response.headers() == {:#?}", response.headers());
 
         let request_id = request_id_from_headers(response.headers())?;
         let date = date_from_headers(response.headers())?;
@@ -30,6 +31,7 @@ impl TryFrom<Response<Bytes>> for GetBlobResponse {
 
         Ok(GetBlobResponse {
             request_id,
+            blob: Blob::from_headers(blob_name, response.headers())?,
             data: response.into_body(),
             date,
             content_range,

--- a/sdk/storage/src/blob/blob/responses/get_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_blob_response.rs
@@ -2,37 +2,35 @@ use crate::blob::blob::Blob;
 use azure_core::errors::AzureError;
 use azure_core::headers::{date_from_headers, request_id_from_headers};
 use azure_core::RequestId;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
-use http::HeaderMap;
+use http::Response;
+use std::convert::TryFrom;
 
 #[derive(Debug, Clone)]
 pub struct GetBlobResponse {
-    pub blob: Blob,
     pub request_id: RequestId,
-    pub data: Vec<u8>,
+    pub data: Bytes,
     pub date: DateTime<Utc>,
     pub content_range: Option<String>,
 }
 
-impl GetBlobResponse {
-    pub(crate) fn from_response(
-        headers: &HeaderMap,
-        blob: Blob,
-        body: &[u8],
-    ) -> Result<GetBlobResponse, AzureError> {
-        debug!("headers == {:#?}", headers);
+impl TryFrom<Response<Bytes>> for GetBlobResponse {
+    type Error = AzureError;
+    fn try_from(response: Response<Bytes>) -> Result<Self, Self::Error> {
+        println!("response.headers() == {:#?}", response.headers());
 
-        let request_id = request_id_from_headers(headers)?;
-        let date = date_from_headers(headers)?;
+        let request_id = request_id_from_headers(response.headers())?;
+        let date = date_from_headers(response.headers())?;
 
-        let content_range = headers
+        let content_range = response
+            .headers()
             .get(http::header::CONTENT_RANGE)
             .map(|h| h.to_str().unwrap().to_owned());
 
         Ok(GetBlobResponse {
-            blob,
             request_id,
-            data: body.to_vec(),
+            data: response.into_body(),
             date,
             content_range,
         })

--- a/sdk/storage/tests/stream_blob00.rs
+++ b/sdk/storage/tests/stream_blob00.rs
@@ -72,7 +72,7 @@ async fn code() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         {
             let mut res_closure = result.borrow_mut();
             while let Some(value) = stream.next().await {
-                let mut value = value?;
+                let mut value = value?.data.to_vec();
                 assert!(value.len() as u64 <= chunk_size);
                 println!("received {:?} bytes", value.len());
                 res_closure.append(&mut value);


### PR DESCRIPTION
Fixes 186.

This also changes the `stream` function return type from `Vec<u8>` to `GetBlobResponse`. This is more consistent with the rest of the crates and also allows the caller to inspect the returned fields if necessary (before it was discarded silently).