### PR TITLE
feat: Add support for getting a specific entity from table storage

### DIFF
--- a/sdk/storage/examples/table_00.rs
+++ b/sdk/storage/examples/table_00.rs
@@ -75,10 +75,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let response = table.insert().return_entity(false).execute(&entity).await?;
     println!("response = {:?}\n", response);
 
-    let mut entity = MyEntity {
-        city: "Rome".to_owned(),
-        ..entity
-    };
+    // Get an entity from the table
+    let response = entity_client.get().execute().await?;
+    println!("response = {:?}\n", response);
+
+    let mut entity: MyEntity = response.entity.expect("the entity we just inserted");
+    entity.city = "Rome".to_owned();
 
     let response = table.insert().return_entity(true).execute(&entity).await?;
     println!("response = {:?}\n", response);

--- a/sdk/storage/examples/table_00.rs
+++ b/sdk/storage/examples/table_00.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let response = entity_client.get().execute().await?;
     println!("response = {:?}\n", response);
 
-    let mut entity: MyEntity = response.entity.expect("the entity we just inserted");
+    let mut entity: MyEntity = response.entity;
     entity.city = "Rome".to_owned();
 
     let response = table.insert().return_entity(true).execute(&entity).await?;

--- a/sdk/storage/src/table/clients/entity_client.rs
+++ b/sdk/storage/src/table/clients/entity_client.rs
@@ -51,6 +51,10 @@ impl EntityClient {
         &self.row_key
     }
 
+    pub fn get(&self) -> GetEntityBuilder {
+        GetEntityBuilder::new(self)
+    }
+
     pub fn update(&self) -> UpdateOrMergeEntityBuilder {
         UpdateOrMergeEntityBuilder::new(self, update_or_merge_entity_builder::Operation::Update)
     }

--- a/sdk/storage/src/table/requests/get_entity_builder.rs
+++ b/sdk/storage/src/table/requests/get_entity_builder.rs
@@ -1,0 +1,64 @@
+use crate::table::prelude::*;
+use crate::table::responses::*;
+use azure_core::prelude::*;
+use azure_core::{headers::add_optional_header, AppendToUrlQuery};
+use http::method::Method;
+use http::status::StatusCode;
+use serde::de::DeserializeOwned;
+use std::convert::TryInto;
+
+#[derive(Debug, Clone)]
+pub struct GetEntityBuilder<'a> {
+    entity_client: &'a EntityClient,
+    select: Option<Select<'a>>,
+    client_request_id: Option<ClientRequestId<'a>>,
+}
+
+impl<'a> GetEntityBuilder<'a> {
+    pub(crate) fn new(entity_client: &'a EntityClient) -> Self {
+        Self {
+            entity_client,
+            select: None,
+            client_request_id: None,
+        }
+    }
+
+    setters! {
+        select: Select<'a> => Some(select),
+        client_request_id: ClientRequestId<'a> => Some(client_request_id),
+    }
+
+    pub async fn execute<E>(
+        &self,
+    ) -> Result<GetEntityResponse<E>, Box<dyn std::error::Error + Sync + Send>>
+    where
+        E: DeserializeOwned,
+    {
+        let mut url = self.entity_client.url().to_owned();
+
+        self.select.append_to_url_query(&mut url);
+
+        debug!("list tables url = {}", url);
+
+        let request = self.entity_client.prepare_request(
+            url.as_str(),
+            &Method::GET,
+            &|mut request| {
+                request = add_optional_header(&self.client_request_id, request);
+                request = request.header("Accept", "application/json;odata=fullmetadata");
+                request
+            },
+            None,
+        )?;
+
+        debug!("request == {:#?}\n", request);
+
+        let response = self
+            .entity_client
+            .http_client()
+            .execute_request_check_status(request.0, StatusCode::OK)
+            .await?;
+
+        Ok((&response).try_into()?)
+    }
+}

--- a/sdk/storage/src/table/requests/mod.rs
+++ b/sdk/storage/src/table/requests/mod.rs
@@ -1,5 +1,6 @@
 mod create_table_builder;
 mod delete_table_builder;
+mod get_entity_builder;
 mod insert_entity_builder;
 pub(crate) mod insert_or_replace_or_merge_entity_builder;
 mod list_tables_builder;
@@ -7,6 +8,7 @@ mod submit_transaction_builder;
 pub(crate) mod update_or_merge_entity_builder;
 pub use create_table_builder::CreateTableBuilder;
 pub use delete_table_builder::DeleteTableBuilder;
+pub use get_entity_builder::GetEntityBuilder;
 pub use insert_entity_builder::InsertEntityBuilder;
 pub use insert_or_replace_or_merge_entity_builder::InsertOrReplaceOrMergeEntityBuilder;
 pub use list_tables_builder::ListTablesBuilder;

