### PR TITLE
improve rust identifier generation

### DIFF
--- a/services/autorust/codegen/src/codegen.rs
+++ b/services/autorust/codegen/src/codegen.rs
@@ -28,11 +28,6 @@ impl CodeGen {
         &self.config.output_folder
     }
 
-    // pub fn api_version(&self) -> Option<&str> {
-    //     // self.config.api_version.as_deref()
-    //     spec.
-    // }
-
     pub fn has_case_workaround(&self, path: &Path) -> bool {
         self.config.fix_case_properties.iter().any(|x| x.file_path == path)
     }
@@ -78,10 +73,16 @@ pub enum Error {
     PropertyName(#[source] crate::identifier::Error),
     #[error("creating name for module: {0}")]
     ModuleName(#[source] crate::identifier::Error),
-    #[error("creating name for enum: {0}")]
-    EnumName(#[source] crate::identifier::Error),
-    #[error("creating name for enum value: {0}")]
-    EnumValueName(#[source] crate::identifier::Error),
+    #[error("creating name for enum {property}: {source}")]
+    EnumName {
+        source: crate::identifier::Error,
+        property: String,
+    },
+    #[error("creating name for enum value {property}: {source}")]
+    EnumValueName {
+        source: crate::identifier::Error,
+        property: String,
+    },
     #[error("creating name for Vec alias: {0}")]
     VecAliasName(#[source] crate::identifier::Error),
     #[error("creating name for struct: {0}")]
@@ -251,4 +252,16 @@ pub static PARAM_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\{(\w+)\}").unwrap(
 pub fn parse_params(path: &str) -> Vec<String> {
     // capture 0 is the whole match and 1 is the actual capture like other languages
     PARAM_RE.captures_iter(path).into_iter().map(|c| c[1].to_string()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_enum_values_as_strings() {
+        let values = vec![json!("/"), json!("/keys")];
+        assert_eq!(enum_values_as_strings(&values), vec!["/", "/keys"]);
+    }
 }

--- a/services/autorust/codegen/src/identifier.rs
+++ b/services/autorust/codegen/src/identifier.rs
@@ -71,10 +71,10 @@ fn prefix_number(text: &str) -> String {
     }
 }
 
-/// add a prefix of `k` if it is a keyword
+/// add an underscore suffix it is a keyword
 fn prefix_keyword(text: &str) -> String {
     if is_keyword(&text) {
-        format!("k{}", text)
+        format!("{}_", text)
     } else {
         text.to_owned()
     }

--- a/services/autorust/codegen/src/identifier.rs
+++ b/services/autorust/codegen/src/identifier.rs
@@ -41,13 +41,13 @@ fn remove_spaces(text: &str) -> String {
     text.replace(" ", "")
 }
 
-/// replace special characters with their hex
+/// replace special characters with underscores
 fn replace_special_chars(text: &str) -> String {
-    let mut txt = text.replace(".", "u2e");
-    txt = txt.replace(",", "u2c");
-    txt = txt.replace("-", "u2d");
-    txt = txt.replace("/", "u2f");
-    txt = txt.replace("*", "u2a");
+    let mut txt = text.replace(".", "_");
+    txt = txt.replace(",", "_");
+    txt = txt.replace("-", "_");
+    txt = txt.replace("/", "_");
+    txt = txt.replace("*", "_");
     txt
 }
 
@@ -157,11 +157,11 @@ mod tests {
 
     #[test]
     fn test_chars() -> Result<(), Error> {
-        assert_eq!(replace_special_chars("."), unicode('.'));
-        assert_eq!(replace_special_chars(","), unicode(','));
-        assert_eq!(replace_special_chars("-"), unicode('-'));
-        assert_eq!(replace_special_chars("/"), unicode('/'));
-        assert_eq!(replace_special_chars("*"), unicode('*'));
+        assert_eq!(replace_special_chars("."), "_");
+        assert_eq!(replace_special_chars(","), "_");
+        assert_eq!(replace_special_chars("-"), "_");
+        assert_eq!(replace_special_chars("/"), "_");
+        assert_eq!(replace_special_chars("*"), "_");
         Ok(())
     }
 
@@ -169,14 +169,14 @@ mod tests {
     fn test_odata_next_link() -> Result<(), Error> {
         let idt = "odata.nextLink".to_snake_case();
         let idt = ident(&idt)?;
-        assert_eq!(idt.to_string(), "odatau2enext_link");
+        assert_eq!(idt.to_string(), "odata_next_link");
         Ok(())
     }
 
     #[test]
     fn test_three_dot_two() -> Result<(), Error> {
         let idt = ident("3.2")?;
-        assert_eq!(idt.to_string(), "n3u2e2");
+        assert_eq!(idt.to_string(), "n3_2");
         Ok(())
     }
 
@@ -184,14 +184,14 @@ mod tests {
     fn test_system_assigned_user_assigned() -> Result<(), Error> {
         assert_eq!(
             "SystemAssigned, UserAssigned".to_camel_case_ident()?.to_string(),
-            "SystemAssignedu2cUserAssigned"
+            "SystemAssignedUserAssigned"
         );
         Ok(())
     }
 
     #[test]
     fn test_gcm_aes_128() -> Result<(), Error> {
-        assert_eq!("gcm-aes-128".to_camel_case_ident()?.to_string(), "Gcmu2daesu2d128");
+        assert_eq!("gcm-aes-128".to_camel_case_ident()?.to_string(), "GcmAes128");
         Ok(())
     }
 
@@ -205,7 +205,7 @@ mod tests {
     fn test_app_configuration() -> Result<(), Error> {
         assert_eq!(
             "Microsoft.AppConfiguration/configurationStores".to_camel_case_ident()?.to_string(),
-            "Microsoftu2eAppConfigurationu2fconfigurationStores"
+            "MicrosoftAppConfigurationConfigurationStores"
         );
         Ok(())
     }
@@ -214,7 +214,7 @@ mod tests {
     fn test_microsoft_key_vault_vaults() -> Result<(), Error> {
         assert_eq!(
             "Microsoft.KeyVault/vaults".to_camel_case_ident()?.to_string(),
-            "Microsoftu2eKeyVaultu2fvaults"
+            "MicrosoftKeyVaultVaults"
         );
         Ok(())
     }
@@ -223,14 +223,14 @@ mod tests {
     fn test_azure_virtual_machine_best_practices() -> Result<(), Error> {
         assert_eq!(
             "Azure virtual machine best practices - Dev/Test".to_camel_case_ident()?.to_string(),
-            "AzureVirtualMachineBestPracticesU2dDevu2fTest"
+            "AzureVirtualMachineBestPracticesDevTest"
         );
         Ok(())
     }
 
     #[test]
     fn test_1_0() -> Result<(), Error> {
-        assert_eq!("1.0".to_camel_case_ident()?.to_string(), "N1u2e0");
+        assert_eq!("1.0".to_camel_case_ident()?.to_string(), "N10");
         Ok(())
     }
 }

--- a/services/autorust/codegen/src/identifier.rs
+++ b/services/autorust/codegen/src/identifier.rs
@@ -14,9 +14,9 @@ pub trait CamelCaseIdent: ToOwned {
 
 impl CamelCaseIdent for str {
     fn to_camel_case_ident(&self) -> Result<TokenStream, Error> {
-        let mut txt = replace_special_chars(self);
-        txt = replace_first(&txt);
+        let mut txt = replace_first(self);
         txt = txt.to_camel_case();
+        txt = replace_special_chars(&txt);
         let idt = syn::parse_str::<syn::Ident>(&txt).map_err(|source| Error::ParseIdentError {
             source,
             text: self.to_owned(),
@@ -26,9 +26,9 @@ impl CamelCaseIdent for str {
 }
 
 pub fn ident(text: &str) -> Result<TokenStream, Error> {
-    let mut txt = replace_special_chars(text);
+    let mut txt = replace_first(&text);
+    txt = replace_special_chars(&txt);
     txt = remove_spaces(&txt);
-    txt = replace_first(&txt);
     txt = suffix_keyword(&txt);
     let idt = syn::parse_str::<syn::Ident>(&txt).map_err(|source| Error::ParseIdentError {
         source,
@@ -212,7 +212,7 @@ mod tests {
     fn test_app_configuration() -> Result<(), Error> {
         assert_eq!(
             "Microsoft.AppConfiguration/configurationStores".to_camel_case_ident()?.to_string(),
-            "MicrosoftAppConfigurationConfigurationStores"
+            "Microsoft_AppConfigurationConfigurationStores"
         );
         Ok(())
     }
@@ -221,7 +221,7 @@ mod tests {
     fn test_microsoft_key_vault_vaults() -> Result<(), Error> {
         assert_eq!(
             "Microsoft.KeyVault/vaults".to_camel_case_ident()?.to_string(),
-            "MicrosoftKeyVaultVaults"
+            "Microsoft_KeyVaultVaults"
         );
         Ok(())
     }

--- a/services/autorust/codegen/src/lib.rs
+++ b/services/autorust/codegen/src/lib.rs
@@ -34,8 +34,8 @@ pub enum Error {
     WriteFile { file: PathBuf, source: std::io::Error },
     #[error("CodeGenNewError")]
     CodeGenNew(#[source] codegen::Error),
-    #[error("CreateModelsError {} {}", config.output_folder.display(), source)]
-    CreateModels { source: codegen::Error, config: Config },
+    #[error("CreateModelsError {0}")]
+    CreateModels(#[source] codegen::Error),
     #[error("CreateOperationsError")]
     CreateOperations(#[source] codegen::Error),
     #[error("path: {0}")]
@@ -103,10 +103,7 @@ pub fn run(config: Config) -> Result<()> {
 
     // create models from schemas
     if config.should_run(&Runs::Models) {
-        let models = codegen_models::create_models(cg).map_err(|source| Error::CreateModels {
-            source,
-            config: config.clone(),
-        })?;
+        let models = codegen_models::create_models(cg).map_err(Error::CreateModels)?;
         let models_path = path::join(&config.output_folder, "models.rs").map_err(Error::Path)?;
         write_file(&models_path, &models, config.print_writing_file)?;
     }


### PR DESCRIPTION
This adds `replace_first` to improve the rust identifier generation. It also improves the error messages. The first goal is to make keyvault 7.2 data-place code generation work. It currently fails on naming `"/"` enum value. This fixes that.

specification\keyvault\data-plane\Microsoft.KeyVault\stable\7.2\rbac.json

``` json
    "RoleScope": {
      "type": "string",
      "description": "The role scope.",
      "enum": [
        "/",
        "/keys"
      ],
      "x-ms-enum": {
        "name": "RoleScope",
        "modelAsString": true,
        "values": [
          {
            "name": "Global",
            "value": "/",
            "description": "Global scope"
          },
          {
            "name": "Keys",
            "value": "/keys",
            "description": "Keys scope"
          }
        ]
      }
    },
```