### PR TITLE
Operation Builder Future

### DIFF
--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -1,6 +1,6 @@
 /// Creates setter methods
 ///
-/// The methods created are of the form `with_$name` that takes an argument of type `$typ`
+/// The methods created are of the form `$name` that takes an argument of type `$typ`
 /// and sets the field $name to result of calling `$transform` with the value of the argument.
 ///
 /// In other words. The following macro call:

--- a/sdk/core/src/options.rs
+++ b/sdk/core/src/options.rs
@@ -17,19 +17,14 @@ use std::time::Duration;
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct ClientOptions {
-    // TODO: Expose transport override.
     /// Policies called per call.
     pub(crate) per_call_policies: Vec<Arc<dyn Policy>>,
-
     /// Policies called per retry.
     pub(crate) per_retry_policies: Vec<Arc<dyn Policy>>,
-
     /// Retry options.
     pub(crate) retry: RetryOptions,
-
     /// Telemetry options.
     pub(crate) telemetry: TelemetryOptions,
-
     /// Transport options.
     pub(crate) transport: TransportOptions,
 }

--- a/sdk/cosmos/examples/cancellation.rs
+++ b/sdk/cosmos/examples/cancellation.rs
@@ -1,4 +1,3 @@
-use azure_core::prelude::*;
 use azure_cosmos::prelude::*;
 use stop_token::prelude::*;
 use stop_token::StopSource;
