### PR TITLE
remove cron schedule

### DIFF
--- a/.github/workflows/services-all-features.yml
+++ b/.github/workflows/services-all-features.yml
@@ -2,8 +2,6 @@ name: Check All Features for Services
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
 
 env:
   RUSTFLAGS: --deny warnings --allow unused_attributes


### PR DESCRIPTION
The cron schedule is running in every fork due to #447. Is there a good way to limit it to just this repo? Disabling it for now. The tests can be still be started manually on any branch in any fork.