### PR TITLE
separate parameter lifetime from token credential lifetime

### DIFF
--- a/sdk/key_vault/examples/pass_client.rs
+++ b/sdk/key_vault/examples/pass_client.rs
@@ -22,13 +22,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     get_secret(&mut client).await?;
 
     Ok(())
-  
 }
 
-async fn get_secret(client: &mut KeyClient<'_, ClientSecretCredential>) ->  Result<(), Box<dyn std::error::Error>> {
-	let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
-	let secrets = client.get_secret(&secret_name).await?;
-	dbg!(&secrets);
-    
-	Ok(())
+async fn get_secret(
+    client: &mut KeyClient<'_, ClientSecretCredential>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
+    let secrets = client.get_secret(&secret_name).await?;
+    dbg!(&secrets);
+
+    Ok(())
 }

--- a/sdk/key_vault/examples/pass_client.rs
+++ b/sdk/key_vault/examples/pass_client.rs
@@ -1,0 +1,34 @@
+use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
+use azure_key_vault::KeyClient;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client_id = env::var("CLIENT_ID").expect("Missing CLIENT_ID environment variable.");
+    let client_secret =
+        env::var("CLIENT_SECRET").expect("Missing CLIENT_SECRET environment variable.");
+    let tenant_id = env::var("TENANT_ID").expect("Missing TENANT_ID environment variable.");
+    let keyvault_url =
+        env::var("KEYVAULT_URL").expect("Missing KEYVAULT_URL environment variable.");
+
+    let creds = ClientSecretCredential::new(
+        tenant_id,
+        client_id,
+        client_secret,
+        TokenCredentialOptions::default(),
+    );
+    let mut client = KeyClient::new(&keyvault_url, &creds)?;
+
+    get_secret(&mut client).await?;
+
+    Ok(())
+  
+}
+
+async fn get_secret(client: &mut KeyClient<'_, ClientSecretCredential>) ->  Result<(), Box<dyn std::error::Error>> {
+	let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
+	let secrets = client.get_secret(&secret_name).await?;
+	dbg!(&secrets);
+    
+	Ok(())
+}

--- a/sdk/key_vault/src/secret.rs
+++ b/sdk/key_vault/src/secret.rs
@@ -138,7 +138,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn get_secret<'b>(&mut self, secret_name: &'b str) -> Result<KeyVaultSecret, Error> {
+    pub async fn get_secret(&mut self, secret_name: &str) -> Result<KeyVaultSecret, Error> {
         Ok(self.get_secret_with_version(secret_name, "").await?)
     }
 
@@ -164,10 +164,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn get_secret_with_version<'b>(
+    pub async fn get_secret_with_version(
         &mut self,
-        secret_name: &'b str,
-        secret_version_name: &'b str,
+        secret_name: &str,
+        secret_version_name: &str,
     ) -> Result<KeyVaultSecret, Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}/{}", secret_name, secret_version_name));
@@ -266,9 +266,9 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn get_secret_versions<'b>(
+    pub async fn get_secret_versions(
         &mut self,
-        secret_name: &'b str,
+        secret_name: &str,
     ) -> Result<Vec<KeyVaultSecretBaseIdentifier>, Error> {
         let mut secret_versions = Vec::<KeyVaultSecretBaseIdentifier>::new();
 
@@ -330,10 +330,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn set_secret<'b>(
+    pub async fn set_secret(
         &mut self,
-        secret_name: &'b str,
-        new_secret_value: &'b str,
+        secret_name: &str,
+        new_secret_value: &str,
     ) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}", secret_name));
@@ -377,10 +377,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn update_secret_enabled<'b>(
+    pub async fn update_secret_enabled(
         &mut self,
-        secret_name: &'b str,
-        secret_version: &'b str,
+        secret_name: &str,
+        secret_version: &str,
         enabled: bool,
     ) -> Result<(), Error> {
         let mut attributes = Map::new();
@@ -418,10 +418,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn update_secret_recovery_level<'b>(
+    pub async fn update_secret_recovery_level(
         &mut self,
-        secret_name: &'b str,
-        secret_version: &'b str,
+        secret_name: &str,
+        secret_version: &str,
         recovery_level: RecoveryLevel,
     ) -> Result<(), Error> {
         let mut attributes = Map::new();
@@ -463,10 +463,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn update_secret_expiration_time<'b>(
+    pub async fn update_secret_expiration_time(
         &mut self,
-        secret_name: &'b str,
-        secret_version: &'b str,
+        secret_name: &str,
+        secret_version: &str,
         expiration_time: DateTime<Utc>,
     ) -> Result<(), Error> {
         let mut attributes = Map::new();
@@ -481,10 +481,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
         Ok(())
     }
 
-    async fn update_secret<'b>(
+    async fn update_secret(
         &mut self,
-        secret_name: &'b str,
-        secret_version: &'b str,
+        secret_name: &str,
+        secret_version: &str,
         attributes: Map<String, Value>,
     ) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
@@ -521,7 +521,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn restore_secret<'b>(&mut self, backup_blob: &'b str) -> Result<(), Error> {
+    pub async fn restore_secret(&mut self, backup_blob: &str) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path("secrets/restore");
         uri.set_query(Some(API_VERSION_PARAM));
@@ -559,9 +559,9 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn backup_secret<'b>(
+    pub async fn backup_secret(
         &mut self,
-        secret_name: &'b str,
+        secret_name: &str,
     ) -> Result<KeyVaultSecretBackupBlob, Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}/backup", secret_name));
@@ -604,7 +604,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn delete_secret<'b>(&mut self, secret_name: &'b str) -> Result<(), Error> {
+    pub async fn delete_secret(&mut self, secret_name: &str) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}", secret_name));
         uri.set_query(Some(API_VERSION_PARAM));

