### PR TITLE
Fix url in QueryEntityBuilder

### DIFF
--- a/sdk/storage/src/table/requests/query_entity_builder.rs
+++ b/sdk/storage/src/table/requests/query_entity_builder.rs
@@ -47,6 +47,7 @@ impl<'a> QueryEntityBuilder<'a> {
         let mut url = self.table_client.url().to_owned();
         url.path_segments_mut()
             .map_err(|_| "Invalid table URL")?
+            .pop()
             .push(&format!("{}()", self.table_client.table_name()));
 
         self.filter.append_to_url_query(&mut url);


### PR DESCRIPTION
Entity queries currently run against `/devstoreaccount1/Tables/<tablename>()` instead of `/devstoreaccount1/<tablename>()`.

https://docs.microsoft.com/en-us/rest/api/storageservices/query-entities