### PR TITLE
Removed Context mutability in pipeline

### DIFF
--- a/sdk/core/src/policies/custom_headers_injector_policy.rs
+++ b/sdk/core/src/policies/custom_headers_injector_policy.rs
@@ -19,7 +19,7 @@ pub struct CustomHeadersInjectorPolicy {}
 impl Policy for CustomHeadersInjectorPolicy {
     async fn send(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/core/src/policies/mock_transport_player_policy.rs
+++ b/sdk/core/src/policies/mock_transport_player_policy.rs
@@ -24,7 +24,7 @@ impl MockTransportPlayerPolicy {
 impl Policy for MockTransportPlayerPolicy {
     async fn send(
         &self,
-        _ctx: &mut Context,
+        _ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/core/src/policies/mock_transport_recorder_policy.rs
+++ b/sdk/core/src/policies/mock_transport_recorder_policy.rs
@@ -25,7 +25,7 @@ impl MockTransportRecorderPolicy {
 impl Policy for MockTransportRecorderPolicy {
     async fn send(
         &self,
-        _ctx: &mut Context,
+        _ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/core/src/policies/mod.rs
+++ b/sdk/core/src/policies/mod.rs
@@ -32,7 +32,7 @@ pub type PolicyResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
 pub trait Policy: Send + Sync + std::fmt::Debug {
     async fn send(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response>;

--- a/sdk/core/src/policies/retry_policies/no_retry.rs
+++ b/sdk/core/src/policies/retry_policies/no_retry.rs
@@ -14,7 +14,7 @@ pub struct NoRetryPolicy {
 impl Policy for NoRetryPolicy {
     async fn send(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -39,7 +39,7 @@ where
 {
     async fn send(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/core/src/policies/telemetry_policy.rs
+++ b/sdk/core/src/policies/telemetry_policy.rs
@@ -61,7 +61,7 @@ impl<'a> TelemetryPolicy {
 impl Policy for TelemetryPolicy {
     async fn send(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -24,7 +24,7 @@ impl TransportPolicy {
 impl Policy for TransportPolicy {
     async fn send(
         &self,
-        _ctx: &mut Context,
+        _ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/cosmos/src/authorization_policy.rs
+++ b/sdk/cosmos/src/authorization_policy.rs
@@ -40,7 +40,7 @@ impl AuthorizationPolicy {
 impl Policy for AuthorizationPolicy {
     async fn send(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {

--- a/sdk/storage/src/data_lake/authorization_policy.rs
+++ b/sdk/storage/src/data_lake/authorization_policy.rs
@@ -18,7 +18,7 @@ impl AuthorizationPolicy {
 impl Policy for AuthorizationPolicy {
     async fn send(
         &self,
-        ctx: &mut Context,
+        ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult<Response> {


### PR DESCRIPTION
This very simple PR fixes the mistake of making the `Context` a mutable reference in the pipeline. Policies are not supposed to mutate the `Context`. 

While the proposed approach does not prevent a policy to clone a `Context` reference and mutate it, preventing it might be more trouble than it is worth.