--- a/sdk/storage/src/table/responses/get_entity_response.rs
+++ b/sdk/storage/src/table/responses/get_entity_response.rs
@@ -1,0 +1,45 @@
+use crate::{table::prelude::*, ContinuationNextTableName};
+use azure_core::{errors::AzureError, headers::CommonStorageResponseHeaders};
+use bytes::Bytes;
+use http::Response;
+use serde::de::DeserializeOwned;
+use std::convert::{TryFrom, TryInto};
+
+#[derive(Debug, Clone)]
+pub struct GetEntityResponse<E>
+where
+    E: DeserializeOwned,
+{
+    pub common_storage_response_headers: CommonStorageResponseHeaders,
+    pub metadata: String,
+    pub entity: Option<E>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct GetEntityResponseInternal<E> {
+    #[serde(rename = "odata.metadata")]
+    pub metadata: String,
+    #[serde(default = "Vec::new")]
+    pub value: Vec<E>,
+}
+
+impl<E> TryFrom<&Response<Bytes>> for GetEntityResponse<E>
+where
+    E: DeserializeOwned,
+{
+    type Error = AzureError;
+
+    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+        debug!("{}", std::str::from_utf8(response.body())?);
+        debug!("headers == {:#?}", response.headers());
+
+        let mut get_entity_response_internal: GetEntityResponseInternal<E> =
+            serde_json::from_slice(response.body())?;
+
+        Ok(GetEntityResponse {
+            common_storage_response_headers: response.headers().try_into()?,
+            metadata: get_entity_response_internal.metadata,
+            entity: get_entity_response_internal.value.pop(),
+        })
+    }
+}

--- a/sdk/storage/src/table/responses/get_entity_response.rs
+++ b/sdk/storage/src/table/responses/get_entity_response.rs
@@ -11,15 +11,15 @@ where
 {
     pub common_storage_response_headers: CommonStorageResponseHeaders,
     pub metadata: String,
-    pub entity: Option<E>,
+    pub entity: E,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct GetEntityResponseInternal<E> {
     #[serde(rename = "odata.metadata")]
     pub metadata: String,
-    #[serde(default = "Vec::new")]
-    pub value: Vec<E>,
+    #[serde(flatten)]
+    pub value: E
 }
 
 impl<E> TryFrom<&Response<Bytes>> for GetEntityResponse<E>
@@ -32,13 +32,13 @@ where
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 
-        let mut get_entity_response_internal: GetEntityResponseInternal<E> =
+        let get_entity_response_internal: GetEntityResponseInternal<E> =
             serde_json::from_slice(response.body())?;
 
         Ok(GetEntityResponse {
             common_storage_response_headers: response.headers().try_into()?,
             metadata: get_entity_response_internal.metadata,
-            entity: get_entity_response_internal.value.pop(),
+            entity: get_entity_response_internal.value,
         })
     }
 }

--- a/sdk/storage/src/table/responses/get_entity_response.rs
+++ b/sdk/storage/src/table/responses/get_entity_response.rs
@@ -19,7 +19,7 @@ struct GetEntityResponseInternal<E> {
     #[serde(rename = "odata.metadata")]
     pub metadata: String,
     #[serde(flatten)]
-    pub value: E
+    pub value: E,
 }
 
 impl<E> TryFrom<&Response<Bytes>> for GetEntityResponse<E>

--- a/sdk/storage/src/table/responses/get_entity_response.rs
+++ b/sdk/storage/src/table/responses/get_entity_response.rs
@@ -1,4 +1,3 @@
-use crate::{table::prelude::*, ContinuationNextTableName};
 use azure_core::{errors::AzureError, headers::CommonStorageResponseHeaders};
 use bytes::Bytes;
 use http::Response;

--- a/sdk/storage/src/table/responses/mod.rs
+++ b/sdk/storage/src/table/responses/mod.rs
@@ -1,11 +1,13 @@
 mod create_table_response;
 mod delete_table_response;
+mod get_entity_response;
 mod insert_entity_response;
 mod list_tables_response;
 mod operation_on_entity_response;
 mod submit_transaction_response;
 pub use create_table_response::CreateTableResponse;
 pub use delete_table_response::DeleteTableResponse;
+pub use get_entity_response::GetEntityResponse;
 pub use insert_entity_response::InsertEntityResponse;
 pub use list_tables_response::ListTablesResponse;
 pub use operation_on_entity_response::OperationOnEntityResponse;


### PR DESCRIPTION
This PR adds the ability to retrieve a specific Table Storage entity through the `EntityClient`. It is modelled, roughly, on the work done in #216 and I've included an example in `table_00.rs` which shows how it can be used, as well as how type information can be used to back-propagate info about the entity being retrieved.