### PR TITLE
fix signing blob URLs where the blob name contains slashes

### DIFF
--- a/sdk/storage/src/blob/clients/blob_client.rs
+++ b/sdk/storage/src/blob/clients/blob_client.rs
@@ -68,7 +68,7 @@ impl BlobClient {
     where
         I: IntoIterator<Item = &'a str>,
     {
-        let blob_name_with_segments = self.blob_name.split("/").into_iter().chain(segments);
+        let blob_name_with_segments = self.blob_name.split('/').into_iter().chain(segments);
         self.container_client
             .url_with_segments(blob_name_with_segments)
     }


### PR DESCRIPTION
Azure Storage Containers supports including / as part of the blob name to enable a "blob hierarchy" similar to a directory structure.

Without this fix, the URL the container a and blob "b/c/d" ends up looking like this:

    https://account.blob.core.windows.net/a/b%2fc%2fd

The expected URL should be:

    https://account.blob.core.windows.net/a/b/c/d

This becomes important when using *resource* SAS URLs, as the SAS signatures must be of the canonical resource location, in this example works out to be:

     "/blob/account/a/b/c/d"

While the storage instance will canonicalize the URL, converting %2f into / when it accesses the resource, it does *not* canonicalize the path to the resource path to validate the signature.

Users can work around this by manually canonicalize the URL from blob_client.shared_access_signature().

Ref: https://docs.microsoft.com/en-us/rest/api/storageservices/create-service-sas
Ref: https://microsoft.github.io/AzureTipsAndTricks/blog/tip79.html