### PR TITLE
enable passing reqwest features to azure_core from azure_storage

### DIFF
--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0", default-features=false }
 ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"
@@ -40,7 +40,7 @@ azure_identity = { path = "../identity" }
 reqwest = "0.11"
 
 [features]
-default = ["account", "blob", "queue", "table", "data_lake"]
+default = ["account", "blob", "queue", "table", "data_lake", "enable_reqwest"]
 test_e2e = ["account", "blob", "queue", "table", "data_lake"]
 mock_transport_framework = [ "azure_core/mock_transport_framework"]
 test_integration = ["account", "blob", "queue", "table", "data_lake"]
@@ -50,6 +50,8 @@ blob = []
 queue = []
 table = []
 data_lake = []
+enable_reqwest = ["azure_core/enable_reqwest"]
+enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
 
 # This section specifies the required features for the examples.
 [[example]]


### PR DESCRIPTION
This enables using reqwest with `rustls` without requiring `native-tls` from the storage crates.