### PR TITLE
Clean up errors

### DIFF
--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -170,6 +170,8 @@ pub enum Parse512AlignedError {
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    #[error("Policy error: {0}")]
+    PolicyError(Box<dyn std::error::Error + Send + Sync>),
     #[error("Error getting token: {0}")]
     GetTokenError(Box<dyn std::error::Error + Send + Sync>),
     #[error("http error: {0}")]

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use crate::policies::TransportPolicy;
-use crate::policies::{Policy, PolicyResult, TelemetryPolicy};
-use crate::{ClientOptions, Context, HttpClient, Request, Response};
+use crate::policies::{Policy, TelemetryPolicy};
+use crate::{ClientOptions, Context, Error, HttpClient, Request, Response};
 use std::sync::Arc;
 
 /// Execution pipeline.
@@ -81,9 +81,10 @@ impl Pipeline {
         self.http_client.as_ref()
     }
 
-    pub async fn send(&self, ctx: &mut Context, request: &mut Request) -> PolicyResult<Response> {
+    pub async fn send(&self, ctx: &mut Context, request: &mut Request) -> Result<Response, Error> {
         self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
             .await
+            .map_err(Error::PolicyError)
     }
 }

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -140,8 +140,7 @@ impl CosmosClient {
         let response = self
             .pipeline()
             .send(&mut ctx, &mut request)
-            .await
-            .map_err(crate::Error::PolicyError)?
+            .await?
             .validate(http::StatusCode::CREATED)
             .await?;
 

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -49,8 +49,7 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(&mut ctx, &mut request)
-            .await
-            .map_err(crate::Error::PolicyError)?
+            .await?
             .validate(http::StatusCode::OK)
             .await?;
 
@@ -83,8 +82,7 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(&mut ctx, &mut request)
-            .await
-            .map_err(crate::Error::PolicyError)?
+            .await?
             .validate(http::StatusCode::CREATED)
             .await?;
 

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -33,6 +33,7 @@ pub enum Error {
     Utf8Error(#[from] std::str::Utf8Error),
     #[error("base64 decode error: {0}")]
     DecodeError(#[from] base64::DecodeError),
-    #[error("Conversion to document failed because at lease one element is raw.")]
-    RawElementError,
+    /// Other errors that can happen but are unlikely to be matched against
+    #[error(transparent)]
+    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -5,28 +5,18 @@
 pub enum Error {
     #[error(transparent)]
     AzureCoreError(#[from] azure_core::Error),
-    #[error("Resource quota parsing error: {0}")]
-    ResourceQuotaParsingError(#[from] crate::resource_quota::ResourceQuotaParsingError),
+    #[error(transparent)]
+    ParsingError(ParsingError),
     #[error("Header not found: {0}")]
     HeaderNotFound(String),
     #[error("To str error: {0}")]
     ToStrError(#[from] http::header::ToStrError),
-    #[error("Parsing error: {0}")]
-    ParsingError(#[from] azure_core::ParsingError),
     #[error("http error: {0}")]
     AzureHttpError(#[from] azure_core::HttpError),
     #[error("stream error: {0}")]
     StreamError(#[from] azure_core::StreamError),
     #[error("http error: {0}")]
     HttpError(#[from] http::Error),
-    #[error("Parse int error: {0}")]
-    ParseIntError(#[from] std::num::ParseIntError),
-    #[error("uuid error: {0}")]
-    ParseUuidError(#[from] uuid::Error),
-    #[error("Date time parse error: {0}")]
-    DateTimeParseError(#[from] chrono::format::ParseError),
-    #[error("Parse float error: {0}")]
-    ParseFloatError(#[from] std::num::ParseFloatError),
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
     #[error("UTF-8 conversion error: {0}")]
@@ -36,4 +26,20 @@ pub enum Error {
     /// Other errors that can happen but are unlikely to be matched against
     #[error(transparent)]
     Other(#[from] Box<dyn std::error::Error + Send + Sync>),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ParsingError {
+    #[error("Parse int error: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("uuid error: {0}")]
+    ParseUuidError(#[from] uuid::Error),
+    #[error("Date time parse error: {0}")]
+    ParseDateTimeError(#[from] chrono::format::ParseError),
+    #[error("Parse float error: {0}")]
+    ParseFloatError(#[from] std::num::ParseFloatError),
+    #[error("Resource quota parsing error: {0}")]
+    ParseResourceQuotaError(#[from] crate::resource_quota::ResourceQuotaParsingError),
+    #[error("parsing error: {0}")]
+    Other(#[from] azure_core::ParsingError),
 }

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -7,8 +7,6 @@ pub enum Error {
     AzureCoreError(#[from] azure_core::Error),
     #[error("Resource quota parsing error: {0}")]
     ResourceQuotaParsingError(#[from] crate::resource_quota::ResourceQuotaParsingError),
-    #[error("Policy error: {0}")]
-    PolicyError(Box<dyn std::error::Error + Send + Sync>),
     #[error("Header not found: {0}")]
     HeaderNotFound(String),
     #[error("To str error: {0}")]

--- a/sdk/cosmos/src/headers/from_headers.rs
+++ b/sdk/cosmos/src/headers/from_headers.rs
@@ -1,3 +1,4 @@
+use crate::errors::{Error, ParsingError};
 use crate::headers::*;
 use crate::resource_quota::resource_quotas_from_str;
 use crate::resources::document::IndexingDirective;
@@ -5,315 +6,208 @@ use crate::ResourceQuota;
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
-pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> Result<f64, crate::Error> {
-    Ok(headers
-        .get(HEADER_REQUEST_CHARGE)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_REQUEST_CHARGE.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> Result<f64, Error> {
+    get_from_headers(headers, HEADER_REQUEST_CHARGE)
 }
 
-pub(crate) fn role_from_headers(headers: &HeaderMap) -> Result<u32, crate::Error> {
-    Ok(headers
-        .get(HEADER_ROLE)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ROLE.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn role_from_headers(headers: &HeaderMap) -> Result<u32, Error> {
+    get_from_headers(headers, HEADER_ROLE)
 }
 
-pub(crate) fn number_of_read_regions_from_headers(
-    headers: &HeaderMap,
-) -> Result<u32, crate::Error> {
-    Ok(headers
-        .get(HEADER_NUMBER_OF_READ_REGIONS)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_NUMBER_OF_READ_REGIONS.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn number_of_read_regions_from_headers(headers: &HeaderMap) -> Result<u32, Error> {
+    get_from_headers(headers, HEADER_NUMBER_OF_READ_REGIONS)
 }
 
-pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> Result<uuid::Uuid, crate::Error> {
-    let s = headers
-        .get(HEADER_ACTIVITY_ID)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ACTIVITY_ID.to_owned()))?
-        .to_str()?;
-    Ok(uuid::Uuid::parse_str(s)?)
+pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> Result<uuid::Uuid, Error> {
+    get_from_headers(headers, HEADER_ACTIVITY_ID)
 }
 
-pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
-    Ok(headers
-        .get(HEADER_CONTENT_PATH)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_CONTENT_PATH.to_owned()))?
-        .to_str()?)
+pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
+    get_str_from_headers(headers, HEADER_CONTENT_PATH)
 }
 
-pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
-    Ok(headers
-        .get(HEADER_ALT_CONTENT_PATH)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ALT_CONTENT_PATH.to_owned()))?
-        .to_str()?)
+pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
+    get_str_from_headers(headers, HEADER_ALT_CONTENT_PATH)
 }
 
 pub(crate) fn resource_quota_from_headers(
     headers: &HeaderMap,
-) -> Result<Vec<ResourceQuota>, crate::Error> {
-    let s = headers
-        .get(HEADER_RESOURCE_QUOTA)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_RESOURCE_QUOTA.to_owned()))?
-        .to_str()?;
-    Ok(resource_quotas_from_str(s)?)
+) -> Result<Vec<ResourceQuota>, Error> {
+    let s = get_str_from_headers(headers, HEADER_RESOURCE_QUOTA)?;
+    Ok(resource_quotas_from_str(s).map_err(|e| Error::ParsingError(e.into()))?)
 }
 
 pub(crate) fn resource_usage_from_headers(
     headers: &HeaderMap,
-) -> Result<Vec<ResourceQuota>, crate::Error> {
-    let s = headers
-        .get(HEADER_RESOURCE_USAGE)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_RESOURCE_USAGE.to_owned()))?
-        .to_str()?;
-    Ok(resource_quotas_from_str(s)?)
+) -> Result<Vec<ResourceQuota>, Error> {
+    let s = get_str_from_headers(headers, HEADER_RESOURCE_USAGE)?;
+    Ok(resource_quotas_from_str(s).map_err(|e| Error::ParsingError(e.into()))?)
 }
 
-pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_QUORUM_ACKED_LSN)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_QUORUM_ACKED_LSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_QUORUM_ACKED_LSN)
 }
 
 pub(crate) fn quorum_acked_lsn_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, crate::Error> {
-    Ok(match headers.get(HEADER_QUORUM_ACKED_LSN) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, Error> {
+    get_option_from_headers(headers, HEADER_QUORUM_ACKED_LSN)
 }
 
-pub(crate) fn cosmos_quorum_acked_llsn_from_headers(
-    headers: &HeaderMap,
-) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_COSMOS_QUORUM_ACKED_LLSN)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COSMOS_QUORUM_ACKED_LLSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn cosmos_quorum_acked_llsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_COSMOS_QUORUM_ACKED_LLSN)
 }
 
 pub(crate) fn cosmos_quorum_acked_llsn_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, crate::Error> {
-    Ok(match headers.get(HEADER_COSMOS_QUORUM_ACKED_LLSN) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, Error> {
+    get_option_from_headers(headers, HEADER_COSMOS_QUORUM_ACKED_LLSN)
 }
 
-pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_CURRENT_WRITE_QUORUM)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_CURRENT_WRITE_QUORUM.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_CURRENT_WRITE_QUORUM)
 }
 
 pub(crate) fn current_write_quorum_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, crate::Error> {
-    Ok(match headers.get(HEADER_CURRENT_WRITE_QUORUM) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, Error> {
+    get_option_from_headers(headers, HEADER_CURRENT_WRITE_QUORUM)
 }
 
-pub(crate) fn collection_partition_index_from_headers(
-    headers: &HeaderMap,
-) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_COLLECTION_PARTITION_INDEX)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COLLECTION_PARTITION_INDEX.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn collection_partition_index_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_COLLECTION_PARTITION_INDEX)
 }
 
 pub(crate) fn indexing_directive_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<IndexingDirective>, crate::Error> {
-    match headers.get(HEADER_INDEXING_DIRECTIVE) {
-        Some(header) => Ok(Some(header.to_str()?.parse()?)),
-        None => Ok(None),
-    }
+) -> Result<Option<IndexingDirective>, Error> {
+    get_option_from_headers(headers, HEADER_INDEXING_DIRECTIVE)
 }
 
-pub(crate) fn collection_service_index_from_headers(
-    headers: &HeaderMap,
-) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_COLLECTION_SERVICE_INDEX)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COLLECTION_SERVICE_INDEX.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn collection_service_index_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_COLLECTION_SERVICE_INDEX)
 }
 
-pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_LSN)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_LSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_LSN)
 }
 
-pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_ITEM_LSN)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_ITEM_LSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_ITEM_LSN)
 }
 
-pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_TRANSPORT_REQUEST_ID)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_TRANSPORT_REQUEST_ID.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_TRANSPORT_REQUEST_ID)
 }
 
-pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    let s = headers
-        .get(HEADER_GLOBAL_COMMITTED_LSN)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_GLOBAL_COMMITTED_LSN.to_owned()))?
-        .to_str()?;
-    Ok(if s == "-1" { 0 } else { s.parse()? })
+pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    let s = get_str_from_headers(headers, HEADER_GLOBAL_COMMITTED_LSN)?;
+    Ok(if s == "-1" {
+        0
+    } else {
+        s.parse()
+            .map_err(|e: <u64 as std::str::FromStr>::Err| Error::ParsingError(e.into()))?
+    })
 }
 
-pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_COSMOS_LLSN)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COSMOS_LLSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_COSMOS_LLSN)
 }
 
-pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_COSMOS_ITEM_LLSN)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_COSMOS_ITEM_LLSN.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_COSMOS_ITEM_LLSN)
 }
 
-pub(crate) fn current_replica_set_size_from_headers(
-    headers: &HeaderMap,
-) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_CURRENT_REPLICA_SET_SIZE)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_CURRENT_REPLICA_SET_SIZE.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn current_replica_set_size_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_CURRENT_REPLICA_SET_SIZE)
 }
 
 pub(crate) fn current_replica_set_size_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>, crate::Error> {
-    Ok(match headers.get(HEADER_CURRENT_REPLICA_SET_SIZE) {
-        Some(val) => Some(val.to_str()?.parse()?),
-        None => None,
-    })
+) -> Result<Option<u64>, Error> {
+    get_option_from_headers(headers, HEADER_CURRENT_REPLICA_SET_SIZE)
 }
 
-pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
-    Ok(headers
-        .get(HEADER_SCHEMA_VERSION)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_SCHEMA_VERSION.to_owned()))?
-        .to_str()?)
+pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
+    get_str_from_headers(headers, HEADER_SCHEMA_VERSION)
 }
 
-pub(crate) fn server_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
-    let header_server = http::header::SERVER;
-
-    Ok(headers
-        .get(http::header::SERVER)
-        .ok_or_else(|| crate::Error::HeaderNotFound(header_server.to_string()))?
-        .to_str()?)
+pub(crate) fn server_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
+    get_str_from_headers(headers, &http::header::SERVER.to_string())
 }
 
-pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
-    Ok(headers
-        .get(HEADER_SERVICE_VERSION)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_SERVICE_VERSION.to_owned()))?
-        .to_str()?)
+pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
+    get_str_from_headers(headers, HEADER_SERVICE_VERSION)
 }
 
-pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
-    Ok(headers
-        .get(http::header::CONTENT_LOCATION)
-        .ok_or_else(|| {
-            let header = http::header::CONTENT_LOCATION;
-            crate::Error::HeaderNotFound(header.as_str().to_owned())
-        })?
-        .to_str()?)
+pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
+    get_str_from_headers(headers, &http::header::CONTENT_LOCATION.to_string())
 }
 
-pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> Result<&str, crate::Error> {
-    Ok(headers
-        .get(HEADER_GATEWAY_VERSION)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_GATEWAY_VERSION.to_owned()))?
-        .to_str()?)
+pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
+    get_str_from_headers(headers, HEADER_GATEWAY_VERSION)
 }
 
-pub(crate) fn max_media_storage_usage_mb_from_headers(
-    headers: &HeaderMap,
-) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_MAX_MEDIA_STORAGE_USAGE_MB)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_MAX_MEDIA_STORAGE_USAGE_MB.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn max_media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_MAX_MEDIA_STORAGE_USAGE_MB)
 }
 
