### PR TITLE
feat(storage): Add the ability to delete a table entity

### DIFF
--- a/sdk/storage/examples/table_00.rs
+++ b/sdk/storage/examples/table_00.rs
@@ -72,6 +72,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .await?;
     println!("response = {:?}\n", response);
 
+    let response = entity_client.delete().execute().await?;
+    println!("response = {:?}\n", response);
+
     let response = table.insert().return_entity(false).execute(&entity).await?;
     println!("response = {:?}\n", response);
 

--- a/sdk/storage/src/table/clients/entity_client.rs
+++ b/sdk/storage/src/table/clients/entity_client.rs
@@ -73,6 +73,12 @@ impl EntityClient {
         )
     }
 
+    pub fn delete(&self) -> DeleteEntityBuilder {
+        DeleteEntityBuilder::new(
+            self,
+        )
+    }
+
     pub(crate) fn url(&self) -> &Url {
         &self.url
     }

--- a/sdk/storage/src/table/clients/entity_client.rs
+++ b/sdk/storage/src/table/clients/entity_client.rs
@@ -74,9 +74,7 @@ impl EntityClient {
     }
 
     pub fn delete(&self) -> DeleteEntityBuilder {
-        DeleteEntityBuilder::new(
-            self,
-        )
+        DeleteEntityBuilder::new(self)
     }
 
     pub(crate) fn url(&self) -> &Url {

--- a/sdk/storage/src/table/requests/delete_entity_builder.rs
+++ b/sdk/storage/src/table/requests/delete_entity_builder.rs
@@ -1,68 +1,55 @@
 use crate::table::prelude::*;
 use crate::table::responses::*;
 use crate::table::TransactionOperation;
-use azure_core::headers::add_optional_header;
+use azure_core::headers::{add_mandatory_header, add_optional_header};
 use azure_core::prelude::*;
+use crate::table::prelude::IfMatchCondition;
 use http::{method::Method, StatusCode};
 use serde::Serialize;
 use std::convert::TryInto;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Operation {
-    InsertOrReplace,
-    InsertOrMerge,
-}
-
 #[derive(Debug, Clone)]
-pub struct InsertOrReplaceOrMergeEntityBuilder<'a> {
+pub struct DeleteEntityBuilder<'a> {
     entity_client: &'a EntityClient,
-    operation: Operation,
+    if_match: IfMatchCondition,
     timeout: Option<Timeout>,
     client_request_id: Option<ClientRequestId<'a>>,
 }
 
