### PR TITLE
Documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is for the development of the *unofficial* Azure SDK for Rust. U
 
 🚨🚨🚨**WARNING**: This project is currently under very active development.🚨🚨🚨
 
-This projects' crates have yet to released to crates.io so in order to use them you will need to specify them as git dependencies. You should be aware that large, breaking changes can happen at any time, and thus it's not yet recommended to use these crates in any serious capacity yet. 
+This projects' crates have yet to released to crates.io so in order to use them you will need to specify them as git dependencies. You should be aware that large, breaking changes can happen at any time, and thus it's not yet recommended to use these crates in any serious capacity yet.
 
 Additionally, this project is the logical successor to the previous Azure SDK crates found under [github.com/MindFlavor/AzureSDKForRust](https://github.com/MindFlavor/AzureSDKForRust). The crates have been renamed, so those older crates should be considered fully deprecated.
 
@@ -18,7 +18,7 @@ Building each crate should be as straight forward as `cargo build`, but check ea
 
 ### Mock testing framework
 
-This library comes with a testing framework that executes against prerecorded sessions to quickly validate code changes without incurring in Azure costs. You can read more about it in the [Mock testing framework's README](docs/mock_transport_REAMDE.md).
+This library comes with a testing framework that executes against prerecorded sessions to quickly validate code changes without incurring in Azure costs. You can read more about it in the [Mock testing framework's README](docs/mock_transport.md).
 
 ## Contributing
 

--- a/services/README.md
+++ b/services/README.md
@@ -5,7 +5,7 @@ Rust crates for accessing [Azure services](https://azure.microsoft.com/services/
 There are 168 specifications. So far, we have generated 100 control plane crates. We expect that number to go up as AutoRust matures and bugs are fixed.
 
 ## Control Plane Crates
-The control plane crates are named `azure_mgmt_${specification_directory}`, such as `azure_mgmt_storage`. Each service may have multiple API versions. Each API version has a set of OpenAPI 2.0 documents, listed under a `Tag` in a [readme.md](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/readme.md) file in a `Conifguration` section. Sometimes there are multiple `Tag`s for the same API version. For example, [Tag: package-2018-07](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/readme.md#tag-package-2018-07) and [Tag: package-2018-07-only](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/readme.md#tag-package-2018-07-only). Rust code is generated for each tag and organized as a crate feature. The first tag without `-preview` is selected as the default feature:
+The control plane crates are named `azure_mgmt_${specification_directory}`, such as `azure_mgmt_storage`. Each service may have multiple API versions. Each API version has a set of OpenAPI 2.0 documents, listed under a `Tag` in a [readme.md](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/readme.md) file in a `Configuration` section. Sometimes there are multiple `Tag`s for the same API version. For example, [Tag: package-2018-07](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/readme.md#tag-package-2018-07) and [Tag: package-2018-07-only](https://github.com/Azure/azure-rest-api-specs/blob/master/specification/storage/resource-manager/readme.md#tag-package-2018-07-only). Rust code is generated for each tag and organized as a crate feature. The first tag without `-preview` is selected as the default feature:
 
 ``` toml
 [features]
@@ -47,7 +47,7 @@ azure_mgmt_storage_2018_02 = { package = "azure_mgmt_storage", git = "https://gi
 ```
 
 ## Data Plane Crates
-The data plane crates will be named `azure_svc_${specification_directory}`, such as `azure_svc_storage`. 
+The data plane crates will be named `azure_svc_${specification_directory}`, such as `azure_svc_storage`.
 
 ## Examples
 There are a few examples:

--- a/services/autorust/openapi/README.md
+++ b/services/autorust/openapi/README.md
@@ -1,6 +1,6 @@
 # autorust_openapi [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 
-Rust crate for deserializing [OpenAPI](http://swagger.io/specification/) documents as needed by [autorust](https://github.com/ctaggart/autorust/), an AutoRest extension. The goal is to be able to deserialize all of the documents found in [Azure/azure-rest-api-specs/specification](https://github.com/Azure/azure-rest-api-specs/tree/master/specification). They follow [OpenAPI Specfication Version 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object) and use several [extensions](https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md).
+Rust crate for deserializing [OpenAPI](http://swagger.io/specification/) documents as needed by [autorust](https://github.com/ctaggart/autorust/), an AutoRest extension. The goal is to be able to deserialize all of the documents found in [Azure/azure-rest-api-specs/specification](https://github.com/Azure/azure-rest-api-specs/tree/master/specification). They follow [OpenAPI Specification Version 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object) and use several [extensions](https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md).
 
 ## Install
 


### PR DESCRIPTION
The changes include:
- fixing a broken link to `docs/mock_transport.md`.
- fixing a few typos in the documenation.