### PR TITLE
Continue to simplify error

### DIFF
--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -35,8 +35,6 @@ pub enum Error {
     StreamError(#[from] StreamError),
     #[error("JSON error: {0}")]
     JsonError(#[from] serde_json::Error),
-    #[error(transparent)]
-    Other(#[from] Box<dyn std::error::Error + Send + Sync>),
 }
 
 #[cfg(feature = "enable_hyper")]

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -11,6 +11,10 @@ pub enum Error {
     ParsingError(#[from] ParsingError),
     #[error("conversion to `{0}` failed because at lease one element is raw")]
     ElementIsRaw(String),
+    #[error("error parsing authorization token: {0}")]
+    AuthorizationTokenParsing(#[from] crate::resources::permission::AuthorizationTokenParsingError),
+    #[error("error parsing permission token: {0}")]
+    PermissionTokenParsing(#[from] crate::resources::permission::PermissionTokenParsingError),
 }
 
 impl From<serde_json::Error> for Error {

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -9,6 +9,8 @@ pub enum Error {
     /// An error related to parsing
     #[error(transparent)]
     ParsingError(#[from] ParsingError),
+    #[error("conversion to `{0}` failed because at lease one element is raw")]
+    ElementIsRaw(String),
 }
 
 impl From<serde_json::Error> for Error {
@@ -29,15 +31,9 @@ impl From<azure_core::HttpError> for Error {
     }
 }
 
-impl From<Box<dyn std::error::Error + Sync + Send>> for Error {
-    fn from(error: Box<dyn std::error::Error + Sync + Send>) -> Self {
-        Self::Core(azure_core::Error::Other(error))
-    }
-}
-
 impl From<http::Error> for Error {
     fn from(error: http::Error) -> Self {
-        Self::Core(azure_core::Error::Other(error.into()))
+        Self::Core(azure_core::Error::HttpPrepareError(error))
     }
 }
 

--- a/sdk/cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/cosmos/src/resources/permission/authorization_token.rs
@@ -18,7 +18,7 @@ impl AuthorizationToken {
     /// The token is *not* verified to be valid.
     pub fn primary_from_base64(
         base64_encoded: &str,
-    ) -> Result<AuthorizationToken, base64::DecodeError> {
+    ) -> Result<AuthorizationToken, AuthorizationTokenParsingError> {
         let key = base64::decode(base64_encoded)?;
         Ok(AuthorizationToken::Primary(key))
     }
@@ -27,6 +27,14 @@ impl AuthorizationToken {
     pub fn new_resource(resource: String) -> AuthorizationToken {
         AuthorizationToken::Resource(resource)
     }
+}
+
+#[allow(missing_docs)]
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum AuthorizationTokenParsingError {
+    #[error("the authorization token was not properly base64 encoded: {0}")]
+    InvalidBase64Encoding(#[from] base64::DecodeError),
 }
 
 impl fmt::Debug for AuthorizationToken {

--- a/sdk/cosmos/src/resources/permission/mod.rs
+++ b/sdk/cosmos/src/resources/permission/mod.rs
@@ -6,8 +6,10 @@ mod permission;
 mod permission_token;
 
 pub use authorization_token::AuthorizationToken;
+pub use authorization_token::AuthorizationTokenParsingError;
 pub use permission::{Permission, PermissionMode};
 pub use permission_token::PermissionToken;
+pub use permission_token::PermissionTokenParsingError;
 
 use crate::headers;
 use azure_core::AddAsHeader;

--- a/sdk/cosmos/src/resources/permission/permission_token.rs
+++ b/sdk/cosmos/src/resources/permission/permission_token.rs
@@ -114,6 +114,8 @@ impl std::convert::From<AuthorizationToken> for PermissionToken {
     }
 }
 
+#[allow(missing_docs)]
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum PermissionTokenParsingError {
     #[error(
@@ -153,11 +155,8 @@ pub enum PermissionTokenParsingError {
         provided_type
     )]
     UnrecognizedPermissionType { provided_type: String },
-    #[error("The authorization token was not properly base64 encoded: {}", error)]
-    InvalidBase64Encoding {
-        #[from]
-        error: base64::DecodeError,
-    },
+    #[error("the authorization token was not properly base64 encoded: {0}")]
+    InvalidBase64Encoding(#[from] base64::DecodeError),
 }
 
 #[cfg(test)]

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -277,7 +277,8 @@ impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsRespo
                     QueryResult::Document(document) => Ok(document),
                     QueryResult::Raw(_) => {
                         // Bail if there is a raw document
-                        Err(Self::Error::Other("conversion to `QueryDocumentsResponseDocuments` failed because at lease one element is raw".into()))
+                        let error: Box<dyn std::error::Error + Sync + Send> = "conversion to `QueryDocumentsResponseDocuments` failed because at lease one element is raw".into();
+                        Err(error.into())
                     }
                 })
                 .collect::<Result<Vec<DocumentQueryResult<T>>, Self::Error>>()?,

--- a/sdk/cosmos/src/responses/query_documents_response.rs
+++ b/sdk/cosmos/src/responses/query_documents_response.rs
@@ -277,8 +277,9 @@ impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsRespo
                     QueryResult::Document(document) => Ok(document),
                     QueryResult::Raw(_) => {
                         // Bail if there is a raw document
-                        let error: Box<dyn std::error::Error + Sync + Send> = "conversion to `QueryDocumentsResponseDocuments` failed because at lease one element is raw".into();
-                        Err(error.into())
+                        Err(crate::Error::ElementIsRaw(
+                            "QueryDocumentsResponseDocuments".to_owned(),
+                        ))
                     }
                 })
                 .collect::<Result<Vec<DocumentQueryResult<T>>, Self::Error>>()?,

--- a/sdk/cosmos/tests/setup.rs
+++ b/sdk/cosmos/tests/setup.rs
@@ -5,8 +5,7 @@ pub fn initialize() -> Result<CosmosClient, azure_cosmos::Error> {
     let key =
         std::env::var("COSMOS_MASTER_KEY").expect("Set env variable COSMOS_MASTER_KEY first!");
 
-    let authorization_token = AuthorizationToken::primary_from_base64(&key)
-        .map_err(|e| azure_core::Error::Other(e.into()))?;
+    let authorization_token = AuthorizationToken::primary_from_base64(&key)?;
     let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
 
     Ok(client)


### PR DESCRIPTION
This collapses the `cosmos` error down relying mostly on error defined in `core`.

This more or less mimics inheritance in the error hierarchy. All errors that are common to all SDKs (e.g., HTTP errors, JSON parsing errors, policy errors, etc) are defined in `core`. Further more, SDK specific errors like `azure_cosmos::Error` can contain an `azure_core::Error`. This error is marked as `#[transparent]` though so its error message will be exactly as it is defined in `core`. 

This gives us the ability to define the vast majority of errors in `core` (since most errors that happen in the SDK can happen with any service and are not unique to an individual service). If users need to match against SDK errors (e.g., `azure_cosmos::Error`) they match syntax will be a bit more verbose than if all the errors had been defined on the SDK specific error type. I believe this to be a worth-while trade off. 