### PR TITLE
Enable blob to support async read

### DIFF
--- a/sdk/storage/examples/async_read_blob.rs
+++ b/sdk/storage/examples/async_read_blob.rs
@@ -1,0 +1,61 @@
+use azure_core::prelude::*;
+use azure_storage::blob::blob::responses::GetBlobResponse;
+use azure_storage::blob::prelude::*;
+use azure_storage::core::prelude::*;
+use futures::stream::TryStreamExt;
+use futures::AsyncBufReadExt;
+use std::io;
+// This example shows how to stream data from a blob. We will create a simple blob first, the we
+// ask it back using streaming features of the future crate. In this simple example we just
+// concatenate the data received in order to make sure the retrieved blob is equals to the one
+// created in the first place.
+// We do not use leases here but you definitely want to do so otherwise the returned stream
+// is not guaranteed to be consistent.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let file_name = "azure_sdk_for_rust_async_read_test.txt";
+
+    // First we retrieve the account name and master key from environment variables.
+    let connection_string =
+        std::env::var("CONNECTION_STRING").expect("Set env variable CONNECTION_STRING first!");
+
+    let container_name = std::env::args()
+        .nth(1)
+        .expect("please specify container name as first command line parameter");
+
+    let http_client = new_http_client();
+
+    let storage_client =
+        StorageAccountClient::new_connection_string(http_client.clone(), &connection_string)?
+            .as_storage_client();
+    let blob = storage_client
+        .as_container_client(&container_name)
+        .as_blob_client(file_name);
+
+    let mut reader = Box::pin(
+        get_blob_stream(&blob).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{}", &e))),
+    )
+    .into_async_read();
+    println!("{}", connection_string);
+    let mut buf = String::new();
+    let mut i = 0;
+    loop {
+        let size = reader.read_line(&mut buf).await?;
+        if size == 0 {
+            break;
+        }
+        println!("line {}: {}", i, buf);
+        i += 1;
+        buf.clear();
+    }
+
+    Ok(())
+}
+
+fn get_blob_stream<'a>(
+    blob: &'a BlobClient,
+) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>> + 'a
+{
+    let stream = blob.get().stream(1024);
+    stream
+}

--- a/sdk/storage/examples/async_read_blob.rs
+++ b/sdk/storage/examples/async_read_blob.rs
@@ -5,12 +5,7 @@ use azure_storage::core::prelude::*;
 use futures::stream::TryStreamExt;
 use futures::AsyncBufReadExt;
 use std::io;
-// This example shows how to stream data from a blob. We will create a simple blob first, the we
-// ask it back using streaming features of the future crate. In this simple example we just
-// concatenate the data received in order to make sure the retrieved blob is equals to the one
-// created in the first place.
-// We do not use leases here but you definitely want to do so otherwise the returned stream
-// is not guaranteed to be consistent.
+// This example shows how to async read data from a blob by wrapping the stream.
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let file_name = "azure_sdk_for_rust_async_read_test.txt";
@@ -36,14 +31,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         get_blob_stream(&blob).map_err(|e| io::Error::new(io::ErrorKind::Other, format!("{}", &e))),
     )
     .into_async_read();
-    println!("{}", connection_string);
+
     let mut buf = String::new();
     let mut i = 0;
-    loop {
-        let size = reader.read_line(&mut buf).await?;
-        if size == 0 {
-            break;
-        }
+    while reader.read_line(&mut buf).await? > 0 {
         println!("line {}: {}", i, buf);
         i += 1;
         buf.clear();

--- a/sdk/storage/src/blob/blob/responses/get_blob_response.rs
+++ b/sdk/storage/src/blob/blob/responses/get_blob_response.rs
@@ -40,3 +40,9 @@ impl TryFrom<(&str, Response<Bytes>)> for GetBlobResponse {
         })
     }
 }
+
+impl AsRef<[u8]> for GetBlobResponse {
+    fn as_ref(&self) -> &[u8] {
+        self.data.as_ref()
+    }
+}


### PR DESCRIPTION
The trait `AsRef<[u8]>` is required by a bound in `IntoAsyncRead`, but not implemented for `GetBlobResponse`.

**had manual test**

PTAL.