### PR TITLE
Bump version on oauth2 and fix deprecated use of Url .into_string()

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -31,7 +31,7 @@ bytes = "1.0"
 hyper-rustls = { version = "0.22", optional = true }
 failure = "0.1"
 async-trait = "0.1"
-oauth2 = "=4.0.0-beta.1"
+oauth2 = "4.0.0"
 reqwest = { version = "0.11", optional = true }
 paste = "1.0"
 md5 = "0.7"

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.1.0" }
-oauth2 = "=4.0.0-beta.1"
+oauth2 = "4.0.0"
 url = "2.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/key_vault/Cargo.toml
+++ b/sdk/key_vault/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-oauth2 = "=4.0.0-beta.1"
+oauth2 = "4.0.0"
 azure_core = { path = "../core", version = "0.1.0" }
 azure_identity = { version = "0.1", path = "../identity" }
 

--- a/sdk/service_bus/src/event_hub/mod.rs
+++ b/sdk/service_bus/src/event_hub/mod.rs
@@ -64,7 +64,7 @@ fn peek_lock_prepare(
     let sas = generate_signature(policy_name, signing_key, &url.as_str(), duration);
     debug!("sas == {}", sas);
 
-    let request = hyper::Request::post(url.into_string())
+    let request = hyper::Request::post(Into::<String>::into(url))
         .header(header::AUTHORIZATION, sas)
         .header(header::CONTENT_LENGTH, 0)
         .body(Body::empty())?;


### PR DESCRIPTION
Bumping the oauth2 dependency on `4.0.0-beta.1` to `4.0.0` to solve some `cargo audit` warnings.

```
Crate:         cpuid-bool
Version:       0.1.2
Warning:       unmaintained
Title:         `cpuid-bool` has been renamed to `cpufeatures`
Date:          2021-05-06
ID:            RUSTSEC-2021-0064
URL:           https://rustsec.org/advisories/RUSTSEC-2021-0064
Dependency tree:
cpuid-bool 0.1.2
└── sha2 0.9.3
    └── oauth2 4.0.0-beta.1
        ├── azure_identity 0.1.0
        │   └── azpolctl 0.1.0
        └── azure_core 0.1.0
            ├── azure_mgmt_resources 0.1.0
            │   └── azpolctl 0.1.0
            ├── azure_identity 0.1.0
            └── azpolctl 0.1.0
```

I've also updated the use of `.into_string()` on the `Url` object [as it is deprecated](https://docs.rs/url/2.2.2/url/struct.Url.html#method.into_string). Let me know if this is the correct way to do this or not. :)

```
    let request = hyper::Request::post(Into::<String>::into(url))
```

All tests pass with `cargo test` on Windows and Mac running Rust 1.51.