-pub(crate) fn media_storage_usage_mb_from_headers(
-    headers: &HeaderMap,
-) -> Result<u64, crate::Error> {
-    Ok(headers
-        .get(HEADER_MEDIA_STORAGE_USAGE_MB)
-        .ok_or_else(|| crate::Error::HeaderNotFound(HEADER_MEDIA_STORAGE_USAGE_MB.to_owned()))?
-        .to_str()?
-        .parse()?)
+pub(crate) fn media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
+    get_from_headers(headers, HEADER_MEDIA_STORAGE_USAGE_MB)
 }
 
-fn _date_from_headers(
-    headers: &HeaderMap,
-    header_name: &str,
-) -> Result<DateTime<Utc>, crate::Error> {
-    let date = headers
-        .get(header_name)
-        .ok_or_else(|| crate::Error::HeaderNotFound(header_name.to_owned()))?
-        .to_str()?;
-    debug!("date == {:#}", date);
+fn _date_from_headers(headers: &HeaderMap, header_name: &str) -> Result<DateTime<Utc>, Error> {
+    let date = get_str_from_headers(headers, header_name)?;
 
     // since Azure returns "GMT" instead of +0000 as timezone we replace it
     // ourselves.
     // For example: Wed, 15 Jan 2020 23:39:44.369 GMT
     let date = date.replace("GMT", "+0000");
-    debug!("date == {:#}", date);
-
-    let date = DateTime::parse_from_str(&date, "%a, %e %h %Y %H:%M:%S%.f %z")?;
-    debug!("date == {:#}", date);
-
+    let date = DateTime::parse_from_str(&date, "%a, %e %h %Y %H:%M:%S%.f %z")
+        .map_err(|e| Error::ParsingError(e.into()))?;
     let date = DateTime::from_utc(date.naive_utc(), Utc);
-    debug!("date == {:#}", date);
 
     Ok(date)
 }
 
-pub(crate) fn last_state_change_from_headers(
-    headers: &HeaderMap,
-) -> Result<DateTime<Utc>, crate::Error> {
+pub(crate) fn last_state_change_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>, Error> {
     _date_from_headers(headers, HEADER_LAST_STATE_CHANGE_UTC)
 }
 
-pub(crate) fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>, crate::Error> {
+pub(crate) fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>, Error> {
     let header = http::header::DATE;
     _date_from_headers(headers, header.as_str())
+}
+
+fn get_str_from_headers<'a>(headers: &'a HeaderMap, key: &str) -> Result<&'a str, Error> {
+    Ok(headers
+        .get(key)
+        .ok_or_else(|| Error::HeaderNotFound(key.to_owned()))?
+        .to_str()?)
+}
+
+fn get_from_headers<T: std::str::FromStr>(headers: &HeaderMap, key: &str) -> Result<T, Error>
+where
+    T: std::str::FromStr,
+    T::Err: Into<ParsingError>,
+{
+    Ok(get_str_from_headers(headers, key)?
+        .parse()
+        .map_err(|e: T::Err| Error::ParsingError(e.into()))?)
+}
+
+fn get_option_from_headers<T>(headers: &HeaderMap, key: &str) -> Result<Option<T>, Error>
+where
+    T: std::str::FromStr,
+    T::Err: Into<ParsingError>,
+{
+    match headers.get(key) {
+        Some(header) => Ok(Some(
+            header
+                .to_str()?
+                .parse()
+                .map_err(|e: T::Err| Error::ParsingError(e.into()))?,
+        )),
+        None => Ok(None),
+    }
 }

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -270,28 +270,20 @@ pub struct QueryDocumentsResponseDocuments<T> {
 impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsResponseDocuments<T> {
     type Error = crate::Error;
 
-    #[inline]
     fn try_from(q: QueryDocumentsResponse<T>) -> Result<Self, Self::Error> {
-        // first check if there is a Raw document. In case we bail out
-        if q.results.iter().any(|r| match r {
-            QueryResult::Document(_) => false,
-            QueryResult::Raw(_) => true,
-        }) {
-            return Err(crate::Error::RawElementError);
-        }
-
         Ok(Self {
             query_response_meta: q.query_response_meta,
             results: q
                 .results
                 .into_iter()
                 .map(|r| match r {
-                    QueryResult::Document(document) => document,
+                    QueryResult::Document(document) => Ok(document),
                     QueryResult::Raw(_) => {
-                        panic!("this should have been caugth by the previous check")
+                        // Bail if there is a raw document
+                        Err(Self::Error::Other("conversion to `QueryDocumentsResponseDocuments` failed because at lease one element is raw".into()))
                     }
                 })
-                .collect(),
+                .collect::<Result<Vec<DocumentQueryResult<T>>, Self::Error>>()?,
             last_state_change: q.last_state_change,
             resource_quota: q.resource_quota,
             resource_usage: q.resource_usage,


### PR DESCRIPTION
This cleans up errors a bit (I'd like to keep going, but this is a good first step):
* This moves the `PolicyError` out of cosmos and to core
* Introduces a catchall error for unimportant errors that are only useful to report to users 
* Moves all parsing errors to its own type