### PR TITLE
[storage] support tags in list blobs operation

### DIFF
--- a/sdk/storage/src/blob/blob/mod.rs
+++ b/sdk/storage/src/blob/blob/mod.rs
@@ -104,6 +104,26 @@ pub struct Blob {
     pub is_current_version: Option<bool>,
     pub deleted: Option<bool>,
     pub properties: BlobProperties,
+    pub tags: Option<Tags>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Tags {
+    pub tag_set: Option<TagSet>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct TagSet {
+    pub tag: Vec<Tag>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct Tag {
+    pub key: String,
+    pub value: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
@@ -369,6 +389,7 @@ impl Blob {
                 metadata,
                 extra: HashMap::new(),
             },
+            tags: None,
         })
     }
 }


### PR DESCRIPTION
Adding struct to match the XML response of the List Blob Operation.

[https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs#response](https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs#response)