@@ -19,8 +18,7 @@ async fn main() -> azure_cosmos::Result<()> {
     let client = CosmosClient::new(account.clone(), authorization_token.clone(), options);
 
     // Create a new database, and time out if it takes more than 1 second.
-    let options = CreateDatabaseOptions::new();
-    let future = client.create_database(Context::new(), "my_database", options);
+    let future = client.create_database("my_database").into_future();
     let deadline = Instant::now() + Duration::from_secs(1);
     match future.until(deadline).await {
         Ok(Ok(r)) => println!("successful response: {:?}", r),
@@ -36,8 +34,7 @@ async fn main() -> azure_cosmos::Result<()> {
         // Clone the stop token for each request.
         let stop = source.token();
         tokio::spawn(async move {
-            let options = CreateDatabaseOptions::new();
-            let future = client.create_database(Context::new(), "my_database", options);
+            let future = client.create_database("my_database").into_future();
             match future.until(stop).await {
                 Ok(Ok(r)) => println!("successful response: {:?}", r),
                 Ok(Err(e)) => println!("request was made but failed: {:?}", e),

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -169,21 +169,8 @@ impl CosmosClient {
     }
 
     /// Create a database
-    pub async fn create_database<S: AsRef<str>>(
-        &self,
-        ctx: Context,
-        database_name: S,
-        options: CreateDatabaseOptions,
-    ) -> crate::Result<CreateDatabaseResponse> {
-        let mut request = self.prepare_request_pipeline("dbs", http::Method::POST);
-
-        options.decorate_request(&mut request, database_name.as_ref())?;
-        let response = self
-            .pipeline()
-            .send(ctx.clone().insert(ResourceType::Databases), &mut request)
-            .await?;
-
-        Ok(CreateDatabaseResponse::try_from(response).await?)
+    pub fn create_database<S: AsRef<str>>(&self, database_name: S) -> CreateDatabaseBuilder {
+        CreateDatabaseBuilder::new(self.clone(), database_name.as_ref().to_owned())
     }
 
     /// List all databases

--- a/sdk/cosmos/src/operations/create_database.rs
+++ b/sdk/cosmos/src/operations/create_database.rs
@@ -49,7 +49,7 @@ impl CreateDatabaseBuilder {
             let response = self
                 .client
                 .pipeline()
-                .send(&mut self.context, &mut request)
+                .send(self.context.insert(ResourceType::Databases), &mut request)
                 .await?;
 
             CreateDatabaseResponse::try_from(response).await

--- a/sdk/cosmos/tests/attachment_00.rs
+++ b/sdk/cosmos/tests/attachment_00.rs
@@ -37,11 +37,8 @@ async fn attachment() -> Result<(), azure_cosmos::Error> {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/collection_operations.rs
+++ b/sdk/cosmos/tests/collection_operations.rs
@@ -17,9 +17,7 @@ async fn collection_operations() -> Result<(), BoxedError> {
     let database_name = "test-collection-operations";
     let context = Context::new();
 
-    client
-        .create_database(context.clone(), database_name, CreateDatabaseOptions::new())
-        .await?;
+    client.create_database(database_name).into_future().await?;
 
     // create collection!
     let db_client = client.clone().into_database_client(database_name.clone());

--- a/sdk/cosmos/tests/cosmos_collection.rs
+++ b/sdk/cosmos/tests/cosmos_collection.rs
@@ -14,11 +14,8 @@ async fn create_and_delete_collection() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 
@@ -85,11 +82,8 @@ async fn replace_collection() {
     const COLLECTION_NAME: &str = "test-collection";
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_database.rs.disabled
+++ b/sdk/cosmos/tests/cosmos_database.rs.disabled
@@ -22,11 +22,8 @@ async fn create_and_delete_database() {
 
     // create a new database and check if the number of DBs increased
     let database = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/cosmos_document.rs
+++ b/sdk/cosmos/tests/cosmos_document.rs
@@ -32,11 +32,8 @@ async fn create_and_delete_document() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 
@@ -126,11 +123,8 @@ async fn query_documents() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
     let database_client = client.into_database_client(DATABASE_NAME);
@@ -203,11 +197,8 @@ async fn replace_document() {
     let client = setup::initialize().unwrap();
 
     client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
     let database_client = client.into_database_client(DATABASE_NAME);

--- a/sdk/cosmos/tests/create_database_and_collection.rs
+++ b/sdk/cosmos/tests/create_database_and_collection.rs
@@ -19,13 +19,7 @@ async fn create_database_and_collection() -> Result<(), BoxedError> {
 
     // create database!
     log::info!("Creating a database with name '{}'...", database_name);
-    let db = client
-        .create_database(
-            context.clone(),
-            &database_name,
-            CreateDatabaseOptions::new(),
-        )
-        .await?;
+    let db = client.create_database(&database_name).into_future().await?;
     log::info!("Successfully created a database");
     log::debug!("The create_database response: {:#?}", db);
 

--- a/sdk/cosmos/tests/permission.rs
+++ b/sdk/cosmos/tests/permission.rs
@@ -17,11 +17,8 @@ async fn permissions() {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/permission_token_usage.rs
+++ b/sdk/cosmos/tests/permission_token_usage.rs
@@ -33,11 +33,8 @@ async fn permission_token_usage() {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/trigger.rs
+++ b/sdk/cosmos/tests/trigger.rs
@@ -45,11 +45,8 @@ async fn trigger() -> Result<(), azure_cosmos::Error> {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/user.rs.disabled
+++ b/sdk/cosmos/tests/user.rs.disabled
@@ -18,11 +18,8 @@ async fn users() {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 

--- a/sdk/cosmos/tests/user_defined_function00.rs
+++ b/sdk/cosmos/tests/user_defined_function00.rs
@@ -28,11 +28,8 @@ async fn user_defined_function00() -> Result<(), azure_cosmos::Error> {
 
     // create a temp database
     let _create_database_response = client
-        .create_database(
-            azure_core::Context::new(),
-            DATABASE_NAME,
-            CreateDatabaseOptions::new(),
-        )
+        .create_database(DATABASE_NAME)
+        .into_future()
         .await
         .unwrap();
 


### PR DESCRIPTION
*coauthored with @yoshuawuyts*

This is a proposal for a new one style of API for operations that eliminates some of the awkwardness of usage without reducing the functionality.

### Summary

Operations now return "builders" which implement an `into_future` method (more of this later) that turns the builder into a future which can be awaited with `await` and yields a response. These builders provide setter methods for any options as well as a way to set a `Context` object. 

**Currently**

```rust
collection_client
            .create_document(
                my_context,
                &document_to_insert,
                CreateDocumentOptions::new().is_upsert(true),
            )
            .await?;
```

**After this PR**

```rust
collection_client
            .create_document(&document_to_insert)
            .is_upsert(true) // if the default is desired this line can be removed
            .context(my_context) // if no context is needed, this line can be removed
            .into_future() // more of this below
            .await?;
```

## `into_future`

Currently, when the code `some_value.await` is called, Rust desugars this to a direct call to the `poll` function on `Future`. However, there is an accepted RFC and [implementation](https://github.com/rust-lang/rust/pull/90737) that changes this desugaring to call the currently unstable `IntoFuture::into_future`. When this lands on stable Rust, we will be able to remove the need for calling `into_future()` as the call to `await` will call `into_future` automatically. 

## The builder pattern

The builder pattern presented here is very common (and is in fact what the Azure SDK for Rust used before the pipeline architecture). Here are examples of it being used in the most popular HTTP crates for Rust:
* [hyper](https://docs.rs/http/0.2.5/http/request/struct.Builder.html)
* [reqwest](https://docs.rs/reqwest/0.11.6/reqwest/blocking/struct.RequestBuilder.html)
* [surf](https://docs.rs/surf/2.3.2/surf/struct.RequestBuilder.html)

Thoughts?

cc @JeffreyRichter @heaths 

I also just saw @JeffreyRichter's [comment](https://github.com/Azure/azure-sdk-for-rust/pull/504#issuecomment-965809346) on requiring `Context`. That doesn't change this proposal too much, it would just mean keeping context as the first argument to every operation. 