### PR TITLE
Format on save

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,28 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  fmt:
+    name: Code Style
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+          components: rustfmt
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo fmt sdk
+        run: cargo fmt --all -- --check
+
+      - name: cargo fmt services
+        run: |
+          ./eng/scripts/check_json_format.sh
+          cargo fmt --manifest-path services/Cargo.toml --all -- --check
+
   test-sdk:
     name: SDK Tests
     runs-on: ubuntu-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,28 +9,6 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  fmt:
-    name: Code Style
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt
-
-      - uses: Swatinem/rust-cache@v1
-
-      - name: cargo fmt sdk
-        run: cargo fmt --all -- --check
-
-      - name: cargo fmt services
-        run: |
-          ./eng/scripts/check_json_format.sh
-          cargo fmt --manifest-path services/Cargo.toml --all -- --check
-
   test-sdk:
     name: SDK Tests
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 target
 Cargo.lock
 *.rs.bk
-.vscode/*
+.vscode/
 !.vscode/extensions.json
+!.vscode/settings.json
 sample/
 /.project
 \#*\#

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}


### PR DESCRIPTION
Instead of removing the fmt build job that creates a barrier to contributions, it's better to format on save in the most popular IDE we're all using for this repo currently to decrease the chances of having a build blocked on formatting, which we don't do in other repos to reduce friction of contributions, especially for our community contributors.