### PR TITLE
Bugfix: Custom deserialization for CRC64 and MD5

### DIFF
--- a/sdk/storage/examples/list_blobs_02.rs
+++ b/sdk/storage/examples/list_blobs_02.rs
@@ -1,0 +1,61 @@
+use azure_core::prelude::*;
+use azure_storage::blob::prelude::*;
+use azure_storage::core::prelude::*;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    // First we retrieve the account name and master key from environment variables.
+    let account =
+        std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
+    let master_key =
+        std::env::var("STORAGE_MASTER_KEY").expect("Set env variable STORAGE_MASTER_KEY first!");
+
+    let container_name = std::env::args()
+        .nth(1)
+        .expect("please specify a non-existing container name as command line parameter");
+
+    let http_client = new_http_client();
+    let storage_account =
+        StorageAccountClient::new_access_key(http_client.clone(), &account, &master_key)
+            .as_storage_client();
+
+    create_container_and_list(storage_account, &container_name).await?;
+
+    let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
+    create_container_and_list(storage_account, &container_name).await?;
+
+    Ok(())
+}
+
+async fn create_container_and_list(
+    storage_account: std::sync::Arc<StorageClient>,
+    container_name: &str,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let container = storage_account.as_container_client(container_name);
+
+    container.create().execute().await?;
+
+    // list empty container
+    let iv = container.list_blobs().execute().await?;
+    println!("List blob returned {} blobs.", iv.blobs.blobs.len());
+
+    for i in 0..3 {
+        container
+            .as_blob_client(format!("blob{}.txt", i))
+            .put_block_blob("somedata")
+            .content_type("text/plain")
+            .execute()
+            .await?;
+        println!("\tAdded blob {}", i);
+    }
+
+    // list full container
+    let iv = container.list_blobs().execute().await?;
+    println!("List blob returned {} blobs.", iv.blobs.blobs.len());
+
+    container.delete().execute().await?;
+    println!("Container {} deleted", container_name);
+
+    Ok(())
+}

