### PR TITLE
support mutliple Scopes in client credential flow

### DIFF
--- a/sdk/identity/README.md
+++ b/sdk/identity/README.md
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         client,
         &client_id,
         &client_secret,
-        "https://management.azure.com/",
+        &["https://management.azure.com/"],
         &tenant_id,
     )
     .await?;

--- a/sdk/identity/examples/client_credentials_flow.rs
+++ b/sdk/identity/examples/client_credentials_flow.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         client,
         &client_id,
         &client_secret,
-        "https://management.azure.com/",
+        &["https://management.azure.com/"],
         &tenant_id,
     )
     .await?;

--- a/sdk/identity/examples/client_credentials_flow_blob.rs
+++ b/sdk/identity/examples/client_credentials_flow_blob.rs
@@ -26,10 +26,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         client,
         &client_id,
         &client_secret,
-        &format!(
+        &[&format!(
             "https://{}.blob.core.windows.net/.default",
             storage_account_name
-        ),
+        )],
         &tenant_id,
     )
     .await?;

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -27,7 +27,7 @@
 //!         client,
 //!         &client_id,
 //!         &client_secret,
-//!         "https://management.azure.com/",
+//!         &["https://management.azure.com/"],
 //!         &tenant_id,
 //!     )
 //!     .await?;
@@ -48,12 +48,12 @@ pub async fn perform(
     client: reqwest::Client,
     client_id: &oauth2::ClientId,
     client_secret: &oauth2::ClientSecret,
-    scope: &str,
+    scopes: &[&str],
     tenant_id: &str,
 ) -> Result<LoginResponse, Error> {
     let encoded: String = form_urlencoded::Serializer::new(String::new())
         .append_pair("client_id", client_id.as_str())
-        .append_pair("scope", scope)
+        .append_pair("scope", &scopes.join(" "))
         .append_pair("client_secret", client_secret.secret())
         .append_pair("grant_type", "client_credentials")
         .finish();

--- a/sdk/identity/src/lib.rs
+++ b/sdk/identity/src/lib.rs
@@ -28,7 +28,7 @@
 //!         client,
 //!         &client_id,
 //!         &client_secret,
-//!         "https://management.azure.com/",
+//!         &["https://management.azure.com/"],
 //!         &tenant_id,
 //!     )
 //!     .await?;


### PR DESCRIPTION
Following both the existing rust DeviceCode model, as well as MSAL for Python and MSAL for Net, allow requesting multiple scopes at once from confidential clients.

Both in documentation and in practice, scopes are space-separated list of permissions.

ref: https://docs.microsoft.com/en-us/dotnet/api/microsoft.identity.client.iconfidentialclientapplication.acquiretokenbyauthorizationcode?view=azure-dotnet#parameters
ref: https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/dev/sample/confidential_client_secret_sample.py#L7
ref: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent#requesting-individual-user-consent
ref: https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/45499ff5a4ba1afbb71ed95aa5491f924f39dbba/msal/oauth2cli/oauth2.py#L180
ref: https://github.com/AzureAD/microsoft-authentication-library-for-python/blob/45499ff5a4ba1afbb71ed95aa5491f924f39dbba/msal/oauth2cli/oauth2.py#L265-L268