### PR TITLE
refresh tokens contain `scope` fields, not `scopes`

### DIFF
--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -68,7 +68,7 @@ pub async fn exchange(
 #[derive(Debug, Clone, Deserialize)]
 pub struct RefreshTokenResponse {
     token_type: String,
-    #[serde(deserialize_with = "deserialize::split")]
+    #[serde(rename = "scope", deserialize_with = "deserialize::split")]
     scopes: Vec<String>,
     expires_in: u64,
     ext_expires_in: u64,


### PR DESCRIPTION
refresh tokens return `scope` not `scopes`.  

Per documentation:
```json
{
    "access_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik5HVEZ2ZEstZnl0aEV1Q...",
    "token_type": "Bearer",
    "expires_in": 3599,
    "scope": "https%3A%2F%2Fgraph.microsoft.com%2Fmail.read",
    "refresh_token": "AwABAAAAvPM1KaPlrEqdFSBzjqfTGAMxZGUTdM0t4B4...",
    "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIyZDRkMTFhMi1mODE0LTQ2YTctOD...",
}
```

ref: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#successful-response-3