### PR TITLE
test: Add automated integration tests for Table Storage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           cargo fmt --manifest-path services/Cargo.toml --all -- --check
 
   test-sdk:
+    name: SDK Tests
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
@@ -62,6 +63,7 @@ jobs:
       run: cargo test --all
 
   test-services:
+    name: Services Tests
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         sqllocaldb create MSSQLLocalDB
         sqllocaldb start MSSQLLocalDB
 
-        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
+        &"C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
 
         cargo test --features test_integration
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,12 +56,13 @@ jobs:
 
     - name: e2e tests build
       run: |
-        PROJECTS=(core  cosmos  identity  service_bus  storage)
-        for PROJ in ${PROJECTS[@]}
-        do
+        $PROJECTS = @("core", "cosmos", "identity", "service_bus", "storage")
+        foreach ($PROJ in $PROJECTS) {
           echo "Checking e2e tests for $PROJ"
-          cargo check --tests --features test_e2e --manifest-path sdk/$PROJ/Cargo.toml || exit 1
-        done
+          if (-not (cargo check --tests --features test_e2e --manifest-path sdk/$PROJ/Cargo.toml)) {
+            exit 1
+          }
+        }
 
     - name: display free disk space
       run: df -h /

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     strategy:
       matrix:
         rust: [stable]
@@ -23,6 +23,8 @@ jobs:
         override: true
         components: rustfmt
         target: wasm32-unknown-unknown
+
+    - uses: Swatinem/rust-cache@v1
 
     - name: fmt
       run: |
@@ -43,6 +45,15 @@ jobs:
     - name: services check
       run: cargo check --manifest-path services/Cargo.toml --all
 
+    - name: integration tests
+      run: |
+        sqllocaldb create MSSQLLocalDB
+        sqllocaldb start MSSQLLocalDB
+
+        "C:\Program Files (x86)\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
+
+        cargo test --features test_integration
+
     - name: e2e tests build
       run: |
         PROJECTS=(core  cosmos  identity  service_bus  storage)
@@ -55,3 +66,4 @@ jobs:
     - name: display free disk space
       run: df -h /
       if: ${{ always() }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,16 +9,35 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  test:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        rust: [stable]
+  fmt:
+    name: Code Style
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo fmt sdk
+        run: cargo fmt --all -- --check
+
+      - name: cargo fmt services
+        run: |
+          ./eng/scripts/check_json_format.sh
+          cargo fmt --manifest-path services/Cargo.toml --all -- --check
+
+  test-sdk:
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ matrix.rust }}
+        toolchain: stable
         profile: minimal
         override: true
         components: rustfmt
@@ -42,8 +61,39 @@ jobs:
     - name: sdk tests
       run: cargo test --all
 
+  test-services:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: rustfmt
+
+    - uses: Swatinem/rust-cache@v1
+
     - name: services check
       run: cargo check --manifest-path services/Cargo.toml --all
+
+    - name: display free disk space
+      run: df -h /
+      if: ${{ always() }}
+
+  test-integration:
+    name: Integration Tests
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: rustfmt
+
+    - uses: Swatinem/rust-cache@v1
 
     - name: integration tests
       run: |
@@ -54,15 +104,32 @@ jobs:
 
         cargo test --features test_integration
 
+    - name: display free disk space
+      run: df -h /
+      if: ${{ always() }}
+
+  test-e2e:
+    name: E2E Tests
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        override: true
+        components: rustfmt
+
+    - uses: Swatinem/rust-cache@v1
+
     - name: e2e tests build
       run: |
-        $PROJECTS = @("core", "cosmos", "identity", "service_bus", "storage")
-        foreach ($PROJ in $PROJECTS) {
+        PROJECTS=(core  cosmos  identity  service_bus  storage)
+        for PROJ in ${PROJECTS[@]}
+        do
           echo "Checking e2e tests for $PROJ"
-          if (-not (cargo check --tests --features test_e2e --manifest-path sdk/$PROJ/Cargo.toml)) {
-            exit 1
-          }
-        }
+          cargo check --tests --features test_e2e --manifest-path sdk/$PROJ/Cargo.toml || exit 1
+        done
 
     - name: display free disk space
       run: df -h /

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = "0.11"
 [features]
 default = ["account", "blob", "queue", "table", "data_lake"]
 test_e2e = ["account", "blob", "queue", "table", "data_lake"]
