### PR TITLE
Inbound streaming with access to the underlying stream

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -18,7 +18,7 @@ base64 = "0.13"
 chrono = "0.4"
 http = "0.2"
 futures = "0.3"
-hyper = "0.14"
+hyper = { version = "0.14", features = ["full" ] }
 log = "0.4"
 quick-error = "1.2"
 serde = "1.0"
@@ -32,9 +32,10 @@ hyper-rustls = "0.22"
 failure = "0.1"
 async-trait = "0.1"
 oauth2 = "=4.0.0-alpha.3"
-reqwest = "0.11"
+reqwest = { version = "0.11" }
 paste = "1.0"
 md5 = "0.7"
+http-body = "0.4"
 
 [dev-dependencies]
 tokio = "1.0"

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod parsing;
 pub mod prelude;
 mod request_options;
 mod stored_access_policy;
+mod streamable;
 pub mod util;
 
 use chrono::{DateTime, Utc};
@@ -33,6 +34,7 @@ use uuid::Uuid;
 pub use headers::AddAsHeader;
 pub use http_client::{to_json, HttpClient};
 pub use stored_access_policy::{StoredAccessPolicy, StoredAccessPolicyList};
+pub use streamable::Streamable;
 
 pub type RequestId = Uuid;
 pub type SessionToken = String;

--- a/sdk/core/src/streamable.rs
+++ b/sdk/core/src/streamable.rs
@@ -1,0 +1,65 @@
+use bytes::Bytes;
+use http::HeaderMap;
+use http_body::Body;
+
+enum SupportedResponse {
+    Reqwest(reqwest::Response),
+    Hyper(hyper::Response<hyper::Body>),
+}
+
+pub struct Streamable {
+    response: SupportedResponse,
+}
+
+impl Streamable {
+    pub(crate) fn new_hyper(response: hyper::Response<hyper::Body>) -> Self {
+        Self {
+            response: SupportedResponse::Hyper(response),
+        }
+    }
+
+    pub(crate) fn new_reqwest(response: reqwest::Response) -> Self {
+        Self {
+            response: SupportedResponse::Reqwest(response),
+        }
+    }
+
+    pub fn headers(&self) -> &HeaderMap {
+        match &self.response {
+            SupportedResponse::Reqwest(reqwest_response) => reqwest_response.headers(),
+            SupportedResponse::Hyper(hyper_response) => hyper_response.headers(),
+        }
+    }
+
+    pub fn status(&self) -> http::StatusCode {
+        match &self.response {
+            SupportedResponse::Reqwest(reqwest_response) => reqwest_response.status(),
+            SupportedResponse::Hyper(hyper_response) => hyper_response.status(),
+        }
+    }
+
+    pub async fn into_bytes(self) -> Result<Bytes, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(match self.response {
+            SupportedResponse::Reqwest(reqwest_response) => reqwest_response.bytes().await?,
+            SupportedResponse::Hyper(hyper_response) => {
+                hyper::body::to_bytes(hyper_response.into_body()).await?
+            }
+        })
+    }
+
+    pub async fn chunk(
+        &mut self,
+    ) -> Result<Option<Bytes>, Box<dyn std::error::Error + Send + Sync>> {
+        match &mut self.response {
+            SupportedResponse::Reqwest(reqwest_response) => reqwest_response
+                .chunk()
+                .await
+                .map_err(|reqwest_err| reqwest_err.into()),
+            SupportedResponse::Hyper(hyper_response) => hyper_response
+                .data()
+                .await
+                .transpose()
+                .map_err(|err| err.into()),
+        }
+    }
+}

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -38,6 +38,8 @@ tokio = { version = "1.0", features = ["macros"] }
 env_logger = "0.8"
 azure_identity = { path = "../identity" }
 reqwest = "0.11"
+hyper = "0.14"
+hyper-rustls = "0.22"
 
 [features]
 default = ["account", "blob", "queue", "table", "data_lake"]

--- a/sdk/storage/examples/blob_00.rs
+++ b/sdk/storage/examples/blob_00.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("{:#?}", response);
 
-    let mut stream = Box::pin(blob_client.get().stream(128));
+    let mut stream = Box::pin(blob_client.get().stream_client_chunk(128));
     while let Some(value) = stream.next().await {
         println!("received {:?} bytes", value?.data.len());
     }

--- a/sdk/storage/examples/blob_range.rs
+++ b/sdk/storage/examples/blob_range.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         assert_eq!(chunk2.data[i], 73);
     }
 
-    let mut stream = Box::pin(blob.get().stream(512));
+    let mut stream = Box::pin(blob.get().stream_client_chunk(512));
 
     println!("\nStreaming");
     let mut chunk: usize = 0;

--- a/sdk/storage/examples/stream_blob_00.rs
+++ b/sdk/storage/examples/stream_blob_00.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // http overhead will be less but it also means you will have to wait for more
     // time before receiving anything. In this example we use a very small chunk size
     // just to make sure to loop at least twice.
