### PR TITLE
expose identity traits

### DIFF
--- a/sdk/identity/src/lib.rs
+++ b/sdk/identity/src/lib.rs
@@ -51,4 +51,4 @@ mod errors;
 pub use errors::Error;
 pub mod refresh_token;
 pub mod token_credentials;
-mod traits;
+pub mod traits;

--- a/sdk/identity/src/lib.rs
+++ b/sdk/identity/src/lib.rs
@@ -51,4 +51,5 @@ mod errors;
 pub use errors::Error;
 pub mod refresh_token;
 pub mod token_credentials;
-pub mod traits;
+mod traits;
+pub use traits::{BearerToken, ExtExpiresIn, RefreshToken};


### PR DESCRIPTION
In order to use an access_token or refresh_token from from a RefreshTokenResponse, the BearerToken and RefreshToken taints must be exposed.  

Given the traits themselves were marked pub, I believe this was an oversight.

https://github.com/Azure/azure-sdk-for-rust/blob/cab39cd64acc78f83a02a9498cc0e7a9992d1c72/sdk/identity/src/traits.rs#L3-L8