+test_integration = ["account", "blob", "queue", "table", "data_lake"]
 account = []
 azurite_workaround = []
 blob = []

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -98,13 +98,13 @@ impl StorageAccountClient {
         table_storage_url: &Url,
     ) -> Arc<Self> {
         let blob_storage_url =
-            Url::parse(&format!("{}devstoreaccount1", blob_storage_url.as_str())).unwrap();
+            Url::parse(&format!("{}devstoreaccount1/", blob_storage_url.as_str())).unwrap();
         let table_storage_url =
-            Url::parse(&format!("{}devstoreaccount1", table_storage_url.as_str())).unwrap();
+            Url::parse(&format!("{}devstoreaccount1/", table_storage_url.as_str())).unwrap();
         let queue_storage_url =
-            Url::parse(&format!("{}devstoreaccount1", table_storage_url.as_str())).unwrap();
+            Url::parse(&format!("{}devstoreaccount1/", table_storage_url.as_str())).unwrap();
         let filesystem_url =
-            Url::parse(&format!("{}devstoreaccount1", blob_storage_url.as_str())).unwrap();
+            Url::parse(&format!("{}devstoreaccount1/", blob_storage_url.as_str())).unwrap();
 
         Arc::new(Self {
             blob_storage_url,

--- a/sdk/storage/src/table/clients/entity_client.rs
+++ b/sdk/storage/src/table/clients/entity_client.rs
@@ -135,7 +135,7 @@ mod integration_tests {
         let table_storage_url =
             Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
 
-        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let http_client: Arc<dyn HttpClient> = Arc::new(reqwest::Client::new());
         let storage_account =
             StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
                 .as_storage_client();

--- a/sdk/storage/src/table/clients/entity_client.rs
+++ b/sdk/storage/src/table/clients/entity_client.rs
@@ -33,7 +33,7 @@ impl EntityClient {
             .storage_account_client()
             .table_storage_url()
             .join(&format!(
-                "/{}(PartitionKey='{}',RowKey='{}')",
+                "{}(PartitionKey='{}',RowKey='{}')",
                 partition_key_client.table_client().table_name(),
                 partition_key_client.partition_key(),
                 &row_key
@@ -97,5 +97,68 @@ impl EntityClient {
     ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
         self.partition_key_client
             .prepare_request(url, method, http_header_adder, request_body)
+    }
+}
+
+
+#[cfg(test)]
+#[cfg(feature = "test_integration")]
+mod integration_tests {
+    use super::*;
+    use azure_core::prelude::*;
+    use futures::StreamExt;
+    use crate::{core::prelude::*, table::clients::{AsTableClient, AsTableServiceClient}};
+    use url::Url;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestEntity {
+        #[serde(rename = "PartitionKey")]
+        pub city: String,
+        pub name: String,
+        #[serde(rename = "RowKey")]
+        pub surname: String,
+    }
+
+    fn get_emulator_client() -> Arc<TableServiceClient> {
+        let blob_storage_url = Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
+        let table_storage_url = Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
+
+        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let storage_account =
+            StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
+                .as_storage_client();
+
+        storage_account.as_table_service_client().expect("a table service client")
+    }
+
+    #[tokio::test]
+    async fn test_insert_or_replace() {
+        let table_client = get_emulator_client();
+
+        let table = table_client.as_table_client("EntityClientInsertOrReplace");
+
+        println!("Delete the table (if it exists)");
+        match table.delete().execute().await {
+            _ => {}
+        }
+
+        println!("Create the table");
+        table.create().execute().await.expect("the table should be created");
+
+        let mut entity = TestEntity {
+            city: "Milan".to_owned(),
+            name: "Francesco".to_owned(),
+            surname: "Cogno".to_owned()
+        };
+
+        let entity_client = table.as_partition_key_client(&entity.city).as_entity_client(&entity.surname).expect("an entity client");
+        entity_client.insert_or_replace().execute(&entity).await.expect("the insert or replace operation should complete");
+
+        // TODO: Confirm that the entity was inserted
+
+        entity.name = "Doe".to_owned();
+        entity_client.insert_or_replace().execute(&entity).await.expect("the insert or replace operation should complete");
+
+        // TODO: Confirm that the entity was updated
     }
 }

--- a/sdk/storage/src/table/clients/entity_client.rs
+++ b/sdk/storage/src/table/clients/entity_client.rs
@@ -100,14 +100,16 @@ impl EntityClient {
     }
 }
 
-
 #[cfg(test)]
 #[cfg(feature = "test_integration")]
 mod integration_tests {
     use super::*;
+    use crate::{
+        core::prelude::*,
+        table::clients::{AsTableClient, AsTableServiceClient},
+    };
     use azure_core::prelude::*;
     use futures::StreamExt;
-    use crate::{core::prelude::*, table::clients::{AsTableClient, AsTableServiceClient}};
     use url::Url;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -120,15 +122,19 @@ mod integration_tests {
     }
 
     fn get_emulator_client() -> Arc<TableServiceClient> {
-        let blob_storage_url = Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
-        let table_storage_url = Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
+        let blob_storage_url =
+            Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
+        let table_storage_url =
+            Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
 
         let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
         let storage_account =
             StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
                 .as_storage_client();
 
-        storage_account.as_table_service_client().expect("a table service client")
+        storage_account
+            .as_table_service_client()
+            .expect("a table service client")
     }
 
     #[tokio::test]
@@ -143,21 +149,36 @@ mod integration_tests {
         }
 
         println!("Create the table");
-        table.create().execute().await.expect("the table should be created");
+        table
+            .create()
+            .execute()
+            .await
+            .expect("the table should be created");
 
         let mut entity = TestEntity {
             city: "Milan".to_owned(),
             name: "Francesco".to_owned(),
-            surname: "Cogno".to_owned()
+            surname: "Cogno".to_owned(),
         };
 
-        let entity_client = table.as_partition_key_client(&entity.city).as_entity_client(&entity.surname).expect("an entity client");
-        entity_client.insert_or_replace().execute(&entity).await.expect("the insert or replace operation should complete");
+        let entity_client = table
+            .as_partition_key_client(&entity.city)
+            .as_entity_client(&entity.surname)
+            .expect("an entity client");
+        entity_client
+            .insert_or_replace()
+            .execute(&entity)
+            .await
+            .expect("the insert or replace operation should complete");
 
         // TODO: Confirm that the entity was inserted
 
         entity.name = "Doe".to_owned();
-        entity_client.insert_or_replace().execute(&entity).await.expect("the insert or replace operation should complete");
+        entity_client
+            .insert_or_replace()
+            .execute(&entity)
+            .await
+            .expect("the insert or replace operation should complete");
 
         // TODO: Confirm that the entity was updated
     }

--- a/sdk/storage/src/table/clients/partition_key_client.rs
+++ b/sdk/storage/src/table/clients/partition_key_client.rs
@@ -65,14 +65,16 @@ impl PartitionKeyClient {
     }
 }
 
-
 #[cfg(test)]
 #[cfg(feature = "test_integration")]
 mod integration_tests {
     use super::*;
+    use crate::{
+        core::prelude::*,
+        table::clients::{AsTableClient, AsTableServiceClient},
+    };
     use azure_core::prelude::*;
     use futures::StreamExt;
-    use crate::{core::prelude::*, table::clients::{AsTableClient, AsTableServiceClient}};
     use url::Url;
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -85,16 +87,18 @@ mod integration_tests {
     }
 
     fn get_emulator_client() -> Arc<TableServiceClient> {
-        let blob_storage_url = Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
-        let table_storage_url = Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
+        let blob_storage_url =
+            Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
+        let table_storage_url =
+            Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
 
         let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
         let storage_account =
             StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
                 .as_storage_client();
 
-        storage_account.as_table_service_client().expect("a table service client")
+        storage_account
+            .as_table_service_client()
+            .expect("a table service client")
     }
-
-
 }

--- a/sdk/storage/src/table/clients/partition_key_client.rs
+++ b/sdk/storage/src/table/clients/partition_key_client.rs
@@ -64,3 +64,37 @@ impl PartitionKeyClient {
             .prepare_request(url, method, http_header_adder, request_body)
     }
 }
+
+
+#[cfg(test)]
+#[cfg(feature = "test_integration")]
+mod integration_tests {
+    use super::*;
+    use azure_core::prelude::*;
+    use futures::StreamExt;
+    use crate::{core::prelude::*, table::clients::{AsTableClient, AsTableServiceClient}};
+    use url::Url;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestEntity {
+        #[serde(rename = "PartitionKey")]
+        pub city: String,
+        pub name: String,
+        #[serde(rename = "RowKey")]
+        pub surname: String,
+    }
+
+    fn get_emulator_client() -> Arc<TableServiceClient> {
+        let blob_storage_url = Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
+        let table_storage_url = Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
+
+        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let storage_account =
+            StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
+                .as_storage_client();
+
+        storage_account.as_table_service_client().expect("a table service client")
+    }
+
+
+}

--- a/sdk/storage/src/table/clients/partition_key_client.rs
+++ b/sdk/storage/src/table/clients/partition_key_client.rs
@@ -92,7 +92,7 @@ mod integration_tests {
         let table_storage_url =
             Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
 
-        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let http_client: Arc<dyn HttpClient> = Arc::new(reqwest::Client::new());
         let storage_account =
             StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
                 .as_storage_client();

--- a/sdk/storage/src/table/clients/table_client.rs
+++ b/sdk/storage/src/table/clients/table_client.rs
@@ -104,7 +104,7 @@ mod integration_tests {
         let table_storage_url =
             Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
 
-        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let http_client: Arc<dyn HttpClient> = Arc::new(reqwest::Client::new());
         let storage_account =
             StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
                 .as_storage_client();

--- a/sdk/storage/src/table/clients/table_client.rs
+++ b/sdk/storage/src/table/clients/table_client.rs
@@ -76,3 +76,94 @@ impl TableClient {
             .prepare_request(url, method, http_header_adder, request_body)
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "test_integration")]
+mod integration_tests {
+    use super::*;
+    use azure_core::prelude::*;
+    use futures::StreamExt;
+    use crate::{core::prelude::*, table::clients::{AsTableClient, AsTableServiceClient}};
+    use url::Url;
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct TestEntity {
+        #[serde(rename = "PartitionKey")]
+        pub city: String,
+        pub name: String,
+        #[serde(rename = "RowKey")]
+        pub surname: String,
+    }
+
+    fn get_emulator_client() -> Arc<TableServiceClient> {
+        let blob_storage_url = Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
+        let table_storage_url = Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
+
+        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let storage_account =
+            StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
+                .as_storage_client();
+
+        storage_account.as_table_service_client().expect("a table service client")
+    }
+
+    #[tokio::test]
+    async fn test_create_delete() {
+        let table_client = get_emulator_client();
+        let table = table_client.as_table_client("TableClientCreateDelete");
+
+        assert_eq!(table.table_name(), "TableClientCreateDelete", "the table name should match what was provided");
+
+        println!("Create the table");
+        match table.create().execute().await {
+            _ => {}
+        }
+
+        println!("Validate that the table was created");
+        let mut stream = Box::pin(table_client.list().stream());
+        while let Some(result) = stream.next().await {
+            let result = result.expect("the request should succeed");
+
+            let has_table = result.tables.iter().any(|t| t.name == "TableClientCreateDelete");
+            assert!(has_table, "the table should be present in the tables list");
+        }
+
+        println!("Delete the table");
+        table.delete().execute().await.expect("we should be able to delete the table");
+
+        println!("Validate that the table was deleted");
+        let mut stream = Box::pin(table_client.list().stream());
+        while let Some(result) = stream.next().await {
+            let result = result.expect("the request should succeed");
+            let has_table = result.tables.iter().any(|t| t.name == "TableClientCreateDelete");
+            assert!(!has_table, "the table should not be present in the tables list");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_insert() {
+        let table_client = get_emulator_client();
+
+        let table = table_client.as_table_client("TableClientInsert");
+        assert_eq!(table.table_name(), "TableClientInsert", "the table name should match what was provided");
+
+        println!("Delete the table (if it exists)");
+        match table.delete().execute().await {
+            _ => {}
+        }
+
+        println!("Create the table");
+        table.create().execute().await.expect("the table should be created");
+
+        let entity = TestEntity {
+            city: "Milan".to_owned(),
+            name: "Francesco".to_owned(),
+            surname: "Cogno".to_owned()
+        };
+
+        println!("Insert an entity into the table");
+        table.insert().return_entity(true).execute(&entity).await.expect("the insert operation should succeed");
+
+        // TODO: Validate that the entity was inserted
+    }
+}

--- a/sdk/storage/src/table/clients/table_service_client.rs
+++ b/sdk/storage/src/table/clients/table_service_client.rs
@@ -30,7 +30,7 @@ impl TableServiceClient {
         let url = storage_client
             .storage_account_client()
             .table_storage_url()
-            .join("/Tables")?;
+            .join("Tables")?;
 
         Ok(Arc::new(Self {
             storage_client,
@@ -70,5 +70,47 @@ impl TableServiceClient {
                 crate::core::clients::ServiceType::Table,
                 request_body,
             )
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "test_integration")]
+mod integration_tests {
+    use super::*;
+    use azure_core::prelude::*;
+    use futures::StreamExt;
+    use crate::{core::prelude::*, table::clients::AsTableClient};
+    use url::Url;
+
+    fn get_emulator_client() -> Arc<StorageClient> {
+        let blob_storage_url = Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
+        let table_storage_url = Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
+
+        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let storage_account =
+            StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
+                .as_storage_client();
+
+        storage_account
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let storage_account = get_emulator_client();
+        let table_client = storage_account.as_table_service_client().expect("a table service client");
+
+        println!("Create a table in the storage account");
+        let table = table_client.as_table_client("TableServiceClientList");
+        match table.create().execute().await {
+            _ => {}
+        }
+
+        println!("Check that the table is listed correctly");
+        let mut stream = Box::pin(table_client.list().stream());
+        while let Some(result) = stream.next().await {
+            let result = result.expect("the request should succeed");
+            let has_table = result.tables.iter().any(|t| t.name == "TableServiceClientList");
+            assert!(has_table, "the table should be present in the tables list");
+        }
     }
 }

--- a/sdk/storage/src/table/clients/table_service_client.rs
+++ b/sdk/storage/src/table/clients/table_service_client.rs
@@ -88,7 +88,7 @@ mod integration_tests {
         let table_storage_url =
             Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
 
-        let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
+        let http_client: Arc<dyn HttpClient> = Arc::new(reqwest::Client::new());
         let storage_account =
             StorageAccountClient::new_emulator(http_client, &blob_storage_url, &table_storage_url)
                 .as_storage_client();

--- a/sdk/storage/src/table/clients/table_service_client.rs
+++ b/sdk/storage/src/table/clients/table_service_client.rs
@@ -77,14 +77,16 @@ impl TableServiceClient {
 #[cfg(feature = "test_integration")]
 mod integration_tests {
     use super::*;
+    use crate::{core::prelude::*, table::clients::AsTableClient};
     use azure_core::prelude::*;
     use futures::StreamExt;
-    use crate::{core::prelude::*, table::clients::AsTableClient};
     use url::Url;
 
     fn get_emulator_client() -> Arc<StorageClient> {
-        let blob_storage_url = Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
-        let table_storage_url = Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
+        let blob_storage_url =
+            Url::parse("http://127.0.0.1:10000").expect("the default local storage emulator URL");
+        let table_storage_url =
+            Url::parse("http://127.0.0.1:10002").expect("the default local storage emulator URL");
 
         let http_client: Arc<Box<dyn HttpClient>> = Arc::new(Box::new(reqwest::Client::new()));
         let storage_account =
@@ -97,7 +99,9 @@ mod integration_tests {
     #[tokio::test]
     async fn test_list() {
         let storage_account = get_emulator_client();
-        let table_client = storage_account.as_table_service_client().expect("a table service client");
+        let table_client = storage_account
+            .as_table_service_client()
+            .expect("a table service client");
 
         println!("Create a table in the storage account");
         let table = table_client.as_table_client("TableServiceClientList");
@@ -109,7 +113,10 @@ mod integration_tests {
         let mut stream = Box::pin(table_client.list().stream());
         while let Some(result) = stream.next().await {
             let result = result.expect("the request should succeed");
-            let has_table = result.tables.iter().any(|t| t.name == "TableServiceClientList");
+            let has_table = result
+                .tables
+                .iter()
+                .any(|t| t.name == "TableServiceClientList");
             assert!(has_table, "the table should be present in the tables list");
         }
     }

--- a/sdk/storage/src/table/requests/delete_table_builder.rs
+++ b/sdk/storage/src/table/requests/delete_table_builder.rs
@@ -6,6 +6,8 @@ use http::method::Method;
 use http::status::StatusCode;
 use std::convert::TryInto;
 
+#[cfg(test)] use std::println as debug;
+
 #[derive(Debug, Clone)]
 pub struct DeleteTableBuilder<'a> {
     table_client: &'a TableClient,
@@ -30,7 +32,7 @@ impl<'a> DeleteTableBuilder<'a> {
         let url = self
             .table_client
             .url()
-            .join(&format!("/Tables('{}')", self.table_client.table_name()))?;
+            .join(&format!("Tables('{}')", self.table_client.table_name()))?;
         debug!("url = {}", url);
 
         let request = self.table_client.prepare_request(

--- a/sdk/storage/src/table/requests/delete_table_builder.rs
+++ b/sdk/storage/src/table/requests/delete_table_builder.rs
@@ -6,7 +6,8 @@ use http::method::Method;
 use http::status::StatusCode;
 use std::convert::TryInto;
 
-#[cfg(test)] use std::println as debug;
+#[cfg(test)]
+use std::println as debug;
 
 #[derive(Debug, Clone)]
 pub struct DeleteTableBuilder<'a> {

--- a/sdk/storage/src/table/requests/list_tables_builder.rs
+++ b/sdk/storage/src/table/requests/list_tables_builder.rs
@@ -8,7 +8,7 @@ use http::status::StatusCode;
 use std::convert::TryInto;
 
 #[cfg(test)]
-use std::{println as debug};
+use std::println as debug;
 
 #[derive(Debug, Clone)]
 pub struct ListTablesBuilder<'a> {

--- a/sdk/storage/src/table/requests/list_tables_builder.rs
+++ b/sdk/storage/src/table/requests/list_tables_builder.rs
@@ -7,6 +7,9 @@ use http::method::Method;
 use http::status::StatusCode;
 use std::convert::TryInto;
 
+#[cfg(test)]
+use std::{println as debug};
+
 #[derive(Debug, Clone)]
 pub struct ListTablesBuilder<'a> {
     table_service_client: &'a TableServiceClient,


### PR DESCRIPTION
This PR introduces some automated integration tests for the Table Storage APIs (which I've used to resolve some issues with the storage emulator and #216). It adds the `test_integration` feature to control the execution of these tests, since they require that the Azure Storage Emulator be running locally before they are executed.

When using the Table Storage API with the emulator, the method by which URIs were joined resulted in us losing the `/devstorageaccount1/` prefix. I've resolved this by adding a trailing slash to the original URI (which marks that as a directory upon which filenames can be appended, rather than a file) and removing the preceding `/` in all relative paths which will be joined there in the request builders. This appears to pass against the emulator.

To make that a bit easier on folks who aren't doing Windows dev here, I've added the Azure Storage Emulator as part of the GitHub Actions build/test process (which required switching to `windows-latest` as the build infra). I'm also happy to move this around and have it run in a separate build job (which should also speed up the build a fair bit by parallelizing these things - perhaps we want to do that for each of the distinct steps?).