### PR TITLE
Update readme where it references data plane crates

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -47,7 +47,7 @@ azure_mgmt_storage_2018_02 = { package = "azure_mgmt_storage", git = "https://gi
 ```
 
 ## Data Plane Crates
-The control plane crates will be named `azure_svc_${specification_directory}`, such as `azure_svc_storage`. 
+The data plane crates will be named `azure_svc_${specification_directory}`, such as `azure_svc_storage`. 
 
 ## Examples
 There are a few examples:


### PR DESCRIPTION
Small change, but it seems like this should read as my change here proposes

For comparison, the control plane section reads
> The control plane crates are named

And so I assume in referencing data plane section here we are referencing data plane crates