### PR TITLE
CosmosDB: support for changing  AuthorizationToken in pipeline

### DIFF
--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -95,6 +95,18 @@ where
         self.http_client.as_ref()
     }
 
+    pub fn replace_policy(
+        &mut self,
+        policy: Arc<dyn Policy<C>>,
+        position: usize,
+    ) -> Arc<dyn Policy<C>> {
+        std::mem::replace(&mut self.pipeline[position], policy)
+    }
+
+    pub fn policies(&self) -> &[Arc<dyn Policy<C>>] {
+        &self.pipeline
+    }
+
     pub async fn send(
         &self,
         ctx: &mut PipelineContext<C>,

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -134,7 +134,16 @@ impl CosmosClient {
 
     /// Set the auth token used
     pub fn auth_token(&mut self, auth_token: AuthorizationToken) {
-        self.auth_token = auth_token;
+        // TODO: To remove once everything uses the AutorizationPolicy
+        self.auth_token = auth_token.clone();
+
+        // we replace the AuthorizationPolicy. This is
+        // the last-1 policy by construction.
+        let auth_policy: Arc<dyn azure_core::Policy<CosmosContext>> =
+            Arc::new(crate::AuthorizationPolicy::new(auth_token));
+
+        self.pipeline
+            .replace_policy(auth_policy, self.pipeline.policies().len() - 2);
     }
 
     /// Create a database


### PR DESCRIPTION
CosmosDB crate allows to change the `AuthorizationToken` without having to recreate the client(s). This is useful for quickly switching security context. 
The relevant code didn't account for the new pipeline architecture. This PR fixes that (so now even the `permission_token_usage` test case works as expected).

Fixes #337.