--- a/sdk/storage/src/blob/blob/mod.rs
+++ b/sdk/storage/src/blob/blob/mod.rs
@@ -152,9 +152,11 @@ pub struct BlobProperties {
     #[serde(rename = "Content-Disposition")]
     pub content_disposition: Option<String>,
     #[serde(rename = "Content-MD5")]
+    #[serde(default)]
     #[serde(with = "md5_optional")]
     pub content_md5: Option<ConsistencyMD5>,
     #[serde(rename = "Content-CRC64")]
+    #[serde(default)]
     #[serde(with = "cr64_optional")]
     pub content_crc64: Option<ConsistencyCRC64>,
     #[serde(rename = "Cache-Control")]

--- a/sdk/storage/src/blob/blob/responses/list_blobs_response.rs
+++ b/sdk/storage/src/blob/blob/responses/list_blobs_response.rs
@@ -64,3 +64,161 @@ impl TryFrom<&http::Response<Bytes>> for ListBlobsResponse {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserde_azure() {
+        const S: &'static str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<EnumerationResults ServiceEndpoint=\"https://azureskdforrust.blob.core.windows.net/\" ContainerName=\"osa2\">
+    <Blobs>
+        <Blob>
+            <Name>blob0.txt</Name>
+            <Properties>
+                <Creation-Time>Thu, 01 Jul 2021 10:44:59 GMT</Creation-Time>
+                <Last-Modified>Thu, 01 Jul 2021 10:44:59 GMT</Last-Modified>
+                <Etag>0x8D93C7D4629C227</Etag>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-Encoding />
+                <Content-Language />
+                <Content-CRC64 />
+                <Content-MD5>rvr3UC1SmUw7AZV2NqPN0g==</Content-MD5>
+                <Cache-Control />
+                <Content-Disposition />
+                <BlobType>BlockBlob</BlobType>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+            </Properties>
+            <OrMetadata />
+        </Blob>
+        <Blob>
+            <Name>blob1.txt</Name>
+            <Properties>
+                <Creation-Time>Thu, 01 Jul 2021 10:44:59 GMT</Creation-Time>
+                <Last-Modified>Thu, 01 Jul 2021 10:44:59 GMT</Last-Modified>
+                <Etag>0x8D93C7D463004D6</Etag>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-Encoding />
+                <Content-Language />
+                <Content-CRC64 />
+                <Content-MD5>rvr3UC1SmUw7AZV2NqPN0g==</Content-MD5>
+                <Cache-Control />
+                <Content-Disposition />
+                <BlobType>BlockBlob</BlobType>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+            </Properties>
+            <OrMetadata />
+        </Blob>
+        <Blob>
+            <Name>blob2.txt</Name>
+            <Properties>
+                <Creation-Time>Thu, 01 Jul 2021 10:44:59 GMT</Creation-Time>
+                <Last-Modified>Thu, 01 Jul 2021 10:44:59 GMT</Last-Modified>
+                <Etag>0x8D93C7D4636478A</Etag>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-Encoding />
+                <Content-Language />
+                <Content-CRC64 />
+                <Content-MD5>rvr3UC1SmUw7AZV2NqPN0g==</Content-MD5>
+                <Cache-Control />
+                <Content-Disposition />
+                <BlobType>BlockBlob</BlobType>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+            </Properties>
+            <OrMetadata />
+        </Blob>
+    </Blobs>
+    <NextMarker />
+</EnumerationResults>";
+
+        let bytes = Bytes::from(S);
+        let _list_blobs_response_internal: ListBlobsResponseInternal = read_xml(&bytes).unwrap();
+    }
+
+    #[test]
+    fn deserde_azurite() {
+        const S: &'static str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+<EnumerationResults ServiceEndpoint=\"http://127.0.0.1:10000/devstoreaccount1\" ContainerName=\"osa2\">
+    <Prefix/>
+    <Marker/>
+    <MaxResults>5000</MaxResults>
+    <Delimiter/>
+    <Blobs>
+        <Blob>
+            <Name>blob0.txt</Name>
+            <Properties>
+                <Creation-Time>Thu, 01 Jul 2021 10:45:02 GMT</Creation-Time>
+                <Last-Modified>Thu, 01 Jul 2021 10:45:02 GMT</Last-Modified>
+                <Etag>0x228281B5D517B20</Etag>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-MD5>rvr3UC1SmUw7AZV2NqPN0g==</Content-MD5>
+                <BlobType>BlockBlob</BlobType>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <AccessTierChangeTime>Thu, 01 Jul 2021 10:45:02 GMT</AccessTierChangeTime>
+            </Properties>
+        </Blob>
+        <Blob>
+            <Name>blob1.txt</Name>
+            <Properties>
+                <Creation-Time>Thu, 01 Jul 2021 10:45:02 GMT</Creation-Time>
+                <Last-Modified>Thu, 01 Jul 2021 10:45:02 GMT</Last-Modified>
+                <Etag>0x1DD959381A8A860</Etag>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-MD5>rvr3UC1SmUw7AZV2NqPN0g==</Content-MD5>
+                <BlobType>BlockBlob</BlobType>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <AccessTierChangeTime>Thu, 01 Jul 2021 10:45:02 GMT</AccessTierChangeTime>
+            </Properties>
+        </Blob>
+        <Blob>
+            <Name>blob2.txt</Name>
+            <Properties>
+                <Creation-Time>Thu, 01 Jul 2021 10:45:02 GMT</Creation-Time>
+                <Last-Modified>Thu, 01 Jul 2021 10:45:02 GMT</Last-Modified>
+                <Etag>0x1FBE9C9B0C7B650</Etag>
+                <Content-Length>8</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-MD5>rvr3UC1SmUw7AZV2NqPN0g==</Content-MD5>
+                <BlobType>BlockBlob</BlobType>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <AccessTierChangeTime>Thu, 01 Jul 2021 10:45:02 GMT</AccessTierChangeTime>
+            </Properties>
+        </Blob>
+    </Blobs>
+    <NextMarker/>
+</EnumerationResults>";
+
+        let bytes = Bytes::from(S);
+        let _list_blobs_response_internal: ListBlobsResponseInternal = read_xml(&bytes).unwrap();
+    }
+}

--- a/sdk/storage/src/core/mod.rs
+++ b/sdk/storage/src/core/mod.rs
@@ -42,7 +42,7 @@ pub struct IPRange {
     pub end: std::net::IpAddr,
 }
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 pub use stored_access_policy::{StoredAccessPolicy, StoredAccessPolicyList};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -75,6 +75,16 @@ impl AsRef<[u8; CRC64_BYTE_LENGTH]> for ConsistencyCRC64 {
     }
 }
 
+impl<'de> Deserialize<'de> for ConsistencyCRC64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = String::deserialize(deserializer)?;
+        Ok(ConsistencyCRC64::decode(bytes).map_err(serde::de::Error::custom)?)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConsistencyMD5(Bytes);
 
@@ -104,6 +114,16 @@ impl ConsistencyMD5 {
 impl AsRef<[u8; MD5_BYTE_LENGTH]> for ConsistencyMD5 {
     fn as_ref(&self) -> &[u8; MD5_BYTE_LENGTH] {
         self.as_slice()
+    }
+}
+
+impl<'de> Deserialize<'de> for ConsistencyMD5 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let bytes = String::deserialize(deserializer)?;
+        Ok(ConsistencyMD5::decode(bytes).map_err(serde::de::Error::custom)?)
     }
 }
 

--- a/sdk/storage/src/core/mod.rs
+++ b/sdk/storage/src/core/mod.rs
@@ -42,7 +42,7 @@ pub struct IPRange {
     pub end: std::net::IpAddr,
 }
 
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 pub use stored_access_policy::{StoredAccessPolicy, StoredAccessPolicyList};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -75,16 +75,6 @@ impl AsRef<[u8; CRC64_BYTE_LENGTH]> for ConsistencyCRC64 {
     }
 }
 
