### PR TITLE
resolve parameters before codegen

### DIFF
--- a/services/autorust/codegen/src/codegen_operations.rs
+++ b/services/autorust/codegen/src/codegen_operations.rs
@@ -14,7 +14,7 @@ use heck::SnakeCase;
 use indexmap::IndexMap;
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::{collections::HashSet, path::Path};
+use std::collections::HashSet;
 
 fn error_variant(operation: &WebOperation) -> Result<TokenStream, Error> {
     let function = operation.rust_function_name().to_camel_case();
@@ -117,16 +117,16 @@ fn create_function(cg: &CodeGen, operation: &WebOperation) -> Result<TokenStream
 
     let fpath = format!("{{}}{}", &format_path(&operation.path));
 
-    let parameters: Vec<Parameter> = cg.spec.resolve_parameters(&operation.doc_file, &operation.parameters)?;
+    let parameters = &operation.parameters;
     let param_names: HashSet<_> = parameters.iter().map(|p| p.name.as_str()).collect();
     let has_param_api_version = param_names.contains("api-version");
     let mut skip = HashSet::new();
     if cg.spec.api_version().is_some() {
         skip.insert("api-version");
     }
-    let parameters: Vec<_> = parameters.into_iter().filter(|p| !skip.contains(p.name.as_str())).collect();
+    let parameters: Vec<_> = parameters.iter().filter(|p| !skip.contains(p.name.as_str())).collect();
 
-    let fparams = create_function_params(cg, &operation.doc_file, &parameters)?;
+    let fparams = create_function_params(&parameters)?;
 
     // see if there is a body parameter
     // let fresponse = create_function_return(operation_verb)?;
@@ -550,7 +550,7 @@ fn format_path(path: &str) -> String {
     PARAM_RE.replace_all(path, "{}").to_string()
 }
 
-fn create_function_params(_cg: &CodeGen, _doc_file: &Path, parameters: &[Parameter]) -> Result<TokenStream, Error> {
+fn create_function_params(parameters: &[&Parameter]) -> Result<TokenStream, Error> {
     let mut params: Vec<TokenStream> = Vec::new();
     for param in parameters {
         let name = get_param_name(param)?;

--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -254,7 +254,7 @@ impl Spec {
                     })
                 }
             })
-            .collect::<Result<Vec<_>, _>>()
+            .collect()
     }
 }
 

--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -397,7 +397,7 @@ pub mod openapi {
 }
 
 // contains unresolved parameters
-pub struct WebOperationUnresolved {
+struct WebOperationUnresolved {
     pub doc_file: PathBuf,
     pub id: Option<String>,
     pub path: String,
@@ -483,7 +483,7 @@ struct OperationVerb<'a> {
     pub verb: WebVerb,
 }
 
-pub fn path_operations_unresolved<P: AsRef<Path>>(doc_file: P, path: &str, item: &PathItem) -> Vec<WebOperationUnresolved> {
+fn path_operations_unresolved<P: AsRef<Path>>(doc_file: P, path: &str, item: &PathItem) -> Vec<WebOperationUnresolved> {
     vec![
         OperationVerb {
             operation: item.get.as_ref(),

--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -152,7 +152,7 @@ impl Spec {
     }
 
     /// Find the parameter for a given doc path and reference
-    fn resolve_parameter_ref<P: AsRef<Path>>(&self, doc_file: P, reference: Reference) -> Result<Parameter> {
+    pub fn resolve_parameter_ref<P: AsRef<Path>>(&self, doc_file: P, reference: Reference) -> Result<Parameter> {
         let doc_file = doc_file.as_ref();
         let full_path = match reference.file {
             None => doc_file.to_owned(),


### PR DESCRIPTION
This moves resolves parameters out of codegen_operations. One step closer to #520. One step closer to separating openapi & codegen. The generated service code is unchanged.