### PR TITLE
VirtualMachineExtension should have SubResource

### DIFF
--- a/services/mgmt/compute/src/package_2020_12_01/models.rs
+++ b/services/mgmt/compute/src/package_2020_12_01/models.rs
@@ -420,7 +420,7 @@ pub struct VirtualMachineExtensionUpdateProperties {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VirtualMachineExtension {
     #[serde(flatten)]
-    pub resource: SubResource,
+    pub sub_resource_read_only: SubResourceReadOnly,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub properties: Option<VirtualMachineExtensionProperties>,
 }

--- a/services/mgmt/compute/src/package_2020_12_01/models.rs
+++ b/services/mgmt/compute/src/package_2020_12_01/models.rs
@@ -420,7 +420,7 @@ pub struct VirtualMachineExtensionUpdateProperties {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct VirtualMachineExtension {
     #[serde(flatten)]
-    pub resource: Resource,
+    pub resource: SubResource,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub properties: Option<VirtualMachineExtensionProperties>,
 }


### PR DESCRIPTION
Do not merge. This is just to show what the fix is in code. While troubleshooting #54, this is the code change to make `cargo run --example vm_list` example work. There is an error in the compute 2021-12-01 API specification https://github.com/Azure/azure-rest-api-specs/pull/12334.  `VirtualMachineExtensionProperties` should contain a `SubResource`, not `Resource`.