### PR TITLE
Add cancellation example to Cosmos

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -40,7 +40,7 @@ rustc_version = "0.4"
 
 [dev-dependencies]
 env_logger = "0.8"
-tokio = { version = "1.0", features = ["default"] }
+tokio = { version = "1", features = ["default"] }
 
 [features]
 default = ["enable_reqwest"]

--- a/sdk/cosmos/Cargo.toml
+++ b/sdk/cosmos/Cargo.toml
@@ -32,10 +32,11 @@ bytes = "1.0"
 
 [dev-dependencies]
 env_logger = "0.8"
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1", features = ["macros"] }
 hyper = "0.14"
 hyper-rustls = "0.22"
 reqwest = "0.11.0"
+stop-token = { version = "0.6.1", features = ["tokio"] }
 
 [features]
 test_e2e = []

--- a/sdk/cosmos/examples/cancellation.rs
+++ b/sdk/cosmos/examples/cancellation.rs
@@ -1,0 +1,60 @@
+use azure_core::prelude::*;
+use azure_cosmos::prelude::*;
+use stop_token::prelude::*;
+use stop_token::StopSource;
+use tokio::time::{Duration, Instant};
+
+#[tokio::main]
+async fn main() -> azure_cosmos::Result<()> {
+    env_logger::init();
+    // First we retrieve the account name and master key from environment variables, and
+    // create an authorization token.
+    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
+    let master_key =
+        std::env::var("COSMOS_MASTER_KEY").expect("Set env variable COSMOS_MASTER_KEY first!");
+    let authorization_token = AuthorizationToken::primary_from_base64(&master_key)?;
+
+    // Create a new Cosmos client.
+    let options = CosmosOptions::default();
+    let client = CosmosClient::new(account.clone(), authorization_token.clone(), options);
+
+    // Create a new database, and time out if it takes more than 1 second.
+    let options = CreateDatabaseOptions::new();
+    let future = client.create_database(Context::new(), "my_database", options);
+    let deadline = Instant::now() + Duration::from_secs(1);
+    match future.until(deadline).await {
+        Ok(Ok(r)) => println!("successful response: {:?}", r),
+        Ok(Err(e)) => println!("request was made but failed: {:?}", e),
+        Err(_) => println!("request timed out!"),
+    };
+
+    // Create multiple new databases, and cancel them if they don't complete before
+    // they're sent a stop signal.
+    let source = StopSource::new();
+    for _ in 1..10 {
+        let client = client.clone();
+        // Clone the stop token for each request.
+        let stop = source.token();
+        tokio::spawn(async move {
+            let options = CreateDatabaseOptions::new();
+            let future = client.create_database(Context::new(), "my_database", options);
+            match future.until(stop).await {
+                Ok(Ok(r)) => println!("successful response: {:?}", r),
+                Ok(Err(e)) => println!("request was made but failed: {:?}", e),
+                Err(_) => println!("request was cancelled!"),
+            };
+        });
+    }
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    // This causes all cancel tokens to fire. Any request tied to a stop token created
+    // from this source will be canceled.
+    println!("cancelling all requests");
+    drop(source);
+    // Any request that has not yet completed will be canceled at this point
+
+    // Keep the program alive for a bit longer so the tasks get a chance to
+    // print before exiting.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    Ok(())
+}


### PR DESCRIPTION
_This PR was co-authored with @rylev._

This PR is a follow-up to https://github.com/Azure/azure-sdk-for-rust/pull/392#pullrequestreview-790986505, adding a cancellation example for the SDK. This PR shows off two methods of cancellation: using a timeout, and using a stop token. But in practice users are free to use any kind of cancellation method they want; what the SDK guarantees is that if the corresponding future is dropped, the request is in fact terminated.

As you can probably tell by reading the code, ensuring cancellation is propagated does not require any changes to the codebase itself. This is because both our `hyper` and `reqwest` backends cancel their corresponding requests when dropped. We're including this example solely to show how users can cancel requests themselves.

## Differences with Golang

The [Go context](https://pkg.go.dev/context) package has three distinct cancellation methods: cancel after a certain time, cancel at a specific time, and cancel based on a signal. In our example we show how to cancel in response to a signal, and at a specific time. This is the core of the time-based example:

```rust
let deadline = Instant::now() + Duration::from_secs(1);
match future.until(deadline).await {
```
Hypothetically the `until` method could also take the relative `Duration` type directly. But internally it would still need to convert the relative type to a concrete instance [^diff]. Because both are equivalent, we've only chosen to include a single time-based example.

[^diff]: The difference between a "duration" and an "instant" is: "5 seconds" vs "5 seconds _from now_". We cannot meaningfully say anything about time elapsed without comparing two instants. Even in Golang, internally [the implementation of `withTimeout` converts a `Duration` into `Time` before calling the `withDeadline` method](https://cs.opensource.google/go/go/+/refs/tags/go1.17.2:src/context/context.go;l=507).

The final difference with the Golang `Context` object is that our context does is not yet able to store key-value pairs. We should consider adapting our context to be able to store objects through [a typemap interface](https://docs.rs/http-types/2.12.0/http_types/struct.Extensions.html) in a future PR. But that's out of scope for this PR, and we should address that separately.

## Cancellation Trees and Cancellation Propagation

As we talked about during our sync meetings and in prior PRs, the main property we want to guarantee is that cancellation propagates. As far as I understand it, this is what we're referring to when we're talking about trees in the context of cancellation.

The SDK as it currently exists ensures that when the client or any of its outgoing requests are dropped, its internal resources are also cleaned up [^borrow-checker]. For a request this means the request is cancelled, and the TCP connection is handed back to the connection pool. For the client it means that when it's dropped the pool of open TCP connections is closed down, and all of the file descriptors are closed.

This ensures that however end-users choose to cancel any part of the SDK, it should always _just work_. Whether we're returning early from a function because of an error, awaiting multiple requests concurrently, or respond to a cancellation token -- the SDK ensures that it itself is well-behaved: it will not leak resources, and close any ongoing operations the moment it knows the user is no longer interested in the results.

Unlike our Golang and C# SDKs we do not need to manually thread through a `Context` to ensure our cancellation propagates throughout our program. This means that our SDK's interface will differ slightly from what existing Azure customers will be used to from other languages; but only because Rust as a language provides stronger guarantees around cancellation out of the box. But this will also have the consequence that for users of the Rust language, the Azure SDK will likely feel more natural and pleasant to use. Which is something we've in the past said is something that we're especially keen on doing too.

## Conclusion

This example shows how to cancel in-flight requests in various manners using the Azure SDK. Because our dependencies already support "cancellation on drop", and we're not doing anything that's incompatible with that, our SDK transitively has that property as well.

Overall we hope this example is useful for people looking to learn how to cancel requests made by the SDK, and act as a useful reference for possible future documentation. Thanks!

cc/ @heaths @JeffreyRichter 

[^borrow-checker]: Note that requests cannot outlive clients due to the borrow checker. So we're guaranteed we have no in-flight requests when the client cleans up its resources.