### PR TITLE
azure_cosmos::Error & azure_storage::Error

### DIFF
--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -174,30 +174,10 @@ pub enum Error {
     GetTokenError(Box<dyn std::error::Error + Send + Sync>),
     #[error("http error: {0}")]
     HttpError(#[from] HttpError),
-    #[error("{}-{} is not 512 byte aligned", start, end)]
-    PageNot512ByteAlignedError { start: u64, end: u64 },
-    #[error("{} is not 512 byte aligned", size)]
-    Not512ByteAlignedError { size: u64 },
-    #[error("Operation not supported. Operation == {0}, reason == {1}")]
-    OperationNotSupported(String, String),
     #[error("parse bool error: {0}")]
     ParseBoolError(#[from] std::str::ParseBoolError),
     #[error("to str error: {0}")]
     ToStrError(#[from] http::header::ToStrError),
-    #[error("json error: {0}")]
-    JSONError(#[from] serde_json::Error),
-    #[error("Permission error: {0}")]
-    PermissionError(#[from] PermissionError),
-    #[error("IO error: {0}")]
-    IOError(#[from] std::io::Error),
-    #[error("UnexpectedXMLError: {0}")]
-    UnexpectedXMLError(String),
-    #[error("Azure Path parse error: {0}")]
-    AzurePathParseError(#[from] AzurePathParseError),
-    #[error("UnexpectedHTTPResult error: {0:?}")]
-    UnexpectedHTTPResult(UnexpectedHTTPResult),
-    #[error("UnexpectedValue error: {0:?}")]
-    UnexpectedValue(UnexpectedValue),
     #[error("Header not found: {0}")]
     HeaderNotFound(String),
     #[error("At least one of these headers must be present: {0:?}")]
@@ -211,45 +191,14 @@ pub enum Error {
         expected_parameter: String,
         url: url::Url,
     },
-    #[error("Traversing error: {0}")]
-    ResponseParsingError(#[from] TraversingError),
     #[error("Parse int error: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
-    #[error("Parse float error: {0}")]
-    ParseFloatError(#[from] std::num::ParseFloatError),
-    #[error("Parse error: {0}")]
-    ParseError(#[from] ParseError),
-    #[error("Parsing error: {0}")]
-    ParsingError(#[from] ParsingError),
-    #[error("Input parameters error: {0}")]
-    InputParametersError(String),
-    #[error("URL parse error: {0}")]
-    UrlParseError(#[from] url::ParseError),
     #[error("Error preparing HTTP request: {0}")]
     HttpPrepareError(#[from] http::Error),
     #[error("uuid error: {0}")]
     ParseUuidError(#[from] uuid::Error),
     #[error("Chrono parser error: {0}")]
     ChronoParserError(#[from] chrono::ParseError),
-    #[error("UTF8 conversion error: {0}")]
-    Utf8Error(#[from] std::str::Utf8Error),
-    #[error("FromUTF8 error: {0}")]
-    FromUtf8Error(#[from] std::string::FromUtf8Error),
-    #[error("A required header is missing: {0}")]
-    MissingHeaderError(String),
-    #[error(
-        "An expected JSON node is missing: {} of expected type {}",
-        value,
-        expected_type
-    )]
-    MissingValueError {
-        value: String,
-        expected_type: String,
-    },
-    #[error("Invalid status code: {:?}", 0)]
-    InvalidStatusCode(#[from] http::status::InvalidStatusCode),
-    #[error("Error parsing the transaction response: {:?}", 0)]
-    TransactionResponseParseError(String),
 }
 
 #[non_exhaustive]

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -16,9 +16,9 @@ pub enum ParsingError {
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum ParseError {
-    #[error("Expected token \"{}\" not found", 0)]
+    #[error("Expected token \"{0}\" not found")]
     TokenNotFound(String),
-    #[error("Expected split char \'{}\' not found", 0)]
+    #[error("Expected split char \'{0}\' not found")]
     SplitNotFound(char),
     #[error("Parse int error {0}")]
     ParseIntError(std::num::ParseIntError),
@@ -222,7 +222,7 @@ pub enum TraversingError {
     ParseIntError(#[from] std::num::ParseIntError),
     #[error("Generic parse error: {0}")]
     GenericParseError(String),
-    #[error("Parsing error: {:?}", 0)]
+    #[error("Parsing error: {0:?}")]
     ParsingError(#[from] ParsingError),
 }
 

--- a/sdk/cosmos/examples/collection.rs
+++ b/sdk/cosmos/examples/collection.rs
@@ -12,8 +12,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // This is how you construct an authorization token.
     // Remember to pick the correct token type.
     // Here we assume master.
-    // Most methods return a ```Result<_, CosmosError>```.
-    // ```CosmosError``` is an enum union of all the possible underlying
+    // Most methods return a ```Result<_, azure_cosmos::Error```.
+    // ```azure_cosmos::Error``` is an enum union of all the possible underlying
     // errors, plus Azure specific ones. For example if a REST call returns the
     // unexpected result (ie NotFound instead of Ok) we return an Err telling
     // you that.

--- a/sdk/cosmos/examples/create_delete_database.rs
+++ b/sdk/cosmos/examples/create_delete_database.rs
@@ -21,8 +21,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // This is how you construct an authorization token.
     // Remember to pick the correct token type.
     // Here we assume master.
-    // Most methods return a ```Result<_, CosmosError>```.
-    // ```CosmosError``` is an enum union of all the possible underlying
+    // Most methods return a ```Result<_, azure_cosmos::Error```.
+    // ```azure_cosmos::Error``` is an enum union of all the possible underlying
     // errors, plus Azure specific ones. For example if a REST call returns the
     // unexpected result (ie NotFound instead of Ok) we return an Err telling
     // you that.

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // list_databases will give us the databases available in our account. If there is
     // an error (for example, the given key is not valid) you will receive a
-    // specific CosmosError. In this example we will look for a specific database
+    // specific azure_cosmos::Error. In this example we will look for a specific database
     // so we chain a filter operation.
     let db = client
         .list_databases()

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -1,8 +1,8 @@
 use super::DatabaseClient;
+use crate::headers::*;
 use crate::operations::*;
 use crate::resources::permission::AuthorizationToken;
 use crate::resources::ResourceType;
-use crate::{headers::*, CosmosError};
 use crate::{requests, ReadonlyString};
 
 use azure_core::pipeline::Pipeline;
@@ -163,7 +163,7 @@ impl CosmosClient {
         ctx: Context,
         database_name: S,
         options: CreateDatabaseOptions,
-    ) -> Result<CreateDatabaseResponse, CosmosError> {
+    ) -> Result<CreateDatabaseResponse, crate::Error> {
         let mut request = self.prepare_request2("dbs", http::Method::POST, ResourceType::Databases);
         let mut ctx = ctx.clone();
         options.decorate_request(&mut request, database_name.as_ref())?;
@@ -171,7 +171,7 @@ impl CosmosClient {
             .pipeline()
             .send(&mut ctx, &mut request)
             .await
-            .map_err(CosmosError::PolicyError)?;
+            .map_err(crate::Error::PolicyError)?;
 
         Ok(CreateDatabaseResponse::try_from(response).await?)
     }

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -2,7 +2,6 @@ use super::*;
 use crate::operations::*;
 use crate::requests;
 use crate::resources::ResourceType;
-use crate::CosmosError;
 use crate::ReadonlyString;
 use azure_core::pipeline::Pipeline;
 use azure_core::{Context, HttpClient, Request};
@@ -56,7 +55,7 @@ impl DatabaseClient {
         ctx: Context,
         collection_name: S,
         options: CreateCollectionOptions,
-    ) -> Result<CreateCollectionResponse, CosmosError> {
+    ) -> Result<CreateCollectionResponse, crate::Error> {
         let request = self.cosmos_client().prepare_request(
             &format!("dbs/{}/colls", self.database_name()),
             http::Method::POST,
@@ -70,7 +69,7 @@ impl DatabaseClient {
             .pipeline()
             .send(&mut ctx, &mut request)
             .await
-            .map_err(CosmosError::PolicyError)?;
+            .map_err(crate::Error::PolicyError)?;
 
         Ok(CreateCollectionResponse::try_from(response).await?)
     }

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -2,7 +2,7 @@
 #[allow(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
-pub enum CosmosError {
+pub enum Error {
     #[error(transparent)]
     AzureCoreError(#[from] azure_core::Error),
     #[error("Resource quota parsing error: {0}")]

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -35,10 +35,6 @@ pub enum CosmosError {
     Utf8Error(#[from] std::str::Utf8Error),
     #[error("base64 decode error: {0}")]
     DecodeError(#[from] base64::DecodeError),
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum ConversionToDocumentError {
     #[error("Conversion to document failed because at lease one element is raw.")]
-    RawElementFound,
+    RawElementError,
 }

--- a/sdk/cosmos/src/headers/from_headers.rs
+++ b/sdk/cosmos/src/headers/from_headers.rs
@@ -1,87 +1,89 @@
+use crate::headers::*;
 use crate::resource_quota::resource_quotas_from_str;
 use crate::resources::document::IndexingDirective;
 use crate::ResourceQuota;
-use crate::{headers::*, CosmosError};
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
-pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> Result<f64, CosmosError> {
+pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> Result<f64, crate::Error> {
     Ok(headers
         .get(HEADER_REQUEST_CHARGE)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_REQUEST_CHARGE.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_REQUEST_CHARGE.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn role_from_headers(headers: &HeaderMap) -> Result<u32, CosmosError> {
+pub(crate) fn role_from_headers(headers: &HeaderMap) -> Result<u32, crate::Error> {
     Ok(headers
         .get(HEADER_ROLE)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_ROLE.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ROLE.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn number_of_read_regions_from_headers(headers: &HeaderMap) -> Result<u32, CosmosError> {
+pub(crate) fn number_of_read_regions_from_headers(
+    headers: &HeaderMap,
+) -> Result<u32, crate::Error> {
     Ok(headers
         .get(HEADER_NUMBER_OF_READ_REGIONS)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_NUMBER_OF_READ_REGIONS.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_NUMBER_OF_READ_REGIONS.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> Result<uuid::Uuid, CosmosError> {
+pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> Result<uuid::Uuid, crate::Error> {
     let s = headers
         .get(HEADER_ACTIVITY_ID)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_ACTIVITY_ID.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ACTIVITY_ID.to_owned()))?
         .to_str()?;
     Ok(uuid::Uuid::parse_str(s)?)
 }
 
-pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> Result<&str, CosmosError> {
+pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
     Ok(headers
         .get(HEADER_CONTENT_PATH)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_CONTENT_PATH.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_CONTENT_PATH.to_owned()))?
         .to_str()?)
 }
 
-pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> Result<&str, CosmosError> {
+pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
     Ok(headers
         .get(HEADER_ALT_CONTENT_PATH)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_ALT_CONTENT_PATH.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ALT_CONTENT_PATH.to_owned()))?
         .to_str()?)
 }
 
 pub(crate) fn resource_quota_from_headers(
     headers: &HeaderMap,
-) -> Result<Vec<ResourceQuota>, CosmosError> {
+) -> Result<Vec<ResourceQuota>, crate::Error> {
     let s = headers
         .get(HEADER_RESOURCE_QUOTA)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_RESOURCE_QUOTA.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_RESOURCE_QUOTA.to_owned()))?
         .to_str()?;
     Ok(resource_quotas_from_str(s)?)
 }
 
 pub(crate) fn resource_usage_from_headers(
     headers: &HeaderMap,
-) -> Result<Vec<ResourceQuota>, CosmosError> {
+) -> Result<Vec<ResourceQuota>, crate::Error> {
     let s = headers
         .get(HEADER_RESOURCE_USAGE)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_RESOURCE_USAGE.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_RESOURCE_USAGE.to_owned()))?
         .to_str()?;
     Ok(resource_quotas_from_str(s)?)
 }
 
-pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_QUORUM_ACKED_LSN)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_QUORUM_ACKED_LSN.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_QUORUM_ACKED_LSN.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
 pub(crate) fn quorum_acked_lsn_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, CosmosError> {
+) -> Result<Option<u64>, crate::Error> {
     Ok(match headers.get(HEADER_QUORUM_ACKED_LSN) {
         Some(val) => Some(val.to_str()?.parse()?),
         None => None,
@@ -90,34 +92,34 @@ pub(crate) fn quorum_acked_lsn_from_headers_optional(
 
 pub(crate) fn cosmos_quorum_acked_llsn_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, CosmosError> {
+) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_COSMOS_QUORUM_ACKED_LLSN)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_COSMOS_QUORUM_ACKED_LLSN.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COSMOS_QUORUM_ACKED_LLSN.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
 pub(crate) fn cosmos_quorum_acked_llsn_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, CosmosError> {
+) -> Result<Option<u64>, crate::Error> {
     Ok(match headers.get(HEADER_COSMOS_QUORUM_ACKED_LLSN) {
         Some(val) => Some(val.to_str()?.parse()?),
         None => None,
     })
 }
 
-pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_CURRENT_WRITE_QUORUM)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_CURRENT_WRITE_QUORUM.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_CURRENT_WRITE_QUORUM.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
 pub(crate) fn current_write_quorum_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, CosmosError> {
+) -> Result<Option<u64>, crate::Error> {
     Ok(match headers.get(HEADER_CURRENT_WRITE_QUORUM) {
         Some(val) => Some(val.to_str()?.parse()?),
         None => None,
@@ -126,17 +128,17 @@ pub(crate) fn current_write_quorum_from_headers_optional(
 
 pub(crate) fn collection_partition_index_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, CosmosError> {
+) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_COLLECTION_PARTITION_INDEX)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_COLLECTION_PARTITION_INDEX.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COLLECTION_PARTITION_INDEX.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
 pub(crate) fn indexing_directive_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<IndexingDirective>, CosmosError> {
+) -> Result<Option<IndexingDirective>, crate::Error> {
     match headers.get(HEADER_INDEXING_DIRECTIVE) {
         Some(header) => Ok(Some(header.to_str()?.parse()?)),
         None => Ok(None),
@@ -145,135 +147,137 @@ pub(crate) fn indexing_directive_from_headers_optional(
 
 pub(crate) fn collection_service_index_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, CosmosError> {
+) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_COLLECTION_SERVICE_INDEX)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_COLLECTION_SERVICE_INDEX.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COLLECTION_SERVICE_INDEX.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_LSN)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_LSN.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_LSN.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_ITEM_LSN)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_ITEM_LSN.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ITEM_LSN.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_TRANSPORT_REQUEST_ID)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_TRANSPORT_REQUEST_ID.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_TRANSPORT_REQUEST_ID.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     let s = headers
         .get(HEADER_GLOBAL_COMMITTED_LSN)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_GLOBAL_COMMITTED_LSN.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_GLOBAL_COMMITTED_LSN.to_owned()))?
         .to_str()?;
     Ok(if s == "-1" { 0 } else { s.parse()? })
 }
 
-pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_COSMOS_LLSN)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_COSMOS_LLSN.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COSMOS_LLSN.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_COSMOS_ITEM_LLSN)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_COSMOS_ITEM_LLSN.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COSMOS_ITEM_LLSN.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
 pub(crate) fn current_replica_set_size_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, CosmosError> {
+) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_CURRENT_REPLICA_SET_SIZE)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_CURRENT_REPLICA_SET_SIZE.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_CURRENT_REPLICA_SET_SIZE.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
 pub(crate) fn current_replica_set_size_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, CosmosError> {
+) -> Result<Option<u64>, crate::Error> {
     Ok(match headers.get(HEADER_CURRENT_REPLICA_SET_SIZE) {
         Some(val) => Some(val.to_str()?.parse()?),
         None => None,
     })
 }
 
-pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> Result<&str, CosmosError> {
+pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
     Ok(headers
         .get(HEADER_SCHEMA_VERSION)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_SCHEMA_VERSION.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_SCHEMA_VERSION.to_owned()))?
         .to_str()?)
 }
 
-pub(crate) fn server_from_headers(headers: &HeaderMap) -> Result<&str, CosmosError> {
+pub(crate) fn server_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
     let header_server = http::header::SERVER;
 
     Ok(headers
         .get(http::header::SERVER)
-        .ok_or_else(|| CosmosError::HeaderNotFound(header_server.to_string()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(header_server.to_string()))?
         .to_str()?)
 }
 
-pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> Result<&str, CosmosError> {
+pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
     Ok(headers
         .get(HEADER_SERVICE_VERSION)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_SERVICE_VERSION.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_SERVICE_VERSION.to_owned()))?
         .to_str()?)
 }
 
-pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> Result<&str, CosmosError> {
+pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
     Ok(headers
         .get(http::header::CONTENT_LOCATION)
         .ok_or_else(|| {
             let header = http::header::CONTENT_LOCATION;
-            CosmosError::HeaderNotFound(header.as_str().to_owned())
+            crate::Error::HeaderNotFound(header.as_str().to_owned())
         })?
         .to_str()?)
 }
 
-pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> Result<&str, CosmosError> {
+pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
     Ok(headers
         .get(HEADER_GATEWAY_VERSION)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_GATEWAY_VERSION.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_GATEWAY_VERSION.to_owned()))?
         .to_str()?)
 }
 
 pub(crate) fn max_media_storage_usage_mb_from_headers(
     headers: &HeaderMap,
-) -> Result<u64, CosmosError> {
+) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_MAX_MEDIA_STORAGE_USAGE_MB)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_MAX_MEDIA_STORAGE_USAGE_MB.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_MAX_MEDIA_STORAGE_USAGE_MB.to_owned()))?
         .to_str()?
         .parse()?)
 }
 
-pub(crate) fn media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result<u64, CosmosError> {
+pub(crate) fn media_storage_usage_mb_from_headers(
+    headers: &HeaderMap,
+) -> Result<u64, crate::Error> {
     Ok(headers
         .get(HEADER_MEDIA_STORAGE_USAGE_MB)
-        .ok_or_else(|| CosmosError::HeaderNotFound(HEADER_MEDIA_STORAGE_USAGE_MB.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_MEDIA_STORAGE_USAGE_MB.to_owned()))?
         .to_str()?
         .parse()?)
 }
@@ -281,10 +285,10 @@ pub(crate) fn media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result
 fn _date_from_headers(
     headers: &HeaderMap,
     header_name: &str,
-) -> Result<DateTime<Utc>, CosmosError> {
+) -> Result<DateTime<Utc>, crate::Error> {
     let date = headers
         .get(header_name)
-        .ok_or_else(|| CosmosError::HeaderNotFound(header_name.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(header_name.to_owned()))?
         .to_str()?;
     debug!("date == {:#}", date);
 
@@ -305,11 +309,11 @@ fn _date_from_headers(
 
 pub(crate) fn last_state_change_from_headers(
     headers: &HeaderMap,
-) -> Result<DateTime<Utc>, CosmosError> {
+) -> Result<DateTime<Utc>, crate::Error> {
     _date_from_headers(headers, HEADER_LAST_STATE_CHANGE_UTC)
 }
 
-pub(crate) fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>, CosmosError> {
+pub(crate) fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>, crate::Error> {
     let header = http::header::DATE;
     _date_from_headers(headers, header.as_str())
 }

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -117,6 +117,6 @@ pub use consistency_level::ConsistencyLevel;
 pub use cosmos_entity::CosmosEntity;
 pub use resource_quota::ResourceQuota;
 
-pub use errors::CosmosError;
+pub use errors::Error;
 
 type ReadonlyString = std::borrow::Cow<'static, str>;

--- a/sdk/cosmos/src/operations/create_collection.rs
+++ b/sdk/cosmos/src/operations/create_collection.rs
@@ -35,7 +35,7 @@ impl CreateCollectionOptions {
         &self,
         request: &mut HttpRequest,
         collection_name: &str,
-    ) -> Result<(), CosmosError> {
+    ) -> Result<(), crate::Error> {
         azure_core::headers::add_optional_header2(&self.offer, request);
         azure_core::headers::add_optional_header2(&self.consistency_level, request);
 
@@ -78,7 +78,7 @@ pub struct CreateCollectionResponse {
 }
 
 impl CreateCollectionResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self, CosmosError> {
+    pub async fn try_from(response: HttpResponse) -> Result<Self, crate::Error> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/cosmos/src/operations/create_database.rs
+++ b/sdk/cosmos/src/operations/create_database.rs
@@ -1,7 +1,7 @@
 use crate::headers::from_headers::*;
 use crate::prelude::*;
 use crate::resources::Database;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use azure_core::{collect_pinned_stream, Request as HttpRequest, Response as HttpResponse};
 use chrono::{DateTime, Utc};
@@ -28,7 +28,7 @@ impl CreateDatabaseOptions {
         &self,
         request: &mut HttpRequest,
         database_name: &str,
-    ) -> Result<(), CosmosError> {
+    ) -> Result<(), crate::Error> {
         #[derive(Serialize)]
         struct CreateDatabaseRequest<'a> {
             pub id: &'a str,
@@ -60,7 +60,7 @@ pub struct CreateDatabaseResponse {
 }
 
 impl CreateDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self, CosmosError> {
+    pub async fn try_from(response: HttpResponse) -> Result<Self, crate::Error> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/cosmos/src/prelude.rs
+++ b/sdk/cosmos/src/prelude.rs
@@ -12,7 +12,7 @@
 //! ```
 
 #[doc(inline)]
-pub use crate::{ConsistencyLevel, CosmosEntity, CosmosError};
+pub use crate::{ConsistencyLevel, CosmosEntity};
 
 #[doc(inline)]
 pub use crate::clients::*;

--- a/sdk/cosmos/src/requests/create_document_builder.rs
+++ b/sdk/cosmos/src/requests/create_document_builder.rs
@@ -58,7 +58,7 @@ impl<'a, 'b, 'c> CreateDocumentBuilder<'a, 'b> {
         &self,
         document: &'c DOC,
         fn_add_primary_key: FNPK,
-    ) -> Result<CreateDocumentResponse, CosmosError>
+    ) -> Result<CreateDocumentResponse, crate::Error>
     where
         DOC: Serialize,
         FNPK: FnOnce(http::request::Builder) -> Result<http::request::Builder, serde_json::Error>,
@@ -120,7 +120,7 @@ impl<'a, 'b, 'c> CreateDocumentBuilder<'a, 'b> {
         &self,
         document: &'c DOC,
         partition_key: &PK,
-    ) -> Result<CreateDocumentResponse, CosmosError> {
+    ) -> Result<CreateDocumentResponse, crate::Error> {
         self.perform_execute(document, |req| {
             Ok(add_as_partition_key_header_serialized(
                 &serialize_partition_key(partition_key)?,
@@ -133,7 +133,7 @@ impl<'a, 'b, 'c> CreateDocumentBuilder<'a, 'b> {
     pub async fn execute<T: Serialize + CosmosEntity<'c>>(
         &self,
         document: &'c T,
-    ) -> Result<CreateDocumentResponse, CosmosError> {
+    ) -> Result<CreateDocumentResponse, crate::Error> {
         self.perform_execute(document, |req| {
             Ok(add_as_partition_key_header(document, req)?)
         })

--- a/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_trigger_builder.rs
@@ -40,7 +40,7 @@ impl<'a> CreateOrReplaceTriggerBuilder<'a> {
         body: B,
         trigger_type: T,
         trigger_operation: O,
-    ) -> Result<CreateTriggerResponse, CosmosError>
+    ) -> Result<CreateTriggerResponse, crate::Error>
     where
         B: AsRef<str>,
         T: Into<TriggerType>,

--- a/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
+++ b/sdk/cosmos/src/requests/create_or_replace_user_defined_function_builder.rs
@@ -40,7 +40,7 @@ impl<'a, 'b> CreateOrReplaceUserDefinedFunctionBuilder<'a, 'b> {
     pub async fn execute<B: AsRef<str>>(
         &self,
         body: B,
-    ) -> Result<CreateUserDefinedFunctionResponse, CosmosError> {
+    ) -> Result<CreateUserDefinedFunctionResponse, crate::Error> {
         trace!("CreateOrReplaceUserDefinedFunctionBuilder::execute called");
 
         // Create is POST with no name in the URL. Expected return is CREATED.

--- a/sdk/cosmos/src/requests/create_permission_builder.rs
+++ b/sdk/cosmos/src/requests/create_permission_builder.rs
@@ -42,7 +42,7 @@ impl<'a, 'b> CreatePermissionBuilder<'a, 'b> {
     pub async fn execute(
         &self,
         permission_mode: &PermissionMode<'a>,
-    ) -> Result<CreatePermissionResponse<'a>, CosmosError> {
+    ) -> Result<CreatePermissionResponse<'a>, crate::Error> {
         trace!("CreatePermissionBuilder::execute called");
 
         let request = self.permission_client.cosmos_client().prepare_request(

--- a/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_reference_attachment_builder.rs
@@ -35,7 +35,7 @@ impl<'a, 'b> CreateReferenceAttachmentBuilder<'a, 'b> {
         &self,
         media: M,
         content_type: C,
-    ) -> Result<crate::responses::CreateReferenceAttachmentResponse, CosmosError>
+    ) -> Result<crate::responses::CreateReferenceAttachmentResponse, crate::Error>
     where
         M: AsRef<str>,
         C: AsRef<str>,

--- a/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/create_slug_attachment_builder.rs
@@ -42,7 +42,7 @@ impl<'a, 'b> CreateSlugAttachmentBuilder<'a, 'b> {
     pub async fn execute<B: Into<Bytes>>(
         &self,
         body: B,
-    ) -> Result<CreateSlugAttachmentResponse, CosmosError> {
+    ) -> Result<CreateSlugAttachmentResponse, crate::Error> {
         let body = body.into();
         let mut req = self.attachment_client.prepare_request(http::Method::POST);
 

--- a/sdk/cosmos/src/requests/create_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/create_stored_procedure_builder.rs
@@ -35,7 +35,7 @@ impl<'a, 'b> CreateStoredProcedureBuilder<'a, 'b> {
     pub async fn execute<B: AsRef<str>>(
         &self,
         body: B,
-    ) -> Result<CreateStoredProcedureResponse, CosmosError> {
+    ) -> Result<CreateStoredProcedureResponse, crate::Error> {
         trace!("CreateStoredProcedureBuilder::execute called");
 
         let req = self

--- a/sdk/cosmos/src/requests/create_user_builder.rs
+++ b/sdk/cosmos/src/requests/create_user_builder.rs
@@ -28,7 +28,7 @@ impl<'a, 'b> CreateUserBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<CreateUserResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<CreateUserResponse, crate::Error> {
         trace!("CreateUserBuilder::execute called");
 
         let req = self.user_client.prepare_request(http::Method::POST);

--- a/sdk/cosmos/src/requests/delete_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/delete_attachment_builder.rs
@@ -31,7 +31,9 @@ impl<'a, 'b> DeleteAttachmentBuilder<'a, 'b> {
         if_match_condition: IfMatchCondition<'b> => Some(if_match_condition),
     }
 
-    pub async fn execute(&self) -> Result<crate::responses::DeleteAttachmentResponse, CosmosError> {
+    pub async fn execute(
+        &self,
+    ) -> Result<crate::responses::DeleteAttachmentResponse, crate::Error> {
         let mut req = self
             .attachment_client
             .prepare_request_with_attachment_name(http::Method::DELETE);

--- a/sdk/cosmos/src/requests/delete_collection_builder.rs
+++ b/sdk/cosmos/src/requests/delete_collection_builder.rs
@@ -29,7 +29,7 @@ impl<'a> DeleteCollectionBuilder<'a> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<DeleteCollectionResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeleteCollectionResponse, crate::Error> {
         trace!("DeleteCollectionBuilder::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/delete_database_builder.rs
+++ b/sdk/cosmos/src/requests/delete_database_builder.rs
@@ -31,7 +31,7 @@ impl<'a> DeleteDatabaseBuilder<'a> {
 }
 
 impl<'a> DeleteDatabaseBuilder<'a> {
-    pub async fn execute(&self) -> Result<DeleteDatabaseResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeleteDatabaseResponse, crate::Error> {
         trace!("DeleteDatabaseResponse::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/delete_document_builder.rs
+++ b/sdk/cosmos/src/requests/delete_document_builder.rs
@@ -39,7 +39,7 @@ impl<'a> DeleteDocumentBuilder<'a> {
         if_modified_since: &'a DateTime<Utc> => Some(IfModifiedSince::new(if_modified_since)),
     }
 
-    pub async fn execute(&self) -> Result<DeleteDocumentResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeleteDocumentResponse, crate::Error> {
         trace!("DeleteDocumentBuilder::execute called");
 
         let mut req = self

--- a/sdk/cosmos/src/requests/delete_permission_builder.rs
+++ b/sdk/cosmos/src/requests/delete_permission_builder.rs
@@ -28,7 +28,7 @@ impl<'a, 'b> DeletePermissionsBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<DeletePermissionResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeletePermissionResponse, crate::Error> {
         trace!("DeletePermissionBuilder::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/delete_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/delete_stored_procedure_builder.rs
@@ -29,7 +29,7 @@ impl<'a, 'b> DeleteStoredProcedureBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<DeleteStoredProcedureResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeleteStoredProcedureResponse, crate::Error> {
         trace!("DeleteStoredProcedureBuilder::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/delete_trigger_builder.rs
+++ b/sdk/cosmos/src/requests/delete_trigger_builder.rs
@@ -29,7 +29,7 @@ impl<'a, 'b> DeleteTriggerBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<DeleteTriggerResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeleteTriggerResponse, crate::Error> {
         trace!("DeleteTriggerBuilder::execute called");
 
         let req = self

--- a/sdk/cosmos/src/requests/delete_user_builder.rs
+++ b/sdk/cosmos/src/requests/delete_user_builder.rs
@@ -29,7 +29,7 @@ impl<'a, 'b> DeleteUserBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<DeleteUserResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeleteUserResponse, crate::Error> {
         trace!("DeleteUserBuilder::execute called");
 
         let req = self

--- a/sdk/cosmos/src/requests/delete_user_defined_function_builder.rs
+++ b/sdk/cosmos/src/requests/delete_user_defined_function_builder.rs
@@ -29,7 +29,7 @@ impl<'a, 'b> DeleteUserDefinedFunctionBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<DeleteUserDefinedFunctionResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<DeleteUserDefinedFunctionResponse, crate::Error> {
         trace!("DeleteUserDefinedFunctionBuilder::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/execute_stored_procedure_builder.rs
@@ -48,7 +48,7 @@ impl<'a, 'b> ExecuteStoredProcedureBuilder<'a, 'b> {
         })
     }
 
-    pub async fn execute<T>(&self) -> Result<ExecuteStoredProcedureResponse<T>, CosmosError>
+    pub async fn execute<T>(&self) -> Result<ExecuteStoredProcedureResponse<T>, crate::Error>
     where
         T: DeserializeOwned,
     {

--- a/sdk/cosmos/src/requests/get_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/get_attachment_builder.rs
@@ -31,7 +31,7 @@ impl<'a, 'b> GetAttachmentBuilder<'a, 'b> {
         if_match_condition: IfMatchCondition<'b> => Some(if_match_condition),
     }
 
-    pub async fn execute(&self) -> Result<crate::responses::GetAttachmentResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<crate::responses::GetAttachmentResponse, crate::Error> {
         let mut req = self
             .attachment_client
             .prepare_request_with_attachment_name(http::Method::GET);

--- a/sdk/cosmos/src/requests/get_collection_builder.rs
+++ b/sdk/cosmos/src/requests/get_collection_builder.rs
@@ -28,7 +28,7 @@ impl<'a> GetCollectionBuilder<'a> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<GetCollectionResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<GetCollectionResponse, crate::Error> {
         trace!("GetCollectionResponse::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/get_database_builder.rs
+++ b/sdk/cosmos/src/requests/get_database_builder.rs
@@ -27,7 +27,7 @@ impl<'a, 'b> GetDatabaseBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<GetDatabaseResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<GetDatabaseResponse, crate::Error> {
         trace!("GetDatabaseResponse::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/get_document_builder.rs
+++ b/sdk/cosmos/src/requests/get_document_builder.rs
@@ -36,7 +36,7 @@ impl<'a, 'b> GetDocumentBuilder<'a, 'b> {
         if_modified_since: &'b DateTime<Utc> => Some(IfModifiedSince::new(if_modified_since)),
     }
 
-    pub async fn execute<T>(&self) -> Result<GetDocumentResponse<T>, CosmosError>
+    pub async fn execute<T>(&self) -> Result<GetDocumentResponse<T>, crate::Error>
     where
         T: DeserializeOwned,
     {

--- a/sdk/cosmos/src/requests/get_partition_key_ranges_builder.rs
+++ b/sdk/cosmos/src/requests/get_partition_key_ranges_builder.rs
@@ -36,7 +36,7 @@ impl<'a, 'b> GetPartitionKeyRangesBuilder<'a, 'b> {
         if_modified_since: &'b DateTime<Utc> => Some(IfModifiedSince::new(if_modified_since)),
     }
 
-    pub async fn execute(&self) -> Result<GetPartitionKeyRangesResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<GetPartitionKeyRangesResponse, crate::Error> {
         trace!("GetPartitionKeyRangesBuilder::execute called");
 
         let request = self.collection_client.cosmos_client().prepare_request(

--- a/sdk/cosmos/src/requests/get_permission_builer.rs
+++ b/sdk/cosmos/src/requests/get_permission_builer.rs
@@ -28,7 +28,7 @@ impl<'a, 'b> GetPermissionBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<Option<GetPermissionResponse<'a>>, CosmosError> {
+    pub async fn execute(&self) -> Result<Option<GetPermissionResponse<'a>>, crate::Error> {
         trace!("GetPermissionBuilder::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/get_user_builder.rs
+++ b/sdk/cosmos/src/requests/get_user_builder.rs
@@ -28,7 +28,7 @@ impl<'a, 'b> GetUserBuilder<'a, 'b> {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
-    pub async fn execute(&self) -> Result<Option<CreateUserResponse>, CosmosError> {
+    pub async fn execute(&self) -> Result<Option<CreateUserResponse>, crate::Error> {
         trace!("GetUserBuilder::execute called");
 
         let req = self

--- a/sdk/cosmos/src/requests/list_attachments_builder.rs
+++ b/sdk/cosmos/src/requests/list_attachments_builder.rs
@@ -42,7 +42,7 @@ impl<'a, 'b> ListAttachmentsBuilder<'a, 'b> {
         a_im: ChangeFeed,
     }
 
-    pub async fn execute(&self) -> Result<ListAttachmentsResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<ListAttachmentsResponse, crate::Error> {
         let mut req = self.document_client.cosmos_client().prepare_request(
             &format!(
                 "dbs/{}/colls/{}/docs/{}/attachments",
@@ -78,7 +78,7 @@ impl<'a, 'b> ListAttachmentsBuilder<'a, 'b> {
             .try_into()?)
     }
 
-    pub fn stream(&self) -> impl Stream<Item = Result<ListAttachmentsResponse, CosmosError>> + '_ {
+    pub fn stream(&self) -> impl Stream<Item = Result<ListAttachmentsResponse, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/list_collections_builder.rs
+++ b/sdk/cosmos/src/requests/list_collections_builder.rs
@@ -36,7 +36,7 @@ impl<'a> ListCollectionsBuilder<'a> {
         max_item_count: i32 => MaxItemCount::new(max_item_count),
     }
 
-    pub async fn execute(&self) -> Result<ListCollectionsResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<ListCollectionsResponse, crate::Error> {
         trace!("ListCollectionsBuilder::execute called");
         let request = self.database_client.cosmos_client().prepare_request(
             &format!("dbs/{}/colls", self.database_client.database_name()),
@@ -62,7 +62,7 @@ impl<'a> ListCollectionsBuilder<'a> {
             .try_into()?)
     }
 
-    pub fn stream(&self) -> impl Stream<Item = Result<ListCollectionsResponse, CosmosError>> + '_ {
+    pub fn stream(&self) -> impl Stream<Item = Result<ListCollectionsResponse, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/list_databases_builder.rs
+++ b/sdk/cosmos/src/requests/list_databases_builder.rs
@@ -36,7 +36,7 @@ impl<'a> ListDatabasesBuilder<'a> {
         max_item_count: i32 => MaxItemCount::new(max_item_count),
     }
 
-    pub async fn execute(&self) -> Result<ListDatabasesResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<ListDatabasesResponse, crate::Error> {
         trace!("ListDatabasesBuilder::execute called");
 
         let request =
@@ -59,7 +59,7 @@ impl<'a> ListDatabasesBuilder<'a> {
             .try_into()?)
     }
 
-    pub fn stream(&self) -> impl Stream<Item = Result<ListDatabasesResponse, CosmosError>> + '_ {
+    pub fn stream(&self) -> impl Stream<Item = Result<ListDatabasesResponse, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/list_documents_builder.rs
+++ b/sdk/cosmos/src/requests/list_documents_builder.rs
@@ -46,7 +46,7 @@ impl<'a, 'b> ListDocumentsBuilder<'a, 'b> {
         partition_range_id: &'b str => Some(PartitionRangeId::new(partition_range_id)),
     }
 
-    pub async fn execute<T>(&self) -> Result<ListDocumentsResponse<T>, CosmosError>
+    pub async fn execute<T>(&self) -> Result<ListDocumentsResponse<T>, crate::Error>
     where
         T: DeserializeOwned,
     {
@@ -82,7 +82,7 @@ impl<'a, 'b> ListDocumentsBuilder<'a, 'b> {
 
     pub fn stream<T>(
         &self,
-    ) -> impl Stream<Item = Result<ListDocumentsResponse<T>, CosmosError>> + '_
+    ) -> impl Stream<Item = Result<ListDocumentsResponse<T>, crate::Error>> + '_
     where
         T: DeserializeOwned,
     {

--- a/sdk/cosmos/src/requests/list_permissions_builder.rs
+++ b/sdk/cosmos/src/requests/list_permissions_builder.rs
@@ -36,7 +36,7 @@ impl<'a, 'b> ListPermissionsBuilder<'a, 'b> {
         max_item_count: i32 => MaxItemCount::new(max_item_count),
     }
 
-    pub async fn execute(&self) -> Result<ListPermissionsResponse<'a>, CosmosError> {
+    pub async fn execute(&self) -> Result<ListPermissionsResponse<'a>, crate::Error> {
         trace!("ListPermissionsBuilder::execute called");
 
         let request = self.user_client.cosmos_client().prepare_request(
@@ -68,7 +68,7 @@ impl<'a, 'b> ListPermissionsBuilder<'a, 'b> {
 
     pub fn stream(
         &self,
-    ) -> impl Stream<Item = Result<ListPermissionsResponse<'a>, CosmosError>> + '_ {
+    ) -> impl Stream<Item = Result<ListPermissionsResponse<'a>, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/list_stored_procedures_builder.rs
+++ b/sdk/cosmos/src/requests/list_stored_procedures_builder.rs
@@ -36,7 +36,7 @@ impl<'a, 'b> ListStoredProceduresBuilder<'a, 'b> {
         max_item_count: i32 => MaxItemCount::new(max_item_count),
     }
 
-    pub async fn execute(&self) -> Result<ListStoredProceduresResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<ListStoredProceduresResponse, crate::Error> {
         trace!("ListStoredProceduresBuilder::execute called");
 
         let request = self.collection_client.cosmos_client().prepare_request(
@@ -68,7 +68,7 @@ impl<'a, 'b> ListStoredProceduresBuilder<'a, 'b> {
 
     pub fn stream(
         &self,
-    ) -> impl Stream<Item = Result<ListStoredProceduresResponse, CosmosError>> + '_ {
+    ) -> impl Stream<Item = Result<ListStoredProceduresResponse, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/list_triggers_builder.rs
+++ b/sdk/cosmos/src/requests/list_triggers_builder.rs
@@ -39,7 +39,7 @@ impl<'a, 'b> ListTriggersBuilder<'a, 'b> {
         if_match_condition: IfMatchCondition<'b> => Some(if_match_condition),
     }
 
-    pub async fn execute(&self) -> Result<ListTriggersResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<ListTriggersResponse, crate::Error> {
         trace!("ListTriggersBuilder::execute called");
 
         let request = self.collection_client.cosmos_client().prepare_request(
@@ -70,7 +70,7 @@ impl<'a, 'b> ListTriggersBuilder<'a, 'b> {
             .try_into()?)
     }
 
-    pub fn stream(&self) -> impl Stream<Item = Result<ListTriggersResponse, CosmosError>> + '_ {
+    pub fn stream(&self) -> impl Stream<Item = Result<ListTriggersResponse, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/list_user_defined_functions_builder.rs
+++ b/sdk/cosmos/src/requests/list_user_defined_functions_builder.rs
@@ -39,7 +39,7 @@ impl<'a, 'b> ListUserDefinedFunctionsBuilder<'a, 'b> {
         if_match_condition: IfMatchCondition<'b> => Some(if_match_condition),
     }
 
-    pub async fn execute(&self) -> Result<ListUserDefinedFunctionsResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<ListUserDefinedFunctionsResponse, crate::Error> {
         trace!("ListUserDefinedFunctionsBuilder::execute called");
 
         let request = self.collection_client.cosmos_client().prepare_request(
@@ -72,7 +72,7 @@ impl<'a, 'b> ListUserDefinedFunctionsBuilder<'a, 'b> {
 
     pub fn stream(
         &self,
-    ) -> impl Stream<Item = Result<ListUserDefinedFunctionsResponse, CosmosError>> + '_ {
+    ) -> impl Stream<Item = Result<ListUserDefinedFunctionsResponse, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/list_users_builder.rs
+++ b/sdk/cosmos/src/requests/list_users_builder.rs
@@ -38,7 +38,7 @@ impl<'a, 'b> ListUsersBuilder<'a, 'b> {
         max_item_count: i32 => MaxItemCount::new(max_item_count),
     }
 
-    pub async fn execute(&self) -> Result<ListUsersResponse, CosmosError> {
+    pub async fn execute(&self) -> Result<ListUsersResponse, crate::Error> {
         trace!("ListUsersBuilder::execute called");
 
         let req = self.database_client.cosmos_client().prepare_request(
@@ -58,7 +58,7 @@ impl<'a, 'b> ListUsersBuilder<'a, 'b> {
             .try_into()?)
     }
 
-    pub fn stream(&self) -> impl Stream<Item = Result<ListUsersResponse, CosmosError>> + '_ {
+    pub fn stream(&self) -> impl Stream<Item = Result<ListUsersResponse, crate::Error>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/cosmos/src/requests/query_documents_builder.rs
+++ b/sdk/cosmos/src/requests/query_documents_builder.rs
@@ -63,7 +63,7 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b> {
         })
     }
 
-    pub async fn execute<T, Q>(&self, query: Q) -> Result<QueryDocumentsResponse<T>, CosmosError>
+    pub async fn execute<T, Q>(&self, query: Q) -> Result<QueryDocumentsResponse<T>, crate::Error>
     where
         T: DeserializeOwned,
         Q: Into<Query<'a>>,
@@ -120,7 +120,7 @@ impl<'a, 'b> QueryDocumentsBuilder<'a, 'b> {
     pub fn stream<T, Q>(
         &'a self,
         query: Q,
-    ) -> impl Stream<Item = Result<QueryDocumentsResponse<T>, CosmosError>> + 'a
+    ) -> impl Stream<Item = Result<QueryDocumentsResponse<T>, crate::Error>> + 'a
     where
         T: DeserializeOwned,
         Q: Into<Query<'a>> + 'a + Copy,

--- a/sdk/cosmos/src/requests/replace_collection_builder.rs
+++ b/sdk/cosmos/src/requests/replace_collection_builder.rs
@@ -41,7 +41,7 @@ impl<'a, 'b> ReplaceCollectionBuilder<'a, 'b> {
     pub async fn execute<P: Into<PartitionKey>>(
         &self,
         partition_key: P,
-    ) -> Result<CreateCollectionResponse, CosmosError> {
+    ) -> Result<CreateCollectionResponse, crate::Error> {
         trace!("ReplaceCollectionBuilder::execute called");
 
         let req = self

--- a/sdk/cosmos/src/requests/replace_document_builder.rs
+++ b/sdk/cosmos/src/requests/replace_document_builder.rs
@@ -52,7 +52,7 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
         &self,
         document: &T,
         fn_add_primary_key: FNPK,
-    ) -> Result<ReplaceDocumentResponse, CosmosError>
+    ) -> Result<ReplaceDocumentResponse, crate::Error>
     where
         T: Serialize,
         FNPK: FnOnce(http::request::Builder) -> Result<http::request::Builder, serde_json::Error>,
@@ -93,7 +93,7 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
             .try_into()?)
     }
 
-    pub async fn execute<T>(&self, document: &T) -> Result<ReplaceDocumentResponse, CosmosError>
+    pub async fn execute<T>(&self, document: &T) -> Result<ReplaceDocumentResponse, crate::Error>
     where
         T: Serialize,
     {
@@ -110,7 +110,7 @@ impl<'a, 'b> ReplaceDocumentBuilder<'a, 'b> {
         &self,
         document: &DOC,
         partition_key: &PK,
-    ) -> Result<ReplaceDocumentResponse, CosmosError> {
+    ) -> Result<ReplaceDocumentResponse, crate::Error> {
         self.perform_execute(document, |req| {
             Ok(add_as_partition_key_header_serialized(
                 &serialize_partition_key(partition_key)?,

--- a/sdk/cosmos/src/requests/replace_permission_builder.rs
+++ b/sdk/cosmos/src/requests/replace_permission_builder.rs
@@ -36,7 +36,7 @@ impl<'a, 'b> ReplacePermissionBuilder<'a, 'b> {
     pub async fn execute(
         &self,
         permission_mode: &PermissionMode<'a>,
-    ) -> Result<ReplacePermissionResponse<'a>, CosmosError> {
+    ) -> Result<ReplacePermissionResponse<'a>, crate::Error> {
         trace!("ReplacePermissionBuilder::execute called");
 
         let request = self

--- a/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_reference_attachment_builder.rs
@@ -39,7 +39,7 @@ impl<'a, 'b> ReplaceReferenceAttachmentBuilder<'a, 'b> {
         &self,
         media: M,
         content_type: C,
-    ) -> Result<crate::responses::ReplaceReferenceAttachmentResponse, CosmosError>
+    ) -> Result<crate::responses::ReplaceReferenceAttachmentResponse, crate::Error>
     where
         M: AsRef<str>,
         C: Into<ContentType<'b>>,

--- a/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
+++ b/sdk/cosmos/src/requests/replace_slug_attachment_builder.rs
@@ -42,7 +42,7 @@ impl<'a, 'b> ReplaceSlugAttachmentBuilder<'a, 'b> {
     pub async fn execute<B: Into<Bytes>>(
         &self,
         body: B,
-    ) -> Result<CreateSlugAttachmentResponse, CosmosError> {
+    ) -> Result<CreateSlugAttachmentResponse, crate::Error> {
         let body = body.into();
         let mut req = self.attachment_client.prepare_request(http::Method::PUT);
 

--- a/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
+++ b/sdk/cosmos/src/requests/replace_stored_procedure_builder.rs
@@ -35,7 +35,7 @@ impl<'a, 'b> ReplaceStoredProcedureBuilder<'a, 'b> {
     pub async fn execute<B: AsRef<str>>(
         &self,
         body: B,
-    ) -> Result<ReplaceStoredProcedureResponse, CosmosError> {
+    ) -> Result<ReplaceStoredProcedureResponse, crate::Error> {
         trace!("ReplaceStoredProcedureBuilder::execute called");
 
         let req = self

--- a/sdk/cosmos/src/requests/replace_user_builder.rs
+++ b/sdk/cosmos/src/requests/replace_user_builder.rs
@@ -35,7 +35,7 @@ impl<'a, 'b> ReplaceUserBuilder<'a, 'b> {
     pub async fn execute<U: AsRef<str>>(
         &self,
         user_name: U,
-    ) -> Result<Option<CreateUserResponse>, CosmosError> {
+    ) -> Result<Option<CreateUserResponse>, crate::Error> {
         trace!("ReplaceUserBuilder::execute called");
 
         let req = self

--- a/sdk/cosmos/src/resources/document/document_attributes.rs
+++ b/sdk/cosmos/src/resources/document/document_attributes.rs
@@ -1,4 +1,3 @@
-use crate::CosmosError;
 use azure_core::prelude::IfMatchCondition;
 use http::response::Response;
 
@@ -45,7 +44,7 @@ impl DocumentAttributes {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DocumentAttributes {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(response.body())?)

--- a/sdk/cosmos/src/resources/document/mod.rs
+++ b/sdk/cosmos/src/resources/document/mod.rs
@@ -9,7 +9,7 @@ pub use indexing_directive::IndexingDirective;
 pub use query::{Param, Query};
 
 use super::Resource;
-use crate::{headers, CosmosError};
+use crate::headers;
 
 use azure_core::AddAsHeader;
 use http::header::HeaderMap;
@@ -44,7 +44,7 @@ impl<T> std::convert::TryFrom<(&HeaderMap, &[u8])> for Document<T>
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
     fn try_from(value: (&HeaderMap, &[u8])) -> Result<Self, Self::Error> {
         let _headers = value.0;
         let body = value.1;

--- a/sdk/cosmos/src/resources/permission/permission.rs
+++ b/sdk/cosmos/src/resources/permission/permission.rs
@@ -1,5 +1,5 @@
 use super::PermissionToken;
-use crate::{resources::Resource, CosmosError};
+use crate::resources::Resource;
 
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -87,7 +87,7 @@ impl<'a> PermissionMode<'a> {
 }
 
 impl<'a> std::convert::TryFrom<&[u8]> for Permission<'a> {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(slice)?)
@@ -99,15 +99,15 @@ mod tests {
     use super::*;
     use crate::resources::permission::AuthorizationToken;
 
-    const PERMISSION_JSON: &str = r#"{  
-    "id": "a_permission",  
-    "permissionMode": "Read",  
-    "resource": "dbs/volcanodb/colls/volcano1",  
-    "_rid": "Sl8fAG8cXgBn6Ju2GqNsAA==",  
-    "_ts": 1449604760,  
-    "_self": "dbs\/Sl8fAA==\/users\/Sl8fAG8cXgA=\/permissions\/Sl8fAG8cXgBn6Ju2GqNsAA==\/",  
-    "_etag": "\"00000e00-0000-0000-0000-566736980000\"",  
-    "_token": "type=resource&ver=1.0&sig=ocPyc9QQFybITu1EqzX0kg==;w+WR1aWafB3+yZq5JSoBwgz78XDlU+k9Xiqvc+Q7TlAl1P4h4t721Cn5cjhZ9h3TSd2\/MJLy+wG+YkhDL9UlGkVv05RZGy2fMaLGdeQkWc7TShkc\/M2boPc3GXq2yiERKl5CN4AZWSOcrFhOFuuTOqF4ZdBlflmNudaakodr\/8qTip0i+a7moz1Jkc5+9iLAsDFyqTR1sirp7kAVNFbiqPdYTjNkvZUHF3nYYmRskOg=;"  
+    const PERMISSION_JSON: &str = r#"{
+    "id": "a_permission",
+    "permissionMode": "Read",
+    "resource": "dbs/volcanodb/colls/volcano1",
+    "_rid": "Sl8fAG8cXgBn6Ju2GqNsAA==",
+    "_ts": 1449604760,
+    "_self": "dbs\/Sl8fAA==\/users\/Sl8fAG8cXgA=\/permissions\/Sl8fAG8cXgBn6Ju2GqNsAA==\/",
+    "_etag": "\"00000e00-0000-0000-0000-566736980000\"",
+    "_token": "type=resource&ver=1.0&sig=ocPyc9QQFybITu1EqzX0kg==;w+WR1aWafB3+yZq5JSoBwgz78XDlU+k9Xiqvc+Q7TlAl1P4h4t721Cn5cjhZ9h3TSd2\/MJLy+wG+YkhDL9UlGkVv05RZGy2fMaLGdeQkWc7TShkc\/M2boPc3GXq2yiERKl5CN4AZWSOcrFhOFuuTOqF4ZdBlflmNudaakodr\/8qTip0i+a7moz1Jkc5+9iLAsDFyqTR1sirp7kAVNFbiqPdYTjNkvZUHF3nYYmRskOg=;"
 } "#;
 
     #[test]

--- a/sdk/cosmos/src/responses/create_collection_response.rs
+++ b/sdk/cosmos/src/responses/create_collection_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Collection;
-use crate::CosmosError;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
 use http::response::Response;
@@ -23,7 +22,7 @@ pub struct CreateCollectionResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateCollectionResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/create_document_response.rs
+++ b/sdk/cosmos/src/responses/create_document_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::document::DocumentAttributes;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
 use http::response::Response;
@@ -36,7 +36,7 @@ pub struct CreateDocumentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateDocumentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let status_code = response.status();

--- a/sdk/cosmos/src/responses/create_permission_response.rs
+++ b/sdk/cosmos/src/responses/create_permission_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Permission;
-use crate::CosmosError;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use http::response::Response;
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ pub struct CreatePermissionResponse<'a> {
 }
 
 impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for CreatePermissionResponse<'a> {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/create_reference_attachment_response.rs
+++ b/sdk/cosmos/src/responses/create_reference_attachment_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::Attachment;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use azure_core::SessionToken;
 use chrono::{DateTime, Utc};
@@ -35,7 +35,7 @@ pub struct CreateReferenceAttachmentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateReferenceAttachmentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/create_slug_attachment_response.rs
+++ b/sdk/cosmos/src/responses/create_slug_attachment_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::Attachment;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use azure_core::SessionToken;
 use chrono::{DateTime, Utc};
@@ -34,7 +34,7 @@ pub struct CreateSlugAttachmentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateSlugAttachmentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/create_stored_procedure_response.rs
+++ b/sdk/cosmos/src/responses/create_stored_procedure_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::StoredProcedure;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
@@ -22,7 +21,7 @@ pub struct CreateStoredProcedureResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateStoredProcedureResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/create_trigger_response.rs
+++ b/sdk/cosmos/src/responses/create_trigger_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Trigger;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
@@ -36,7 +35,7 @@ pub struct CreateTriggerResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateTriggerResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/create_user_defined_function_response.rs
+++ b/sdk/cosmos/src/responses/create_user_defined_function_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::UserDefinedFunction;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
@@ -36,7 +35,7 @@ pub struct CreateUserDefinedFunctionResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateUserDefinedFunctionResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/create_user_response.rs
+++ b/sdk/cosmos/src/responses/create_user_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::User;
-use crate::CosmosError;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use http::response::Response;
 use std::convert::TryInto;
@@ -15,7 +14,7 @@ pub struct CreateUserResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for CreateUserResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_attachment_response.rs
+++ b/sdk/cosmos/src/responses/delete_attachment_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
 use azure_core::SessionToken;
@@ -33,7 +32,7 @@ pub struct DeleteAttachmentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteAttachmentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_collection_response.rs
+++ b/sdk/cosmos/src/responses/delete_collection_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use http::response::Response;
 
 #[derive(Debug, Clone)]
@@ -9,7 +8,7 @@ pub struct DeleteCollectionResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteCollectionResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
 

--- a/sdk/cosmos/src/responses/delete_database_response.rs
+++ b/sdk/cosmos/src/responses/delete_database_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
 use http::response::Response;
@@ -14,7 +13,7 @@ pub struct DeleteDatabaseResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteDatabaseResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_document_response.rs
+++ b/sdk/cosmos/src/responses/delete_document_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use azure_core::headers::session_token_from_headers;
 use http::response::Response;
 
@@ -11,7 +10,7 @@ pub struct DeleteDocumentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteDocumentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_permission_response.rs
+++ b/sdk/cosmos/src/responses/delete_permission_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use azure_core::headers::session_token_from_headers;
 use http::response::Response;
 
@@ -13,7 +12,7 @@ pub struct DeletePermissionResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeletePermissionResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_stored_procedure_response.rs
+++ b/sdk/cosmos/src/responses/delete_stored_procedure_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
 use chrono::{DateTime, Utc};
@@ -16,7 +15,7 @@ pub struct DeleteStoredProcedureResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteStoredProcedureResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_trigger_response.rs
+++ b/sdk/cosmos/src/responses/delete_trigger_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
 use chrono::{DateTime, Utc};
@@ -34,7 +33,7 @@ pub struct DeleteTriggerResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteTriggerResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_user_defined_function_response.rs
+++ b/sdk/cosmos/src/responses/delete_user_defined_function_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
 use chrono::{DateTime, Utc};
@@ -34,7 +33,7 @@ pub struct DeleteUserDefinedFunctionResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteUserDefinedFunctionResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/delete_user_response.rs
+++ b/sdk/cosmos/src/responses/delete_user_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use http::response::Response;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -9,7 +8,7 @@ pub struct DeleteUserResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeleteUserResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/execute_stored_procedure_response.rs
+++ b/sdk/cosmos/src/responses/execute_stored_procedure_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use azure_core::headers::session_token_from_headers;
 use azure_core::SessionToken;
 use chrono::{DateTime, Utc};
@@ -38,7 +37,7 @@ impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for ExecuteStoredProcedure
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/get_attachment_response.rs
+++ b/sdk/cosmos/src/responses/get_attachment_response.rs
@@ -1,7 +1,7 @@
 use crate::headers::from_headers::*;
 use crate::resources::document::IndexingDirective;
 use crate::resources::Attachment;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{
     content_type_from_headers, etag_from_headers, session_token_from_headers,
 };
@@ -38,7 +38,7 @@ pub struct GetAttachmentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for GetAttachmentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/get_collection_response.rs
+++ b/sdk/cosmos/src/responses/get_collection_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Collection;
-use crate::CosmosError;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
 use http::response::Response;
@@ -30,7 +29,7 @@ pub struct GetCollectionResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for GetCollectionResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/get_database_response.rs
+++ b/sdk/cosmos/src/responses/get_database_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::Database;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
 use http::response::Response;
@@ -21,7 +21,7 @@ pub struct GetDatabaseResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for GetDatabaseResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/get_document_response.rs
+++ b/sdk/cosmos/src/responses/get_document_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Document;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use azure_core::SessionToken;
@@ -19,7 +18,7 @@ impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for GetDocumentResponse<T>
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let status_code = response.status();
@@ -76,7 +75,7 @@ impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for FoundDocumentResponse<
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
@@ -134,7 +133,7 @@ pub struct NotFoundDocumentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for NotFoundDocumentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/get_partition_key_ranges_response.rs
+++ b/sdk/cosmos/src/responses/get_partition_key_ranges_response.rs
@@ -1,5 +1,4 @@
 use crate::headers::from_headers::*;
-use crate::CosmosError;
 use azure_core::headers::{item_count_from_headers, session_token_from_headers};
 use chrono::{DateTime, Utc};
 use http::response::Response;
@@ -29,7 +28,7 @@ pub struct GetPartitionKeyRangesResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for GetPartitionKeyRangesResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/get_permission_response.rs
+++ b/sdk/cosmos/src/responses/get_permission_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Permission;
-use crate::CosmosError;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use http::response::Response;
 
@@ -16,7 +15,7 @@ pub struct GetPermissionResponse<'a> {
 }
 
 impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for GetPermissionResponse<'a> {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_attachments_response.rs
+++ b/sdk/cosmos/src/responses/list_attachments_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::Attachment;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{
     continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
 };
@@ -47,7 +47,7 @@ pub struct ListAttachmentsResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ListAttachmentsResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_collections_response.rs
+++ b/sdk/cosmos/src/responses/list_collections_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Collection;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use chrono::{DateTime, Utc};
@@ -26,7 +25,7 @@ pub struct ListCollectionsResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ListCollectionsResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_databases_response.rs
+++ b/sdk/cosmos/src/responses/list_databases_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Database;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use chrono::{DateTime, Utc};
@@ -24,7 +23,7 @@ pub struct ListDatabasesResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ListDatabasesResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_documents_response.rs
+++ b/sdk/cosmos/src/responses/list_documents_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::document::{Document, DocumentAttributes};
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 
 use azure_core::headers::{
     continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
@@ -58,7 +58,7 @@ pub struct ListDocumentsResponseEntities<T> {
 }
 
 impl std::convert::TryFrom<&[u8]> for ListDocumentsResponseAttributes {
-    type Error = CosmosError;
+    type Error = crate::Error;
     fn try_from(body: &[u8]) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(body)?)
     }
@@ -68,7 +68,7 @@ impl<T> std::convert::TryFrom<&[u8]> for ListDocumentsResponseEntities<T>
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(body: &[u8]) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(body)?)
@@ -79,7 +79,7 @@ impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for ListDocumentsResponse<
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_permissions_response.rs
+++ b/sdk/cosmos/src/responses/list_permissions_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Permission;
-use crate::CosmosError;
 use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use http::response::Response;
 
@@ -16,7 +15,7 @@ pub struct ListPermissionsResponse<'a> {
 }
 
 impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for ListPermissionsResponse<'a> {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_stored_procedures_response.rs
+++ b/sdk/cosmos/src/responses/list_stored_procedures_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::StoredProcedure;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use chrono::{DateTime, Utc};
@@ -20,7 +19,7 @@ pub struct ListStoredProceduresResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ListStoredProceduresResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_triggers_response.rs
+++ b/sdk/cosmos/src/responses/list_triggers_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Trigger;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{
     continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
@@ -37,7 +36,7 @@ pub struct ListTriggersResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ListTriggersResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_user_defined_functions_response.rs
+++ b/sdk/cosmos/src/responses/list_user_defined_functions_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::UserDefinedFunction;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::{
     continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
@@ -37,7 +36,7 @@ pub struct ListUserDefinedFunctionsResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ListUserDefinedFunctionsResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/list_users_response.rs
+++ b/sdk/cosmos/src/responses/list_users_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::User;
-use crate::CosmosError;
 use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use azure_core::SessionToken;
 use http::response::Response;
@@ -26,7 +25,7 @@ pub struct ListUsersResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ListUsersResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -1,4 +1,3 @@
-use crate::errors::ConversionToDocumentError;
 use crate::headers::from_headers::*;
 use crate::resources::document::DocumentAttributes;
 use crate::{CosmosError, ResourceQuota};
@@ -88,9 +87,7 @@ impl<T> QueryDocumentsResponse<T> {
         self.into()
     }
 
-    pub fn into_documents(
-        self,
-    ) -> Result<QueryDocumentsResponseDocuments<T>, ConversionToDocumentError> {
+    pub fn into_documents(self) -> Result<QueryDocumentsResponseDocuments<T>, CosmosError> {
         self.try_into()
     }
 }
@@ -271,7 +268,7 @@ pub struct QueryDocumentsResponseDocuments<T> {
 }
 
 impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsResponseDocuments<T> {
-    type Error = ConversionToDocumentError;
+    type Error = CosmosError;
 
     #[inline]
     fn try_from(q: QueryDocumentsResponse<T>) -> Result<Self, Self::Error> {
@@ -280,7 +277,7 @@ impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsRespo
             QueryResult::Document(_) => false,
             QueryResult::Raw(_) => true,
         }) {
-            return Err(ConversionToDocumentError::RawElementFound {});
+            return Err(CosmosError::RawElementError);
         }
 
         Ok(Self {

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::document::DocumentAttributes;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{
     continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
 };
@@ -23,7 +23,7 @@ impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for DocumentQueryResult<T>
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(response.body())?)
@@ -39,7 +39,7 @@ pub struct QueryResponseMeta {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for QueryResponseMeta {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         Ok(serde_json::from_slice(response.body())?)
@@ -87,7 +87,7 @@ impl<T> QueryDocumentsResponse<T> {
         self.into()
     }
 
-    pub fn into_documents(self) -> Result<QueryDocumentsResponseDocuments<T>, CosmosError> {
+    pub fn into_documents(self) -> Result<QueryDocumentsResponseDocuments<T>, crate::Error> {
         self.try_into()
     }
 }
@@ -96,7 +96,7 @@ impl<T> std::convert::TryFrom<Response<bytes::Bytes>> for QueryDocumentsResponse
 where
     T: DeserializeOwned,
 {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
@@ -268,7 +268,7 @@ pub struct QueryDocumentsResponseDocuments<T> {
 }
 
 impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsResponseDocuments<T> {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     #[inline]
     fn try_from(q: QueryDocumentsResponse<T>) -> Result<Self, Self::Error> {
@@ -277,7 +277,7 @@ impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsRespo
             QueryResult::Document(_) => false,
             QueryResult::Raw(_) => true,
         }) {
-            return Err(CosmosError::RawElementError);
+            return Err(crate::Error::RawElementError);
         }
 
         Ok(Self {

--- a/sdk/cosmos/src/responses/replace_document_response.rs
+++ b/sdk/cosmos/src/responses/replace_document_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::document::DocumentAttributes;
-use crate::CosmosError;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
 use azure_core::SessionToken;
@@ -38,7 +37,7 @@ pub struct ReplaceDocumentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ReplaceDocumentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/replace_permission_response.rs
+++ b/sdk/cosmos/src/responses/replace_permission_response.rs
@@ -1,6 +1,5 @@
 use crate::headers::from_headers::*;
 use crate::resources::Permission;
-use crate::CosmosError;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use http::response::Response;
 use std::convert::TryInto;
@@ -17,7 +16,7 @@ pub struct ReplacePermissionResponse<'a> {
 }
 
 impl<'a> std::convert::TryFrom<Response<bytes::Bytes>> for ReplacePermissionResponse<'a> {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/src/responses/replace_reference_attachment_response.rs
+++ b/sdk/cosmos/src/responses/replace_reference_attachment_response.rs
@@ -1,6 +1,6 @@
 use crate::headers::from_headers::*;
 use crate::resources::Attachment;
-use crate::{CosmosError, ResourceQuota};
+use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use azure_core::SessionToken;
 use chrono::{DateTime, Utc};
@@ -33,7 +33,7 @@ pub struct ReplaceReferenceAttachmentResponse {
 }
 
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ReplaceReferenceAttachmentResponse {
-    type Error = CosmosError;
+    type Error = crate::Error;
 
     fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -29,7 +29,7 @@ impl<'a> azure_cosmos::CosmosEntity<'a> for MySampleStruct<'a> {
 }
 
 #[tokio::test]
-async fn attachment() -> Result<(), CosmosError> {
+async fn attachment() -> Result<(), azure_cosmos::Error> {
     const DATABASE_NAME: &str = "test-cosmos-db-attachment";
     const COLLECTION_NAME: &str = "test-collection-attachment";
 

--- a/sdk/cosmos/tests/setup.rs
+++ b/sdk/cosmos/tests/setup.rs
@@ -1,6 +1,6 @@
 use azure_cosmos::prelude::*;
 
-pub fn initialize() -> Result<CosmosClient, CosmosError> {
+pub fn initialize() -> Result<CosmosClient, azure_cosmos::Error> {
     let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
     let key =
         std::env::var("COSMOS_MASTER_KEY").expect("Set env variable COSMOS_MASTER_KEY first!");

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -36,7 +36,7 @@ function updateMetadata() {
 }"#;
 
 #[tokio::test]
-async fn trigger() -> Result<(), crate::Error> {
+async fn trigger() -> Result<(), azure_cosmos::Error> {
     const DATABASE_NAME: &str = "test-cosmos-db-trigger";
     const COLLECTION_NAME: &str = "test-udf";
     const TRIGGER_NAME: &str = "test";

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -36,7 +36,7 @@ function updateMetadata() {
 }"#;
 
 #[tokio::test]
-async fn trigger() -> Result<(), CosmosError> {
+async fn trigger() -> Result<(), crate::Error> {
     const DATABASE_NAME: &str = "test-cosmos-db-trigger";
     const COLLECTION_NAME: &str = "test-udf";
     const TRIGGER_NAME: &str = "test";

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -19,7 +19,7 @@ function tax(income) {
 }"#;
 
 #[tokio::test]
-async fn user_defined_function00() -> Result<(), crate::Error> {
+async fn user_defined_function00() -> Result<(), azure_cosmos::Error> {
     const DATABASE_NAME: &str = "test-cosmos-db-udf";
     const COLLECTION_NAME: &str = "test-udf";
     const USER_DEFINED_FUNCTION_NAME: &str = "test";

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -19,7 +19,7 @@ function tax(income) {
 }"#;
 
 #[tokio::test]
-async fn user_defined_function00() -> Result<(), CosmosError> {
+async fn user_defined_function00() -> Result<(), crate::Error> {
     const DATABASE_NAME: &str = "test-cosmos-db-udf";
     const COLLECTION_NAME: &str = "test-udf";
     const USER_DEFINED_FUNCTION_NAME: &str = "test";

--- a/sdk/storage/src/account/responses/get_account_information_response.rs
+++ b/sdk/storage/src/account/responses/get_account_information_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::{
     account_kind_from_headers, date_from_headers, request_id_from_headers, sku_name_from_headers,
 };
@@ -17,7 +16,7 @@ pub struct GetAccountInformationResponse {
 impl GetAccountInformationResponse {
     pub(crate) fn from_headers(
         headers: &HeaderMap,
-    ) -> Result<GetAccountInformationResponse, AzureStorageError> {
+    ) -> Result<GetAccountInformationResponse, crate::Error> {
         let request_id = request_id_from_headers(headers)?;
         let date = date_from_headers(headers)?;
         let sku_name = sku_name_from_headers(headers)?;

--- a/sdk/storage/src/blob/blob/block_with_size_list.rs
+++ b/sdk/storage/src/blob/blob/block_with_size_list.rs
@@ -1,5 +1,5 @@
+use crate::blob::blob::BlobBlockType;
 use crate::blob::blob::BlobBlockWithSize;
-use crate::{blob::blob::BlobBlockType, AzureStorageError};
 #[derive(Debug, Deserialize)]
 struct Name {
     #[serde(rename = "$value")]
@@ -40,7 +40,7 @@ pub struct BlockWithSizeList {
 }
 
 impl BlockWithSizeList {
-    pub fn try_from_xml(xml: &str) -> Result<Self, AzureStorageError> {
+    pub fn try_from_xml(xml: &str) -> Result<Self, crate::Error> {
         let bl: BlockList = serde_xml_rs::de::from_reader(xml.as_bytes())?;
         debug!("bl == {:?}", bl);
 

--- a/sdk/storage/src/blob/blob/responses/copy_blob_from_url_response.rs
+++ b/sdk/storage/src/blob/blob/responses/copy_blob_from_url_response.rs
@@ -1,8 +1,5 @@
+use crate::blob::blob::{copy_status_from_headers, CopyStatus};
 use crate::core::CopyId;
-use crate::{
-    blob::blob::{copy_status_from_headers, CopyStatus},
-    AzureStorageError,
-};
 use crate::{core::copy_id_from_headers, headers::content_md5_from_headers_optional};
 use azure_core::headers::{
     date_from_headers, etag_from_headers, last_modified_from_headers, request_id_from_headers,
@@ -27,7 +24,7 @@ pub struct CopyBlobFromUrlResponse {
 }
 
 impl TryFrom<&HeaderMap> for CopyBlobFromUrlResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
     fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
         debug!("headers == {:#?}", headers);
         Ok(Self {

--- a/sdk/storage/src/blob/blob/responses/copy_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/copy_blob_response.rs
@@ -1,8 +1,5 @@
+use crate::blob::blob::{copy_status_from_headers, CopyStatus};
 use crate::core::{copy_id_from_headers, CopyId};
-use crate::{
-    blob::blob::{copy_status_from_headers, CopyStatus},
-    AzureStorageError,
-};
 use azure_core::headers::{
     client_request_id_from_headers_optional, date_from_headers, etag_from_headers,
     last_modified_from_headers, request_id_from_headers, server_from_headers, version_from_headers,
@@ -26,7 +23,7 @@ pub struct CopyBlobResponse {
 }
 
 impl TryFrom<&HeaderMap> for CopyBlobResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
         trace!("CopyBlobResponse headers == {:#?}", headers);

--- a/sdk/storage/src/blob/blob/responses/get_blob_metadata_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_blob_metadata_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::{
     date_from_headers, etag_from_headers, request_id_from_headers, server_from_headers,
 };
@@ -18,7 +17,7 @@ pub struct GetBlobMetadataResponse {
 }
 
 impl TryFrom<&HeaderMap> for GetBlobMetadataResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(headers: &HeaderMap) -> Result<Self, Self::Error> {
         debug!("headers == {:#?}", headers);

--- a/sdk/storage/src/blob/blob/responses/get_blob_properties_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_blob_properties_response.rs
@@ -1,4 +1,4 @@
-use crate::{blob::blob::Blob, AzureStorageError};
+use crate::blob::blob::Blob;
 use azure_core::headers::{date_from_headers, request_id_from_headers};
 use azure_core::RequestId;
 use chrono::{DateTime, Utc};
@@ -15,7 +15,7 @@ impl GetBlobPropertiesResponse {
     pub(crate) fn from_response(
         headers: &HeaderMap,
         blob: Blob,
-    ) -> Result<GetBlobPropertiesResponse, AzureStorageError> {
+    ) -> Result<GetBlobPropertiesResponse, crate::Error> {
         debug!("headers == {:#?}", headers);
 
         let request_id = request_id_from_headers(headers)?;

--- a/sdk/storage/src/blob/blob/responses/get_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_blob_response.rs
@@ -1,4 +1,4 @@
-use crate::{blob::blob::Blob, AzureStorageError};
+use crate::blob::blob::Blob;
 use azure_core::headers::{date_from_headers, request_id_from_headers};
 use azure_core::prelude::ContentRange;
 use azure_core::RequestId;
@@ -18,7 +18,7 @@ pub struct GetBlobResponse {
 }
 
 impl TryFrom<(&str, Response<Bytes>)> for GetBlobResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
     fn try_from((blob_name, response): (&str, Response<Bytes>)) -> Result<Self, Self::Error> {
         debug!("response.headers() == {:#?}", response.headers());
 

--- a/sdk/storage/src/blob/blob/responses/get_block_list_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_block_list_response.rs
@@ -1,4 +1,4 @@
-use crate::{blob::blob::BlockWithSizeList, AzureStorageError};
+use crate::blob::blob::BlockWithSizeList;
 use azure_core::headers::{
     date_from_headers, etag_from_headers_optional, last_modified_from_headers_optional,
     request_id_from_headers,
@@ -21,7 +21,7 @@ impl GetBlockListResponse {
     pub(crate) fn from_response(
         headers: &HeaderMap,
         body: &[u8],
-    ) -> Result<GetBlockListResponse, AzureStorageError> {
+    ) -> Result<GetBlockListResponse, crate::Error> {
         let etag = etag_from_headers_optional(headers)?;
         let last_modified = last_modified_from_headers_optional(headers)?;
         let request_id = request_id_from_headers(headers)?;

--- a/sdk/storage/src/blob/blob/responses/list_blobs_response.rs
+++ b/sdk/storage/src/blob/blob/responses/list_blobs_response.rs
@@ -1,4 +1,4 @@
-use crate::{blob::blob::Blob, AzureStorageError};
+use crate::blob::blob::Blob;
 use azure_core::headers::{date_from_headers, request_id_from_headers};
 use azure_core::prelude::NextMarker;
 use azure_core::util::to_str_without_bom;
@@ -43,7 +43,7 @@ pub struct BlobPrefix {
 }
 
 impl TryFrom<&http::Response<Bytes>> for ListBlobsResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &http::Response<Bytes>) -> Result<Self, Self::Error> {
         let body = to_str_without_bom(response.body())?;

--- a/sdk/storage/src/blob/blob/responses/put_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_blob_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::{
     date_from_headers, etag_from_headers, last_modified_from_headers, request_id_from_headers,
     request_server_encrypted_from_headers,
@@ -17,7 +16,7 @@ pub struct PutBlobResponse {
 }
 
 impl PutBlobResponse {
-    pub fn from_headers(headers: &HeaderMap) -> Result<PutBlobResponse, AzureStorageError> {
+    pub fn from_headers(headers: &HeaderMap) -> Result<PutBlobResponse, crate::Error> {
         debug!("{:#?}", headers);
 
         let etag = etag_from_headers(headers)?;

--- a/sdk/storage/src/blob/blob/responses/put_block_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_block_blob_response.rs
@@ -1,6 +1,4 @@
-use crate::{
-    headers::consistency_from_headers, AzureStorageError, ConsistencyCRC64, ConsistencyMD5,
-};
+use crate::{headers::consistency_from_headers, ConsistencyCRC64, ConsistencyMD5};
 use azure_core::headers::{
     date_from_headers, etag_from_headers, last_modified_from_headers, request_id_from_headers,
     request_server_encrypted_from_headers,
@@ -21,7 +19,7 @@ pub struct PutBlockBlobResponse {
 }
 
 impl PutBlockBlobResponse {
-    pub fn from_headers(headers: &HeaderMap) -> Result<PutBlockBlobResponse, AzureStorageError> {
+    pub fn from_headers(headers: &HeaderMap) -> Result<PutBlockBlobResponse, crate::Error> {
         debug!("headers == {:#?}", headers);
 
         let etag = etag_from_headers(headers)?;

--- a/sdk/storage/src/blob/blob/responses/put_block_list_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_block_list_response.rs
@@ -1,4 +1,4 @@
-use crate::{headers::content_md5_from_headers, AzureStorageError};
+use crate::headers::content_md5_from_headers;
 use azure_core::headers::{
     date_from_headers, etag_from_headers, last_modified_from_headers, request_id_from_headers,
     request_server_encrypted_from_headers,
@@ -18,9 +18,7 @@ pub struct PutBlockListResponse {
 }
 
 impl PutBlockListResponse {
-    pub(crate) fn from_headers(
-        headers: &HeaderMap,
-    ) -> Result<PutBlockListResponse, AzureStorageError> {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> Result<PutBlockListResponse, crate::Error> {
         debug!("headers == {:#?}", headers);
 
         let etag = etag_from_headers(headers)?;

--- a/sdk/storage/src/blob/blob/responses/put_block_response.rs
+++ b/sdk/storage/src/blob/blob/responses/put_block_response.rs
@@ -1,6 +1,4 @@
-use crate::{
-    headers::consistency_from_headers, AzureStorageError, ConsistencyCRC64, ConsistencyMD5,
-};
+use crate::{headers::consistency_from_headers, ConsistencyCRC64, ConsistencyMD5};
 use azure_core::headers::{
     date_from_headers, request_id_from_headers, request_server_encrypted_from_headers,
 };
@@ -18,7 +16,7 @@ pub struct PutBlockResponse {
 }
 
 impl PutBlockResponse {
-    pub(crate) fn from_headers(headers: &HeaderMap) -> Result<PutBlockResponse, AzureStorageError> {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> Result<PutBlockResponse, crate::Error> {
         debug!("{:#?}", headers);
 
         let (content_md5, content_crc64) = consistency_from_headers(headers)?;

--- a/sdk/storage/src/blob/blob/responses/update_page_response.rs
+++ b/sdk/storage/src/blob/blob/responses/update_page_response.rs
@@ -1,4 +1,4 @@
-use crate::{headers::content_md5_from_headers, AzureStorageError};
+use crate::headers::content_md5_from_headers;
 use azure_core::headers::{
     date_from_headers, etag_from_headers, last_modified_from_headers, request_id_from_headers,
     request_server_encrypted_from_headers, sequence_number_from_headers,
@@ -19,9 +19,7 @@ pub struct UpdatePageResponse {
 }
 
 impl UpdatePageResponse {
-    pub(crate) fn from_headers(
-        headers: &HeaderMap,
-    ) -> Result<UpdatePageResponse, AzureStorageError> {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> Result<UpdatePageResponse, crate::Error> {
         let etag = etag_from_headers(headers)?;
         let last_modified = last_modified_from_headers(headers)?;
         let content_md5 = content_md5_from_headers(headers)?;

--- a/sdk/storage/src/blob/clients/blob_client.rs
+++ b/sdk/storage/src/blob/clients/blob_client.rs
@@ -1,7 +1,7 @@
+use crate::blob::blob::requests::*;
 use crate::blob::prelude::*;
 use crate::core::prelude::*;
 use crate::shared_access_signature::SharedAccessSignature;
-use crate::{blob::blob::requests::*, AzureStorageError};
 use azure_core::prelude::*;
 use azure_core::HttpClient;
 use bytes::Bytes;
@@ -168,7 +168,7 @@ impl BlobClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.container_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/blob/clients/blob_lease_client.rs
+++ b/sdk/storage/src/blob/clients/blob_lease_client.rs
@@ -1,6 +1,6 @@
+use crate::blob::blob::requests::*;
 use crate::blob::prelude::*;
 use crate::core::prelude::*;
-use crate::{blob::blob::requests::*, AzureStorageError};
 use azure_core::prelude::*;
 use azure_core::HttpClient;
 use bytes::Bytes;
@@ -83,7 +83,7 @@ impl BlobLeaseClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.blob_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/blob/clients/container_client.rs
+++ b/sdk/storage/src/blob/clients/container_client.rs
@@ -1,6 +1,6 @@
+use crate::blob::prelude::PublicAccess;
 use crate::container::requests::*;
 use crate::core::clients::{StorageAccountClient, StorageClient};
-use crate::{blob::prelude::PublicAccess, AzureStorageError};
 use azure_core::prelude::*;
 use bytes::Bytes;
 use http::method::Method;
@@ -102,7 +102,7 @@ impl ContainerClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.storage_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/blob/clients/container_lease_client.rs
+++ b/sdk/storage/src/blob/clients/container_lease_client.rs
@@ -1,6 +1,6 @@
+use crate::blob::container::requests::*;
 use crate::blob::prelude::*;
 use crate::core::prelude::*;
-use crate::{blob::container::requests::*, AzureStorageError};
 use azure_core::prelude::*;
 use azure_core::HttpClient;
 use bytes::Bytes;
@@ -74,7 +74,7 @@ impl ContainerLeaseClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.container_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/blob/container/responses/get_acl_response.rs
+++ b/sdk/storage/src/blob/container/responses/get_acl_response.rs
@@ -1,6 +1,6 @@
 use crate::{
     container::{public_access_from_header, PublicAccess},
-    AzureStorageError, StoredAccessPolicyList,
+    StoredAccessPolicyList,
 };
 use azure_core::headers::REQUEST_ID;
 use azure_core::RequestId;
@@ -21,7 +21,7 @@ pub struct GetACLResponse {
 }
 
 impl TryFrom<(&str, &HeaderMap)> for GetACLResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from((body, header_map): (&str, &HeaderMap)) -> Result<Self, Self::Error> {
         GetACLResponse::from_response(body, header_map)
@@ -33,14 +33,14 @@ impl GetACLResponse {
     pub(crate) fn from_response(
         body: &str,
         headers: &HeaderMap,
-    ) -> Result<GetACLResponse, AzureStorageError> {
+    ) -> Result<GetACLResponse, crate::Error> {
         let public_access = public_access_from_header(&headers)?;
 
         let etag = match headers.get(header::ETAG) {
             Some(etag) => etag.to_str()?,
             None => {
                 static E: header::HeaderName = header::ETAG;
-                return Err(AzureStorageError::MissingHeaderError(E.as_str().to_owned()));
+                return Err(crate::Error::MissingHeaderError(E.as_str().to_owned()));
             }
         };
 
@@ -48,23 +48,21 @@ impl GetACLResponse {
             Some(last_modified) => last_modified.to_str()?,
             None => {
                 static LM: header::HeaderName = header::LAST_MODIFIED;
-                return Err(AzureStorageError::MissingHeaderError(
-                    LM.as_str().to_owned(),
-                ));
+                return Err(crate::Error::MissingHeaderError(LM.as_str().to_owned()));
             }
         };
         let last_modified = DateTime::parse_from_rfc2822(last_modified)?;
 
         let request_id = match headers.get(REQUEST_ID) {
             Some(request_id) => request_id.to_str()?,
-            None => return Err(AzureStorageError::MissingHeaderError(REQUEST_ID.to_owned())),
+            None => return Err(crate::Error::MissingHeaderError(REQUEST_ID.to_owned())),
         };
 
         let date = match headers.get(header::DATE) {
             Some(date) => date.to_str()?,
             None => {
                 static D: header::HeaderName = header::DATE;
-                return Err(AzureStorageError::MissingHeaderError(D.as_str().to_owned()));
+                return Err(crate::Error::MissingHeaderError(D.as_str().to_owned()));
             }
         };
         let date = DateTime::parse_from_rfc2822(date)?;

--- a/sdk/storage/src/blob/container/responses/get_properties_response.rs
+++ b/sdk/storage/src/blob/container/responses/get_properties_response.rs
@@ -1,4 +1,4 @@
-use crate::{container::Container, AzureStorageError};
+use crate::container::Container;
 use azure_core::headers::REQUEST_ID;
 use azure_core::RequestId;
 use chrono::{DateTime, FixedOffset};
@@ -14,7 +14,7 @@ pub struct GetPropertiesResponse {
 }
 
 impl TryFrom<(&str, &HeaderMap)> for GetPropertiesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from((body, header_map): (&str, &HeaderMap)) -> Result<Self, Self::Error> {
         GetPropertiesResponse::from_response(body, header_map)
@@ -25,17 +25,17 @@ impl GetPropertiesResponse {
     pub(crate) fn from_response(
         container_name: &str,
         headers: &HeaderMap,
-    ) -> Result<GetPropertiesResponse, AzureStorageError> {
+    ) -> Result<GetPropertiesResponse, crate::Error> {
         let request_id = match headers.get(REQUEST_ID) {
             Some(request_id) => Uuid::parse_str(request_id.to_str()?)?,
-            None => return Err(AzureStorageError::MissingHeaderError(REQUEST_ID.to_owned())),
+            None => return Err(crate::Error::MissingHeaderError(REQUEST_ID.to_owned())),
         };
 
         let date = match headers.get(header::DATE) {
             Some(date) => DateTime::parse_from_rfc2822(date.to_str()?)?,
             None => {
                 static D: header::HeaderName = header::DATE;
-                return Err(AzureStorageError::MissingHeaderError(D.as_str().to_owned()));
+                return Err(crate::Error::MissingHeaderError(D.as_str().to_owned()));
             }
         };
 

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -2,7 +2,6 @@ use crate::headers::CONTENT_MD5;
 use crate::{
     core::{ConnectionString, No},
     shared_access_signature::SharedAccessSignatureBuilder,
-    AzureStorageError,
 };
 use azure_core::headers::*;
 use azure_core::prelude::*;
@@ -208,7 +207,7 @@ impl StorageAccountClient {
     pub fn new_connection_string(
         http_client: Arc<dyn HttpClient>,
         connection_string: &str,
-    ) -> Result<Arc<Self>, AzureStorageError> {
+    ) -> Result<Arc<Self>, crate::Error> {
         match ConnectionString::new(connection_string)? {
             ConnectionString {
                 account_name: Some(account),
@@ -269,7 +268,7 @@ impl StorageAccountClient {
                 http_client,
             })),
            _ => {
-                Err(AzureStorageError::GenericErrorWithText(
+                Err(crate::Error::GenericErrorWithText(
                     "Could not create a storage client from the provided connection string. Please validate that you have specified the account name and means of authentication (key, SAS, etc.)."
                         .to_owned(),
                 ).into())
@@ -303,12 +302,12 @@ impl StorageAccountClient {
 
     pub fn shared_access_signature(
         &self,
-    ) -> Result<SharedAccessSignatureBuilder<No, No, No, No>, AzureStorageError> {
+    ) -> Result<SharedAccessSignatureBuilder<No, No, No, No>, crate::Error> {
         match self.storage_credentials {
             StorageCredentials::Key(ref account, ref key) => {
                 Ok(SharedAccessSignatureBuilder::new(account, key))
             }
-            _ => Err(AzureStorageError::OperationNotSupported(
+            _ => Err(crate::Error::OperationNotSupported(
                 "Shared access signature generation".to_owned(),
                 "SAS can be generated only from key and account clients".to_owned(),
             )
@@ -323,7 +322,7 @@ impl StorageAccountClient {
         http_header_adder: &dyn Fn(Builder) -> Builder,
         service_type: ServiceType,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         let dt = chrono::Utc::now();
         let time = format!("{}", dt.format("%a, %d %h %Y %T GMT"));
 

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -1,7 +1,4 @@
-use crate::{
-    core::clients::{ServiceType, StorageAccountClient},
-    AzureStorageError,
-};
+use crate::core::clients::{ServiceType, StorageAccountClient};
 use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
@@ -123,7 +120,7 @@ impl StorageClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.storage_account_client.prepare_request(
             url,
             method,

--- a/sdk/storage/src/core/copy_id.rs
+++ b/sdk/storage/src/core/copy_id.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use http::HeaderMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::convert::TryFrom;
@@ -9,10 +8,10 @@ use super::headers::COPY_ID;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyId(uuid::Uuid);
 
-pub fn copy_id_from_headers(headers: &HeaderMap) -> Result<CopyId, AzureStorageError> {
+pub fn copy_id_from_headers(headers: &HeaderMap) -> Result<CopyId, crate::Error> {
     let copy_id = headers
         .get(COPY_ID)
-        .ok_or_else(|| AzureStorageError::HeaderNotFound(COPY_ID.to_owned()))?;
+        .ok_or_else(|| crate::Error::HeaderNotFound(COPY_ID.to_owned()))?;
     Ok(CopyId(uuid::Uuid::parse_str(copy_id.to_str()?)?))
 }
 

--- a/sdk/storage/src/core/errors.rs
+++ b/sdk/storage/src/core/errors.rs
@@ -1,5 +1,6 @@
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
-pub enum AzureStorageError {
+pub enum Error {
     #[error(transparent)]
     CoreError(#[from] azure_core::Error),
     #[error("Parse error: {0}")]
@@ -30,7 +31,7 @@ pub enum AzureStorageError {
     FromUtf8Error(#[from] std::string::FromUtf8Error),
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
-    #[error("Invalid status code: {:?}", 0)]
+    #[error("Invalid status code: {0:?}")]
     InvalidStatusCode(#[from] http::status::InvalidStatusCode),
     #[error("UTF-8 conversion error: {0}")]
     Utf8Error(#[from] std::str::Utf8Error),
@@ -53,18 +54,18 @@ pub enum AzureStorageError {
     ParseIntError(#[from] std::num::ParseIntError),
     #[error("Header not found: {0}")]
     HeaderNotFound(String),
-    #[error("Error parsing the transaction response: {:?}", 0)]
+    #[error("Error parsing the transaction response: {0:?}")]
     TransactionResponseParseError(String),
     #[error("Generic error: {0}")]
     GenericErrorWithText(String),
-    #[error("Operation not supported. Operation == {}, reason == {}", 0, 1)]
+    #[error("Operation not supported. Operation == {0}, reason == {1}")]
     OperationNotSupported(String, String),
     #[error("UnexpectedXMLError: {0}")]
     UnexpectedXMLError(String),
-    #[error("digest length {} bytes instead of 16", 0)]
+    #[error("digest length {0} bytes instead of 16")]
     DigestNot16BytesLong(u64),
-    #[error("CRC64 length {} bytes instead of 8", 0)]
+    #[error("CRC64 length {0} bytes instead of 8")]
     CRC64Not8BytesLong(u64),
-    #[error("At least one of these headers must be present: {:?}", 0)]
+    #[error("At least one of these headers must be present: {0:?}")]
     HeadersNotFound(Vec<String>),
 }

--- a/sdk/storage/src/core/headers/mod.rs
+++ b/sdk/storage/src/core/headers/mod.rs
@@ -1,21 +1,21 @@
-use crate::{AzureStorageError, ConsistencyCRC64, ConsistencyMD5};
+use crate::{ConsistencyCRC64, ConsistencyMD5};
 use http::HeaderMap;
 
 pub const CONTENT_CRC64: &str = "x-ms-content-crc64";
 pub const CONTENT_MD5: &str = "Content-MD5";
 pub const COPY_ID: &str = "x-ms-copy-id";
 
-pub fn content_crc64_from_headers(headers: &HeaderMap) -> Result<[u8; 8], AzureStorageError> {
+pub fn content_crc64_from_headers(headers: &HeaderMap) -> Result<[u8; 8], crate::Error> {
     let content_crc64 = headers
         .get(CONTENT_CRC64)
-        .ok_or_else(|| AzureStorageError::HeaderNotFound(CONTENT_CRC64.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(CONTENT_CRC64.to_owned()))?
         .to_str()?;
 
     let content_crc64_vec = base64::decode(&content_crc64)?;
 
     if content_crc64_vec.len() != 8 {
-        return Err(AzureStorageError::CRC64Not8BytesLong(
-            content_crc64_vec.len() as u64,
+        return Err(crate::Error::CRC64Not8BytesLong(
+            content_crc64_vec.len() as u64
         ));
     }
     let mut content_crc64 = [0; 8];
@@ -27,7 +27,7 @@ pub fn content_crc64_from_headers(headers: &HeaderMap) -> Result<[u8; 8], AzureS
 
 pub fn content_crc64_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<[u8; 8]>, AzureStorageError> {
+) -> Result<Option<[u8; 8]>, crate::Error> {
     if headers.contains_key(CONTENT_CRC64) {
         Ok(Some(content_crc64_from_headers(headers)?))
     } else {
@@ -35,17 +35,17 @@ pub fn content_crc64_from_headers_optional(
     }
 }
 
-pub fn content_md5_from_headers(headers: &HeaderMap) -> Result<[u8; 16], AzureStorageError> {
+pub fn content_md5_from_headers(headers: &HeaderMap) -> Result<[u8; 16], crate::Error> {
     let content_md5 = headers
         .get(CONTENT_MD5)
-        .ok_or_else(|| AzureStorageError::HeaderNotFound(CONTENT_MD5.to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound(CONTENT_MD5.to_owned()))?
         .to_str()?;
 
     let content_md5_vec = base64::decode(&content_md5)?;
 
     if content_md5_vec.len() != 16 {
-        return Err(AzureStorageError::DigestNot16BytesLong(
-            content_md5_vec.len() as u64,
+        return Err(crate::Error::DigestNot16BytesLong(
+            content_md5_vec.len() as u64
         ));
     }
     let mut content_md5 = [0; 16];
@@ -57,7 +57,7 @@ pub fn content_md5_from_headers(headers: &HeaderMap) -> Result<[u8; 16], AzureSt
 
 pub fn content_md5_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<[u8; 16]>, AzureStorageError> {
+) -> Result<Option<[u8; 16]>, crate::Error> {
     if headers.contains_key(CONTENT_MD5) {
         Ok(Some(content_md5_from_headers(headers)?))
     } else {
@@ -67,7 +67,7 @@ pub fn content_md5_from_headers_optional(
 
 pub fn consistency_from_headers(
     headers: &HeaderMap,
-) -> Result<(Option<ConsistencyMD5>, Option<ConsistencyCRC64>), AzureStorageError> {
+) -> Result<(Option<ConsistencyMD5>, Option<ConsistencyCRC64>), crate::Error> {
     let content_crc64 = content_crc64_from_headers_optional(headers)?.map(ConsistencyCRC64);
     let content_md5 = content_md5_from_headers_optional(headers)?.map(ConsistencyMD5);
     Ok((content_md5, content_crc64))

--- a/sdk/storage/src/core/mod.rs
+++ b/sdk/storage/src/core/mod.rs
@@ -15,7 +15,7 @@ pub use copy_id::{copy_id_from_headers, CopyId};
 pub use copy_progress::CopyProgress;
 pub(crate) mod parsing_xml;
 mod stored_access_policy;
-pub use errors::AzureStorageError;
+pub use errors::Error;
 
 #[derive(Debug, Clone, Eq, PartialEq, Copy, Serialize, Deserialize)]
 pub struct Yes;

--- a/sdk/storage/src/core/stored_access_policy.rs
+++ b/sdk/storage/src/core/stored_access_policy.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use chrono::{DateTime, FixedOffset};
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -39,7 +38,7 @@ impl StoredAccessPolicyList {
         StoredAccessPolicyList::default()
     }
 
-    pub fn from_xml(xml: &str) -> Result<StoredAccessPolicyList, AzureStorageError> {
+    pub fn from_xml(xml: &str) -> Result<StoredAccessPolicyList, crate::Error> {
         debug!("{}", xml);
 
         let mut sal = StoredAccessPolicyList::default();

--- a/sdk/storage/src/data_lake/clients/data_lake_client.rs
+++ b/sdk/storage/src/data_lake/clients/data_lake_client.rs
@@ -1,5 +1,5 @@
+use crate::core::prelude::*;
 use crate::data_lake::requests::*;
-use crate::{core::prelude::*, AzureStorageError};
 use azure_core::prelude::*;
 use bytes::Bytes;
 use http::method::Method;
@@ -95,7 +95,7 @@ impl DataLakeClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.storage_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/data_lake/clients/file_system_client.rs
+++ b/sdk/storage/src/data_lake/clients/file_system_client.rs
@@ -1,5 +1,5 @@
+use crate::data_lake::requests::*;
 use crate::{data_lake::clients::DataLakeClient, Properties};
-use crate::{data_lake::requests::*, AzureStorageError};
 use azure_core::prelude::*;
 use bytes::Bytes;
 use http::method::Method;
@@ -74,7 +74,7 @@ impl FileSystemClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.data_lake_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/data_lake/file_system.rs
+++ b/sdk/storage/src/data_lake/file_system.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::prelude::Etag;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -21,7 +20,7 @@ pub(crate) struct FileSystemList {
 }
 
 impl TryFrom<&Response<Bytes>> for FileSystemList {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         trace!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/data_lake/responses/create_file_system_response.rs
+++ b/sdk/storage/src/data_lake/responses/create_file_system_response.rs
@@ -1,4 +1,4 @@
-use crate::{data_lake::util::*, AzureStorageError};
+use crate::data_lake::util::*;
 use azure_core::{
     headers::{etag_from_headers, last_modified_from_headers, CommonStorageResponseHeaders},
     prelude::Etag,
@@ -17,7 +17,7 @@ pub struct CreateFileSystemResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for CreateFileSystemResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         trace!("body == {}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/data_lake/responses/delete_file_system_response.rs
+++ b/sdk/storage/src/data_lake/responses/delete_file_system_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -10,7 +9,7 @@ pub struct DeleteFileSystemResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for DeleteFileSystemResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("body == {}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/data_lake/responses/get_file_system_properties_response.rs
+++ b/sdk/storage/src/data_lake/responses/get_file_system_properties_response.rs
@@ -1,4 +1,4 @@
-use crate::{data_lake::util::*, AzureStorageError, Properties};
+use crate::{data_lake::util::*, Properties};
 use azure_core::{
     headers::{etag_from_headers, last_modified_from_headers, CommonStorageResponseHeaders},
     prelude::Etag,
@@ -18,7 +18,7 @@ pub struct GetFileSystemPropertiesResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for GetFileSystemPropertiesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("body == {}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/data_lake/responses/list_file_systems_response.rs
+++ b/sdk/storage/src/data_lake/responses/list_file_systems_response.rs
@@ -1,5 +1,5 @@
+use crate::data_lake::file_system::FileSystemList;
 use crate::data_lake::FileSystem;
-use crate::{data_lake::file_system::FileSystemList, AzureStorageError};
 use azure_core::{headers::CommonStorageResponseHeaders, prelude::NextMarker};
 use bytes::Bytes;
 use http::Response;
@@ -13,7 +13,7 @@ pub struct ListFileSystemsResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for ListFileSystemsResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         trace!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/data_lake/responses/set_file_system_properties_response.rs
+++ b/sdk/storage/src/data_lake/responses/set_file_system_properties_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::{
     headers::{etag_from_headers, last_modified_from_headers, CommonStorageResponseHeaders},
     prelude::Etag,
@@ -16,7 +15,7 @@ pub struct SetFileSystemPropertiesResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for SetFileSystemPropertiesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         trace!("body == {}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/data_lake/util.rs
+++ b/sdk/storage/src/data_lake/util.rs
@@ -1,12 +1,9 @@
-use crate::AzureStorageError;
 use http::HeaderMap;
 
-pub(crate) fn namespace_enabled_from_headers(
-    headers: &HeaderMap,
-) -> Result<bool, AzureStorageError> {
+pub(crate) fn namespace_enabled_from_headers(headers: &HeaderMap) -> Result<bool, crate::Error> {
     Ok(headers
         .get("x-ms-namespace-enabled")
-        .ok_or_else(|| AzureStorageError::HeaderNotFound("x-ms-namespace-enabled".to_owned()))?
+        .ok_or_else(|| crate::Error::HeaderNotFound("x-ms-namespace-enabled".to_owned()))?
         .to_str()?
         .parse()?)
 }

--- a/sdk/storage/src/lib.rs
+++ b/sdk/storage/src/lib.rs
@@ -8,7 +8,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate azure_core;
 
-pub use self::core::AzureStorageError;
+pub use self::core::Error;
 
 #[cfg(feature = "account")]
 pub mod account;

--- a/sdk/storage/src/queue/responses/clear_messages_response.rs
+++ b/sdk/storage/src/queue/responses/clear_messages_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -10,7 +9,7 @@ pub struct ClearMessagesResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for ClearMessagesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/queue/responses/create_queue_response.rs
+++ b/sdk/storage/src/queue/responses/create_queue_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -10,7 +9,7 @@ pub struct CreateQueueResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for CreateQueueResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/queue/responses/delete_message_response.rs
+++ b/sdk/storage/src/queue/responses/delete_message_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -10,7 +9,7 @@ pub struct DeleteMessageResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for DeleteMessageResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/queue/responses/delete_queue_response.rs
+++ b/sdk/storage/src/queue/responses/delete_queue_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -10,7 +9,7 @@ pub struct DeleteQueueResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for DeleteQueueResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/queue/responses/get_messages_response.rs
+++ b/sdk/storage/src/queue/responses/get_messages_response.rs
@@ -1,4 +1,4 @@
-use crate::{queue::PopReceipt, AzureStorageError};
+use crate::queue::PopReceipt;
 use azure_core::headers::{utc_date_from_rfc2822, CommonStorageResponseHeaders};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -52,7 +52,7 @@ struct MessagesInternal {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetMessagesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/storage/src/queue/responses/get_queue_acl_response.rs
+++ b/sdk/storage/src/queue/responses/get_queue_acl_response.rs
@@ -1,4 +1,4 @@
-use crate::{AzureStorageError, QueueStoredAccessPolicy, StoredAccessPolicyList};
+use crate::{QueueStoredAccessPolicy, StoredAccessPolicyList};
 use azure_core::headers::CommonStorageResponseHeaders;
 use azure_core::PermissionError;
 use bytes::Bytes;
@@ -12,7 +12,7 @@ pub struct GetQueueACLResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueACLResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/storage/src/queue/responses/get_queue_metadata_response.rs
+++ b/sdk/storage/src/queue/responses/get_queue_metadata_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use azure_core::prelude::*;
 use bytes::Bytes;
@@ -12,7 +11,7 @@ pub struct GetQueueMetadataResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueMetadataResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/storage/src/queue/responses/get_queue_service_properties_response.rs
+++ b/sdk/storage/src/queue/responses/get_queue_service_properties_response.rs
@@ -1,4 +1,4 @@
-use crate::{AzureStorageError, QueueServiceProperties};
+use crate::QueueServiceProperties;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -11,7 +11,7 @@ pub struct GetQueueServicePropertiesResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueServicePropertiesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/storage/src/queue/responses/get_queue_service_stats_response.rs
+++ b/sdk/storage/src/queue/responses/get_queue_service_stats_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -34,7 +33,7 @@ struct GeoReplication {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueServiceStatsResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/storage/src/queue/responses/list_queues_response.rs
+++ b/sdk/storage/src/queue/responses/list_queues_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use azure_core::prelude::*;
 use bytes::Bytes;
@@ -56,7 +55,7 @@ pub struct Queue {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for ListQueuesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();

--- a/sdk/storage/src/queue/responses/peek_messages_response.rs
+++ b/sdk/storage/src/queue/responses/peek_messages_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::{utc_date_from_rfc2822, CommonStorageResponseHeaders};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -41,7 +40,7 @@ struct PeekMessagesInternal {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for PeekMessagesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/storage/src/queue/responses/put_message_response.rs
+++ b/sdk/storage/src/queue/responses/put_message_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::{utc_date_from_rfc2822, CommonStorageResponseHeaders};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -41,7 +40,7 @@ struct QueueMessageInternal {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for PutMessageResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let headers = response.headers();
         let body = response.body();

--- a/sdk/storage/src/queue/responses/set_queue_acl_response.rs
+++ b/sdk/storage/src/queue/responses/set_queue_acl_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -10,7 +9,7 @@ pub struct SetQueueACLResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueACLResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/queue/responses/set_queue_metadata_response.rs
+++ b/sdk/storage/src/queue/responses/set_queue_metadata_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -10,7 +9,7 @@ pub struct SetQueueMetadataResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueMetadataResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/queue/responses/set_queue_service_properties_response.rs
+++ b/sdk/storage/src/queue/responses/set_queue_service_properties_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -10,7 +9,7 @@ pub struct SetQueueServicePropertiesResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueServicePropertiesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/queue/responses/update_message_response.rs
+++ b/sdk/storage/src/queue/responses/update_message_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::{
     rfc2822_from_headers_mandatory, string_from_headers_mandatory, CommonStorageResponseHeaders,
 };
@@ -15,7 +14,7 @@ pub struct UpdateMessageResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for UpdateMessageResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("response == {:?}", response);

--- a/sdk/storage/src/table/clients/entity_client.rs
+++ b/sdk/storage/src/table/clients/entity_client.rs
@@ -1,5 +1,5 @@
+use crate::table::prelude::*;
 use crate::table::requests::*;
-use crate::{table::prelude::*, AzureStorageError};
 use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
@@ -97,7 +97,7 @@ impl EntityClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.partition_key_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/table/clients/partition_key_client.rs
+++ b/sdk/storage/src/table/clients/partition_key_client.rs
@@ -1,6 +1,6 @@
+use crate::core::clients::StorageAccountClient;
 use crate::table::prelude::*;
 use crate::table::requests::*;
-use crate::{core::clients::StorageAccountClient, AzureStorageError};
 use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
@@ -59,7 +59,7 @@ impl PartitionKeyClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.table_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/table/clients/table_client.rs
+++ b/sdk/storage/src/table/clients/table_client.rs
@@ -1,6 +1,6 @@
+use crate::core::clients::StorageAccountClient;
 use crate::table::clients::TableServiceClient;
 use crate::table::requests::*;
-use crate::{core::clients::StorageAccountClient, AzureStorageError};
 use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
@@ -71,7 +71,7 @@ impl TableClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.table_service_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage/src/table/clients/table_service_client.rs
+++ b/sdk/storage/src/table/clients/table_service_client.rs
@@ -1,8 +1,5 @@
+use crate::core::clients::{StorageAccountClient, StorageClient};
 use crate::table::requests::ListTablesBuilder;
-use crate::{
-    core::clients::{StorageAccountClient, StorageClient},
-    AzureStorageError,
-};
 use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
@@ -63,7 +60,7 @@ impl TableServiceClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url), AzureStorageError> {
+    ) -> Result<(Request<Bytes>, url::Url), crate::Error> {
         self.storage_client
             .storage_account_client()
             .prepare_request(

--- a/sdk/storage/src/table/continuation_next_partition_and_row_key.rs
+++ b/sdk/storage/src/table/continuation_next_partition_and_row_key.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::AppendToUrlQuery;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -16,9 +15,7 @@ impl ContinuationNextPartitionAndRowKey {
         &self.0
     }
 
-    pub fn from_header_optional(
-        headers: &http::HeaderMap,
-    ) -> Result<Option<Self>, AzureStorageError> {
+    pub fn from_header_optional(headers: &http::HeaderMap) -> Result<Option<Self>, crate::Error> {
         let partition_header_as_str = headers
             .get("x-ms-continuation-NextPartitionKey")
             .map(|item| item.to_str())

--- a/sdk/storage/src/table/continuation_next_table_name.rs
+++ b/sdk/storage/src/table/continuation_next_table_name.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::AppendToUrlQuery;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -13,9 +12,7 @@ impl ContinuationNextTableName {
         &self.0
     }
 
-    pub fn from_header_optional(
-        headers: &http::HeaderMap,
-    ) -> Result<Option<Self>, AzureStorageError> {
+    pub fn from_header_optional(headers: &http::HeaderMap) -> Result<Option<Self>, crate::Error> {
         let header_as_str = headers
             .get("x-ms-continuation-NextTableName")
             .map(|item| item.to_str())

--- a/sdk/storage/src/table/responses/create_table_response.rs
+++ b/sdk/storage/src/table/responses/create_table_response.rs
@@ -1,4 +1,4 @@
-use crate::{table::prelude::*, AzureStorageError};
+use crate::table::prelude::*;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -11,7 +11,7 @@ pub struct CreateTableResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for CreateTableResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/table/responses/delete_entity_response.rs
+++ b/sdk/storage/src/table/responses/delete_entity_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -10,7 +9,7 @@ pub struct DeleteEntityResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for DeleteEntityResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/table/responses/delete_table_response.rs
+++ b/sdk/storage/src/table/responses/delete_table_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -10,7 +9,7 @@ pub struct DeleteTableResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for DeleteTableResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/table/responses/get_entity_response.rs
+++ b/sdk/storage/src/table/responses/get_entity_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -27,7 +26,7 @@ impl<E> TryFrom<&Response<Bytes>> for GetEntityResponse<E>
 where
     E: DeserializeOwned,
 {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/table/responses/insert_entity_response.rs
+++ b/sdk/storage/src/table/responses/insert_entity_response.rs
@@ -1,4 +1,4 @@
-use crate::{AzureStorageError, EntityWithMetadata};
+use crate::EntityWithMetadata;
 use azure_core::{
     headers::{etag_from_headers, string_from_headers_mandatory, CommonStorageResponseHeaders},
     prelude::Etag,
@@ -24,7 +24,7 @@ impl<E> TryFrom<&Response<Bytes>> for InsertEntityResponse<E>
 where
     E: DeserializeOwned,
 {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         println!("{}", std::str::from_utf8(response.body())?);
@@ -35,7 +35,7 @@ where
                 "return-no-content" => None,
                 "return-content" => Some(response.try_into()?),
                 _ => {
-                    return Err(AzureStorageError::GenericErrorWithText(
+                    return Err(crate::Error::GenericErrorWithText(
                         "Unexpected value for preference-applied header".to_owned(),
                     ))
                 }

--- a/sdk/storage/src/table/responses/list_tables_response.rs
+++ b/sdk/storage/src/table/responses/list_tables_response.rs
@@ -1,4 +1,4 @@
-use crate::{table::prelude::*, AzureStorageError, ContinuationNextTableName};
+use crate::{table::prelude::*, ContinuationNextTableName};
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -21,7 +21,7 @@ struct ListTablesResponseInternal {
 }
 
 impl TryFrom<&Response<Bytes>> for ListTablesResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/table/responses/operation_on_entity_response.rs
+++ b/sdk/storage/src/table/responses/operation_on_entity_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::{
     headers::{etag_from_headers, CommonStorageResponseHeaders},
     prelude::Etag,
@@ -14,7 +13,7 @@ pub struct OperationOnEntityResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for OperationOnEntityResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         println!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/table/responses/query_entity_response.rs
+++ b/sdk/storage/src/table/responses/query_entity_response.rs
@@ -1,4 +1,4 @@
-use crate::{AzureStorageError, ContinuationNextPartitionAndRowKey};
+use crate::ContinuationNextPartitionAndRowKey;
 use azure_core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -25,7 +25,7 @@ struct QueryEntityResponseInternal<E> {
 }
 
 impl<E: DeserializeOwned> TryFrom<&Response<Bytes>> for QueryEntityResponse<E> {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         debug!("{}", std::str::from_utf8(response.body())?);

--- a/sdk/storage/src/table/responses/submit_transaction_response.rs
+++ b/sdk/storage/src/table/responses/submit_transaction_response.rs
@@ -1,4 +1,3 @@
-use crate::AzureStorageError;
 use azure_core::{headers::CommonStorageResponseHeaders, prelude::Etag};
 use bytes::Bytes;
 use http::{Response, StatusCode};
@@ -20,7 +19,7 @@ pub struct SubmitTransactionResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for SubmitTransactionResponse {
-    type Error = AzureStorageError;
+    type Error = crate::Error;
 
     fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
         let body = std::str::from_utf8(response.body())?;
@@ -44,7 +43,7 @@ impl TryFrom<&Response<Bytes>> for SubmitTransactionResponse {
                         .split_whitespace()
                         .nth(1)
                         .ok_or_else(|| {
-                            AzureStorageError::TransactionResponseParseError(
+                            crate::Error::TransactionResponseParseError(
                                 "missing HTTP status code".to_owned(),
                             )
                         })?
@@ -54,7 +53,7 @@ impl TryFrom<&Response<Bytes>> for SubmitTransactionResponse {
                         line.split_whitespace()
                             .nth(1)
                             .ok_or_else(|| {
-                                AzureStorageError::TransactionResponseParseError(
+                                crate::Error::TransactionResponseParseError(
                                     "invalid Location header".to_owned(),
                                 )
                             })?
@@ -67,7 +66,7 @@ impl TryFrom<&Response<Bytes>> for SubmitTransactionResponse {
                             .ok_or_else(|| {
                                 {
                                     {
-                                        AzureStorageError::TransactionResponseParseError(
+                                        crate::Error::TransactionResponseParseError(
                                             "invalid DataServiceId header".to_owned(),
                                         )
                                     }
@@ -82,7 +81,7 @@ impl TryFrom<&Response<Bytes>> for SubmitTransactionResponse {
                             .ok_or_else(|| {
                                 {
                                     {
-                                        AzureStorageError::TransactionResponseParseError(
+                                        crate::Error::TransactionResponseParseError(
                                             "invalid ETag header".to_owned(),
                                         )
                                     }


### PR DESCRIPTION
This pull request renames two errors to `crate::Error` pattern.
- `azure_cosmos::CosmosError` becomes `azure_cosmos::Error`
- `azure_storage::AzureStorageError` becomes `azure_storage::Error`

This also removes some unused cases from `azure_core::Error`.