-impl<'a> InsertOrReplaceOrMergeEntityBuilder<'a> {
-    pub(crate) fn new(entity_client: &'a EntityClient, operation: Operation) -> Self {
+impl<'a> DeleteEntityBuilder<'a> {
+    pub(crate) fn new(entity_client: &'a EntityClient) -> Self {
         Self {
             entity_client,
-            operation,
+            if_match: IfMatchCondition::Any,
             timeout: None,
             client_request_id: None,
         }
     }
 
     setters! {
+        if_match: IfMatchCondition => if_match,
         timeout: Timeout => Some(timeout),
         client_request_id: ClientRequestId<'a> => Some(client_request_id),
     }
 
-    pub async fn execute<E>(
+    pub async fn execute(
         &self,
-        entity: &E,
-    ) -> Result<OperationOnEntityResponse, Box<dyn std::error::Error + Sync + Send>>
-    where
-        E: Serialize,
+    ) -> Result<DeleteEntityResponse, Box<dyn std::error::Error + Sync + Send>>
     {
         let mut url = self.entity_client.url().clone();
 
         self.timeout.append_to_url_query(&mut url);
         println!("url = {}", url);
 
-        let request_body_serialized = serde_json::to_string(entity)?;
-        println!("payload == {}", request_body_serialized);
-
         let request = self.entity_client.prepare_request(
             url.as_str(),
-            match self.operation {
-                Operation::InsertOrMerge => &crate::table::MERGE,
-                Operation::InsertOrReplace => &Method::PUT,
-            },
+            &Method::DELETE,
             &|mut request| {
                 request = add_optional_header(&self.client_request_id, request);
-                request = request.header("Content-Type", "application/json");
+                request = add_mandatory_header(&self.if_match, request);
                 request
             },
-            Some(bytes::Bytes::from(request_body_serialized)),
+            None,
         )?;
 
         println!("request == {:#?}\n", request);
@@ -86,14 +73,9 @@ impl<'a> InsertOrReplaceOrMergeEntityBuilder<'a> {
         let url = self.entity_client.url();
 
         let request = http::Request::builder()
-            .method(match self.operation {
-                Operation::InsertOrMerge => &crate::table::MERGE,
-                Operation::InsertOrReplace => &Method::PUT,
-            })
+            .method(Method::DELETE)
             .uri(url.as_str());
         let request = add_optional_header(&self.client_request_id, request);
-        let request = request.header("Accept", "application/json;odata=fullmetadata");
-        let request = request.header("Content-Type", "application/json");
 
         let request = request.body(serde_json::to_string(entity)?)?;
 

--- a/sdk/storage/src/table/requests/delete_entity_builder.rs
+++ b/sdk/storage/src/table/requests/delete_entity_builder.rs
@@ -1,9 +1,9 @@
+use crate::table::prelude::IfMatchCondition;
 use crate::table::prelude::*;
 use crate::table::responses::*;
 use crate::table::TransactionOperation;
 use azure_core::headers::{add_mandatory_header, add_optional_header};
 use azure_core::prelude::*;
-use crate::table::prelude::IfMatchCondition;
 use http::{method::Method, StatusCode};
 use serde::Serialize;
 use std::convert::TryInto;
@@ -34,8 +34,7 @@ impl<'a> DeleteEntityBuilder<'a> {
 
     pub async fn execute(
         &self,
-    ) -> Result<DeleteEntityResponse, Box<dyn std::error::Error + Sync + Send>>
-    {
+    ) -> Result<DeleteEntityResponse, Box<dyn std::error::Error + Sync + Send>> {
         let mut url = self.entity_client.url().clone();
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage/src/table/requests/mod.rs
+++ b/sdk/storage/src/table/requests/mod.rs
@@ -1,4 +1,5 @@
 mod create_table_builder;
+mod delete_entity_builder;
 mod delete_table_builder;
 mod insert_entity_builder;
 pub(crate) mod insert_or_replace_or_merge_entity_builder;
@@ -6,6 +7,7 @@ mod list_tables_builder;
 mod submit_transaction_builder;
 pub(crate) mod update_or_merge_entity_builder;
 pub use create_table_builder::CreateTableBuilder;
+pub use delete_entity_builder::DeleteEntityBuilder;
 pub use delete_table_builder::DeleteTableBuilder;
 pub use insert_entity_builder::InsertEntityBuilder;
 pub use insert_or_replace_or_merge_entity_builder::InsertOrReplaceOrMergeEntityBuilder;

--- a/sdk/storage/src/table/responses/delete_entity_response.rs
+++ b/sdk/storage/src/table/responses/delete_entity_response.rs
@@ -1,0 +1,22 @@
+use azure_core::{errors::AzureError, headers::CommonStorageResponseHeaders};
+use bytes::Bytes;
+use http::Response;
+use std::convert::{TryFrom, TryInto};
+
+#[derive(Debug, Clone)]
+pub struct DeleteEntityResponse {
+    pub common_storage_response_headers: CommonStorageResponseHeaders,
+}
+
+impl TryFrom<&Response<Bytes>> for DeleteEntityResponse {
+    type Error = AzureError;
+
+    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+        debug!("{}", std::str::from_utf8(response.body())?);
+        debug!("headers == {:#?}", response.headers());
+
+        Ok(DeleteEntityResponse {
+            common_storage_response_headers: response.headers().try_into()?,
+        })
+    }
+}

--- a/sdk/storage/src/table/responses/mod.rs
+++ b/sdk/storage/src/table/responses/mod.rs
@@ -1,10 +1,12 @@
 mod create_table_response;
+mod delete_entity_response;
 mod delete_table_response;
 mod insert_entity_response;
 mod list_tables_response;
 mod operation_on_entity_response;
 mod submit_transaction_response;
 pub use create_table_response::CreateTableResponse;
+pub use delete_entity_response::DeleteEntityResponse;
 pub use delete_table_response::DeleteTableResponse;
 pub use insert_entity_response::InsertEntityResponse;
 pub use list_tables_response::ListTablesResponse;


### PR DESCRIPTION
This PR introduces a `EntityClient.delete()` method which enables you to remove specific entities from a Table Storage collection. I have tried to align it with the rest of the entity-level operations both in API and code style, but if you'd like me to change any of that I'm more than happy to.

You'll also notice that I've introduced an example into the `table_00.rs` file to help ensure that we don't leave this functionality out in future changes.