### PR TITLE
Refactor pipeline operation dispatch

### DIFF
--- a/sdk/core/src/util.rs
+++ b/sdk/core/src/util.rs
@@ -8,6 +8,14 @@ use serde::{
 
 use std::{convert::TryFrom, fmt::Display, str::FromStr};
 
+/// An async version of the `std::convert::TryFrom` trait.
+#[async_trait::async_trait]
+pub trait AsyncTryFrom<T>: Sized {
+    type Error;
+
+    async fn try_from(value: T) -> Result<Self, Self::Error>;
+}
+
 pub fn format_header_value<D: Display>(value: D) -> Result<HeaderValue, http::Error> {
     let value: &str = &format(value);
     Ok(HeaderValue::try_from(value)?)

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -348,8 +348,7 @@ impl CosmosClient {
     where
         F: FnOnce(&mut azure_core::Request) -> crate::Result<()>,
     {
-        let mut request = self
-            .prepare_request_pipeline(uri_path, http_method);
+        let mut request = self.prepare_request_pipeline(uri_path, http_method);
         let mut pipeline_context = PipelineContext::new(ctx, resource_type.into());
         decorate_request(&mut request)?;
         let response = self

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -61,8 +61,7 @@ impl DatabaseClient {
         ctx: Context,
         options: GetDatabaseOptions,
     ) -> crate::Result<GetDatabaseResponse> {
-        let response = self
-            .cosmos_client()
+        self.cosmos_client()
             .run_pipeline(
                 ctx,
                 &format!("dbs/{}", self.database_name()),
@@ -70,9 +69,7 @@ impl DatabaseClient {
                 ResourceType::Databases,
                 |request| options.decorate_request(request),
             )
-            .await?;
-
-        Ok(GetDatabaseResponse::try_from(response).await?)
+            .await
     }
 
     /// Delete the database
@@ -81,8 +78,7 @@ impl DatabaseClient {
         ctx: Context,
         options: DeleteDatabaseOptions,
     ) -> crate::Result<DeleteDatabaseResponse> {
-        let response = self
-            .cosmos_client()
+        self.cosmos_client()
             .run_pipeline(
                 ctx,
                 &format!("dbs/{}", self.database_name()),
@@ -90,9 +86,7 @@ impl DatabaseClient {
                 ResourceType::Databases,
                 |request| options.decorate_request(request),
             )
-            .await?;
-
-        Ok(DeleteDatabaseResponse::try_from(response).await?)
+            .await
     }
 
     /// List collections in the database
@@ -109,8 +103,7 @@ impl DatabaseClient {
         where
             F: FnOnce(&mut azure_core::Request) -> crate::Result<()> + 'a,
         {
-            let response = this
-                .cosmos_client()
+            this.cosmos_client()
                 .run_pipeline(
                     ctx,
                     &format!("dbs/{}/colls", this.database_name()),
@@ -118,8 +111,7 @@ impl DatabaseClient {
                     ResourceType::Users,
                     options,
                 )
-                .await?;
-            ListCollectionsResponse::try_from(response).await
+                .await
         }
         unfold(State::Init, move |state: State| {
             let ctx = ctx.clone();
@@ -159,8 +151,7 @@ impl DatabaseClient {
         collection_name: S,
         options: CreateCollectionOptions,
     ) -> crate::Result<CreateCollectionResponse> {
-        let response = self
-            .cosmos_client()
+        self.cosmos_client()
             .run_pipeline(
                 ctx,
                 &format!("dbs/{}/colls", self.database_name()),
@@ -168,9 +159,7 @@ impl DatabaseClient {
                 ResourceType::Collections,
                 |request| options.decorate_request(request, collection_name.as_ref()),
             )
-            .await?;
-
-        Ok(CreateCollectionResponse::try_from(response).await?)
+            .await
     }
 
     /// List users
@@ -187,8 +176,7 @@ impl DatabaseClient {
         where
             F: FnOnce(&mut azure_core::Request) -> crate::Result<()> + 'a,
         {
-            let response = this
-                .cosmos_client()
+            this.cosmos_client()
                 .run_pipeline(
                     ctx,
                     &format!("dbs/{}/users", this.database_name()),
@@ -196,8 +184,7 @@ impl DatabaseClient {
                     ResourceType::Users,
                     options,
                 )
-                .await?;
-            ListUsersResponse::try_from(response).await
+                .await
         }
         unfold(State::Init, move |state: State| {
             let ctx = ctx.clone();

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -68,7 +68,7 @@ impl DatabaseClient {
                 &format!("dbs/{}", self.database_name()),
                 http::Method::GET,
                 ResourceType::Databases,
-                |request: &mut azure_core::Request| options.decorate_request(request),
+                |request| options.decorate_request(request),
             )
             .await?;
 

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -63,15 +63,15 @@ impl DatabaseClient {
         ctx: Context,
         options: GetDatabaseOptions,
     ) -> crate::Result<GetDatabaseResponse> {
-        let mut request = self
-            .cosmos_client()
-            .prepare_request_pipeline(&format!("dbs/{}", self.database_name()), http::Method::GET);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Databases.into());
-
-        options.decorate_request(&mut request)?;
         let response = self
-            .pipeline()
-            .send(&mut pipeline_context, &mut request)
+            .cosmos_client()
+            .run_pipeline(
+                ctx,
+                &format!("dbs/{}", self.database_name()),
+                http::Method::GET,
+                ResourceType::Databases,
+                |request: &mut azure_core::Request| options.decorate_request(request),
+            )
             .await?;
 
         Ok(GetDatabaseResponse::try_from(response).await?)
@@ -83,16 +83,15 @@ impl DatabaseClient {
         ctx: Context,
         options: DeleteDatabaseOptions,
     ) -> crate::Result<DeleteDatabaseResponse> {
-        let mut request = self.cosmos_client().prepare_request_pipeline(
-            &format!("dbs/{}", self.database_name()),
-            http::Method::DELETE,
-        );
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Databases.into());
-
-        options.decorate_request(&mut request)?;
         let response = self
-            .pipeline()
-            .send(&mut pipeline_context, &mut request)
+            .cosmos_client()
+            .run_pipeline(
+                ctx,
+                &format!("dbs/{}", self.database_name()),
+                http::Method::DELETE,
+                ResourceType::Databases,
+                |request| options.decorate_request(request),
+            )
             .await?;
 
         Ok(DeleteDatabaseResponse::try_from(response).await?)
@@ -167,16 +166,15 @@ impl DatabaseClient {
         collection_name: S,
         options: CreateCollectionOptions,
     ) -> crate::Result<CreateCollectionResponse> {
-        let mut request = self.cosmos_client().prepare_request_pipeline(
-            &format!("dbs/{}/colls", self.database_name()),
-            http::Method::POST,
-        );
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Collections.into());
-
-        options.decorate_request(&mut request, collection_name.as_ref())?;
         let response = self
-            .pipeline()
-            .send(&mut pipeline_context, &mut request)
+            .cosmos_client()
+            .run_pipeline(
+                ctx,
+                &format!("dbs/{}/colls", self.database_name()),
+                http::Method::POST,
+                ResourceType::Collections,
+                |request| options.decorate_request(request, collection_name.as_ref()),
+            )
             .await?;
 
         Ok(CreateCollectionResponse::try_from(response).await?)

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -61,7 +61,7 @@ impl DatabaseClient {
         ctx: Context,
         options: GetDatabaseOptions,
     ) -> crate::Result<GetDatabaseResponse> {
-        self.run_databases_pipeline(ctx, http::Method::GET, |request| {
+        self.run_dbs_pipeline(ctx, http::Method::GET, |request| {
             options.decorate_request(request)
         })
         .await
@@ -73,7 +73,7 @@ impl DatabaseClient {
         ctx: Context,
         options: DeleteDatabaseOptions,
     ) -> crate::Result<DeleteDatabaseResponse> {
-        self.run_databases_pipeline(ctx, http::Method::DELETE, |request| {
+        self.run_dbs_pipeline(ctx, http::Method::DELETE, |request| {
             options.decorate_request(request)
         })
         .await
@@ -91,14 +91,14 @@ impl DatabaseClient {
             async move {
                 let response = match state {
                     State::Init => {
-                        self.run_collections_pipeline(ctx, http::Method::GET, |req| {
+                        self.run_colls_pipeline(ctx, http::Method::GET, |req| {
                             options.decorate_request(req)
                         })
                         .await
                     }
                     State::Continuation(continuation_token) => {
                         let continuation = Continuation::new(continuation_token.as_str());
-                        self.run_collections_pipeline(ctx, http::Method::GET, |req| {
+                        self.run_colls_pipeline(ctx, http::Method::GET, |req| {
                             options.decorate_request(req)?;
                             continuation.add_as_header2(req)?;
                             Ok(())
@@ -128,7 +128,7 @@ impl DatabaseClient {
         collection_name: S,
         options: CreateCollectionOptions,
     ) -> crate::Result<CreateCollectionResponse> {
-        self.run_collections_pipeline(ctx, http::Method::POST, |request| {
+        self.run_colls_pipeline(ctx, http::Method::POST, |request| {
             options.decorate_request(request, collection_name.as_ref())
         })
         .await
@@ -189,7 +189,7 @@ impl DatabaseClient {
         UserClient::new(self, user_name)
     }
 
-    async fn run_databases_pipeline<'a, F, T>(
+    async fn run_dbs_pipeline<'a, F, T>(
         &'a self,
         ctx: Context,
         method: http::Method,
@@ -210,7 +210,7 @@ impl DatabaseClient {
             .await
     }
 
-    async fn run_collections_pipeline<'a, F, T>(
+    async fn run_colls_pipeline<'a, F, T>(
         &'a self,
         ctx: Context,
         method: http::Method,

--- a/sdk/cosmos/src/operations/create_collection.rs
+++ b/sdk/cosmos/src/operations/create_collection.rs
@@ -75,8 +75,11 @@ pub struct CreateCollectionResponse {
     pub current_replica_set_size: u64,
 }
 
-impl CreateCollectionResponse {
-    pub async fn try_from(response: HttpResponse) -> crate::Result<Self> {
+#[async_trait::async_trait]
+impl azure_core::util::AsyncTryFrom<HttpResponse> for CreateCollectionResponse {
+    type Error = crate::Error;
+
+    async fn try_from(response: HttpResponse) -> crate::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/cosmos/src/operations/create_database.rs
+++ b/sdk/cosmos/src/operations/create_database.rs
@@ -59,8 +59,11 @@ pub struct CreateDatabaseResponse {
     pub gateway_version: String,
 }
 
-impl CreateDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> crate::Result<Self> {
+#[async_trait::async_trait]
+impl azure_core::util::AsyncTryFrom<HttpResponse> for CreateDatabaseResponse {
+    type Error = crate::Error;
+
+    async fn try_from(response: HttpResponse) -> crate::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/cosmos/src/operations/delete_database.rs
+++ b/sdk/cosmos/src/operations/delete_database.rs
@@ -36,8 +36,11 @@ pub struct DeleteDatabaseResponse {
     pub resource_usage: Vec<ResourceQuota>,
 }
 
-impl DeleteDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> crate::Result<Self> {
+#[async_trait::async_trait]
+impl azure_core::util::AsyncTryFrom<HttpResponse> for DeleteDatabaseResponse {
+    type Error = crate::Error;
+
+    async fn try_from(response: HttpResponse) -> crate::Result<Self> {
         let headers = response.headers();
 
         let charge = request_charge_from_headers(headers)?;

--- a/sdk/cosmos/src/operations/get_database.rs
+++ b/sdk/cosmos/src/operations/get_database.rs
@@ -45,8 +45,11 @@ pub struct GetDatabaseResponse {
     pub gateway_version: String,
 }
 
-impl GetDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> crate::Result<Self> {
+#[async_trait::async_trait]
+impl azure_core::util::AsyncTryFrom<HttpResponse> for GetDatabaseResponse {
+    type Error = crate::Error;
+
+    async fn try_from(response: HttpResponse) -> crate::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/cosmos/src/operations/list_collections.rs
+++ b/sdk/cosmos/src/operations/list_collections.rs
@@ -55,8 +55,11 @@ pub struct ListCollectionsResponse {
     pub continuation_token: Option<String>,
 }
 
-impl ListCollectionsResponse {
-    pub async fn try_from(response: HttpResponse) -> crate::Result<Self> {
+#[async_trait::async_trait]
+impl azure_core::util::AsyncTryFrom<HttpResponse> for ListCollectionsResponse {
+    type Error = crate::Error;
+
+    async fn try_from(response: HttpResponse) -> crate::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/cosmos/src/operations/list_databases.rs
+++ b/sdk/cosmos/src/operations/list_databases.rs
@@ -26,7 +26,7 @@ impl ListDatabasesOptions {
         max_item_count: i32 => MaxItemCount::new(max_item_count),
     }
 
-    pub async fn decorate_request(&self, request: &mut Request) -> crate::Result<()> {
+    pub fn decorate_request(&self, request: &mut Request) -> crate::Result<()> {
         azure_core::headers::add_optional_header2(&self.consistency_level, request)?;
         azure_core::headers::add_mandatory_header2(&self.max_item_count, request)?;
         Ok(())
@@ -50,10 +50,11 @@ pub struct ListDatabasesResponse {
     pub gateway_version: String,
 }
 
-impl ListDatabasesResponse {
-    // TODO: To remove pragma when list_databases has been re-enabled
-    #[allow(dead_code)]
-    pub(crate) async fn try_from(response: Response) -> crate::Result<Self> {
+#[async_trait::async_trait]
+impl azure_core::util::AsyncTryFrom<Response> for ListDatabasesResponse {
+    type Error = crate::Error;
+
+    async fn try_from(response: Response) -> crate::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/cosmos/src/operations/list_users.rs
+++ b/sdk/cosmos/src/operations/list_users.rs
@@ -46,8 +46,11 @@ pub struct ListUsersResponse {
     pub continuation_token: Option<String>,
 }
 
-impl ListUsersResponse {
-    pub async fn try_from(response: HttpResponse) -> crate::Result<Self> {
+#[async_trait::async_trait]
+impl azure_core::util::AsyncTryFrom<HttpResponse> for ListUsersResponse {
+    type Error = crate::Error;
+
+    async fn try_from(response: HttpResponse) -> crate::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 


### PR DESCRIPTION
This is an attempt to clean up the dispatching of pipeline operations. Unfortunately, it doesn't really save very much on *lines* of code, but it is less code overall. 

Abstracting over the stream code has proven to be quite difficult, and is likely impossible without resorting to dynamic dispatch and adding some traits for things. 