### PR TITLE
fix storage table delete for azurite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ sample/
 *.swo
 *.vim
 __azurite*.json
+__blobstorage__

--- a/sdk/storage/src/table/requests/delete_table_builder.rs
+++ b/sdk/storage/src/table/requests/delete_table_builder.rs
@@ -42,7 +42,7 @@ impl<'a> DeleteTableBuilder<'a> {
             &Method::DELETE,
             &|mut request| {
                 request = add_optional_header(&self.client_request_id, request);
-                request = request.header("Content-Type", "application/json");
+                request = request.header("Accept", "application/json");
                 request
             },
             None,


### PR DESCRIPTION
This fixes this integration test when running against Azurite:
test blob::clients::container_client::integration_tests::test_create_delete ... FAILED

It can be reproduced by running:
``` ps1
$env:AZURE_STORAGE_ACCOUNT="devstoreaccount1"
$env:AZURE_STORAGE_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
cargo test --features test_integration test_create_delete
```

When doing a
```
DELETE http://127.0.0.1:10002/devstoreaccount1/Tables('TableClientCreateDelete') HTTP/1.1
```
Azurite responds with this:

``` xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<Error>
  <Code>AtomFormatNotSupported</Code>
  <Message>Atom format is not supported.
RequestId:2056c1a0-90c6-44f8-ade7-b4ed3a3d3189
Time:2021-06-11T21:25:56.442Z</Message>
</Error>
```

azure_storage is doing this:
```
DELETE http://127.0.0.1:10002/devstoreaccount1/Tables('TableClientCreateDelete') HTTP/1.1
content-length: 0
content-type: application/json
x-ms-date: Fri, 11 Jun 2021 21:25:56 GMT
x-ms-version: 2019-12-12
authorization: SharedKey devstoreaccount1:3zoY0Cw6JImLJlFlH/S8ME150NBOqOTFUXpWvyZ59Ws=
accept: */*
host: 127.0.0.1:10002
```

Using `az storage table delete -n TableClientCreateDelete` it does this:
```
DELETE http://127.0.0.1:10002/devstoreaccount1/Tables('TableClientCreateDelete') HTTP/1.1
Host: 127.0.0.1:10002
Accept-Encoding: identity
User-Agent: Azure-CosmosDB/0.37.1 (Python CPython 3.6.8; Windows 10) AZURECLI/2.19.1 (MSI)
Connection: keep-alive
Accept: application/json;odata=minimalmetadata
DataServiceVersion: 3.0;NetFx
MaxDataServiceVersion: 3.0
x-ms-version: 2017-04-17
x-ms-client-request-id: 22ce9f4a-cafc-11eb-9198-f8ffc25f0c7d
x-ms-date: Fri, 11 Jun 2021 21:29:44 GMT
Authorization: SharedKey devstoreaccount1:ofoHLheZkVH2NIcmjL9vWxwA/vhbC+MwGIZ1Iy0mBic=
Content-Length: 0
```

Notice that it is not sending a `content-type` header and the `accept` header has `application/json`. I don't think a `content-type` header makes sense when `content-length` is 0. Asking fora return of `application/json` made things work with Azurite.
