### PR TITLE
work around applicationinsights data plane spec error

### DIFF
--- a/services/autorust/codegen/examples/gen_svc.rs
+++ b/services/autorust/codegen/examples/gen_svc.rs
@@ -35,6 +35,12 @@ const SKIP_SERVICE_TAGS: &[(&str, &str)] = &[
     ("batch", "package-2017-06.5.1"),            // TODO #81 DataType::File
 ];
 
+const INVALID_TYPE_WORKAROUND: &[(&str, &str, &str)] = &[(
+    "../../../azure-rest-api-specs/specification/applicationinsights/data-plane/Microsoft.Insights/preview/v1/AppInsights.json",
+    "table",
+    "rows",
+)];
+
 const FIX_CASE_PROPERTIES: &[(&str, &str, &str)] = &[
     (
         "../../../azure-rest-api-specs/specification/batch/data-plane/Microsoft.Batch/stable/2021-06-01.14.0/BatchService.json",
@@ -185,6 +191,15 @@ fn gen_crate(spec: &SpecConfigs) -> Result<()> {
         });
     }
 
+    let mut invalid_types = HashSet::new();
+    for (file_path, schema_name, property_name) in INVALID_TYPE_WORKAROUND {
+        invalid_types.insert(PropertyName {
+            file_path: PathBuf::from(file_path),
+            schema_name: schema_name.to_string(),
+            property_name: property_name.to_string(),
+        });
+    }
+
     for config in spec.configs() {
         let tag = config.tag.as_str();
         if skip_service_tags.contains(&(spec.spec(), tag)) {
@@ -217,6 +232,7 @@ fn gen_crate(spec: &SpecConfigs) -> Result<()> {
                 input_files,
                 box_properties: box_properties.clone(),
                 fix_case_properties: fix_case_properties.clone(),
+                invalid_types: invalid_types.clone(),
                 print_writing_file: false,
                 ..Config::default()
             })

--- a/services/autorust/codegen/src/codegen.rs
+++ b/services/autorust/codegen/src/codegen.rs
@@ -44,6 +44,10 @@ impl CodeGen {
         self.config.optional_properties.contains(prop_nm)
     }
 
+    pub fn should_force_obj(&self, prop_nm: &PropertyName) -> bool {
+        self.config.invalid_types.contains(prop_nm)
+    }
+
     pub fn should_box_property(&self, prop_nm: &PropertyName) -> bool {
         self.config.box_properties.contains(prop_nm)
     }

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -206,6 +206,10 @@ fn create_struct(cg: &CodeGen, doc_file: &Path, struct_name: &str, schema: &Reso
         // let prop_nm_str = format!("{:?}", prop_nm);
         // props.extend(quote! { #[doc = #prop_nm_str ]});
 
+        if cg.should_force_obj(prop_nm) {
+            field_tp_name = quote! { serde_json::Value };
+        }
+
         let is_required = required.contains(property_name.as_str()) && !cg.should_force_optional(prop_nm);
 
         let is_vec = is_vec(&field_tp_name);

--- a/services/autorust/codegen/src/lib.rs
+++ b/services/autorust/codegen/src/lib.rs
@@ -68,6 +68,7 @@ pub struct Config {
     pub box_properties: HashSet<PropertyName>,
     pub optional_properties: HashSet<PropertyName>,
     pub fix_case_properties: HashSet<PropertyName>,
+    pub invalid_types: HashSet<PropertyName>,
     pub runs: Vec<Runs>,
     pub print_writing_file: bool,
 }
@@ -87,6 +88,7 @@ impl Default for Config {
             box_properties: HashSet::new(),
             optional_properties: HashSet::new(),
             fix_case_properties: HashSet::new(),
+            invalid_types: HashSet::new(),
             runs: vec![Runs::Models, Runs::Operations],
             print_writing_file: true,
         }

--- a/services/svc/applicationinsights/examples/query.rs
+++ b/services/svc/applicationinsights/examples/query.rs
@@ -1,0 +1,52 @@
+/*
+Performs an Application Insights query
+
+Example:
+
+$ cargo run --release --example query -- $APP_INSIGHTS_INSTANCE 'traces | take 2 | project severityLevel, message'
+severityLevel:1 message:"Executing 'Functions.agent_commands' (Reason='This function was programmatically called via the host APIs.', Id=4253c319-dc36-4981-850a-d4a2584b65aa)"
+severityLevel:1 message:"Executed 'Functions.agent_commands' (Succeeded, Id=4253c319-dc36-4981-850a-d4a2584b65aa, Duration=19ms)"
+$
+
+*/
+
+use azure_identity::token_credentials::AzureCliCredential;
+use azure_svc_applicationinsights::{models::QueryBody, operations::query};
+
+const ENDPOINT: &str = "https://api.applicationinsights.io";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let app_id = std::env::args().nth(1).expect("please specify application id");
+    let query = std::env::args().nth(2).expect("please specify query");
+    let timespan = std::env::args().nth(3);
+
+    let base_path = format!("{}/v1", ENDPOINT);
+    let http_client = azure_core::new_http_client();
+    let token_credential = Box::new(AzureCliCredential {});
+    let config = &azure_svc_applicationinsights::config(http_client, token_credential)
+        .base_path(base_path)
+        .token_credential_resource(ENDPOINT)
+        .build();
+
+    let body = &QueryBody {
+        query,
+        timespan,
+        applications: None,
+    };
+
+    let response = query::execute(config, &app_id, body).await?;
+
+    let unnamed = "unnamed".to_string();
+
+    for table in &response.tables {
+        for row in table.rows.as_array().unwrap().iter() {
+            for (j, value) in row.as_array().unwrap().iter().enumerate() {
+                print!("{}:{} ", table.columns[j].name.as_ref().unwrap_or_else(|| &unnamed), value);
+            }
+            println!();
+        }
+    }
+
+    Ok(())
+}

--- a/services/svc/applicationinsights/src/v1/models.rs
+++ b/services/svc/applicationinsights/src/v1/models.rs
@@ -583,7 +583,7 @@ pub struct QueryResults {
 pub struct Table {
     pub name: String,
     pub columns: Vec<Column>,
-    pub rows: Vec<Vec<String>>,
+    pub rows: serde_json::Value,
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Column {


### PR DESCRIPTION
The Application Insights dataplane spec states that table.row should be Vec<Vec<String>>.  However, in practice can be other data types.  I've personally experienced JSON `int` as well as `string`.

This force sets the data type to a serde_json::Value.  While this is less optimal, it means the SDK is functional while waiting on the spec to be fixed.

This PR includes a working example that executes a query and naively renders the results.

Ref: https://github.com/Azure/azure-rest-api-specs/issues/16425