### PR TITLE
List databases stream impl

### DIFF
--- a/sdk/cosmos/examples/collection.rs
+++ b/sdk/cosmos/examples/collection.rs
@@ -1,5 +1,6 @@
 use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
+use futures::stream::StreamExt;
 use std::error::Error;
 
 #[tokio::main]
@@ -33,9 +34,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // The Cosmos' client exposes a lot of methods. This one lists the databases in the specified
     // account. Database do not implement Display but deref to &str so you can pass it to methods
     // both as struct or id.
-    let databases = client
-        .list_databases(Context::new(), ListDatabasesOptions::new())
-        .await?;
+    let databases = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+        .next()
+        .await
+        .unwrap()?;
 
     println!(
         "Account {} has {} database(s)",

--- a/sdk/cosmos/examples/create_delete_database.rs
+++ b/sdk/cosmos/examples/create_delete_database.rs
@@ -34,10 +34,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // account. Database do not implement Display but deref to &str so you can pass it to methods
     // both as struct or id.
 
-    let list_databases_response = client
-        .list_databases(Context::new(), ListDatabasesOptions::new())
-        .await?;
-    println!("list_databases_response = {:#?}", list_databases_response);
+    let mut list_databases_stream =
+        Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()));
+    while let Some(list_databases_response) = list_databases_stream.next().await {
+        println!("list_databases_response = {:#?}", list_databases_response?);
+    }
+    drop(list_databases_stream);
 
     let db = client
         .create_database(Context::new(), &database_name, CreateDatabaseOptions::new())

--- a/sdk/cosmos/examples/database_00.rs
+++ b/sdk/cosmos/examples/database_00.rs
@@ -1,5 +1,6 @@
 use azure_core::Context;
 use azure_cosmos::prelude::*;
+use futures::stream::StreamExt;
 use serde_json::Value;
 use std::error::Error;
 
@@ -15,9 +16,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
 
-    let dbs = client
-        .list_databases(Context::new(), ListDatabasesOptions::new())
-        .await?;
+    let dbs = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+        .next()
+        .await
+        .unwrap()?;
 
     for db in dbs.databases {
         println!("database == {:?}", db);

--- a/sdk/cosmos/examples/document_00.rs
+++ b/sdk/cosmos/examples/document_00.rs
@@ -1,3 +1,4 @@
+use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos
 // DB.
@@ -57,9 +58,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // an error (for example, the given key is not valid) you will receive a
     // specific azure_cosmos::Error. In this example we will look for a specific database
     // so we chain a filter operation.
-    let db = client
-        .list_databases(Context::new(), ListDatabasesOptions::new())
-        .await?
+    let db = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+        .next()
+        .await
+        .unwrap()?
         .databases
         .into_iter()
         .find(|db| db.id == DATABASE);

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -229,12 +229,13 @@ impl CosmosClient {
 
                 let response = r#try!(response);
 
-                let continuation_token = response
+                let next_state = response
                     .continuation_token
                     .clone()
-                    .map(|ct| State::Continuation(ct))?;
+                    .map(|ct| State::Continuation(ct))
+                    .unwrap_or(State::Done);
 
-                Some((Ok(response), continuation_token))
+                Some((Ok(response), next_state))
             }
         })
     }

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -5,12 +5,17 @@ use crate::operations::*;
 use crate::resources::permission::AuthorizationToken;
 use crate::resources::ResourceType;
 use crate::{ReadonlyString, TimeNonce};
+
 use azure_core::pipeline::Pipeline;
+use azure_core::prelude::Continuation;
 use azure_core::HttpClient;
 use azure_core::Request;
 use azure_core::*;
+use futures::stream::unfold;
+use futures::Stream;
 use http::request::Builder as RequestBuilder;
 use http::{header, HeaderValue};
+
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -158,28 +163,80 @@ impl CosmosClient {
         Ok(CreateDatabaseResponse::try_from(response).await?)
     }
 
-    pub(crate) fn pipeline(&self) -> &Pipeline<CosmosContext> {
-        &self.pipeline
-    }
-
     /// List all databases
-    pub async fn list_databases(
+    pub fn list_databases(
         &self,
         ctx: Context,
         options: ListDatabasesOptions,
-    ) -> Result<ListDatabasesResponse, crate::Error> {
-        let mut request = self.prepare_request_pipeline("dbs", http::Method::GET);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Databases.into());
+    ) -> impl Stream<Item = Result<ListDatabasesResponse, crate::Error>> + '_ {
+        macro_rules! r#try {
+            ($expr:expr $(,)?) => {
+                match $expr {
+                    Result::Ok(val) => val,
+                    Result::Err(err) => {
+                        return Some((Err(err.into()), State::Done));
+                    }
+                }
+            };
+        }
 
-        options.decorate_request(&mut request).await?;
-        let response = self
-            .pipeline()
-            .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
-            .await?;
+        #[derive(Debug, Clone, PartialEq)]
+        enum State {
+            Init,
+            Continuation(String),
+            Done,
+        }
 
