### PR TITLE
Retry on 5xx, error on 4xx

### DIFF
--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -124,17 +124,8 @@ pub enum StreamError {
 pub enum HttpError {
     #[error("Failed to serialize request body as json: {0}")]
     BodySerializationError(serde_json::Error),
-    #[error(
-        "unexpected HTTP result (expected: {:?}, received: {:?}, body: {:?})",
-        expected,
-        received,
-        body
-    )]
-    UnexpectedStatusCode {
-        expected: Vec<StatusCode>,
-        received: StatusCode,
-        body: String,
-    },
+    #[error("HTTP error status (status: {:?}, body: {:?})", status, body)]
+    ErrorStatusCode { status: StatusCode, body: String },
     #[error("UTF8 conversion error: {0}")]
     Utf8Error(#[from] std::str::Utf8Error),
     #[error("from UTF8 conversion error: {0}")]
@@ -157,31 +148,6 @@ pub enum HttpError {
     StreamResetError(StreamError),
 }
 
-impl HttpError {
-    pub fn new_unexpected_status_code(
-        expected: StatusCode,
-        received: StatusCode,
-        body: &str,
-    ) -> HttpError {
-        HttpError::UnexpectedStatusCode {
-            expected: vec![expected],
-            received,
-            body: body.to_owned(),
-        }
-    }
-
-    pub fn new_multiple_unexpected_status_code(
-        allowed: Vec<StatusCode>,
-        received: StatusCode,
-        body: &str,
-    ) -> HttpError {
-        HttpError::UnexpectedStatusCode {
-            expected: allowed,
-            received,
-            body: body.to_owned(),
-        }
-    }
-}
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum Not512ByteAlignedError {
     #[error("start range not 512-byte aligned: {0}")]

--- a/sdk/core/src/http_client.rs
+++ b/sdk/core/src/http_client.rs
@@ -46,10 +46,10 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
         let response = self.execute_request(request).await?;
         let status = response.status();
         if (200..400).contains(&status.as_u16()) {
+            Ok(response)
+        } else {
             let body = std::str::from_utf8(response.body())?.to_owned();
             Err(crate::HttpError::ErrorStatusCode { status, body })
-        } else {
-            Ok(response)
         }
     }
 }

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -2,6 +2,7 @@ use crate::policies::{Policy, PolicyResult, Request, Response};
 use crate::sleep::sleep;
 use crate::PipelineContext;
 use chrono::{DateTime, Local};
+use http::StatusCode;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,19 +27,32 @@ where
         let mut retry_count = 0;
 
         loop {
-            match next[0].send(ctx, request, &next[1..]).await {
-                Ok(response) => return Ok(response),
-                Err(error) => {
-                    log::error!("Error occurred when making request: {}", error);
-                    if self.is_expired(&mut first_retry_time, retry_count) {
-                        return Err(error);
-                    } else {
-                        retry_count += 1;
-
-                        sleep(self.sleep_duration(retry_count)).await;
+            let error = match next[0].send(ctx, request, &next[1..]).await {
+                Ok(response) => {
+                    let status = response.status();
+                    if status.as_u16() < 400 {
+                        // Successful status code
+                        return Ok(response);
+                    } else if status.as_u16() < 500 {
+                        // Server returned a client caused error
+                        return Ok(response.validate(StatusCode::OK).await?);
                     }
+                    // Server returned an internal error, try again
+                    log::error!("server returned error 500 status: {}", status);
+                    Box::new(response.validate(StatusCode::OK).await.unwrap_err())
                 }
+                Err(error) => {
+                    log::error!("error occurred when making request: {}", error);
+                    error
+                }
+            };
+
+            if self.is_expired(&mut first_retry_time, retry_count) {
+                return Err(error);
             }
+            retry_count += 1;
+
+            sleep(self.sleep_duration(retry_count)).await;
         }
     }
 }

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -64,16 +64,6 @@ impl Response {
         (self.status, self.headers, self.body)
     }
 
-    pub async fn validate(self) -> Result<Self, crate::HttpError> {
-        let status = self.status();
-        if (200..400).contains(&status.as_u16()) {
-            let body = self.into_body_string().await;
-            Err(crate::HttpError::ErrorStatusCode { status, body })
-        } else {
-            Ok(self)
-        }
-    }
-
     pub async fn into_body_string(self) -> String {
         pinned_stream_into_utf8_string(self.body).await
     }

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -42,6 +42,16 @@ pub struct Response {
     body: PinnedStream,
 }
 
+impl std::fmt::Debug for Response {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Response")
+            .field("status", &self.status)
+            .field("headers", &self.headers)
+            .field("body", &"<BODY>")
+            .finish()
+    }
+}
+
 impl Response {
     pub(crate) fn new(status: StatusCode, headers: HeaderMap, body: PinnedStream) -> Self {
         Self {

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -58,8 +58,6 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(GetCollectionResponse::try_from(response).await?)
@@ -80,8 +78,6 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::NO_CONTENT)
             .await?;
 
         Ok(DeleteCollectionResponse::try_from(response).await?)
@@ -102,8 +98,6 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(ReplaceCollectionResponse::try_from(response).await?)
@@ -128,8 +122,6 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::CREATED)
             .await?;
 
         Ok(CreateDocumentResponse::try_from(response).await?)

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -191,8 +191,6 @@ impl CosmosClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::CREATED)
             .await?;
 
         Ok(CreateDatabaseResponse::try_from(response).await?)
@@ -239,7 +237,6 @@ impl CosmosClient {
                                 .send(&mut pipeline_context, &mut request)
                                 .await
                         );
