### PR TITLE
[storage] add x-ms-tags header to PutBlockBlobBuilder

### DIFF
--- a/sdk/core/src/request_options/mod.rs
+++ b/sdk/core/src/request_options/mod.rs
@@ -26,6 +26,7 @@ mod range;
 mod sequence_number;
 mod sequence_number_condition;
 mod source_lease_id;
+mod tags;
 mod timeout;
 mod user_agent;
 
@@ -57,5 +58,6 @@ pub use range::Range;
 pub use sequence_number::SequenceNumber;
 pub use sequence_number_condition::SequenceNumberCondition;
 pub use source_lease_id::SourceLeaseId;
+pub use tags::Tags;
 pub use timeout::Timeout;
 pub use user_agent::UserAgent;

--- a/sdk/core/src/request_options/tags.rs
+++ b/sdk/core/src/request_options/tags.rs
@@ -1,0 +1,94 @@
+use crate::AddAsHeader;
+use http::request::Builder;
+use http::HeaderMap;
+use std::collections::HashMap;
+use url::form_urlencoded;
+
+#[derive(Debug, Clone)]
+pub struct Tags(HashMap<String, String>);
+
+impl Default for Tags {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AsMut<HashMap<String, String>> for Tags {
+    fn as_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.0
+    }
+}
+
+impl Tags {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    pub fn insert<K, V>(&mut self, k: K, v: V) -> Option<String>
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.0.insert(k.into(), v.into())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn get(&self, k: &str) -> Option<String> {
+        self.0.get(k).cloned()
+    }
+}
+
+impl AddAsHeader for &Tags {
+    fn add_as_header(&self, builder: Builder) -> Builder {
+        let mut encoded = form_urlencoded::Serializer::new(String::new());
+        let mut encoder = &mut encoded;
+        for (key, value) in self.0.iter() {
+            encoder = encoder.append_pair(key, value);
+        }
+        builder.header("x-ms-tags", encoded.finish().to_string())
+    }
+
+    fn add_as_header2(
+        &self,
+        request: &mut crate::Request,
+    ) -> Result<(), crate::errors::HTTPHeaderError> {
+        let mut encoded = form_urlencoded::Serializer::new(String::new());
+        let mut encoder = &mut encoded;
+        for (key, value) in self.0.iter() {
+            encoder = encoder.append_pair(key, value);
+        }
+        let header_name = http::header::HeaderName::from_bytes("x-ms-tags".as_bytes())?;
+        let encoded_tags = encoded.finish();
+        let header_value = http::header::HeaderValue::from_bytes(encoded_tags.as_bytes())?;
+        request.headers_mut().append(header_name, header_value);
+
+        Ok(())
+    }
+}
+
+impl From<&HeaderMap> for Tags {
+    fn from(header_map: &HeaderMap) -> Self {
+        let mut tags = Tags::new();
+        header_map
+            .iter()
+            .map(|header| (header.0.as_str(), header.1.as_bytes()))
+            .filter(|(key, _)| key.starts_with("x-ms-tags"))
+            .for_each(|(_key, value)| {
+                let x: String = String::from_utf8(value.to_vec()).unwrap();
+                let key_value_pair: Vec<&str> = x.split("=").collect::<Vec<_>>();
+                tags.insert(
+                    key_value_pair.get(0).unwrap().to_string(),
+                    key_value_pair.get(1).unwrap().to_string(),
+                );
+            });
+
+        tags
+    }
+}

--- a/sdk/storage/src/blob/blob/requests/put_block_blob_builder.rs
+++ b/sdk/storage/src/blob/blob/requests/put_block_blob_builder.rs
@@ -16,7 +16,7 @@ pub struct PutBlockBlobBuilder<'a> {
     content_disposition: Option<ContentDisposition<'a>>,
     metadata: Option<&'a Metadata>,
     access_tier: Option<AccessTier>,
-    // TODO: Support tags
+    tags: Option<&'a Tags>,
     lease_id: Option<&'a LeaseId>,
     client_request_id: Option<ClientRequestId<'a>>,
     timeout: Option<Timeout>,
@@ -34,6 +34,7 @@ impl<'a> PutBlockBlobBuilder<'a> {
             content_disposition: None,
             metadata: None,
             access_tier: None,
+            tags: None,
             lease_id: None,
             client_request_id: None,
             timeout: None,
@@ -48,6 +49,7 @@ impl<'a> PutBlockBlobBuilder<'a> {
         content_disposition: ContentDisposition<'a> => Some(content_disposition),
         metadata: &'a Metadata => Some(metadata),
         access_tier: AccessTier => Some(access_tier),
+        tags: &'a Tags => Some(&tags),
         lease_id: &'a LeaseId => Some(lease_id),
         client_request_id: ClientRequestId<'a> => Some(client_request_id),
         timeout: Timeout => Some(timeout),
@@ -74,6 +76,7 @@ impl<'a> PutBlockBlobBuilder<'a> {
                 request = add_optional_header(&self.content_disposition, request);
                 request = add_optional_header(&self.metadata, request);
                 request = add_optional_header(&self.access_tier, request);
+                request = add_optional_header(&self.tags, request);
                 request = add_optional_header_ref(&self.lease_id, request);
                 request = add_optional_header(&self.client_request_id, request);
                 request


### PR DESCRIPTION
Adding tags header to match Put Blob Operation specification.

[https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob#request-headers-all-blob-types](https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob#request-headers-all-blob-types)