--- a/sdk/key_vault/src/secret.rs
+++ b/sdk/key_vault/src/secret.rs
@@ -138,7 +138,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn get_secret(&mut self, secret_name: &'a str) -> Result<KeyVaultSecret, Error> {
+    pub async fn get_secret<'b>(&mut self, secret_name: &'b str) -> Result<KeyVaultSecret, Error> {
         Ok(self.get_secret_with_version(secret_name, "").await?)
     }
 
@@ -164,10 +164,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn get_secret_with_version(
+    pub async fn get_secret_with_version<'b>(
         &mut self,
-        secret_name: &'a str,
-        secret_version_name: &'a str,
+        secret_name: &'b str,
+        secret_version_name: &'b str,
     ) -> Result<KeyVaultSecret, Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}/{}", secret_name, secret_version_name));
@@ -266,9 +266,9 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn get_secret_versions(
+    pub async fn get_secret_versions<'b>(
         &mut self,
-        secret_name: &'a str,
+        secret_name: &'b str,
     ) -> Result<Vec<KeyVaultSecretBaseIdentifier>, Error> {
         let mut secret_versions = Vec::<KeyVaultSecretBaseIdentifier>::new();
 
@@ -330,10 +330,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn set_secret(
+    pub async fn set_secret<'b>(
         &mut self,
-        secret_name: &'a str,
-        new_secret_value: &'a str,
+        secret_name: &'b str,
+        new_secret_value: &'b str,
     ) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}", secret_name));
@@ -377,10 +377,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn update_secret_enabled(
+    pub async fn update_secret_enabled<'b>(
         &mut self,
-        secret_name: &'a str,
-        secret_version: &'a str,
+        secret_name: &'b str,
+        secret_version: &'b str,
         enabled: bool,
     ) -> Result<(), Error> {
         let mut attributes = Map::new();
@@ -418,10 +418,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn update_secret_recovery_level(
+    pub async fn update_secret_recovery_level<'b>(
         &mut self,
-        secret_name: &'a str,
-        secret_version: &'a str,
+        secret_name: &'b str,
+        secret_version: &'b str,
         recovery_level: RecoveryLevel,
     ) -> Result<(), Error> {
         let mut attributes = Map::new();
@@ -463,10 +463,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn update_secret_expiration_time(
+    pub async fn update_secret_expiration_time<'b>(
         &mut self,
-        secret_name: &'a str,
-        secret_version: &'a str,
+        secret_name: &'b str,
+        secret_version: &'b str,
         expiration_time: DateTime<Utc>,
     ) -> Result<(), Error> {
         let mut attributes = Map::new();
@@ -481,10 +481,10 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
         Ok(())
     }
 
-    async fn update_secret(
+    async fn update_secret<'b>(
         &mut self,
-        secret_name: &'a str,
-        secret_version: &'a str,
+        secret_name: &'b str,
+        secret_version: &'b str,
         attributes: Map<String, Value>,
     ) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
@@ -521,7 +521,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn restore_secret(&mut self, backup_blob: &'a str) -> Result<(), Error> {
+    pub async fn restore_secret<'b>(&mut self, backup_blob: &'b str) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path("secrets/restore");
         uri.set_query(Some(API_VERSION_PARAM));
@@ -559,9 +559,9 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn backup_secret(
+    pub async fn backup_secret<'b>(
         &mut self,
-        secret_name: &'a str,
+        secret_name: &'b str,
     ) -> Result<KeyVaultSecretBackupBlob, Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}/backup", secret_name));
@@ -604,7 +604,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn delete_secret(&mut self, secret_name: &'a str) -> Result<(), Error> {
+    pub async fn delete_secret<'b>(&mut self, secret_name: &'b str) -> Result<(), Error> {
         let mut uri = self.vault_url.clone();
         uri.set_path(&format!("secrets/{}", secret_name));
         uri.set_query(Some(API_VERSION_PARAM));


### PR DESCRIPTION
In the current API, the lifetime of the `T: TokenCredential` stored within the `KeyClient` is `'a` and all parameters to functions that take a `secret_name` or similar, are also using that `'a`. This can make the current API tricky to use, however there is no issue to separate these lifetimes, although there are other ways to solve this that may be preferable, for example storing an owned `TokenCredential` in the `KeyClient`.  The advantage of this change is that it doesn't break API compatibility, but storing an owned `TokenCredential` may be more ergonomic (this may require a discussion on whether `TokenCredential` should require `Clone`). 