-    let mut stream = Box::pin(blob.get().stream(128));
+    let mut stream = Box::pin(blob.get().stream_client_chunk(128));
 
     let result = Rc::new(RefCell::new(Vec::new()));
 

--- a/sdk/storage/examples/stream_blob_02.rs
+++ b/sdk/storage/examples/stream_blob_02.rs
@@ -3,12 +3,8 @@ use azure_storage::blob::prelude::*;
 use azure_storage::core::prelude::*;
 use std::sync::Arc;
 
-// This example shows how to stream data from a blob. We will create a simple blob first, the we
-// ask it back using streaming features of the future crate. In this simple example we just
-// concatenate the data received in order to make sure the retrieved blob is equals to the one
-// created in the first place.
-// We do not use leases here but you definitely want to do so otherwise the returned stream
-// is not guaranteed to be consistent.
+// This example shows how to stream data from a blob accessing the underlying stream. This is
+// useful if you want to receive a big data stream without buffering the received data.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // First we retrieve the account name and master key from environment variables.

--- a/sdk/storage/src/blob/blob/responses/get_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_blob_response.rs
@@ -1,40 +1,53 @@
 use crate::blob::blob::Blob;
-use azure_core::errors::AzureError;
 use azure_core::headers::{date_from_headers, request_id_from_headers};
 use azure_core::RequestId;
+use azure_core::{errors::AzureError, Streamable};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use http::Response;
 use std::convert::TryFrom;
 
 #[derive(Debug, Clone)]
-pub struct GetBlobResponse {
+pub struct GetBlobResponse<T> {
     pub request_id: RequestId,
     pub blob: Blob,
-    pub data: Bytes,
+    pub data: T,
     pub date: DateTime<Utc>,
     pub content_range: Option<String>,
 }
 
-impl TryFrom<(&str, Response<Bytes>)> for GetBlobResponse {
+impl TryFrom<(&str, Response<Bytes>)> for GetBlobResponse<Bytes> {
     type Error = AzureError;
     fn try_from((blob_name, response): (&str, Response<Bytes>)) -> Result<Self, Self::Error> {
         debug!("response.headers() == {:#?}", response.headers());
 
-        let request_id = request_id_from_headers(response.headers())?;
-        let date = date_from_headers(response.headers())?;
+        Ok(GetBlobResponse {
+            request_id: request_id_from_headers(response.headers())?,
+            blob: Blob::from_headers(blob_name, response.headers())?,
+            date: date_from_headers(response.headers())?,
+            content_range: response
+                .headers()
+                .get(http::header::CONTENT_RANGE)
+                .map(|h| h.to_str().unwrap().to_owned()),
+            data: response.into_body(),
+        })
+    }
+}
 
-        let content_range = response
-            .headers()
-            .get(http::header::CONTENT_RANGE)
-            .map(|h| h.to_str().unwrap().to_owned());
+impl TryFrom<(&str, Streamable)> for GetBlobResponse<Streamable> {
+    type Error = AzureError;
+    fn try_from((blob_name, streamable): (&str, Streamable)) -> Result<Self, Self::Error> {
+        println!("streamable.headers() == {:#?}", streamable.headers());
 
         Ok(GetBlobResponse {
-            request_id,
-            blob: Blob::from_headers(blob_name, response.headers())?,
-            data: response.into_body(),
-            date,
-            content_range,
+            request_id: request_id_from_headers(streamable.headers())?,
+            blob: Blob::from_headers(blob_name, streamable.headers())?,
+            date: date_from_headers(streamable.headers())?,
+            content_range: streamable
+                .headers()
+                .get(http::header::CONTENT_RANGE)
+                .map(|h| h.to_str().unwrap().to_owned()),
+            data: streamable,
         })
     }
 }

--- a/sdk/storage/tests/stream_blob00.rs
+++ b/sdk/storage/tests/stream_blob00.rs
@@ -65,7 +65,7 @@ async fn code() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
         let chunk_size = 8;
 
-        let mut stream = Box::pin(blob.get().range(range).stream(chunk_size));
+        let mut stream = Box::pin(blob.get().range(range).stream_client_chunk(chunk_size));
 
         let result = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
 


### PR DESCRIPTION
This PR proposes a change in the core `HttpClient` trait. It allows the clients to receive the underlying byte stream instead on relying on `HttpClient` to buffer the whole response (see example `stream_blob_02`).

Buffering makes sense for responses that have to be considered as a whole (for example, a JSON document) so the current `HttpClient` takes care of presenting the complete response. For big, unstructured data flows this PR allows to interact with the received bytes as soon as possibile (ie as soon as the HTTP implementation gives back some data). 

This PR renames the old *stream* function of `get blob` that used client side chunking in `stream_client_chunk` to better show its behavior.

To discuss:

1. Implement `Stream` for the `Streamable` trait (maybe not worth the effort).

To do:

1. Allow outbound streaming (for sending bytes without buffering).
2. Extend the streaming approach to the other blob requests.