-        Ok(ListDatabasesResponse::try_from(response).await?)
+        unfold(State::Init, move |state: State| {
+            let this = self.clone();
+            let ctx = ctx.clone();
+            let options = options.clone();
+            async move {
+                let response = match state {
+                    State::Init => {
+                        let mut request = this.prepare_request_pipeline("dbs", http::Method::GET);
+                        let mut pipeline_context =
+                            PipelineContext::new(ctx.clone(), ResourceType::Databases.into());
+
+                        r#try!(options.decorate_request(&mut request).await);
+                        let response = r#try!(
+                            this.pipeline()
+                                .send(&mut pipeline_context, &mut request)
+                                .await
+                        );
+                        let response = r#try!(response.validate(http::StatusCode::OK).await);
+
+                        ListDatabasesResponse::try_from(response).await
+                    }
+                    State::Continuation(continuation_token) => {
+                        let continuation = Continuation::new(continuation_token.as_str());
+                        let mut request = this.prepare_request_pipeline("dbs", http::Method::GET);
+                        let mut pipeline_context =
+                            PipelineContext::new(ctx.clone(), ResourceType::Databases.into());
+
+                        r#try!(options.decorate_request(&mut request).await);
+                        r#try!(continuation.add_as_header2(&mut request));
+                        let response = r#try!(
+                            this.pipeline()
+                                .send(&mut pipeline_context, &mut request)
+                                .await
+                        );
+                        let response = r#try!(response.validate(http::StatusCode::OK).await);
+                        ListDatabasesResponse::try_from(response).await
+                    }
+                    State::Done => return None,
+                };
+
+                let response = r#try!(response);
+
+                let continuation_token = response
+                    .continuation_token
+                    .clone()
+                    .map(|ct| State::Continuation(ct))?;
+
+                Some((Ok(response), continuation_token))
+            }
+        })
     }
 
     /// Convert into a [`DatabaseClient`]
@@ -239,10 +296,6 @@ impl CosmosClient {
             .into()
     }
 
-    pub(crate) fn http_client(&self) -> &dyn HttpClient {
-        self.pipeline.http_client()
-    }
-
     fn prepare_request_with_signature(
         &self,
         uri_path: &str,
@@ -263,6 +316,14 @@ impl CosmosClient {
             .header(HEADER_DATE, time_nonce.to_string())
             .header(HEADER_VERSION, HeaderValue::from_static(AZURE_VERSION))
             .header(header::AUTHORIZATION, signature)
+    }
+
+    pub(crate) fn pipeline(&self) -> &Pipeline<CosmosContext> {
+        &self.pipeline
+    }
+
+    pub(crate) fn http_client(&self) -> &dyn HttpClient {
+        self.pipeline.http_client()
     }
 }
 

--- a/sdk/cosmos/src/operations/list_databases.rs
+++ b/sdk/cosmos/src/operations/list_databases.rs
@@ -31,47 +31,6 @@ impl ListDatabasesOptions {
         azure_core::headers::add_mandatory_header2(&self.max_item_count, request)?;
         Ok(())
     }
-
-    // pub fn stream(&self) -> impl Stream<Item = Result<ListDatabasesResponse, crate::Error>> + '_ {
-    //     #[derive(Debug, Clone, PartialEq)]
-    //     enum States {
-    //         Init,
-    //         Continuation(String),
-    //     }
-
-    //     unfold(
-    //         Some(States::Init),
-    //         move |continuation_token: Option<States>| {
-    //             async move {
-    //                 debug!("continuation_token == {:?}", &continuation_token);
-    //                 let response = match continuation_token {
-    //                     Some(States::Init) => self.decorate_request().await,
-    //                     Some(States::Continuation(continuation_token)) => {
-    //                         self.clone()
-    //                             .continuation(continuation_token.as_str())
-    //                             .decorate_request()
-    //                             .await
-    //                     }
-    //                     None => return None,
-    //                 };
-
-    //                 // the ? operator does not work in async move (yet?)
-    //                 // so we have to resort to this boilerplate
-    //                 let response = match response {
-    //                     Ok(response) => response,
-    //                     Err(err) => return Some((Err(err), None)),
-    //                 };
-
-    //                 let continuation_token = response
-    //                     .continuation_token
-    //                     .as_ref()
-    //                     .map(|ct| States::Continuation(ct.to_owned()));
-
-    //                 Some((Ok(response), continuation_token))
-    //             }
-    //         },
-    //     )
-    // }
 }
 
 #[derive(Clone, PartialEq, PartialOrd, Debug)]
@@ -123,5 +82,15 @@ impl ListDatabasesResponse {
             continuation_token: continuation_token_from_headers_optional(&headers)?,
             gateway_version: gateway_version_from_headers(&headers)?.to_owned(),
         })
+    }
+}
+
+impl IntoIterator for ListDatabasesResponse {
+    type Item = Database;
+
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.databases.into_iter()
     }
 }

--- a/sdk/cosmos/tests/user.rs
+++ b/sdk/cosmos/tests/user.rs
@@ -2,6 +2,7 @@
 
 use azure_core::Context;
 use azure_cosmos::prelude::*;
+use futures::stream::StreamExt;
 
 mod setup;
 
@@ -68,8 +69,10 @@ async fn users() {
         .execute()
         .await
         .unwrap();
-    let _databases = client
-        .list_databases(Context::new(), ListDatabasesOptions::new())
+
+    let _databases = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+        .next()
         .await
+        .unwrap()
         .unwrap();
 }


### PR DESCRIPTION
This add stream support for listing databases. This changes `list_databases` to always return a `Stream`. This might not be what we want since streams are not the most ergonomic of Rust constructs, but it does work. 

I co-authored this with @yoshuawuyts 