-impl<'de> Deserialize<'de> for ConsistencyCRC64 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes = String::deserialize(deserializer)?;
-        Ok(ConsistencyCRC64::decode(bytes).map_err(serde::de::Error::custom)?)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConsistencyMD5(Bytes);
 
@@ -114,16 +104,6 @@ impl ConsistencyMD5 {
 impl AsRef<[u8; MD5_BYTE_LENGTH]> for ConsistencyMD5 {
     fn as_ref(&self) -> &[u8; MD5_BYTE_LENGTH] {
         self.as_slice()
-    }
-}
-
-impl<'de> Deserialize<'de> for ConsistencyMD5 {
-    fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let bytes = String::deserialize(deserializer)?;
-        Ok(ConsistencyMD5::decode(bytes).map_err(serde::de::Error::custom)?)
     }
 }
 

--- a/sdk/storage/tests/append_blob.rs
+++ b/sdk/storage/tests/append_blob.rs
@@ -38,7 +38,7 @@ async fn put_append_blob() {
     {
         container
             .create()
-            .public_access(PublicAccess::Blob)
+            .public_access(PublicAccess::None)
             .execute()
             .await
             .unwrap();

--- a/sdk/storage/tests/blob.rs
+++ b/sdk/storage/tests/blob.rs
@@ -26,7 +26,7 @@ async fn create_and_delete_container() {
 
     container
         .create()
-        .public_access(PublicAccess::Container)
+        .public_access(PublicAccess::None)
         .execute()
         .await
         .unwrap();
@@ -43,7 +43,7 @@ async fn create_and_delete_container() {
         .push(StoredAccessPolicy::new("pollo", dt_start, dt_end, "rwd"));
 
     let _result = container
-        .set_acl(PublicAccess::Blob)
+        .set_acl(PublicAccess::None)
         .stored_access_policy_list(&sapl)
         .execute()
         .await
@@ -52,7 +52,7 @@ async fn create_and_delete_container() {
     // now we get back the acess policy list and compare to the one created
     let result = container.get_acl().execute().await.unwrap();
 
-    assert!(result.public_access == PublicAccess::Blob);
+    assert!(result.public_access == PublicAccess::None);
     // we cannot compare the returned result because Azure will
     // trim the milliseconds
     // assert!(sapl == result.stored_access_policy_list);
@@ -67,7 +67,7 @@ async fn create_and_delete_container() {
     }
 
     let res = container.get_properties().execute().await.unwrap();
-    assert!(res.container.public_access == PublicAccess::Blob);
+    assert!(res.container.public_access == PublicAccess::None);
 
     let list = storage_client
         .list_containers()
@@ -116,7 +116,7 @@ async fn put_and_get_block_list() {
 
     container
         .create()
-        .public_access(PublicAccess::Container)
+        .public_access(PublicAccess::None)
         .execute()
         .await
         .expect("container already present");
@@ -248,7 +248,7 @@ async fn put_block_blob() {
     {
         container
             .create()
-            .public_access(PublicAccess::Blob)
+            .public_access(PublicAccess::None)
             .execute()
             .await
             .unwrap();
@@ -289,7 +289,7 @@ async fn copy_blob() {
     {
         container
             .create()
-            .public_access(PublicAccess::Blob)
+            .public_access(PublicAccess::None)
             .execute()
             .await
             .unwrap();
@@ -350,7 +350,7 @@ async fn put_block_blob_and_get_properties() {
     {
         container
             .create()
-            .public_access(PublicAccess::Blob)
+            .public_access(PublicAccess::None)
             .execute()
             .await
             .unwrap();

--- a/sdk/storage/tests/container.rs
+++ b/sdk/storage/tests/container.rs
@@ -15,7 +15,7 @@ async fn lease() {
 
     container
         .create()
-        .public_access(PublicAccess::Container)
+        .public_access(PublicAccess::None)
         .execute()
         .await
         .unwrap();
@@ -43,7 +43,7 @@ async fn break_lease() {
 
     container
         .create()
-        .public_access(PublicAccess::Container)
+        .public_access(PublicAccess::None)
         .execute()
         .await
         .unwrap();

--- a/sdk/storage/tests/stream_blob00.rs
+++ b/sdk/storage/tests/stream_blob00.rs
@@ -37,7 +37,7 @@ async fn code() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     {
         container
             .create()
-            .public_access(PublicAccess::Blob)
+            .public_access(PublicAccess::None)
             .execute()
             .await?;
     }


### PR DESCRIPTION
This PR introduces a workaround in the empty XML parsing error that causes some responses to fail (ie `list blobs` as seen in https://github.com/Azure/azure-sdk-for-rust/issues/318).

This should fix https://github.com/Azure/azure-sdk-for-rust/issues/318.