### PR TITLE
Remove context as a parameter the user provides

### DIFF
--- a/sdk/cosmos/examples/attachments_00.rs
+++ b/sdk/cosmos/examples/attachments_00.rs
@@ -1,4 +1,3 @@
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -58,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // let's add an entity.
     match client
-        .create_document(Context::new(), &doc, CreateDocumentOptions::new())
+        .create_document(&doc, CreateDocumentOptions::new())
         .await
     {
         Ok(_) => {

--- a/sdk/cosmos/examples/cancellation.rs
+++ b/sdk/cosmos/examples/cancellation.rs
@@ -1,4 +1,3 @@
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use stop_token::prelude::*;
 use stop_token::StopSource;
@@ -20,7 +19,7 @@ async fn main() -> azure_cosmos::Result<()> {
 
     // Create a new database, and time out if it takes more than 1 second.
     let options = CreateDatabaseOptions::new();
-    let future = client.create_database(Context::new(), "my_database", options);
+    let future = client.create_database("my_database", options);
     let deadline = Instant::now() + Duration::from_secs(1);
     match future.until(deadline).await {
         Ok(Ok(r)) => println!("successful response: {:?}", r),
@@ -37,7 +36,7 @@ async fn main() -> azure_cosmos::Result<()> {
         let stop = source.token();
         tokio::spawn(async move {
             let options = CreateDatabaseOptions::new();
-            let future = client.create_database(Context::new(), "my_database", options);
+            let future = client.create_database("my_database", options);
             match future.until(stop).await {
                 Ok(Ok(r)) => println!("successful response: {:?}", r),
                 Ok(Err(e)) => println!("request was made but failed: {:?}", e),

--- a/sdk/cosmos/examples/collection.rs.disabled
+++ b/sdk/cosmos/examples/collection.rs.disabled
@@ -1,4 +1,4 @@
-use azure_core::prelude::*;
+
 use azure_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use std::error::Error;
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // The Cosmos' client exposes a lot of methods. This one lists the databases in the specified
     // account. Database do not implement Display but deref to &str so you can pass it to methods
     // both as struct or id.
-    let databases = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+    let databases = Box::pin(client.list_databases(ListDatabasesOptions::new()))
         .next()
         .await
         .unwrap()?;
@@ -51,7 +51,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let db = client
             .clone()
             .into_database_client(db.id.clone())
-            .get_database(Context::new(), GetDatabaseOptions::default())
+            .get_database(GetDatabaseOptions::default())
             .await?;
         println!("db {} found == {:?}", &db.database.id, &db);
     }
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             let collection_response = database_client
                 .clone()
                 .into_collection_client(collection.id)
-                .get_collection(Context::new(), GetCollectionOptions::new())
+                .get_collection(GetCollectionOptions::new())
                 .await?;
 
             println!("\tcollection_response {:?}", collection_response);

--- a/sdk/cosmos/examples/create_delete_database.rs.disabled
+++ b/sdk/cosmos/examples/create_delete_database.rs.disabled
@@ -1,4 +1,4 @@
-use azure_core::Context;
+
 use azure_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use std::error::Error;
@@ -37,14 +37,14 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // both as struct or id.
 
     let mut list_databases_stream =
-        Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()));
+        Box::pin(client.list_databases(ListDatabasesOptions::new()));
     while let Some(list_databases_response) = list_databases_stream.next().await {
         println!("list_databases_response = {:#?}", list_databases_response?);
     }
     drop(list_databases_stream);
 
     let db = client
-        .create_database(Context::new(), &database_name, CreateDatabaseOptions::new())
+        .create_database(&database_name, CreateDatabaseOptions::new())
         .await?;
     println!("created database = {:#?}", db);
 
@@ -54,7 +54,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
         let create_collection_response = db_client
             .create_collection(
-                Context::new(),
+                
                 "panzadoro",
                 CreateCollectionOptions::new("/id"),
             )
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         let db_collection = db_client.clone().into_collection_client("panzadoro");
 
         let get_collection_response = db_collection
-            .get_collection(Context::new(), GetCollectionOptions::new())
+            .get_collection(GetCollectionOptions::new())
             .await?;
         println!("get_collection_response == {:#?}", get_collection_response);
 
@@ -80,7 +80,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         }
 
         let delete_response = db_collection
-            .delete_collection(Context::new(), DeleteCollectionOptions::new())
+            .delete_collection(DeleteCollectionOptions::new())
             .await?;
         println!("collection deleted: {:#?}", delete_response);
     }

--- a/sdk/cosmos/examples/database_00.rs.disabled
+++ b/sdk/cosmos/examples/database_00.rs.disabled
@@ -1,4 +1,4 @@
-use azure_core::Context;
+
 use azure_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use serde_json::Value;
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
 
-    let dbs = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+    let dbs = Box::pin(client.list_databases(ListDatabasesOptions::new()))
         .next()
         .await
         .unwrap()?;
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                     .partition_key(&43u32)
                     .unwrap();
                 let resp = collection_client
-                    .create_document(Context::new(), &document, options)
+                    .create_document(&document, options)
                     .await?;
 
                 println!("resp == {:?}", resp);
@@ -64,7 +64,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 println!("\nReplacing collection");
                 let replace_collection_response = collection_client
                     .replace_collection(
-                        Context::new(),
+                        
                         ReplaceCollectionOptions::new("/age").indexing_policy(indexing_policy_new),
                     )
                     .await?;

--- a/sdk/cosmos/examples/database_01.rs
+++ b/sdk/cosmos/examples/database_01.rs
@@ -1,4 +1,3 @@
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use std::error::Error;
@@ -18,16 +17,15 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let database_client = client.into_database_client("pollo");
     println!("database_name == {}", database_client.database_name());
 
-    let collections =
-        Box::pin(database_client.list_collections(Context::new(), ListCollectionsOptions::new()))
-            .next()
-            .await
-            .unwrap()?;
+    let collections = Box::pin(database_client.list_collections(ListCollectionsOptions::new()))
+        .next()
+        .await
+        .unwrap()?;
     println!("collections == {:#?}", collections);
 
     let collection_client = database_client.into_collection_client("cnt");
     let collection = collection_client
-        .get_collection(Context::new(), GetCollectionOptions::new())
+        .get_collection(GetCollectionOptions::new())
         .await?;
     println!("collection == {:#?}", collection);
 

--- a/sdk/cosmos/examples/document_00.rs.disabled
+++ b/sdk/cosmos/examples/document_00.rs.disabled
@@ -2,7 +2,7 @@ use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos
 // DB.
-use azure_core::prelude::*;
+
 use azure_cosmos::prelude::*;
 use std::borrow::Cow;
 use std::error::Error;
@@ -57,7 +57,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // an error (for example, the given key is not valid) you will receive a
     // specific azure_cosmos::Error. In this example we will look for a specific database
     // so we chain a filter operation.
-    let db = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+    let db = Box::pin(client.list_databases(ListDatabasesOptions::new()))
         .next()
         .await
         .unwrap()?
@@ -70,7 +70,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         Some(db) => db,
         None => {
             client
-                .create_database(Context::new(), DATABASE, CreateDatabaseOptions::new())
+                .create_database(DATABASE, CreateDatabaseOptions::new())
                 .await?
                 .database
         }
@@ -99,7 +99,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 .clone()
                 .into_database_client(database.id.clone())
                 .create_collection(
-                    Context::new(),
+                    
                     COLLECTION,
                     CreateCollectionOptions::new("/id"),
                 )
@@ -131,7 +131,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // the document attributes.
 
     let create_document_response = collection_client
-        .create_document(Context::new(), &doc, CreateDocumentOptions::new())
+        .create_document(&doc, CreateDocumentOptions::new())
         .await?;
     println!(
         "create_document_response == {:#?}",
@@ -155,7 +155,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let get_document_response = collection_client
         .clone()
         .into_document_client(doc.id.clone(), &doc.id)?
-        .get_document::<MySampleStruct>(Context::new(), GetDocumentOptions::new())
+        .get_document::<MySampleStruct>(GetDocumentOptions::new())
         .await?;
     println!("get_document_response == {:#?}", get_document_response);
 
@@ -187,7 +187,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .clone()
         .into_database_client(DATABASE.to_owned())
         .into_collection_client(COLLECTION.to_owned())
-        .delete_collection(Context::new(), DeleteCollectionOptions::new())
+        .delete_collection(DeleteCollectionOptions::new())
         .await?;
     println!("collection deleted");
 

--- a/sdk/cosmos/examples/document_entries_00.rs
+++ b/sdk/cosmos/examples/document_entries_00.rs
@@ -60,7 +60,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // let's add an entity.
         response = Some(
             client
-                .create_document(Context::new(), &doc, CreateDocumentOptions::new())
+                .create_document(&doc, CreateDocumentOptions::new())
                 .await?,
         );
     }
@@ -128,10 +128,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let response = client
         .clone()
         .into_document_client(id.clone(), partition_key)?
-        .get_document::<MySampleStruct>(
-            Context::new(),
-            GetDocumentOptions::new().consistency_level(session_token),
-        )
+        .get_document::<MySampleStruct>(GetDocumentOptions::new().consistency_level(session_token))
         .await?;
 
     assert!(matches!(response, GetDocumentResponse::Found(_)));
@@ -166,10 +163,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let response = client
         .clone()
         .into_document_client(id.clone(), &id)?
-        .get_document::<MySampleStruct>(
-            Context::new(),
-            GetDocumentOptions::new().consistency_level(&response),
-        )
+        .get_document::<MySampleStruct>(GetDocumentOptions::new().consistency_level(&response))
         .await?;
 
     assert!(matches!(response, GetDocumentResponse::NotFound(_)));

--- a/sdk/cosmos/examples/document_entries_01.rs
+++ b/sdk/cosmos/examples/document_entries_01.rs
@@ -1,4 +1,3 @@
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -50,11 +49,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // let's add an entity.
     let create_document_response = client
-        .create_document(
-            Context::new(),
-            &doc,
-            CreateDocumentOptions::new().is_upsert(true),
-        )
+        .create_document(&doc, CreateDocumentOptions::new().is_upsert(true))
         .await?;
 
     println!(
@@ -66,7 +61,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .clone()
         .into_document_client(doc.id.clone(), &doc.id)?
         .get_document::<serde_json::Value>(
-            Context::new(),
             GetDocumentOptions::new().consistency_level(&create_document_response),
         )
         .await?;
@@ -76,7 +70,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .clone()
         .into_document_client("ciccia", &doc.id)?
         .get_document::<serde_json::Value>(
-            Context::new(),
             GetDocumentOptions::new().consistency_level(&create_document_response),
         )
         .await?;

--- a/sdk/cosmos/examples/get_database.rs
+++ b/sdk/cosmos/examples/get_database.rs
@@ -1,4 +1,3 @@
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use std::error::Error;
 
@@ -25,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let database_client = client.into_database_client(database_name.clone());
 
     let response = database_client
-        .get_database(Context::new(), GetDatabaseOptions::new())
+        .get_database(GetDatabaseOptions::new())
         .await?;
     println!("response == {:?}", response);
 

--- a/sdk/cosmos/examples/permission_00.rs
+++ b/sdk/cosmos/examples/permission_00.rs
@@ -1,4 +1,3 @@
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use std::error::Error;
 
@@ -41,17 +40,17 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let user_client = database_client.clone().into_user_client(user_name);
 
     let get_database_response = database_client
-        .get_database(Context::new(), GetDatabaseOptions::new())
+        .get_database(GetDatabaseOptions::new())
         .await?;
     println!("get_database_response == {:#?}", get_database_response);
 
     let get_collection_response = collection_client
-        .get_collection(Context::new(), GetCollectionOptions::new())
+        .get_collection(GetCollectionOptions::new())
         .await?;
     println!("get_collection_response == {:#?}", get_collection_response);
 
     let get_collection2_response = collection2_client
-        .get_collection(Context::new(), GetCollectionOptions::new())
+        .get_collection(GetCollectionOptions::new())
         .await?;
     println!(
         "get_collection2_response == {:#?}",
@@ -59,7 +58,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     );
 
     let create_user_response = user_client
-        .create_user(Context::new(), CreateUserOptions::default())
+        .create_user(CreateUserOptions::default())
         .await?;
     println!("create_user_response == {:#?}", create_user_response);
 
@@ -69,7 +68,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_permission_response = permission_client
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new()
                 .consistency_level(&create_user_response)
                 .expiry_seconds(18000u64),
@@ -88,7 +86,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_permission2_response = permission_client
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new().consistency_level(&create_user_response),
             &permission_mode,
         )
@@ -113,15 +110,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         list_permissions_response
     );
 
-    let get_permission_response = permission_client
-        .get_permission(
-            Context::new(),
-            GetPermissionOptions::new().consistency_level(ConsistencyLevel::Session(
-                list_permissions_response.session_token,
-            )),
-        )
-        .await
-        .unwrap();
+    let get_permission_response =
+        permission_client
+            .get_permission(GetPermissionOptions::new().consistency_level(
+                ConsistencyLevel::Session(list_permissions_response.session_token),
+            ))
+            .await
+            .unwrap();
     println!("get_permission_response == {:#?}", get_permission_response);
 
     let permission_mode = &get_permission_response.permission.permission_mode;
@@ -129,7 +124,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // renew permission extending its validity for 60 seconds more.
     let replace_permission_response = permission_client
         .replace_permission(
-            Context::new(),
             ReplacePermissionOptions::new()
                 .expiry_seconds(600u64)
                 .consistency_level(ConsistencyLevel::Session(
@@ -145,12 +139,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     );
 
     let delete_permission_response = permission_client
-        .delete_permission(
-            Context::new(),
-            DeletePermissionOptions::new().consistency_level(ConsistencyLevel::Session(
-                replace_permission_response.session_token,
-            )),
-        )
+        .delete_permission(DeletePermissionOptions::new().consistency_level(
+            ConsistencyLevel::Session(replace_permission_response.session_token),
+        ))
         .await
         .unwrap();
 
@@ -161,7 +152,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let delete_user_response = user_client
         .delete_user(
-            Context::new(),
             DeleteUserOptions::new().consistency_level(ConsistencyLevel::Session(
                 delete_permission_response.session_token,
             )),

--- a/sdk/cosmos/examples/readme.rs
+++ b/sdk/cosmos/examples/readme.rs
@@ -1,4 +1,3 @@
-use azure_core::Context;
 use serde::{Deserialize, Serialize};
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos.
 use azure_cosmos::prelude::*;
@@ -81,7 +80,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         session_token = Some(
             collection_client
                 .create_document(
-                    Context::new(),
                     &document_to_insert,
                     CreateDocumentOptions::new().is_upsert(true),
                 )

--- a/sdk/cosmos/examples/user_00.rs
+++ b/sdk/cosmos/examples/user_00.rs
@@ -1,4 +1,3 @@
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use std::error::Error;
@@ -29,35 +28,29 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let database_client = client.into_database_client(database_name);
     let user_client = database_client.clone().into_user_client(user_name.clone());
 
-    let create_user_response = user_client
-        .create_user(Context::new(), CreateUserOptions::new())
-        .await?;
+    let create_user_response = user_client.create_user(CreateUserOptions::new()).await?;
     println!("create_user_response == {:#?}", create_user_response);
 
-    let users = Box::pin(database_client.list_users(Context::new(), ListUsersOptions::new()))
+    let users = Box::pin(database_client.list_users(ListUsersOptions::new()))
         .next()
         .await
         .unwrap()?;
 
     println!("list_users_response == {:#?}", users);
 
-    let get_user_response = user_client
-        .get_user(Context::new(), GetUserOptions::new())
-        .await?;
+    let get_user_response = user_client.get_user(GetUserOptions::new()).await?;
     println!("get_user_response == {:#?}", get_user_response);
 
     let new_user = format!("{}replaced", user_name);
 
     let replace_user_response = user_client
-        .replace_user(Context::new(), &new_user, ReplaceUserOptions::new())
+        .replace_user(&new_user, ReplaceUserOptions::new())
         .await?;
     println!("replace_user_response == {:#?}", replace_user_response);
 
     let user_client = database_client.into_user_client(new_user);
 
-    let delete_user_response = user_client
-        .delete_user(Context::new(), DeleteUserOptions::new())
-        .await?;
+    let delete_user_response = user_client.delete_user(DeleteUserOptions::new()).await?;
     println!("delete_user_response == {:#?}", delete_user_response);
 
     Ok(())

--- a/sdk/cosmos/examples/user_permission_token.rs
+++ b/sdk/cosmos/examples/user_permission_token.rs
@@ -1,4 +1,3 @@
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use std::error::Error;
 
@@ -35,12 +34,12 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let user_client = database_client.into_user_client(user_name);
 
     let get_collection_response = collection_client
-        .get_collection(Context::new(), GetCollectionOptions::new())
+        .get_collection(GetCollectionOptions::new())
         .await?;
     println!("get_collection_response == {:#?}", get_collection_response);
 
     let create_user_response = user_client
-        .create_user(Context::new(), CreateUserOptions::default())
+        .create_user(CreateUserOptions::default())
         .await?;
     println!("create_user_response == {:#?}", create_user_response);
 
@@ -62,7 +61,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let create_permission_response = permission_client
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new().expiry_seconds(18000u64), // 5 hours, max!
             &permission_mode,
         )
@@ -121,7 +119,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_database_client(database_name.clone())
         .into_collection_client(collection_name.clone())
         .create_document(
-            Context::new(),
             &document,
             CreateDocumentOptions::new()
                 .is_upsert(true)
@@ -135,14 +132,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     }
 
     permission_client
-        .delete_permission(Context::new(), DeletePermissionOptions::new())
+        .delete_permission(DeletePermissionOptions::new())
         .await?;
 
     // All includes read and write.
     let permission_mode = get_collection_response.collection.all_permission();
     let create_permission_response = permission_client
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new().expiry_seconds(18000u64), // 5 hours, max!
             &permission_mode,
         )
@@ -170,7 +166,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .into_database_client(database_name)
         .into_collection_client(collection_name)
         .create_document(
-            Context::new(),
             &document,
             CreateDocumentOptions::new()
                 .is_upsert(true)
@@ -184,9 +179,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     );
 
     println!("Cleaning up user.");
-    let delete_user_response = user_client
-        .delete_user(Context::new(), DeleteUserOptions::new())
-        .await?;
+    let delete_user_response = user_client.delete_user(DeleteUserOptions::new()).await?;
     println!("delete_user_response == {:#?}", delete_user_response);
 
     Ok(())

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -46,12 +46,12 @@ impl CollectionClient {
     /// Get a collection
     pub async fn get_collection(
         &self,
-        ctx: Context,
         options: GetCollectionOptions,
     ) -> crate::Result<GetCollectionResponse> {
         let mut request = self.prepare_request_with_collection_name(http::Method::GET);
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Collections.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Collections.into());
 
         options.decorate_request(&mut request)?;
 
@@ -66,12 +66,12 @@ impl CollectionClient {
     /// Delete a collection
     pub async fn delete_collection(
         &self,
-        ctx: Context,
         options: DeleteCollectionOptions,
     ) -> crate::Result<DeleteCollectionResponse> {
         let mut request = self.prepare_request_with_collection_name(http::Method::DELETE);
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Collections.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Collections.into());
 
         options.decorate_request(&mut request)?;
 
@@ -86,12 +86,12 @@ impl CollectionClient {
     /// Replace a collection
     pub async fn replace_collection(
         &self,
-        ctx: Context,
         options: ReplaceCollectionOptions,
     ) -> crate::Result<ReplaceCollectionResponse> {
         let mut request = self.prepare_request_with_collection_name(http::Method::PUT);
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Collections.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Collections.into());
 
         options.decorate_request(&mut request, self.collection_name())?;
 
@@ -111,12 +111,12 @@ impl CollectionClient {
     /// create a document in a collection
     pub async fn create_document<'a, D: Serialize + CosmosEntity<'a>>(
         &self,
-        ctx: Context,
         document: &'a D,
         options: CreateDocumentOptions<'_>,
     ) -> crate::Result<CreateDocumentResponse> {
         let mut request = self.prepare_doc_request_pipeline(http::Method::POST);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Documents.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Documents.into());
 
         options.decorate_request(&mut request, document)?;
         let response = self

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -179,13 +179,13 @@ impl CosmosClient {
     /// Create a database
     pub async fn create_database<S: AsRef<str>>(
         &self,
-        ctx: Context,
         database_name: S,
         options: CreateDatabaseOptions,
     ) -> crate::Result<CreateDatabaseResponse> {
         let mut request = self.prepare_request_pipeline("dbs", http::Method::POST);
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Databases.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Databases.into());
 
         options.decorate_request(&mut request, database_name.as_ref())?;
         let response = self
@@ -199,9 +199,9 @@ impl CosmosClient {
     /// List all databases
     pub fn list_databases(
         &self,
-        ctx: Context,
         options: ListDatabasesOptions,
     ) -> impl Stream<Item = crate::Result<ListDatabasesResponse>> + '_ {
+        let ctx = Context::new();
         macro_rules! r#try {
             ($expr:expr $(,)?) => {
                 match $expr {

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -60,13 +60,13 @@ impl DatabaseClient {
     /// Get the database
     pub async fn get_database(
         &self,
-        ctx: Context,
         options: GetDatabaseOptions,
     ) -> crate::Result<GetDatabaseResponse> {
         let mut request = self
             .cosmos_client()
             .prepare_request_pipeline(&format!("dbs/{}", self.database_name()), http::Method::GET);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Databases.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Databases.into());
 
         options.decorate_request(&mut request)?;
         let response = self
@@ -80,14 +80,14 @@ impl DatabaseClient {
     /// Delete the database
     pub async fn delete_database(
         &self,
-        ctx: Context,
         options: DeleteDatabaseOptions,
     ) -> crate::Result<DeleteDatabaseResponse> {
         let mut request = self.cosmos_client().prepare_request_pipeline(
             &format!("dbs/{}", self.database_name()),
             http::Method::DELETE,
         );
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Databases.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Databases.into());
 
         options.decorate_request(&mut request)?;
         let response = self
@@ -101,9 +101,9 @@ impl DatabaseClient {
     /// List collections in the database
     pub fn list_collections(
         &self,
-        ctx: Context,
         options: ListCollectionsOptions,
     ) -> impl Stream<Item = crate::Result<ListCollectionsResponse>> + '_ {
+        let ctx = Context::new();
         unfold(State::Init, move |state: State| {
             let this = self.clone();
             let ctx = ctx.clone();
@@ -163,7 +163,6 @@ impl DatabaseClient {
     /// Create a collection
     pub async fn create_collection<S: AsRef<str>>(
         &self,
-        ctx: Context,
         collection_name: S,
         options: CreateCollectionOptions,
     ) -> crate::Result<CreateCollectionResponse> {
@@ -171,7 +170,8 @@ impl DatabaseClient {
             &format!("dbs/{}/colls", self.database_name()),
             http::Method::POST,
         );
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Collections.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Collections.into());
 
         options.decorate_request(&mut request, collection_name.as_ref())?;
         let response = self
@@ -185,9 +185,9 @@ impl DatabaseClient {
     /// List users
     pub fn list_users(
         &self,
-        ctx: Context,
         options: ListUsersOptions,
     ) -> impl Stream<Item = crate::Result<ListUsersResponse>> + '_ {
+        let ctx = Context::new();
         unfold(State::Init, move |state: State| {
             let this = self.clone();
             let ctx = ctx.clone();

--- a/sdk/cosmos/src/clients/document_client.rs
+++ b/sdk/cosmos/src/clients/document_client.rs
@@ -65,14 +65,14 @@ impl DocumentClient {
     /// Get a document
     pub async fn get_document<T>(
         &self,
-        ctx: Context,
         options: GetDocumentOptions<'_>,
     ) -> crate::Result<GetDocumentResponse<T>>
     where
         T: DeserializeOwned,
     {
         let mut request = self.prepare_request_pipeline_with_document_name(http::Method::GET);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Databases.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Databases.into());
 
         options.decorate_request(&mut request)?;
 

--- a/sdk/cosmos/src/clients/permission_client.rs
+++ b/sdk/cosmos/src/clients/permission_client.rs
@@ -47,7 +47,6 @@ impl PermissionClient {
     /// Create the permission
     pub async fn create_permission(
         &self,
-        ctx: Context,
         options: CreatePermissionOptions,
         permission_mode: &PermissionMode<'_>,
     ) -> crate::Result<PermissionResponse<'_>> {
@@ -60,7 +59,8 @@ impl PermissionClient {
             http::Method::POST,
         );
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Permissions.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Permissions.into());
 
         options.decorate_request(&mut request, self.permission_name(), permission_mode)?;
 
@@ -75,13 +75,13 @@ impl PermissionClient {
     /// Replace the permission
     pub async fn replace_permission(
         &self,
-        ctx: Context,
         options: ReplacePermissionOptions,
         permission_mode: &PermissionMode<'_>,
     ) -> crate::Result<PermissionResponse<'_>> {
         let mut request = self.prepare_request_with_permission_name(http::Method::PUT);
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Permissions.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Permissions.into());
 
         options.decorate_request(&mut request, self.permission_name(), permission_mode)?;
 
@@ -96,12 +96,12 @@ impl PermissionClient {
     /// Get the permission
     pub async fn get_permission(
         &self,
-        ctx: Context,
         options: GetPermissionOptions,
     ) -> crate::Result<PermissionResponse<'_>> {
         let mut request = self.prepare_request_with_permission_name(http::Method::GET);
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Permissions.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Permissions.into());
 
         options.decorate_request(&mut request)?;
 
@@ -116,12 +116,12 @@ impl PermissionClient {
     /// Delete the permission
     pub async fn delete_permission(
         &self,
-        ctx: Context,
         options: DeletePermissionOptions,
     ) -> crate::Result<DeletePermissionResponse> {
         let mut request = self.prepare_request_with_permission_name(http::Method::DELETE);
 
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Permissions.into());
+        let mut pipeline_context =
+            PipelineContext::new(Context::new(), ResourceType::Permissions.into());
 
         options.decorate_request(&mut request)?;
 

--- a/sdk/cosmos/src/clients/user_client.rs
+++ b/sdk/cosmos/src/clients/user_client.rs
@@ -41,16 +41,12 @@ impl UserClient {
     }
 
     /// Create the user
-    pub async fn create_user(
-        &self,
-        ctx: Context,
-        options: CreateUserOptions,
-    ) -> crate::Result<UserResponse> {
+    pub async fn create_user(&self, options: CreateUserOptions) -> crate::Result<UserResponse> {
         let mut request = self.cosmos_client().prepare_request_pipeline(
             &format!("dbs/{}/users", self.database_client.database_name()),
             http::Method::POST,
         );
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Users.into());
+        let mut pipeline_context = PipelineContext::new(Context::new(), ResourceType::Users.into());
 
         options.decorate_request(&mut request, self.user_name())?;
         let response = self
@@ -62,13 +58,9 @@ impl UserClient {
     }
 
     /// Get the user
-    pub async fn get_user(
-        &self,
-        ctx: Context,
-        options: GetUserOptions,
-    ) -> crate::Result<UserResponse> {
+    pub async fn get_user(&self, options: GetUserOptions) -> crate::Result<UserResponse> {
         let mut request = self.prepare_request_with_user_name(http::Method::GET);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Users.into());
+        let mut pipeline_context = PipelineContext::new(Context::new(), ResourceType::Users.into());
 
         options.decorate_request(&mut request)?;
         let response = self
@@ -82,12 +74,11 @@ impl UserClient {
     /// Replace the user
     pub async fn replace_user<S: AsRef<str>>(
         &self,
-        ctx: Context,
         user_name: S,
         options: ReplaceUserOptions,
     ) -> crate::Result<UserResponse> {
         let mut request = self.prepare_request_with_user_name(http::Method::PUT);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Users.into());
+        let mut pipeline_context = PipelineContext::new(Context::new(), ResourceType::Users.into());
 
         options.decorate_request(&mut request, user_name.as_ref())?;
         let response = self
@@ -101,11 +92,10 @@ impl UserClient {
     /// Delete the user
     pub async fn delete_user(
         &self,
-        ctx: Context,
         options: DeleteUserOptions,
     ) -> crate::Result<DeleteUserResponse> {
         let mut request = self.prepare_request_with_user_name(http::Method::DELETE);
-        let mut pipeline_context = PipelineContext::new(ctx, ResourceType::Users.into());
+        let mut pipeline_context = PipelineContext::new(Context::new(), ResourceType::Users.into());
 
         options.decorate_request(&mut request)?;
         let response = self

--- a/sdk/cosmos/src/lib.rs
+++ b/sdk/cosmos/src/lib.rs
@@ -10,7 +10,6 @@ should also be possible with this crate.
 ```no_run
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos DB.
 use azure_cosmos::prelude::*;
-use azure_core::Context;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 
@@ -77,7 +76,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         // insert it
         collection_client
             .create_document(
-                Context::new(),
                 &document_to_insert,
                 CreateDocumentOptions::new().is_upsert(true),
             )

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -37,11 +36,7 @@ async fn attachment() -> Result<(), azure_cosmos::Error> {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -71,7 +66,7 @@ async fn attachment() -> Result<(), azure_cosmos::Error> {
             .offer(Offer::Throughput(400))
             .indexing_policy(ip);
         database_client
-            .create_collection(Context::new(), COLLECTION_NAME, options)
+            .create_collection(COLLECTION_NAME, options)
             .await
             .unwrap()
     };
@@ -91,7 +86,7 @@ async fn attachment() -> Result<(), azure_cosmos::Error> {
 
     // let's add an entity.
     let session_token: ConsistencyLevel = collection_client
-        .create_document(Context::new(), &doc, CreateDocumentOptions::new())
+        .create_document(&doc, CreateDocumentOptions::new())
         .await?
         .into();
 
@@ -179,7 +174,7 @@ async fn attachment() -> Result<(), azure_cosmos::Error> {
 
     // delete the database
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await?;
 
     Ok(())

--- a/sdk/cosmos/tests/collection_operations.rs
+++ b/sdk/cosmos/tests/collection_operations.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "mock_transport_framework")]
 
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use azure_cosmos::resources::collection::*;
 use std::error::Error;
@@ -15,10 +14,9 @@ async fn collection_operations() -> Result<(), BoxedError> {
 
     let client = setup::initialize("collection_operations")?;
     let database_name = "test-collection-operations";
-    let context = Context::new();
 
     client
-        .create_database(context.clone(), database_name, CreateDatabaseOptions::new())
+        .create_database(database_name, CreateDatabaseOptions::new())
         .await?;
 
     // create collection!
@@ -28,11 +26,7 @@ async fn collection_operations() -> Result<(), BoxedError> {
     log::info!("Creating a collection with name '{}'...", collection_name);
 
     let create_collection_response = db_client
-        .create_collection(
-            context.clone(),
-            collection_name,
-            CreateCollectionOptions::new("/id"),
-        )
+        .create_collection(collection_name, CreateCollectionOptions::new("/id"))
         .await?;
 
     assert_eq!(create_collection_response.collection.id, collection_name);
@@ -47,7 +41,7 @@ async fn collection_operations() -> Result<(), BoxedError> {
 
     // get collection!
     let get_collection_response = collection_client
-        .get_collection(context.clone(), GetCollectionOptions::new())
+        .get_collection(GetCollectionOptions::new())
         .await?;
 
     assert_eq!(get_collection_response.collection.id, collection_name);
@@ -83,7 +77,6 @@ async fn collection_operations() -> Result<(), BoxedError> {
     // replace collection!
     let replace_collection_response = collection_client
         .replace_collection(
-            context.clone(),
             ReplaceCollectionOptions::new("/id").indexing_policy(new_indexing_policy),
         )
         .await?;
@@ -115,7 +108,7 @@ async fn collection_operations() -> Result<(), BoxedError> {
 
     // delete collection!
     let delete_collection_response = collection_client
-        .delete_collection(context.clone(), DeleteCollectionOptions::new())
+        .delete_collection(DeleteCollectionOptions::new())
         .await?;
 
     log::info!("Successfully deleted collection");
@@ -125,7 +118,7 @@ async fn collection_operations() -> Result<(), BoxedError> {
     );
 
     db_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_collection.rs
+++ b/sdk/cosmos/tests/cosmos_collection.rs
@@ -1,7 +1,6 @@
 #![cfg(all(test, feature = "test_e2e"))]
 mod setup;
 
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use azure_cosmos::resources::collection::*;
 use futures::stream::StreamExt;
@@ -14,11 +13,7 @@ async fn create_and_delete_collection() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -26,19 +21,14 @@ async fn create_and_delete_collection() {
 
     // create a new collection
     let collection = database_client
-        .create_collection(
-            Context::new(),
-            COLLECTION_NAME,
-            CreateCollectionOptions::new("/id"),
-        )
+        .create_collection(COLLECTION_NAME, CreateCollectionOptions::new("/id"))
         .await
         .unwrap();
-    let collections =
-        Box::pin(database_client.list_collections(Context::new(), ListCollectionsOptions::new()))
-            .next()
-            .await
-            .unwrap()
-            .unwrap();
+    let collections = Box::pin(database_client.list_collections(ListCollectionsOptions::new()))
+        .next()
+        .await
+        .unwrap()
+        .unwrap();
     assert!(collections.collections.len() == 1);
 
     // try to get the previously created collection
@@ -47,7 +37,7 @@ async fn create_and_delete_collection() {
         .into_collection_client(COLLECTION_NAME);
 
     let collection_after_get = collection_client
-        .get_collection(Context::new(), GetCollectionOptions::new())
+        .get_collection(GetCollectionOptions::new())
         .await
         .unwrap();
     assert!(collection.collection.rid == collection_after_get.collection.rid);
@@ -61,19 +51,18 @@ async fn create_and_delete_collection() {
 
     // delete the collection
     collection_client
-        .delete_collection(Context::new(), DeleteCollectionOptions::new())
+        .delete_collection(DeleteCollectionOptions::new())
         .await
         .unwrap();
-    let collections =
-        Box::pin(database_client.list_collections(Context::new(), ListCollectionsOptions::new()))
-            .next()
-            .await
-            .unwrap()
-            .unwrap();
+    let collections = Box::pin(database_client.list_collections(ListCollectionsOptions::new()))
+        .next()
+        .await
+        .unwrap()
+        .unwrap();
     assert!(collections.collections.len() == 0);
 
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 }
@@ -85,11 +74,7 @@ async fn replace_collection() {
     const COLLECTION_NAME: &str = "test-collection";
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -106,16 +91,15 @@ async fn replace_collection() {
         .offer(Offer::S2)
         .indexing_policy(indexing_policy);
     let collection = database_client
-        .create_collection(Context::new(), COLLECTION_NAME, options)
+        .create_collection(COLLECTION_NAME, options)
         .await
         .unwrap();
 
-    let collections =
-        Box::pin(database_client.list_collections(Context::new(), ListCollectionsOptions::new()))
-            .next()
-            .await
-            .unwrap()
-            .unwrap();
+    let collections = Box::pin(database_client.list_collections(ListCollectionsOptions::new()))
+        .next()
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(collections.collections.len(), 1);
     assert_eq!(
         collection.collection.indexing_policy,
@@ -150,19 +134,15 @@ async fn replace_collection() {
         .into_collection_client(COLLECTION_NAME);
 
     let _replace_collection_response = collection_client
-        .replace_collection(
-            Context::new(),
-            ReplaceCollectionOptions::new("/id").indexing_policy(new_ip),
-        )
+        .replace_collection(ReplaceCollectionOptions::new("/id").indexing_policy(new_ip))
         .await
         .unwrap();
 
-    let collections =
-        Box::pin(database_client.list_collections(Context::new(), ListCollectionsOptions::new()))
-            .next()
-            .await
-            .unwrap()
-            .unwrap();
+    let collections = Box::pin(database_client.list_collections(ListCollectionsOptions::new()))
+        .next()
+        .await
+        .unwrap()
+        .unwrap();
     assert_eq!(collections.collections.len(), 1);
     let eps: Vec<&ExcludedPath> = collections.collections[0]
         .indexing_policy
@@ -173,7 +153,7 @@ async fn replace_collection() {
     assert!(eps.len() > 0);
 
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 }

--- a/sdk/cosmos/tests/cosmos_database.rs.disabled
+++ b/sdk/cosmos/tests/cosmos_database.rs.disabled
@@ -13,7 +13,7 @@ async fn create_and_delete_database() {
     let client = setup::initialize().unwrap();
 
     // list existing databases and remember their number
-    let databases = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+    let databases = Box::pin(client.list_databases(ListDatabasesOptions::new()))
         .next()
         .await
         .unwrap()
@@ -23,14 +23,14 @@ async fn create_and_delete_database() {
     // create a new database and check if the number of DBs increased
     let database = client
         .create_database(
-            azure_core::Context::new(),
+            
             DATABASE_NAME,
             CreateDatabaseOptions::new(),
         )
         .await
         .unwrap();
 
-    let databases = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+    let databases = Box::pin(client.list_databases(ListDatabasesOptions::new()))
         .next()
         .await
         .unwrap()
@@ -42,7 +42,7 @@ async fn create_and_delete_database() {
     let database_after_get = client
         .clone()
         .into_database_client(DATABASE_NAME)
-        .get_database(Context::new(), GetDatabaseOptions::new())
+        .get_database(GetDatabaseOptions::new())
         .await
         .unwrap();
     assert!(database.database.rid == database_after_get.database.rid);
@@ -56,7 +56,7 @@ async fn create_and_delete_database() {
         .await
         .unwrap();
 
-    let databases = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+    let databases = Box::pin(client.list_databases(ListDatabasesOptions::new()))
         .next()
         .await
         .unwrap()

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_core::Context;
 use azure_cosmos::prelude::{CreateDocumentOptions, DeleteDatabaseOptions, GetDocumentOptions};
 use serde::{Deserialize, Serialize};
 
@@ -32,11 +31,7 @@ async fn create_and_delete_document() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -54,7 +49,7 @@ async fn create_and_delete_document() {
         .offer(Offer::Throughput(400))
         .indexing_policy(indexing_policy);
     database_client
-        .create_collection(Context::new(), COLLECTION_NAME, options)
+        .create_collection(COLLECTION_NAME, options)
         .await
         .unwrap();
 
@@ -68,7 +63,7 @@ async fn create_and_delete_document() {
         hello: 42,
     };
     collection_client
-        .create_document(Context::new(), &document_data, CreateDocumentOptions::new())
+        .create_document(&document_data, CreateDocumentOptions::new())
         .await
         .unwrap();
 
@@ -87,7 +82,7 @@ async fn create_and_delete_document() {
         .unwrap();
 
     let document_after_get = document_client
-        .get_document::<MyDocument>(Context::new(), GetDocumentOptions::new())
+        .get_document::<MyDocument>(GetDocumentOptions::new())
         .await
         .unwrap();
 
@@ -109,7 +104,7 @@ async fn create_and_delete_document() {
     assert!(documents.len() == 0);
 
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 }
@@ -123,11 +118,7 @@ async fn query_documents() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
     let database_client = client.into_database_client(DATABASE_NAME);
@@ -144,7 +135,7 @@ async fn query_documents() {
         .indexing_policy(indexing_policy)
         .offer(Offer::S2);
     database_client
-        .create_collection(Context::new(), COLLECTION_NAME, options)
+        .create_collection(COLLECTION_NAME, options)
         .await
         .unwrap();
 
@@ -158,7 +149,7 @@ async fn query_documents() {
         hello: 42,
     };
     collection_client
-        .create_document(Context::new(), &document_data, CreateDocumentOptions::new())
+        .create_document(&document_data, CreateDocumentOptions::new())
         .await
         .unwrap();
 
@@ -186,7 +177,7 @@ async fn query_documents() {
     assert_eq!(query_result[0].result, document_data);
 
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 }
@@ -200,11 +191,7 @@ async fn replace_document() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
     let database_client = client.into_database_client(DATABASE_NAME);
@@ -221,7 +208,7 @@ async fn replace_document() {
         .indexing_policy(indexing_policy)
         .offer(Offer::S2);
     database_client
-        .create_collection(Context::new(), COLLECTION_NAME, options)
+        .create_collection(COLLECTION_NAME, options)
         .await
         .unwrap();
 
@@ -235,7 +222,7 @@ async fn replace_document() {
         hello: 42,
     };
     collection_client
-        .create_document(Context::new(), &document_data, CreateDocumentOptions::new())
+        .create_document(&document_data, CreateDocumentOptions::new())
         .await
         .unwrap();
 
@@ -266,7 +253,7 @@ async fn replace_document() {
         .into_document_client(DOCUMENT_NAME, &DOCUMENT_NAME)
         .unwrap();
     let document_after_get = document_client
-        .get_document::<MyDocument>(Context::new(), GetDocumentOptions::new())
+        .get_document::<MyDocument>(GetDocumentOptions::new())
         .await
         .unwrap();
 
@@ -277,7 +264,7 @@ async fn replace_document() {
     }
 
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 }

--- a/sdk/cosmos/tests/create_database_and_collection.rs
+++ b/sdk/cosmos/tests/create_database_and_collection.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "mock_transport_framework")]
 
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use std::error::Error;
@@ -15,16 +14,11 @@ async fn create_database_and_collection() -> Result<(), BoxedError> {
 
     let client = setup::initialize("create_database_and_collection")?;
     let database_name = "test-create-database-and-collection";
-    let context = Context::new();
 
     // create database!
     log::info!("Creating a database with name '{}'...", database_name);
     let db = client
-        .create_database(
-            context.clone(),
-            &database_name,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(&database_name, CreateDatabaseOptions::new())
         .await?;
     log::info!("Successfully created a database");
     log::debug!("The create_database response: {:#?}", db);
@@ -36,11 +30,7 @@ async fn create_database_and_collection() -> Result<(), BoxedError> {
     let collection_name = "panzadoro";
     log::info!("Creating a collection with name '{}'...", collection_name);
     let collection = db_client
-        .create_collection(
-            context.clone(),
-            collection_name,
-            CreateCollectionOptions::new("/id"),
-        )
+        .create_collection(collection_name, CreateCollectionOptions::new("/id"))
         .await?;
     assert_eq!(collection.collection.id, collection_name);
     log::info!("Successfully created a collection");
@@ -48,11 +38,10 @@ async fn create_database_and_collection() -> Result<(), BoxedError> {
 
     // list collections!
     log::info!("Listing all collections...");
-    let collections =
-        Box::pin(db_client.list_collections(context.clone(), ListCollectionsOptions::new()))
-            .next()
-            .await
-            .expect("No collection page")?;
+    let collections = Box::pin(db_client.list_collections(ListCollectionsOptions::new()))
+        .next()
+        .await
+        .expect("No collection page")?;
     assert_eq!(collections.count, 1);
     log::info!("Successfully listed collections");
     log::debug!("The list_collection response: {:#?}", collections);
@@ -60,7 +49,7 @@ async fn create_database_and_collection() -> Result<(), BoxedError> {
     // delete database
     log::info!("Deleting the database...");
     let deleted_database = db_client
-        .delete_database(context.clone(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await?;
     log::info!("Successfully deleted database");
     log::debug!("The delete_database response: {:#?}", deleted_database);

--- a/sdk/cosmos/tests/permission.rs
+++ b/sdk/cosmos/tests/permission.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 
 mod setup;
@@ -17,11 +16,7 @@ async fn permissions() {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -30,22 +25,18 @@ async fn permissions() {
     // create two users
     let user1_client = database_client.clone().into_user_client(USER_NAME1);
     let _create_user_response = user1_client
-        .create_user(Context::new(), CreateUserOptions::new())
+        .create_user(CreateUserOptions::new())
         .await
         .unwrap();
     let user2_client = database_client.clone().into_user_client(USER_NAME2);
     let _create_user_response = user2_client
-        .create_user(Context::new(), CreateUserOptions::new())
+        .create_user(CreateUserOptions::new())
         .await
         .unwrap();
 
     // create a temp collection
     let create_collection_response = database_client
-        .create_collection(
-            Context::new(),
-            COLLECTION_NAME,
-            CreateCollectionOptions::new("/id"),
-        )
+        .create_collection(COLLECTION_NAME, CreateCollectionOptions::new("/id"))
         .await
         .unwrap();
 
@@ -55,7 +46,6 @@ async fn permissions() {
 
     let _create_permission_user1_response = permission_client_user1
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new().expiry_seconds(18000u64), // 5 hours, max!
             &create_collection_response.collection.all_permission(),
         )
@@ -64,7 +54,6 @@ async fn permissions() {
 
     let _create_permission_user2_response = permission_client_user2
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new().expiry_seconds(18000u64), // 5 hours, max!
             &create_collection_response.collection.read_permission(),
         )
@@ -79,7 +68,7 @@ async fn permissions() {
 
     // delete the database
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 }

--- a/sdk/cosmos/tests/permission_token_usage.rs
+++ b/sdk/cosmos/tests/permission_token_usage.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_core::Context;
 use azure_cosmos::prelude::*;
 use collection::*;
 use serde::{Deserialize, Serialize};
@@ -33,11 +32,7 @@ async fn permission_token_usage() {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -55,13 +50,13 @@ async fn permission_token_usage() {
         .offer(Offer::Throughput(400))
         .indexing_policy(indexing_policy);
     let create_collection_response = database_client
-        .create_collection(Context::new(), COLLECTION_NAME, create_collection_options)
+        .create_collection(COLLECTION_NAME, create_collection_options)
         .await
         .unwrap();
 
     let user_client = database_client.clone().into_user_client(USER_NAME);
     user_client
-        .create_user(Context::new(), CreateUserOptions::new())
+        .create_user(CreateUserOptions::new())
         .await
         .unwrap();
 
@@ -71,7 +66,6 @@ async fn permission_token_usage() {
 
     let create_permission_response = permission_client
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new().expiry_seconds(18000u64), // 5 hours, max!
             &permission_mode,
         )
@@ -108,16 +102,12 @@ async fn permission_token_usage() {
     };
 
     new_collection_client
-        .create_document(
-            Context::new(),
-            &document,
-            CreateDocumentOptions::new().is_upsert(true),
-        )
+        .create_document(&document, CreateDocumentOptions::new().is_upsert(true))
         .await
         .unwrap_err();
 
     permission_client
-        .delete_permission(Context::new(), DeletePermissionOptions::new())
+        .delete_permission(DeletePermissionOptions::new())
         .await
         .unwrap();
 
@@ -125,7 +115,6 @@ async fn permission_token_usage() {
     let permission_mode = create_collection_response.collection.all_permission();
     let create_permission_response = permission_client
         .create_permission(
-            Context::new(),
             CreatePermissionOptions::new().expiry_seconds(18000u64), // 5 hours, max!
             &permission_mode,
         )
@@ -143,11 +132,7 @@ async fn permission_token_usage() {
     // now we have an "All" authorization_token
     // so the create_document should succeed!
     let create_document_response = new_collection_client
-        .create_document(
-            Context::new(),
-            &document,
-            CreateDocumentOptions::new().is_upsert(true),
-        )
+        .create_document(&document, CreateDocumentOptions::new().is_upsert(true))
         .await
         .unwrap();
     println!(
@@ -157,7 +142,7 @@ async fn permission_token_usage() {
 
     // cleanup
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await
         .unwrap();
 }

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use futures::stream::StreamExt;
 
@@ -45,11 +44,7 @@ async fn trigger() -> Result<(), azure_cosmos::Error> {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -58,11 +53,7 @@ async fn trigger() -> Result<(), azure_cosmos::Error> {
     // create a temp collection
     let _create_collection_response = {
         database_client
-            .create_collection(
-                Context::new(),
-                COLLECTION_NAME,
-                CreateCollectionOptions::new("/id"),
-            )
+            .create_collection(COLLECTION_NAME, CreateCollectionOptions::new("/id"))
             .await
             .unwrap()
     };
@@ -111,7 +102,7 @@ async fn trigger() -> Result<(), azure_cosmos::Error> {
 
     // delete the database
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await?;
 
     Ok(())

--- a/sdk/cosmos/tests/user.rs.disabled
+++ b/sdk/cosmos/tests/user.rs.disabled
@@ -19,7 +19,7 @@ async fn users() {
     // create a temp database
     let _create_database_response = client
         .create_database(
-            azure_core::Context::new(),
+            
             DATABASE_NAME,
             CreateDatabaseOptions::new(),
         )
@@ -30,12 +30,12 @@ async fn users() {
     let user_client = database_client.clone().into_user_client(USER_NAME);
 
     let _create_user_response = user_client
-        .create_user(Context::new(), CreateUserOptions::new())
+        .create_user(CreateUserOptions::new())
         .await
         .unwrap();
 
     let list_users_response =
-        Box::pin(database_client.list_users(Context::new(), ListUsersOptions::new()))
+        Box::pin(database_client.list_users(ListUsersOptions::new()))
             .next()
             .await
             .unwrap()
@@ -44,7 +44,7 @@ async fn users() {
     assert_eq!(list_users_response.users.len(), 1);
 
     let get_user_response = user_client
-        .get_user(Context::new(), GetUserOptions::new())
+        .get_user(GetUserOptions::new())
         .await;
     assert!(get_user_response.is_ok());
     let retrieved_user = get_user_response.unwrap();
@@ -52,7 +52,7 @@ async fn users() {
 
     let _replace_user_response = user_client
         .replace_user(
-            Context::new(),
+            
             USER_NAME_REPLACED,
             ReplaceUserOptions::new(),
         )
@@ -60,7 +60,7 @@ async fn users() {
         .unwrap();
 
     let list_users_response =
-        Box::pin(database_client.list_users(Context::new(), ListUsersOptions::new()))
+        Box::pin(database_client.list_users(ListUsersOptions::new()))
             .next()
             .await
             .unwrap()
@@ -70,12 +70,12 @@ async fn users() {
     let user_client = database_client.clone().into_user_client(USER_NAME_REPLACED);
 
     let _delete_user_response = user_client
-        .delete_user(Context::new(), DeleteUserOptions::new())
+        .delete_user(DeleteUserOptions::new())
         .await
         .unwrap();
 
     let list_users_response =
-        Box::pin(database_client.list_users(Context::new(), ListUsersOptions::new()))
+        Box::pin(database_client.list_users(ListUsersOptions::new()))
             .next()
             .await
             .unwrap()
@@ -91,7 +91,7 @@ async fn users() {
         .await
         .unwrap();
 
-    let _databases = Box::pin(client.list_databases(Context::new(), ListDatabasesOptions::new()))
+    let _databases = Box::pin(client.list_databases(ListDatabasesOptions::new()))
         .next()
         .await
         .unwrap()

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use azure_cosmos::responses::QueryDocumentsResponseRaw;
 use futures::stream::StreamExt;
@@ -28,11 +27,7 @@ async fn user_defined_function00() -> Result<(), azure_cosmos::Error> {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME, CreateDatabaseOptions::new())
         .await
         .unwrap();
 
@@ -40,11 +35,7 @@ async fn user_defined_function00() -> Result<(), azure_cosmos::Error> {
 
     // create a temp collection
     let _create_collection_response = database_client
-        .create_collection(
-            Context::new(),
-            COLLECTION_NAME,
-            CreateCollectionOptions::new("/id"),
-        )
+        .create_collection(COLLECTION_NAME, CreateCollectionOptions::new("/id"))
         .await
         .unwrap();
 
@@ -121,7 +112,7 @@ async fn user_defined_function00() -> Result<(), azure_cosmos::Error> {
 
     // delete the database
     database_client
-        .delete_database(Context::new(), DeleteDatabaseOptions::new())
+        .delete_database(DeleteDatabaseOptions::new())
         .await?;
 
     Ok(())

--- a/sdk/storage/examples/data_lake_00.rs
+++ b/sdk/storage/examples/data_lake_00.rs
@@ -72,14 +72,14 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("creating path '{}'...", file_name);
     let create_path_response = file_system
-        .create_path(Context::default(), file_name, CreatePathOptions::default())
+        .create_path(file_name, CreatePathOptions::default())
         .await?;
     println!("create path response == {:?}", create_path_response);
     println!();
 
     println!("creating path '{}' (overwrite)...", file_name);
     let create_path_response = file_system
-        .create_path(Context::default(), file_name, CreatePathOptions::default())
+        .create_path(file_name, CreatePathOptions::default())
         .await?;
     println!("create path response == {:?}", create_path_response);
     println!();
@@ -87,9 +87,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("creating path '{}' (do not overwrite)...", file_name);
     let do_not_overwrite =
         CreatePathOptions::new().if_match_condition(IfMatchCondition::NotMatch("*"));
-    let create_path_result = file_system
-        .create_path(Context::default(), file_name, do_not_overwrite)
-        .await;
+    let create_path_result = file_system.create_path(file_name, do_not_overwrite).await;
     println!(
         "create path result (should fail) == {:?}",
         create_path_result

--- a/sdk/storage/src/data_lake/clients/file_system_client.rs
+++ b/sdk/storage/src/data_lake/clients/file_system_client.rs
@@ -65,13 +65,12 @@ impl FileSystemClient {
     /// Create a path
     pub async fn create_path(
         &self,
-        ctx: Context,
         path_name: &str,
         options: CreatePathOptions<'_>,
     ) -> Result<CreatePathResponse, crate::Error> {
         let mut request = self.prepare_request_pipeline(&path_name, http::Method::PUT);
         let contents = DataLakeContext {};
-        let mut pipeline_context = PipelineContext::new(ctx, contents);
+        let mut pipeline_context = PipelineContext::new(Context::new(), contents);
 
         options.decorate_request(&mut request)?;
         let response = self

--- a/sdk/storage/tests/data_lake.rs
+++ b/sdk/storage/tests/data_lake.rs
@@ -83,17 +83,17 @@ async fn test_data_lake_file_system_functions() -> Result<(), Box<dyn Error + Se
     let file_name = "e2etest-file.txt";
 
     file_system_client
-        .create_path(Context::default(), file_name, CreatePathOptions::default())
+        .create_path(file_name, CreatePathOptions::default())
         .await?;
 
     file_system_client
-        .create_path(Context::default(), file_name, CreatePathOptions::default())
+        .create_path(file_name, CreatePathOptions::default())
         .await?;
 
     let do_not_overwrite =
         CreatePathOptions::new().if_match_condition(IfMatchCondition::NotMatch("*"));
     let create_path_result = file_system_client
-        .create_path(Context::default(), file_name, do_not_overwrite)
+        .create_path(file_name, do_not_overwrite)
         .await;
     assert!(create_path_result.is_err());
 


### PR DESCRIPTION
As a continuation to discussion started [here](https://github.com/Azure/azure-sdk-for-rust/pull/392#discussion_r739397716):

This removes the `Context` parameter from all pipeline based operations while keeping the context as an internal detail (meaning all policies still have access to the `Context` and can use it as a key/value store (though this functionality still needs to be implemented).

We originally included `Context` as a parameter for all operations because we believed it would be essential for cancelation just like in other SDKs. However, #457 and the related discussion showed that we don't need to send an explicit struct for doing cancelation since Rust's futures allow for cancelation through other means. The only remaining feature that `Context` is used for is as a key/value store which is a secondary feature that is not widely used. Requiring the context argument in every operation call is a heavy price to pay to support this feature. 

This change makes it so that (by default) users don't have to pass a `Context` object since this would require the user to type `Context::new` when almost always they don't need a custom context object. Instead the context is constructed internally so that the pipeline (and thus all individual policies) can still take advantage of the `Context`. 

Open questions:
* Presumably there are cases where the user wants to set a key/value in the `Context` key/value store when setting up an operation. After this PR this will no longer be possible. Since Rust does not offer default args or method overloading, to add this feature back we will need to add a new method for each operation that allows setting `Context`. Before we add this back, I'd like to understand what use cases there are for the user to set a key/value pair in the `Context` from outside of the pipeline. 
* Right now each operation is required to construct a `Context` object that gets passed to a `PipelineContext` object. We may be able to simply construct the `Context` from inside the `PipelineContext` constructor. 

cc @JeffreyRichter @heaths 