### PR TITLE
compile all features for services nightly & on demand

### DIFF
--- a/.github/workflows/services-all-features.yml
+++ b/.github/workflows/services-all-features.yml
@@ -2,8 +2,8 @@ name: Check All Features for Services
 
 on:
   workflow_dispatch:
-  # schedule:
-  #   - cron: "0 0 * * *"
+  schedule:
+    - cron: "0 0 * * *"
 
 env:
   RUSTFLAGS: --deny warnings --allow unused_attributes


### PR DESCRIPTION
For #421, I'm want to compile all feature flags to compile all versions, but rustc dies on GitHub builds for a few crates with lots of features. I've tried latest stable rustc 1.56.0 & 1.55.0. I removed `--all`, which I think may have failed more crates.

You can see the failed runs from the ctaggart Actions tab.
https://github.com/ctaggart/azure-sdk-for-rust/runs/3997468843?check_suite_focus=true