### PR TITLE
Rename DefaultCredential to DefaultAzureCredential

### DIFF
--- a/sdk/identity/examples/default_credentials.rs
+++ b/sdk/identity/examples/default_credentials.rs
@@ -6,7 +6,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
     let sub_id = std::env::var("AZURE_SUBSCRIPTION_ID")?;
-    let creds = DefaultCredential::default();
+    let creds = DefaultAzureCredential::default();
     let res = creds
         .get_token("https://management.azure.com/")
         .await

--- a/sdk/identity/src/errors.rs
+++ b/sdk/identity/src/errors.rs
@@ -16,7 +16,7 @@ pub enum Error {
         #[from] crate::token_credentials::ManagedIdentityCredentialError,
     ),
     #[error("Error getting default credential: {0}")]
-    DefaultCredentialError(#[from] crate::token_credentials::DefaultCredentialError),
+    DefaultAzureCredentialError(#[from] crate::token_credentials::DefaultAzureCredentialError),
     #[error("Error refreshing token: {0}")]
     RefreshTokenError(#[from] crate::refresh_token::Error),
     /// An unrecognized error response from an identity service.

--- a/sdk/security_keyvault/src/client.rs
+++ b/sdk/security_keyvault/src/client.rs
@@ -12,8 +12,8 @@ pub(crate) const API_VERSION_PARAM: &str = formatcp!("api-version={}", API_VERSI
 ///
 /// ```no_run
 /// use azure_security_keyvault::KeyClient;
-/// use azure_identity::token_credentials::DefaultCredential;
-/// let creds = DefaultCredential::default();
+/// use azure_identity::token_credentials::DefaultAzureCredential;
+/// let creds = DefaultAzureCredential::default();
 /// let client = KeyClient::new(&"https://test-key-vault.vault.azure.net", &creds).unwrap();
 /// ```
 #[derive(Debug)]
@@ -31,8 +31,8 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
-    /// let creds = DefaultCredential::default();
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
+    /// let creds = DefaultAzureCredential::default();
     /// let client = KeyClient::new("test-key-vault.vault.azure.net", &creds).unwrap();
     /// ```
     pub fn new(vault_url: &str, token_credential: &'a T) -> Result<Self, Error> {

--- a/sdk/security_keyvault/src/secret.rs
+++ b/sdk/security_keyvault/src/secret.rs
@@ -123,11 +123,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -149,11 +149,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     /// let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -196,11 +196,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -251,11 +251,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -316,11 +316,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -363,11 +363,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -404,11 +404,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::{KeyClient, RecoveryLevel};
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -448,12 +448,12 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::{KeyClient, RecoveryLevel};
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     /// use chrono::{Utc, Duration};
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -507,11 +507,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -545,11 +545,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::KeyClient;
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,
@@ -590,11 +590,11 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
     ///
     /// ```no_run
     /// use azure_security_keyvault::{KeyClient, RecoveryLevel};
-    /// use azure_identity::token_credentials::DefaultCredential;
+    /// use azure_identity::token_credentials::DefaultAzureCredential;
     /// use tokio::runtime::Runtime;
     ///
     /// async fn example() {
-    ///     let creds = DefaultCredential::default();
+    ///     let creds = DefaultAzureCredential::default();
     ///     let mut client = KeyClient::new(
     ///     &"KEYVAULT_URL",
     ///     &creds,

--- a/sdk/storage/examples/blob_05_default_credential.rs
+++ b/sdk/storage/examples/blob_05_default_credential.rs
@@ -2,7 +2,7 @@
 extern crate log;
 
 use azure_core::prelude::*;
-use azure_identity::token_credentials::DefaultCredential;
+use azure_identity::token_credentials::DefaultAzureCredential;
 use azure_identity::token_credentials::TokenCredential;
 use azure_storage::blob::prelude::*;
 use azure_storage::core::prelude::*;
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(3)
         .expect("please specify the blob name as third command line parameter");
 
-    let bearer_token = DefaultCredential::default()
+    let bearer_token = DefaultAzureCredential::default()
         .get_token("https://storage.azure.com/")
         .await?;
 

--- a/sdk/storage/examples/data_lake_00.rs
+++ b/sdk/storage/examples/data_lake_00.rs
@@ -1,6 +1,6 @@
 use azure_core::prelude::IfMatchCondition;
 use azure_core::prelude::*;
-use azure_identity::token_credentials::DefaultCredential;
+use azure_identity::token_credentials::DefaultAzureCredential;
 use azure_identity::token_credentials::TokenCredential;
 use azure_storage::core::prelude::*;
 use azure_storage::data_lake::prelude::*;
@@ -26,7 +26,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let resource_id = "https://storage.azure.com/";
     println!("getting bearer token for '{}'...", resource_id);
-    let bearer_token = DefaultCredential::default().get_token(resource_id).await?;
+    let bearer_token = DefaultAzureCredential::default()
+        .get_token(resource_id)
+        .await?;
     println!("token expires on {}", bearer_token.expires_on);
     println!();
 

--- a/sdk/storage/tests/data_lake.rs
+++ b/sdk/storage/tests/data_lake.rs
@@ -2,7 +2,7 @@
 // #![cfg(feature = "mock_transport_framework")]
 
 use azure_core::prelude::*;
-use azure_identity::token_credentials::DefaultCredential;
+use azure_identity::token_credentials::DefaultAzureCredential;
 use azure_identity::token_credentials::TokenCredential;
 use azure_storage::core::prelude::*;
 use azure_storage::data_lake::prelude::*;
@@ -27,7 +27,9 @@ async fn test_data_lake_file_system_functions() -> Result<(), Box<dyn Error + Se
         StorageAccountClient::new_access_key(http_client.clone(), &account, &master_key);
 
     let resource_id = "https://storage.azure.com/";
-    let bearer_token = DefaultCredential::default().get_token(resource_id).await?;
+    let bearer_token = DefaultAzureCredential::default()
+        .get_token(resource_id)
+        .await?;
 
     let data_lake_client = storage_account_client
         .as_storage_client()


### PR DESCRIPTION
Renamed `DefaultCredential` to `DefaultAzureCredential` as requested by https://github.com/Azure/azure-sdk-for-rust/issues/425.

I also renamed other associated types.  Full list of changes:
- `DefaultCredential` => `DefaultAzureCredential`
- `DefaultCredentialError` => `DefaultAzureCredentialError`
- `DefaultCredentialBuilder` => `DefaultAzureCredentialBuilder`
- `DefaultCredentialEnum` => `DefaultAzureCredentialEnum`