### PR TITLE
Fix consistency response

### DIFF
--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -64,10 +64,10 @@ pub trait TokenCredential: Send + Sync {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Consistency {
-    Md5([u8; 16]),
-    Crc64([u8; 8]),
-}
+pub struct ConsistencyCRC64(pub [u8; 8]);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConsistencyMD5(pub [u8; 16]);
 
 pub trait AppendToUrlQuery {
     fn append_to_url_query(&self, url: &mut url::Url);

--- a/sdk/core/src/prelude.rs
+++ b/sdk/core/src/prelude.rs
@@ -2,6 +2,6 @@ pub use crate::errors::AzureError;
 pub use crate::etag::Etag;
 pub use crate::request_options::*;
 pub use crate::{
-    AddAsHeader, AppendToUrlQuery, Consistency, HttpClient, RequestId, SessionToken,
-    StoredAccessPolicy, StoredAccessPolicyList, EMPTY_BODY,
+    AddAsHeader, AppendToUrlQuery, ConsistencyCRC64, ConsistencyMD5, HttpClient, RequestId,
+    SessionToken, StoredAccessPolicy, StoredAccessPolicyList, EMPTY_BODY,
 };

--- a/sdk/storage/src/blob/blob/responses/put_block_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_block_blob_response.rs
@@ -3,7 +3,7 @@ use azure_core::headers::{
     consistency_from_headers, date_from_headers, etag_from_headers, last_modified_from_headers,
     request_id_from_headers, request_server_encrypted_from_headers,
 };
-use azure_core::{Consistency, RequestId};
+use azure_core::{ConsistencyCRC64, ConsistencyMD5, RequestId};
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
@@ -11,7 +11,8 @@ use http::HeaderMap;
 pub struct PutBlockBlobResponse {
     pub etag: String,
     pub last_modified: DateTime<Utc>,
-    pub consistency: Consistency,
+    pub content_md5: ConsistencyMD5,
+    pub content_crc64: Option<ConsistencyCRC64>,
     pub request_id: RequestId,
     pub date: DateTime<Utc>,
     pub request_server_encrypted: bool,
@@ -23,7 +24,7 @@ impl PutBlockBlobResponse {
 
         let etag = etag_from_headers(headers)?;
         let last_modified = last_modified_from_headers(headers)?;
-        let consistency = consistency_from_headers(headers)?;
+        let (content_md5, content_crc64) = consistency_from_headers(headers)?;
         let request_id = request_id_from_headers(headers)?;
         let date = date_from_headers(headers)?;
         let request_server_encrypted = request_server_encrypted_from_headers(headers)?;
@@ -31,7 +32,8 @@ impl PutBlockBlobResponse {
         Ok(PutBlockBlobResponse {
             etag,
             last_modified,
-            consistency,
+            content_md5,
+            content_crc64,
             request_id,
             date,
             request_server_encrypted,

--- a/sdk/storage/src/blob/blob/responses/put_block_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_block_response.rs
@@ -3,13 +3,14 @@ use azure_core::headers::{
     consistency_from_headers, date_from_headers, request_id_from_headers,
     request_server_encrypted_from_headers,
 };
-use azure_core::{Consistency, RequestId};
+use azure_core::{ConsistencyCRC64, ConsistencyMD5, RequestId};
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PutBlockResponse {
-    pub consistency: Consistency,
+    pub content_md5: ConsistencyMD5,
+    pub content_crc64: Option<ConsistencyCRC64>,
     pub request_id: RequestId,
     pub date: DateTime<Utc>,
     pub request_server_encrypted: bool,
@@ -19,13 +20,14 @@ impl PutBlockResponse {
     pub(crate) fn from_headers(headers: &HeaderMap) -> Result<PutBlockResponse, AzureError> {
         debug!("{:#?}", headers);
 
-        let consistency = consistency_from_headers(headers)?;
+        let (content_md5, content_crc64) = consistency_from_headers(headers)?;
         let request_id = request_id_from_headers(headers)?;
         let date = date_from_headers(headers)?;
         let request_server_encrypted = request_server_encrypted_from_headers(headers)?;
 
         Ok(PutBlockResponse {
-            consistency,
+            content_md5,
+            content_crc64,
             request_id,
             date,
             request_server_encrypted,


### PR DESCRIPTION
Hi, according to the online documentation, both the content MD5 and CRC64 can be found in put blob responses. This PR fixes that on the client side.

I kept the CRC64 optional, but it could easily be mandatory.