### PR TITLE
Fix feature "azurite_workaround"

### DIFF
--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -249,6 +249,7 @@ pub fn lease_time_from_headers(headers: &HeaderMap) -> Result<u8, AzureError> {
     Ok(lease_time)
 }
 
+#[cfg(not(feature = "azurite_workaround"))]
 pub fn delete_type_permanent_from_headers(headers: &HeaderMap) -> Result<bool, AzureError> {
     let delete_type_permanent = headers
         .get(DELETE_TYPE_PERMANENT)
@@ -256,6 +257,19 @@ pub fn delete_type_permanent_from_headers(headers: &HeaderMap) -> Result<bool, A
         .to_str()?;
 
     let delete_type_permanent = delete_type_permanent.parse::<bool>()?;
+
+    trace!("delete_type_permanent == {:?}", delete_type_permanent);
+    Ok(delete_type_permanent)
+}
+
+#[cfg(feature = "azurite_workaround")]
+pub fn delete_type_permanent_from_headers(headers: &HeaderMap) -> Result<Option<bool>, AzureError> {
+    let delete_type_permanent = headers
+        .get(DELETE_TYPE_PERMANENT)
+        .map(|delete_type_permanent| -> Result<_, AzureError> {
+            Ok(delete_type_permanent.to_str()?.parse::<bool>()?)
+        })
+        .transpose()?;
 
     trace!("delete_type_permanent == {:?}", delete_type_permanent);
     Ok(delete_type_permanent)

--- a/sdk/storage/src/blob/blob/mod.rs
+++ b/sdk/storage/src/blob/blob/mod.rs
@@ -82,9 +82,14 @@ pub struct Blob {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct BlobProperties {
+    #[cfg(not(feature = "azurite_workaround"))]
     #[serde(rename = "Creation-Time")]
     #[serde(with = "azure_core::parsing::rfc2822_time_format")]
     pub creation_time: DateTime<Utc>,
+    #[cfg(feature = "azurite_workaround")]
+    #[serde(rename = "Creation-Time")]
+    #[serde(with = "azure_core::parsing::rfc2822_time_format_optional")]
+    pub creation_time: Option<DateTime<Utc>>,
     #[serde(rename = "Last-Modified")]
     #[serde(with = "azure_core::parsing::rfc2822_time_format")]
     pub last_modified: DateTime<Utc>,

--- a/sdk/storage/src/blob/blob/responses/delete_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/delete_blob_response.rs
@@ -2,8 +2,16 @@ use azure_core::headers::*;
 use azure_core::RequestId;
 use chrono::{DateTime, Utc};
 
+#[cfg(not(feature = "azurite_workaround"))]
 response_from_headers!(DeleteBlobResponse ,
                delete_type_permanent_from_headers => delete_type_permanent: bool,
+               request_id_from_headers => request_id: RequestId,
+               date_from_headers => date: DateTime<Utc>
+);
+
+#[cfg(feature = "azurite_workaround")]
+response_from_headers!(DeleteBlobResponse ,
+               delete_type_permanent_from_headers => delete_type_permanent: Option<bool>,
                request_id_from_headers => request_id: RequestId,
                date_from_headers => date: DateTime<Utc>
 );


### PR DESCRIPTION
Hi,

this PR fixes the feature "azurite_workaround" (`creation_time`) and makes another field optional when guarded by the same feature (`delete_type_permanent`).

If that is not the way to go then could one advise on what it should be?

Cheers!