### PR TITLE
Endpoints for Azure Resource Manager in different Azure clouds

### DIFF
--- a/sdk/core/src/constants.rs
+++ b/sdk/core/src/constants.rs
@@ -1,0 +1,15 @@
+/// Endpoints for Azure Resource Manager in different Azure clouds
+pub mod resource_manager_endpoint {
+
+    /// Azure Resource Manager China cloud endpoint
+    pub const AZURE_CHINA_CLOUD: &str = "https://management.chinacloudapi.cn";
+
+    /// Azure Resource Manager Germany cloud endpoint
+    pub const AZURE_GERMANY_CLOUD: &str = "https://management.microsoftazure.de";
+
+    /// Azure Resource Manager public cloud endpoint
+    pub const AZURE_PUBLIC_CLOUD: &str = "https://management.azure.com";
+
+    /// Azure Resource Manager US government cloud endpoint
+    pub const AZURE_US_GOVERNMENT_CLOUD: &str = "https://management.usgovcloudapi.net";
+}

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -10,6 +10,7 @@ extern crate serde_derive;
 mod macros;
 
 mod bytes_stream;
+mod constants;
 mod context;
 mod errors;
 pub mod headers;
@@ -34,6 +35,7 @@ use std::fmt::Debug;
 use uuid::Uuid;
 
 pub use bytes_stream::*;
+pub use constants::*;
 pub use context::Context;
 pub use errors::*;
 pub use headers::AddAsHeader;


### PR DESCRIPTION
This provides similar constants as the Go SDK:
https://github.com/Azure/azure-sdk-for-go/blob/master/sdk/armcore/connection.go
https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/armcore#pkg-constants
``` go
const (
	// AzureChina is the Azure Resource Manager China cloud endpoint.
	AzureChina = "https://management.chinacloudapi.cn/"
	// AzureGermany is the Azure Resource Manager Germany cloud endpoint.
	AzureGermany = "https://management.microsoftazure.de/"
	// AzureGovernment is the Azure Resource Manager US government cloud endpoint.
	AzureGovernment = "https://management.usgovcloudapi.net/"
	// AzurePublicCloud is the Azure Resource Manager public cloud endpoint.
	AzurePublicCloud = "https://management.azure.com/"
)
```

They also match up with the list of clouds that come from the Az CLI:
```
az cloud list --query "[].{cloud: name, ResourceManagerEndpoint: endpoints.resourceManager}" --output table

Cloud              ResourceManagerEndpoint
-----------------  ----------------------------------------------
AzureCloud         https://management.azure.com/
AzureChinaCloud    https://management.chinacloudapi.cn
AzureUSGovernment  https://management.usgovcloudapi.net/
AzureGermanCloud   https://management.microsoftazure.de
```

It will be able to be used like this from the service configurations:
``` rust
base_path: self.base_path.unwrap_or(azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD.to_owned()),
```