### PR TITLE
Prepend scheme to vault endpoint

### DIFF
--- a/sdk/key_vault/src/client.rs
+++ b/sdk/key_vault/src/client.rs
@@ -200,7 +200,8 @@ mod tests {
         assert_eq!(suffix, "https://internal/");
 
         let suffix =
-            extract_endpoint(&Url::parse("some-scheme://myvault.vault.azure.net").unwrap()).unwrap();
+            extract_endpoint(&Url::parse("some-scheme://myvault.vault.azure.net").unwrap())
+                .unwrap();
         assert_eq!(suffix, "some-scheme://vault.azure.net/");
     }
 }

--- a/sdk/key_vault/src/client.rs
+++ b/sdk/key_vault/src/client.rs
@@ -38,7 +38,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     /// ```
     pub fn new(vault_url: &str, token_credential: &'a T) -> Result<Self> {
         let vault_url = Url::parse(vault_url)?;
-        let endpoint = endpoint_suffix(&vault_url)?;
+        let endpoint = extract_endpoint(&vault_url)?;
         let client = KeyClient {
             vault_url,
             endpoint,
@@ -169,9 +169,9 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     }
 }
 
-/// Helper to get vault endpoint suffix with a scheme and a trailing slash
+/// Helper to get vault endpoint with a scheme and a trailing slash
 /// ex. `https://vault.azure.net/` where the full client url is `https://myvault.vault.azure.net`
-fn endpoint_suffix(url: &Url) -> Result<String, KeyVaultError> {
+fn extract_endpoint(url: &Url) -> Result<String, KeyVaultError> {
     let endpoint = url
         .host_str()
         .ok_or(KeyVaultError::DomainParse)?
@@ -186,21 +186,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn can_get_endpoint_suffix() {
+    fn can_extract_endpoint() {
         let suffix =
-            endpoint_suffix(&Url::parse("https://myvault.vault.azure.net").unwrap()).unwrap();
+            extract_endpoint(&Url::parse("https://myvault.vault.azure.net").unwrap()).unwrap();
         assert_eq!(suffix, "https://vault.azure.net/");
 
         let suffix =
-            endpoint_suffix(&Url::parse("https://myvault.mycustom.vault.server.net").unwrap())
+            extract_endpoint(&Url::parse("https://myvault.mycustom.vault.server.net").unwrap())
                 .unwrap();
         assert_eq!(suffix, "https://mycustom.vault.server.net/");
 
-        let suffix = endpoint_suffix(&Url::parse("https://myvault.internal").unwrap()).unwrap();
+        let suffix = extract_endpoint(&Url::parse("https://myvault.internal").unwrap()).unwrap();
         assert_eq!(suffix, "https://internal/");
 
         let suffix =
-            endpoint_suffix(&Url::parse("some-scheme://myvault.vault.azure.net").unwrap()).unwrap();
+            extract_endpoint(&Url::parse("some-scheme://myvault.vault.azure.net").unwrap()).unwrap();
         assert_eq!(suffix, "some-scheme://vault.azure.net/");
     }
 }


### PR DESCRIPTION
Hi :wave:,

I stumbled on something that seems to be done on purpose, but it makes the `KeyClient` unusable with the public cloud. Currently, the `KeyClient`, when constructing resource name for the token, [strips the vault name AND URL scheme](https://github.com/Azure/azure-sdk-for-rust/blob/master/sdk/key_vault/src/client.rs#L174-L184), which is wrong for public cloud (I can't say for others). That is, from `https://myvault.vault.azure.net`, it makes `vault.azure.net/` where it should make `https://vault.azure.net`. This PR just changes the way the endpoint is extracted and stops calling that `suffix`.