### PR TITLE
Fix Cosmos response header key

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -93,4 +93,5 @@ pub const VERSION: &str = "x-ms-version";
 pub const PROPERTIES: &str = "x-ms-properties";
 pub const NAMESPACE_ENABLED: &str = "x-ms-namespace-enabled";
 pub const MAX_ITEM_COUNT: &str = "x-ms-max-item-count";
+pub const ITEM_COUNT: &str = "x-ms-item-count";
 pub const ITEM_TYPE: &str = "x-ms-item-type";

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -261,8 +261,8 @@ pub fn content_type_from_headers(headers: &HeaderMap) -> Result<&str, Error> {
 
 pub fn item_count_from_headers(headers: &HeaderMap) -> Result<u32, Error> {
     Ok(headers
-        .get(crate::headers::MAX_ITEM_COUNT)
-        .ok_or_else(|| Error::HeaderNotFound(crate::MAX_ITEM_COUNT.to_owned()))?
+        .get(crate::headers::ITEM_COUNT)
+        .ok_or_else(|| Error::HeaderNotFound(crate::ITEM_COUNT.to_owned()))?
         .to_str()?
         .parse()?)
 }


### PR DESCRIPTION
This fixes #310. 
The bug is that the sdk expects the "x-ms-max-item-count" HTTP response header for a Cosmos response. However, instead "x-ms-max-item-count" is an optional request header[1]. Instead a new const has been added, "x-ms-item-count", to coincide with the expected response header[2] from Cosmos requests.

[1] https://docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-request-headers
[2] https://docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-response-headers 