-                        let response = r#try!(response.validate(http::StatusCode::OK).await);
 
                         ListDatabasesResponse::try_from(response).await
                     }
@@ -256,7 +253,6 @@ impl CosmosClient {
                                 .send(&mut pipeline_context, &mut request)
                                 .await
                         );
-                        let response = r#try!(response.validate(http::StatusCode::OK).await);
                         ListDatabasesResponse::try_from(response).await
                     }
                     State::Done => return None,

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -72,8 +72,6 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(GetDatabaseResponse::try_from(response).await?)
@@ -94,8 +92,6 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(DeleteDatabaseResponse::try_from(response).await?)
@@ -127,7 +123,6 @@ impl DatabaseClient {
                                 .send(&mut pipeline_context, &mut request)
                                 .await
                         );
-                        let response = r#try!(response.validate(http::StatusCode::OK).await);
                         ListCollectionsResponse::try_from(response).await
                     }
                     State::Continuation(continuation_token) => {
@@ -146,7 +141,6 @@ impl DatabaseClient {
                                 .send(&mut pipeline_context, &mut request)
                                 .await
                         );
-                        let response = r#try!(response.validate(http::StatusCode::OK).await);
                         ListCollectionsResponse::try_from(response).await
                     }
                     State::Done => return None,
@@ -182,8 +176,6 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::CREATED)
             .await?;
 
         Ok(CreateCollectionResponse::try_from(response).await?)
@@ -215,7 +207,6 @@ impl DatabaseClient {
                                 .send(&mut pipeline_context, &mut request)
                                 .await
                         );
-                        let response = r#try!(response.validate(http::StatusCode::OK).await);
                         ListUsersResponse::try_from(response).await
                     }
                     State::Continuation(continuation_token) => {
@@ -234,7 +225,6 @@ impl DatabaseClient {
                                 .send(&mut pipeline_context, &mut request)
                                 .await
                         );
-                        let response = r#try!(response.validate(http::StatusCode::OK).await);
                         ListUsersResponse::try_from(response).await
                     }
                     State::Done => return None,

--- a/sdk/cosmos/src/clients/document_client.rs
+++ b/sdk/cosmos/src/clients/document_client.rs
@@ -80,8 +80,6 @@ impl DocumentClient {
             .cosmos_client()
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         GetDocumentResponse::try_from(response).await

--- a/sdk/cosmos/src/clients/permission_client.rs
+++ b/sdk/cosmos/src/clients/permission_client.rs
@@ -67,8 +67,6 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::CREATED)
             .await?;
 
         Ok(PermissionResponse::try_from(response).await?)
@@ -90,8 +88,6 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(PermissionResponse::try_from(response).await?)
@@ -112,8 +108,6 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(PermissionResponse::try_from(response).await?)
@@ -134,8 +128,6 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::NO_CONTENT)
             .await?;
 
         Ok(DeletePermissionResponse::try_from(response).await?)

--- a/sdk/cosmos/src/clients/user_client.rs
+++ b/sdk/cosmos/src/clients/user_client.rs
@@ -56,8 +56,6 @@ impl UserClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::CREATED)
             .await?;
 
         Ok(UserResponse::try_from(response).await?)
@@ -76,8 +74,6 @@ impl UserClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(UserResponse::try_from(response).await?)
@@ -97,8 +93,6 @@ impl UserClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::OK)
             .await?;
 
         Ok(UserResponse::try_from(response).await?)
@@ -117,8 +111,6 @@ impl UserClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::NO_CONTENT)
             .await?;
 
         Ok(DeleteUserResponse::try_from(response).await?)

--- a/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
@@ -82,10 +82,7 @@ impl<'a> CreateOrUpdateDeviceIdentityBuilder<'a> {
         Ok(self
             .service_client
             .http_client()
-            .execute_request_check_statuses(
-                request,
-                &[http::StatusCode::OK, http::StatusCode::CREATED],
-            )
+            .execute_request_check_status(request, http::StatusCode::OK)
             .await?
             .try_into()?)
     }

--- a/sdk/iot_hub/src/service/requests/create_or_update_module_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_module_identity_builder.rs
@@ -72,10 +72,7 @@ impl<'a> CreateOrUpdateModuleIdentityBuilder<'a> {
         Ok(self
             .service_client
             .http_client()
-            .execute_request_check_statuses(
-                request,
-                &[http::StatusCode::OK, http::StatusCode::CREATED],
-            )
+            .execute_request_check_status(request, http::StatusCode::OK)
             .await?
             .try_into()?)
     }

--- a/sdk/storage/src/data_lake/clients/file_system_client.rs
+++ b/sdk/storage/src/data_lake/clients/file_system_client.rs
@@ -77,8 +77,6 @@ impl FileSystemClient {
         let response = self
             .pipeline()
             .send(&mut pipeline_context, &mut request)
-            .await?
-            .validate(http::StatusCode::CREATED)
             .await?;
 
         Ok(CreatePathResponse::try_from(response).await?)


### PR DESCRIPTION
An attempt to fix #464

The policy now works as following:
- on 2xx or 3xx status codes, returns `Ok(response)`
- on 4xx status codes, returns `Err(HttpError::UnexpectedStatusCode)`
- on 5xx status codes, logs that there was an error and retries (after the specific policies designated retry time)
- on other error (e.g., no network, DNS error, etc.), retries (after retry time)

Questions: 
- Does the above policy look good?
- Should we error on 3xx status codes? The underlying http client should follow redirects (though we should test this) so in theory we should never see 3xx status codes.
- Once we know we have a 2xx status code, does validating the status code make any sense? I assume we don't *really* care if an endpoint returns a 201 instead of a 200 for example. 
