### PR TITLE
Fix copy-paste error in example

### DIFF
--- a/sdk/iothub/examples/directmethod.rs
+++ b/sdk/iothub/examples/directmethod.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let module_id = std::env::args()
         .nth(2)
-        .expect("Please pass the device id as the second parameter");
+        .expect("Please pass the module id as the second parameter");
 
     let method_name = std::env::args()
         .nth(3)


### PR DESCRIPTION
Text refers to device id while it's about the module id.