### PR TITLE
Revert "Fix consistency response"

### DIFF
--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::errors::*;
 use crate::request_options::LeaseId;
 use crate::util::HeaderMapExt;
-use crate::{ConsistencyCRC64, ConsistencyMD5, RequestId, SessionToken};
+use crate::{Consistency, RequestId, SessionToken};
 use chrono::{DateTime, Utc};
 use http::header::{HeaderName, DATE, ETAG, LAST_MODIFIED};
 #[cfg(feature = "enable_hyper")]
@@ -116,17 +116,17 @@ pub fn content_crc64_from_headers(headers: &HeaderMap) -> Result<[u8; 8], AzureE
     Ok(content_crc64)
 }
 
-pub fn consistency_from_headers(
-    headers: &HeaderMap,
-) -> Result<(ConsistencyMD5, Option<ConsistencyCRC64>), AzureError> {
-    let content_crc64 = content_crc64_from_headers_optional(headers)?.map(ConsistencyCRC64);
-    let content_md5 = if let Some(content_md5) = content_md5_from_headers_optional(headers)? {
-        ConsistencyMD5(content_md5)
-    } else {
-        return Err(AzureError::HeadersNotFound(vec![CONTENT_MD5.to_owned()]));
-    };
+pub fn consistency_from_headers(headers: &HeaderMap) -> Result<Consistency, AzureError> {
+    if let Some(content_crc64) = content_crc64_from_headers_optional(headers)? {
+        return Ok(Consistency::Crc64(content_crc64));
+    } else if let Some(content_md5) = content_md5_from_headers_optional(headers)? {
+        return Ok(Consistency::Md5(content_md5));
+    }
 
-    Ok((content_md5, content_crc64))
+    Err(AzureError::HeadersNotFound(vec![
+        CONTENT_CRC64.to_owned(),
+        CONTENT_MD5.to_owned(),
+    ]))
 }
 
 pub fn last_modified_from_headers_optional(

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -64,10 +64,10 @@ pub trait TokenCredential: Send + Sync {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct ConsistencyCRC64(pub [u8; 8]);
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct ConsistencyMD5(pub [u8; 16]);
+pub enum Consistency {
+    Md5([u8; 16]),
+    Crc64([u8; 8]),
+}
 
 pub trait AppendToUrlQuery {
     fn append_to_url_query(&self, url: &mut url::Url);

--- a/sdk/core/src/prelude.rs
+++ b/sdk/core/src/prelude.rs
@@ -2,6 +2,6 @@ pub use crate::errors::AzureError;
 pub use crate::etag::Etag;
 pub use crate::request_options::*;
 pub use crate::{
-    AddAsHeader, AppendToUrlQuery, ConsistencyCRC64, ConsistencyMD5, HttpClient, RequestId,
-    SessionToken, StoredAccessPolicy, StoredAccessPolicyList, EMPTY_BODY,
+    AddAsHeader, AppendToUrlQuery, Consistency, HttpClient, RequestId, SessionToken,
+    StoredAccessPolicy, StoredAccessPolicyList, EMPTY_BODY,
 };

--- a/sdk/storage/src/blob/blob/responses/put_block_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_block_blob_response.rs
@@ -3,7 +3,7 @@ use azure_core::headers::{
     consistency_from_headers, date_from_headers, etag_from_headers, last_modified_from_headers,
     request_id_from_headers, request_server_encrypted_from_headers,
 };
-use azure_core::{ConsistencyCRC64, ConsistencyMD5, RequestId};
+use azure_core::{Consistency, RequestId};
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
@@ -11,8 +11,7 @@ use http::HeaderMap;
 pub struct PutBlockBlobResponse {
     pub etag: String,
     pub last_modified: DateTime<Utc>,
-    pub content_md5: ConsistencyMD5,
-    pub content_crc64: Option<ConsistencyCRC64>,
+    pub consistency: Consistency,
     pub request_id: RequestId,
     pub date: DateTime<Utc>,
     pub request_server_encrypted: bool,
@@ -24,7 +23,7 @@ impl PutBlockBlobResponse {
 
         let etag = etag_from_headers(headers)?;
         let last_modified = last_modified_from_headers(headers)?;
-        let (content_md5, content_crc64) = consistency_from_headers(headers)?;
+        let consistency = consistency_from_headers(headers)?;
         let request_id = request_id_from_headers(headers)?;
         let date = date_from_headers(headers)?;
         let request_server_encrypted = request_server_encrypted_from_headers(headers)?;
@@ -32,8 +31,7 @@ impl PutBlockBlobResponse {
         Ok(PutBlockBlobResponse {
             etag,
             last_modified,
-            content_md5,
-            content_crc64,
+            consistency,
             request_id,
             date,
             request_server_encrypted,

--- a/sdk/storage/src/blob/blob/responses/put_block_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_block_response.rs
@@ -3,14 +3,13 @@ use azure_core::headers::{
     consistency_from_headers, date_from_headers, request_id_from_headers,
     request_server_encrypted_from_headers,
 };
-use azure_core::{ConsistencyCRC64, ConsistencyMD5, RequestId};
+use azure_core::{Consistency, RequestId};
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PutBlockResponse {
-    pub content_md5: ConsistencyMD5,
-    pub content_crc64: Option<ConsistencyCRC64>,
+    pub consistency: Consistency,
     pub request_id: RequestId,
     pub date: DateTime<Utc>,
     pub request_server_encrypted: bool,
@@ -20,14 +19,13 @@ impl PutBlockResponse {
     pub(crate) fn from_headers(headers: &HeaderMap) -> Result<PutBlockResponse, AzureError> {
         debug!("{:#?}", headers);
 
-        let (content_md5, content_crc64) = consistency_from_headers(headers)?;
+        let consistency = consistency_from_headers(headers)?;
         let request_id = request_id_from_headers(headers)?;
         let date = date_from_headers(headers)?;
         let request_server_encrypted = request_server_encrypted_from_headers(headers)?;
 
         Ok(PutBlockResponse {
-            content_md5,
-            content_crc64,
+            consistency,
             request_id,
             date,
             request_server_encrypted,


### PR DESCRIPTION
Reverts Azure/azure-sdk-for-rust#236: Azure storage does not always return `Content-MD5` so this implementation fails at runtime.