### PR TITLE
use Url instead of String for Blob URLs

### DIFF
--- a/sdk/storage/src/blob/blob/requests/copy_blob_builder.rs
+++ b/sdk/storage/src/blob/blob/requests/copy_blob_builder.rs
@@ -5,11 +5,12 @@ use azure_core::headers::COPY_SOURCE;
 use azure_core::headers::{add_mandatory_header, add_optional_header, add_optional_header_ref};
 use azure_core::prelude::*;
 use std::convert::TryInto;
+use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct CopyBlobBuilder<'a> {
     blob_client: &'a BlobClient,
-    source_url: &'a str,
+    source_url: &'a Url,
     metadata: Option<&'a Metadata>,
     sequence_number_condition: Option<SequenceNumberCondition>,
     if_modified_since_condition: Option<IfModifiedSinceCondition>,
@@ -25,7 +26,7 @@ pub struct CopyBlobBuilder<'a> {
 }
 
 impl<'a> CopyBlobBuilder<'a> {
-    pub(crate) fn new(blob_client: &'a BlobClient, source_url: &'a str) -> Self {
+    pub(crate) fn new(blob_client: &'a BlobClient, source_url: &'a Url) -> Self {
         Self {
             blob_client,
             source_url,
@@ -72,7 +73,7 @@ impl<'a> CopyBlobBuilder<'a> {
             url.as_str(),
             &http::Method::PUT,
             &|mut request| {
-                request = request.header(COPY_SOURCE, self.source_url);
+                request = request.header(COPY_SOURCE, self.source_url.as_str());
                 request = add_optional_header(&self.metadata, request);
                 request = add_optional_header(&self.sequence_number_condition, request);
                 request = add_optional_header(&self.if_modified_since_condition, request);

--- a/sdk/storage/src/blob/clients/blob_client.rs
+++ b/sdk/storage/src/blob/clients/blob_client.rs
@@ -8,6 +8,7 @@ use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
 use std::sync::Arc;
+use url::Url;
 
 pub trait AsBlobClient<BN: Into<String>> {
     fn as_blob_client(&self, blob_name: BN) -> Arc<BlobClient>;
@@ -103,7 +104,7 @@ impl BlobClient {
         DeleteBlobVersionBuilder::new(self, version_id)
     }
 
-    pub fn copy<'a>(&'a self, copy_source: &'a str) -> CopyBlobBuilder<'a> {
+    pub fn copy<'a>(&'a self, copy_source: &'a Url) -> CopyBlobBuilder<'a> {
         CopyBlobBuilder::new(self, copy_source)
     }
 

--- a/sdk/storage/src/blob/clients/blob_client.rs
+++ b/sdk/storage/src/blob/clients/blob_client.rs
@@ -161,9 +161,10 @@ impl BlobClient {
     pub fn generate_signed_blob_url(
         &self,
         signature: &SharedAccessSignature,
-    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let url = self.url_with_segments(None)?;
-        Ok(format!("{}?{}", url.as_str(), signature.token()))
+    ) -> Result<url::Url, Box<dyn std::error::Error + Send + Sync>> {
+        let mut url = self.url_with_segments(None)?;
+        url.set_query(Some(&signature.token()));
+        Ok(url)
     }
 
     pub(crate) fn prepare_request(

--- a/sdk/storage/tests/blob.rs
+++ b/sdk/storage/tests/blob.rs
@@ -15,6 +15,7 @@ use std::ops::Add;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
+use url::Url;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -309,16 +310,15 @@ async fn copy_blob() {
 
     let cloned_blob = container.as_blob_client("cloned_blob");
 
-    cloned_blob
-        .copy(&format!(
-            "https://{}.blob.core.windows.net/{}/{}",
-            &std::env::var("STORAGE_ACCOUNT").unwrap(),
-            &container_name,
-            &blob_name
-        ))
-        .execute()
-        .await
-        .unwrap();
+    let url = Url::parse(&format!(
+        "https://{}.blob.core.windows.net/{}/{}",
+        &std::env::var("STORAGE_ACCOUNT").unwrap(),
+        &container_name,
+        &blob_name
+    ))
+    .unwrap();
+
+    cloned_blob.copy(&url).execute().await.unwrap();
 }
 
 async fn requires_send_future<F, O>(fut: F) -> O


### PR DESCRIPTION
As a user, I expect `generate_*_url` to return a Url, not a String.
