### PR TITLE
[Identity] Check status code for ManagedIdentityCredential

### DIFF
--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -1,5 +1,5 @@
 use super::{
-    AzureCliCredential, EnvironmentCredential, ManagedIdentityCredential, TokenCredential,
+    AzureCliCredential, EnvironmentCredential, ImdsManagedIdentityCredential, TokenCredential,
 };
 use azure_core::TokenResponse;
 
@@ -47,7 +47,7 @@ impl DefaultAzureCredentialBuilder {
         }
         if self.include_managed_identity_credential {
             sources.push(DefaultAzureCredentialEnum::ManagedIdentity(
-                ManagedIdentityCredential {},
+                ImdsManagedIdentityCredential {},
             ))
         }
         if self.include_cli_credential {
@@ -76,7 +76,7 @@ pub enum DefaultAzureCredentialError {
 /// Types of TokenCredential supported by DefaultAzureCredential
 pub enum DefaultAzureCredentialEnum {
     Environment(EnvironmentCredential),
-    ManagedIdentity(ManagedIdentityCredential),
+    ManagedIdentity(ImdsManagedIdentityCredential),
     AzureCli(AzureCliCredential),
 }
 
@@ -124,7 +124,7 @@ impl Default for DefaultAzureCredential {
         DefaultAzureCredential {
             sources: vec![
                 DefaultAzureCredentialEnum::Environment(EnvironmentCredential::default()),
-                DefaultAzureCredentialEnum::ManagedIdentity(ManagedIdentityCredential {}),
+                DefaultAzureCredentialEnum::ManagedIdentity(ImdsManagedIdentityCredential {}),
                 DefaultAzureCredentialEnum::AzureCli(AzureCliCredential {}),
             ],
         }

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -18,7 +18,7 @@ const MSI_API_VERSION: &str = "2019-08-01";
 /// This authentication type works in Azure VMs, App Service and Azure Functions applications, as well as the Azure Cloud Shell
 ///
 /// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
-pub struct ManagedIdentityCredential;
+pub struct ImdsManagedIdentityCredential;
 
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
@@ -43,7 +43,7 @@ pub enum ManagedIdentityCredentialError {
 }
 
 #[async_trait::async_trait]
-impl TokenCredential for ManagedIdentityCredential {
+impl TokenCredential for ImdsManagedIdentityCredential {
     type Error = ManagedIdentityCredentialError;
 
     async fn get_token(&self, resource: &str) -> Result<TokenResponse, Self::Error> {
@@ -88,7 +88,7 @@ impl TokenCredential for ManagedIdentityCredential {
 }
 
 #[async_trait::async_trait]
-impl azure_core::TokenCredential for ManagedIdentityCredential {
+impl azure_core::TokenCredential for ImdsManagedIdentityCredential {
     async fn get_token(
         &self,
         resource: &str,

--- a/sdk/identity/src/token_credentials/mod.rs
+++ b/sdk/identity/src/token_credentials/mod.rs
@@ -9,13 +9,13 @@ mod cli_credentials;
 mod client_secret_credentials;
 mod default_credentials;
 mod environment_credentials;
-mod managed_identity_credentials;
+mod imds_managed_identity_credentials;
 
 pub use cli_credentials::*;
 pub use client_secret_credentials::*;
 pub use default_credentials::*;
 pub use environment_credentials::*;
-pub use managed_identity_credentials::*;
+pub use imds_managed_identity_credentials::*;
 
 /// Represents a credential capable of providing an OAuth token.
 /// Same as [azure_core::TokenCredential](azure_core::TokenCredential), except a more specific error is returned.


### PR DESCRIPTION
Initial thoughts on handling failed status codes for `ManagedIdentityCredential` `get_token`
I added a check for 400, 502, and 504 because that's what I see getting check in the [.net sdk](https://github.com/Azure/azure-sdk-for-net/blob/c5738f34a5ded5bf4b49e380a8eec179e12a1c6b/sdk/identity/Azure.Identity/src/ImdsManagedIdentitySource.cs#L109) 

#428 