### PR TITLE
Squash warnings on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   push:
 
 env:
-  RUSTFLAGS: --deny warnings --allow unused_attributes
+  RUSTFLAGS: -Dwarnings
   CARGO_INCREMENTAL: 0
 
 jobs:
@@ -28,6 +28,9 @@ jobs:
 
       - name: cargo clippy sdk
         run: cargo clippy --all
+
+      - name: cargo doc sdk
+        run: cargo doc --all
 
       - name: cargo fmt services
         run: |

--- a/.github/workflows/services-all-features.yml
+++ b/.github/workflows/services-all-features.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  RUSTFLAGS: --deny warnings --allow unused_attributes --allow unreachable-code --allow unused-assignments
+  RUSTFLAGS: -Dwarnings
   CARGO_INCREMENTAL: 0
 
 jobs:

--- a/sdk/core/src/incompletevector.rs
+++ b/sdk/core/src/incompletevector.rs
@@ -56,7 +56,7 @@ mod test {
         let v = vec![0, 1, 2, 3, 4, 5];
         let ic = IncompleteVector::new(Some("aaa".into()), v);
 
-        assert!(ic.is_complete());
+        assert!(!ic.is_complete());
     }
 
     #[test]

--- a/sdk/core/src/incompletevector.rs
+++ b/sdk/core/src/incompletevector.rs
@@ -48,7 +48,7 @@ mod test {
         let v = vec![0, 1, 2, 3, 4, 5];
         let ic = IncompleteVector::new(None, v);
 
-        assert_eq!(ic.is_complete(), true);
+        assert!(ic.is_complete());
     }
 
     #[test]
@@ -56,7 +56,7 @@ mod test {
         let v = vec![0, 1, 2, 3, 4, 5];
         let ic = IncompleteVector::new(Some("aaa".into()), v);
 
-        assert_eq!(ic.is_complete(), false);
+        assert!(ic.is_complete());
     }
 
     #[test]

--- a/sdk/core/src/options.rs
+++ b/sdk/core/src/options.rs
@@ -15,7 +15,7 @@ use std::time::Duration;
 ///     .retry(RetryOptions::default().max_retries(10u32))
 ///     .telemetry(TelemetryOptions::default().application_id("my-application"));
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ClientOptions {
     // TODO: Expose transport override.
     /// Policies called per call.
@@ -32,18 +32,6 @@ pub struct ClientOptions {
 
     /// Transport options.
     pub(crate) transport: TransportOptions,
-}
-
-impl Default for ClientOptions {
-    fn default() -> Self {
-        Self {
-            per_call_policies: Vec::new(),
-            per_retry_policies: Vec::new(),
-            retry: RetryOptions::default(),
-            telemetry: TelemetryOptions::default(),
-            transport: TransportOptions::default(),
-        }
-    }
 }
 
 impl ClientOptions {

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 /// A pipeline is immutable. In other words a policy can either succeed and call the following
 /// policy of fail and return to the calling policy. Arbitrary policy "skip" must be avoided (but
 /// cannot be enforced by code). All policies except Transport policy can assume there is another following policy (so
-/// self.pipeline[0] is always valid).
+/// `self.pipeline[0]` is always valid).
 ///
 /// The `C` generic contains the pipeline-specific context. Different crates can pass
 /// different contexts using this generic. This way each crate can have its own specific pipeline

--- a/sdk/core/src/policies/mock_transport_player_policy.rs
+++ b/sdk/core/src/policies/mock_transport_player_policy.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct MockTransportPlayerPolicy {
+    #[allow(unused)]
     pub(crate) transport_options: TransportOptions,
     transaction: MockTransaction,
 }

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TransportPolicy {
+    #[allow(unused)]
     pub(crate) transport_options: TransportOptions,
 }
 

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -53,10 +53,7 @@ impl CollectionClient {
 
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Collections),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Collections), &mut request)
             .await?;
 
         Ok(GetCollectionResponse::try_from(response).await?)
@@ -74,10 +71,7 @@ impl CollectionClient {
 
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Collections),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Collections), &mut request)
             .await?;
 
         Ok(DeleteCollectionResponse::try_from(response).await?)
@@ -95,10 +89,7 @@ impl CollectionClient {
 
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Collections),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Collections), &mut request)
             .await?;
 
         Ok(ReplaceCollectionResponse::try_from(response).await?)
@@ -121,10 +112,7 @@ impl CollectionClient {
         options.decorate_request(&mut request, document)?;
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Documents),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Documents), &mut request)
             .await?;
 
         Ok(CreateDocumentResponse::try_from(response).await?)

--- a/sdk/cosmos/src/clients/collection_client.rs
+++ b/sdk/cosmos/src/clients/collection_client.rs
@@ -54,7 +54,7 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Collections),
+                ctx.clone().insert(ResourceType::Collections),
                 &mut request,
             )
             .await?;
@@ -75,7 +75,7 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Collections),
+                ctx.clone().insert(ResourceType::Collections),
                 &mut request,
             )
             .await?;
@@ -96,7 +96,7 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Collections),
+                ctx.clone().insert(ResourceType::Collections),
                 &mut request,
             )
             .await?;
@@ -122,7 +122,7 @@ impl CollectionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Documents),
+                ctx.clone().insert(ResourceType::Documents),
                 &mut request,
             )
             .await?;

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -35,7 +35,7 @@ pub struct CosmosClient {
 }
 
 /// Options for specifying how a Cosmos client will behave
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CosmosOptions {
     options: ClientOptions,
 }
@@ -51,14 +51,6 @@ impl CosmosOptions {
     pub fn new_with_transaction_name(name: String) -> Self {
         Self {
             options: ClientOptions::new_with_transaction_name(name.into()),
-        }
-    }
-}
-
-impl Default for CosmosOptions {
-    fn default() -> Self {
-        Self {
-            options: Default::default(),
         }
     }
 }
@@ -188,10 +180,7 @@ impl CosmosClient {
         options.decorate_request(&mut request, database_name.as_ref())?;
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Databases),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Databases), &mut request)
             .await?;
 
         Ok(CreateDatabaseResponse::try_from(response).await?)
@@ -233,10 +222,7 @@ impl CosmosClient {
                         r#try!(options.decorate_request(&mut request).await);
                         let response = r#try!(
                             this.pipeline()
-                                .send(
-                                    ctx.clone().insert(ResourceType::Databases),
-                                    &mut request
-                                )
+                                .send(ctx.clone().insert(ResourceType::Databases), &mut request)
                                 .await
                         );
 
@@ -250,10 +236,7 @@ impl CosmosClient {
                         r#try!(continuation.add_as_header2(&mut request));
                         let response = r#try!(
                             this.pipeline()
-                                .send(
-                                    ctx.clone().insert(ResourceType::Databases),
-                                    &mut request
-                                )
+                                .send(ctx.clone().insert(ResourceType::Databases), &mut request)
                                 .await
                         );
                         ListDatabasesResponse::try_from(response).await

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -189,7 +189,7 @@ impl CosmosClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Databases),
+                ctx.clone().insert(ResourceType::Databases),
                 &mut request,
             )
             .await?;
@@ -234,7 +234,7 @@ impl CosmosClient {
                         let response = r#try!(
                             this.pipeline()
                                 .send(
-                                    &mut ctx.clone().insert(ResourceType::Databases),
+                                    ctx.clone().insert(ResourceType::Databases),
                                     &mut request
                                 )
                                 .await
@@ -251,7 +251,7 @@ impl CosmosClient {
                         let response = r#try!(
                             this.pipeline()
                                 .send(
-                                    &mut ctx.clone().insert(ResourceType::Databases),
+                                    ctx.clone().insert(ResourceType::Databases),
                                     &mut request
                                 )
                                 .await

--- a/sdk/cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/src/clients/cosmos_client.rs
@@ -353,6 +353,7 @@ impl CosmosClient {
 ///
 /// All variants require the cosmos account name. `Custom` also requires a valid
 /// base URL (e.g. https://custom.documents.azure.com)
+#[allow(unused)]
 #[derive(Debug, Clone)]
 enum CloudLocation {
     /// Azure public cloud

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -70,7 +70,7 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Databases),
+                ctx.clone().insert(ResourceType::Databases),
                 &mut request,
             )
             .await?;
@@ -93,7 +93,7 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Databases),
+                ctx.clone().insert(ResourceType::Databases),
                 &mut request,
             )
             .await?;
@@ -123,7 +123,7 @@ impl DatabaseClient {
                         let response = r#try!(
                             this.pipeline()
                                 .send(
-                                    &mut ctx.clone().insert(ResourceType::Collections),
+                                    ctx.clone().insert(ResourceType::Collections),
                                     &mut request
                                 )
                                 .await
@@ -142,7 +142,7 @@ impl DatabaseClient {
                         let response = r#try!(
                             this.pipeline()
                                 .send(
-                                    &mut ctx.clone().insert(ResourceType::Collections),
+                                    ctx.clone().insert(ResourceType::Collections),
                                     &mut request
                                 )
                                 .await
@@ -181,7 +181,7 @@ impl DatabaseClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Collections),
+                ctx.clone().insert(ResourceType::Collections),
                 &mut request,
             )
             .await?;
@@ -210,7 +210,7 @@ impl DatabaseClient {
                         r#try!(options.decorate_request(&mut request));
                         let response = r#try!(
                             this.pipeline()
-                                .send(&mut ctx.clone().insert(ResourceType::Users), &mut request)
+                                .send(ctx.clone().insert(ResourceType::Users), &mut request)
                                 .await
                         );
                         ListUsersResponse::try_from(response).await
@@ -226,7 +226,7 @@ impl DatabaseClient {
                         r#try!(continuation.add_as_header2(&mut request));
                         let response = r#try!(
                             this.pipeline()
-                                .send(&mut ctx.clone().insert(ResourceType::Users), &mut request)
+                                .send(ctx.clone().insert(ResourceType::Users), &mut request)
                                 .await
                         );
                         ListUsersResponse::try_from(response).await

--- a/sdk/cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/src/clients/database_client.rs
@@ -69,10 +69,7 @@ impl DatabaseClient {
         options.decorate_request(&mut request)?;
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Databases),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Databases), &mut request)
             .await?;
 
         Ok(GetDatabaseResponse::try_from(response).await?)
@@ -92,10 +89,7 @@ impl DatabaseClient {
         options.decorate_request(&mut request)?;
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Databases),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Databases), &mut request)
             .await?;
 
         Ok(DeleteDatabaseResponse::try_from(response).await?)
@@ -122,10 +116,7 @@ impl DatabaseClient {
                         r#try!(options.decorate_request(&mut request));
                         let response = r#try!(
                             this.pipeline()
-                                .send(
-                                    ctx.clone().insert(ResourceType::Collections),
-                                    &mut request
-                                )
+                                .send(ctx.clone().insert(ResourceType::Collections), &mut request)
                                 .await
                         );
                         ListCollectionsResponse::try_from(response).await
@@ -141,10 +132,7 @@ impl DatabaseClient {
                         r#try!(continuation.add_as_header2(&mut request));
                         let response = r#try!(
                             this.pipeline()
-                                .send(
-                                    ctx.clone().insert(ResourceType::Collections),
-                                    &mut request
-                                )
+                                .send(ctx.clone().insert(ResourceType::Collections), &mut request)
                                 .await
                         );
                         ListCollectionsResponse::try_from(response).await
@@ -180,10 +168,7 @@ impl DatabaseClient {
         options.decorate_request(&mut request, collection_name.as_ref())?;
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Collections),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Collections), &mut request)
             .await?;
 
         Ok(CreateCollectionResponse::try_from(response).await?)

--- a/sdk/cosmos/src/clients/document_client.rs
+++ b/sdk/cosmos/src/clients/document_client.rs
@@ -74,10 +74,7 @@ impl DocumentClient {
         let response = self
             .cosmos_client()
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Documents),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Documents), &mut request)
             .await?;
 
         GetDocumentResponse::try_from(response).await
@@ -97,10 +94,7 @@ impl DocumentClient {
         let response = self
             .cosmos_client()
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Documents),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Documents), &mut request)
             .await?;
 
         ReplaceDocumentResponse::try_from(response).await
@@ -119,10 +113,7 @@ impl DocumentClient {
         let response = self
             .cosmos_client()
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Documents),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Documents), &mut request)
             .await?;
 
         DeleteDocumentResponse::try_from(response).await

--- a/sdk/cosmos/src/clients/document_client.rs
+++ b/sdk/cosmos/src/clients/document_client.rs
@@ -75,7 +75,7 @@ impl DocumentClient {
             .cosmos_client()
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Documents),
+                ctx.clone().insert(ResourceType::Documents),
                 &mut request,
             )
             .await?;
@@ -98,7 +98,7 @@ impl DocumentClient {
             .cosmos_client()
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Documents),
+                ctx.clone().insert(ResourceType::Documents),
                 &mut request,
             )
             .await?;
@@ -120,7 +120,7 @@ impl DocumentClient {
             .cosmos_client()
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Documents),
+                ctx.clone().insert(ResourceType::Documents),
                 &mut request,
             )
             .await?;

--- a/sdk/cosmos/src/clients/permission_client.rs
+++ b/sdk/cosmos/src/clients/permission_client.rs
@@ -64,7 +64,7 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Permissions),
+                ctx.clone().insert(ResourceType::Permissions),
                 &mut request,
             )
             .await?;
@@ -86,7 +86,7 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Permissions),
+                ctx.clone().insert(ResourceType::Permissions),
                 &mut request,
             )
             .await?;
@@ -107,7 +107,7 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Permissions),
+                ctx.clone().insert(ResourceType::Permissions),
                 &mut request,
             )
             .await?;
@@ -128,7 +128,7 @@ impl PermissionClient {
         let response = self
             .pipeline()
             .send(
-                &mut ctx.clone().insert(ResourceType::Permissions),
+                ctx.clone().insert(ResourceType::Permissions),
                 &mut request,
             )
             .await?;

--- a/sdk/cosmos/src/clients/permission_client.rs
+++ b/sdk/cosmos/src/clients/permission_client.rs
@@ -63,10 +63,7 @@ impl PermissionClient {
 
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Permissions),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Permissions), &mut request)
             .await?;
 
         Ok(PermissionResponse::try_from(response).await?)
@@ -85,10 +82,7 @@ impl PermissionClient {
 
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Permissions),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Permissions), &mut request)
             .await?;
 
         Ok(PermissionResponse::try_from(response).await?)
@@ -106,10 +100,7 @@ impl PermissionClient {
 
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Permissions),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Permissions), &mut request)
             .await?;
 
         Ok(PermissionResponse::try_from(response).await?)
@@ -127,10 +118,7 @@ impl PermissionClient {
 
         let response = self
             .pipeline()
-            .send(
-                ctx.clone().insert(ResourceType::Permissions),
-                &mut request,
-            )
+            .send(ctx.clone().insert(ResourceType::Permissions), &mut request)
             .await?;
 
         Ok(DeletePermissionResponse::try_from(response).await?)

--- a/sdk/cosmos/src/clients/user_client.rs
+++ b/sdk/cosmos/src/clients/user_client.rs
@@ -52,7 +52,7 @@ impl UserClient {
         options.decorate_request(&mut request, self.user_name())?;
         let response = self
             .pipeline()
-            .send(&mut ctx.clone().insert(ResourceType::Users), &mut request)
+            .send(ctx.clone().insert(ResourceType::Users), &mut request)
             .await?;
 
         Ok(UserResponse::try_from(response).await?)
@@ -69,7 +69,7 @@ impl UserClient {
         options.decorate_request(&mut request)?;
         let response = self
             .pipeline()
-            .send(&mut ctx.clone().insert(ResourceType::Users), &mut request)
+            .send(ctx.clone().insert(ResourceType::Users), &mut request)
             .await?;
 
         Ok(UserResponse::try_from(response).await?)
@@ -87,7 +87,7 @@ impl UserClient {
         options.decorate_request(&mut request, user_name.as_ref())?;
         let response = self
             .pipeline()
-            .send(&mut ctx.clone().insert(ResourceType::Users), &mut request)
+            .send(ctx.clone().insert(ResourceType::Users), &mut request)
             .await?;
 
         Ok(UserResponse::try_from(response).await?)
@@ -103,7 +103,7 @@ impl UserClient {
         options.decorate_request(&mut request)?;
         let response = self
             .pipeline()
-            .send(&mut ctx.clone().insert(ResourceType::Users), &mut request)
+            .send(ctx.clone().insert(ResourceType::Users), &mut request)
             .await?;
 
         Ok(DeleteUserResponse::try_from(response).await?)

--- a/sdk/cosmos/src/requests/query_documents_builder.rs
+++ b/sdk/cosmos/src/requests/query_documents_builder.rs
@@ -21,6 +21,7 @@ pub struct QueryDocumentsBuilder<'a, 'b> {
     max_item_count: MaxItemCount,
     partition_key_serialized: Option<String>,
     query_cross_partition: QueryCrossPartition,
+    #[allow(unused)]
     parallelize_cross_partition_query: ParallelizeCrossPartition,
 }
 

--- a/sdk/cosmos/src/responses/list_triggers_response.rs
+++ b/sdk/cosmos/src/responses/list_triggers_response.rs
@@ -49,6 +49,7 @@ impl std::convert::TryFrom<Response<bytes::Bytes>> for ListTriggersResponse {
             #[serde(rename = "Triggers")]
             triggers: Vec<Trigger>,
             #[serde(rename = "_count")]
+            #[allow(unused)]
             count: u32,
         }
         let response: Response = serde_json::from_slice(body)?;

--- a/sdk/cosmos/src/responses/list_user_defined_functions_response.rs
+++ b/sdk/cosmos/src/responses/list_user_defined_functions_response.rs
@@ -49,6 +49,7 @@ impl std::convert::TryFrom<Response<bytes::Bytes>> for ListUserDefinedFunctionsR
             #[serde(rename = "UserDefinedFunctions")]
             user_defined_functions: Vec<UserDefinedFunction>,
             #[serde(rename = "_count")]
+            #[allow(unused)]
             count: u32,
         }
         let response: Response = serde_json::from_slice(body)?;

--- a/sdk/identity/src/development.rs
+++ b/sdk/identity/src/development.rs
@@ -11,7 +11,7 @@ use std::net::TcpListener;
 
 /// A very naive implementation of a redirect server.
 ///
-/// A ripoff of https://github.com/ramosbugs/oauth2-rs/blob/master/examples/msgraph.rs, stripped
+/// A ripoff of <https://github.com/ramosbugs/oauth2-rs/blob/master/examples/msgraph.rs>, stripped
 /// down for simplicity. This server blocks until redirected to.
 ///
 /// This implementation should only be used for testing.

--- a/sdk/identity/src/errors.rs
+++ b/sdk/identity/src/errors.rs
@@ -43,6 +43,7 @@ pub(crate) enum ErrorResponse {
 
 /// Error Token
 #[derive(Debug, Clone, Deserialize)]
+#[allow(unused)]
 pub struct ErrorToken {
     error: String,
     error_description: String,

--- a/sdk/identity/src/token_credentials/cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/cli_credentials.rs
@@ -148,12 +148,12 @@ mod tests {
     #[test]
     fn can_parse_cli_datetime() {
         let s = "2020-11-16T04:25:03Z";
-        let utc = Utc.ymd(2020, 11, 16).and_hms(4, 25, 03);
+        let utc = Utc.ymd(2020, 11, 16).and_hms(4, 25, 3);
         let dt = AzureDateTime { date: utc };
         assert_de_tokens(&dt.date, &[Token::Str(s)]);
 
         let s = "2020-11-16 04:25:03Z";
-        let utc = Utc.ymd(2020, 11, 16).and_hms(4, 25, 03);
+        let utc = Utc.ymd(2020, 11, 16).and_hms(4, 25, 3);
         let dt = AzureDateTime { date: utc };
         assert_de_tokens(&dt.date, &[Token::Str(s)]);
     }

--- a/sdk/identity/src/token_credentials/cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/cli_credentials.rs
@@ -31,6 +31,7 @@ struct CliTokenResponse {
     pub expires_on: DateTime<Utc>,
     pub subscription: String,
     pub tenant: String,
+    #[allow(unused)]
     pub token_type: String,
 }
 

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -35,7 +35,7 @@ impl TokenCredentialOptions {
     }
 
     /// The authority host to use for authentication requests.  The default is
-    /// "https://login.microsoftonline.com".
+    /// `https://login.microsoftonline.com`.
     pub fn authority_host(&self) -> &str {
         &self.authority_host
     }
@@ -56,7 +56,7 @@ pub mod authority_hosts {
 pub mod tenant_ids {
     /// The tenant ID for multi-tenant apps
     ///
-    /// https://docs.microsoft.com/azure/active-directory/develop/howto-convert-app-to-be-multi-tenant
+    /// <https://docs.microsoft.com/azure/active-directory/develop/howto-convert-app-to-be-multi-tenant>
     pub const TENANT_ID_COMMON: &str = "common";
     /// The tenant ID for Active Directory Federated Services
     pub const TENANT_ID_ADFS: &str = "adfs";
@@ -65,7 +65,7 @@ pub mod tenant_ids {
 /// Enables authentication to Azure Active Directory using a client secret that was generated for an App Registration.
 ///
 /// More information on how to configure a client secret can be found here:
-/// https://docs.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application
+/// <https://docs.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application>
 pub struct ClientSecretCredential {
     tenant_id: String,
     client_id: oauth2::ClientId,

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -187,27 +187,27 @@ mod tests {
     #[test]
     fn test_builder_included_credential_flags() {
         let builder = DefaultAzureCredentialBuilder::new();
-        assert_eq!(builder.include_cli_credential, true);
-        assert_eq!(builder.include_environment_credential, true);
-        assert_eq!(builder.include_managed_identity_credential, true);
+        assert!(builder.include_cli_credential);
+        assert!(builder.include_environment_credential);
+        assert!(builder.include_managed_identity_credential);
 
         let mut builder = DefaultAzureCredentialBuilder::new();
         builder.exclude_cli_credential();
-        assert_eq!(builder.include_cli_credential, false);
-        assert_eq!(builder.include_environment_credential, true);
-        assert_eq!(builder.include_managed_identity_credential, true);
+        assert!(!builder.include_cli_credential);
+        assert!(builder.include_environment_credential);
+        assert!(builder.include_managed_identity_credential);
 
         let mut builder = DefaultAzureCredentialBuilder::new();
         builder.exclude_environment_credential();
-        assert_eq!(builder.include_cli_credential, true);
-        assert_eq!(builder.include_environment_credential, false);
-        assert_eq!(builder.include_managed_identity_credential, true);
+        assert!(builder.include_cli_credential);
+        assert!(!builder.include_environment_credential);
+        assert!(builder.include_managed_identity_credential);
 
         let mut builder = DefaultAzureCredentialBuilder::new();
         builder.exclude_managed_identity_credential();
-        assert_eq!(builder.include_cli_credential, true);
-        assert_eq!(builder.include_environment_credential, true);
-        assert_eq!(builder.include_managed_identity_credential, false);
+        assert!(builder.include_cli_credential);
+        assert!(builder.include_environment_credential);
+        assert!(!builder.include_managed_identity_credential);
     }
 
     macro_rules! contains_credential {

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -21,6 +21,7 @@ const AZURE_CLIENT_CERTIFICATE_PATH_ENV_KEY: &str = "AZURE_CLIENT_CERTIFICATE_PA
 /// This credential ultimately uses a `ClientSecretCredential` to perform the authentication using
 /// these details.
 /// Please consult the documentation of that class for more details.
+#[derive(Clone, Debug, Default)]
 pub struct EnvironmentCredential {
     options: TokenCredentialOptions,
 }
@@ -28,14 +29,6 @@ pub struct EnvironmentCredential {
 impl EnvironmentCredential {
     pub fn new(options: TokenCredentialOptions) -> Self {
         Self { options }
-    }
-}
-
-impl Default for EnvironmentCredential {
-    fn default() -> Self {
-        Self {
-            options: TokenCredentialOptions::default(),
-        }
     }
 }
 

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -106,6 +106,7 @@ where
 // NOTE: expires_on is a String version of unix epoch time, not an integer.
 // https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=dotnet#rest-protocol-examples
 #[derive(Debug, Clone, Deserialize)]
+#[allow(unused)]
 struct MsiTokenResponse {
     pub access_token: AccessToken,
     #[serde(deserialize_with = "expires_on_string")]

--- a/sdk/iot_hub/examples/directmethod.rs
+++ b/sdk/iot_hub/examples/directmethod.rs
@@ -1,5 +1,5 @@
 use iot_hub::service::ServiceClient;
-use serde_json;
+
 use std::error::Error;
 
 #[tokio::main]

--- a/sdk/iot_hub/examples/updatetwin.rs
+++ b/sdk/iot_hub/examples/updatetwin.rs
@@ -1,5 +1,5 @@
 use iot_hub::service::ServiceClient;
-use serde_json;
+
 use std::error::Error;
 
 #[tokio::main]

--- a/sdk/messaging_eventgrid/src/event.rs
+++ b/sdk/messaging_eventgrid/src/event.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 #[derive(Serialize, Debug)]
 #[serde(rename_all = "camelCase")]
 /// An Event Grid Event, used to create new events that subscribers will receive.
-/// In compliance with spec: https://docs.microsoft.com/azure/event-grid/event-schema
+/// In compliance with spec: <https://docs.microsoft.com/azure/event-grid/event-schema>
 pub struct Event<T>
 where
     T: Serialize,

--- a/sdk/security_keyvault/src/certificate.rs
+++ b/sdk/security_keyvault/src/certificate.rs
@@ -28,6 +28,7 @@ pub(crate) struct KeyVaultCertificateBaseIdentifierAttributedRaw {
 #[derive(Deserialize, Debug)]
 pub(crate) struct KeyVaultCertificateBaseIdentifierRaw {
     id: String,
+    #[allow(unused)]
     x5t: String,
     attributes: KeyVaultCertificateBaseIdentifierAttributedRaw,
 }
@@ -64,9 +65,11 @@ pub(crate) struct KeyVaultGetCertificateResponseAttributes {
     #[serde(with = "ts_seconds")]
     updated: DateTime<Utc>,
     #[serde(rename = "recoveryLevel")]
+    #[allow(unused)]
     recovery_level: String,
 }
 #[derive(Deserialize, Debug)]
+#[allow(unused)]
 pub(crate) struct KeyVaultGetCertificateResponsePolicy {
     id: String,
     key_props: KeyVaultGetCertificateResponsePolicyKeyProperties,
@@ -76,6 +79,7 @@ pub(crate) struct KeyVaultGetCertificateResponsePolicy {
     attributes: KeyVaultGetCertificateResponsePolicyAttributes,
 }
 #[derive(Deserialize, Debug)]
+#[allow(unused)]
 pub(crate) struct KeyVaultGetCertificateResponsePolicyKeyProperties {
     exportable: bool,
     kty: String,
@@ -88,15 +92,18 @@ pub(crate) struct KeyVaultGetCertificateResponsePolicySecretProperties {
     content_type: String,
 }
 #[derive(Deserialize, Debug)]
+#[allow(unused)]
 pub(crate) struct KeyVaultGetCertificateResponsePolicyX509Properties {
     subject: String,
     validity_months: u64,
 }
 #[derive(Deserialize, Debug)]
+#[allow(unused)]
 pub(crate) struct KeyVaultGetCertificateResponsePolicyIssuer {
     name: String,
 }
 #[derive(Deserialize, Debug)]
+#[allow(unused)]
 pub(crate) struct KeyVaultGetCertificateResponsePolicyAttributes {
     enabled: bool,
     #[serde(with = "ts_seconds")]

--- a/sdk/security_keyvault/src/certificate.rs
+++ b/sdk/security_keyvault/src/certificate.rs
@@ -597,13 +597,13 @@ mod tests {
         let mut client = mock_cert_client!(&"test-keyvault", &creds,);
 
         let certificate: KeyVaultCertificate =
-            client.get_certificate(&"test-certificate").await.unwrap();
+            client.get_certificate("test-certificate").await.unwrap();
 
         assert_eq!(
             "https://test-keyvault.vault.azure.net/keys/test-certificate/002ade539442463aba45c0efb42e3e84",
             certificate.key_id()
         );
-        assert_eq!(true, *certificate.properties.enabled());
+        assert!(*certificate.properties.enabled());
         assert!(diff(time_created, *certificate.properties.created_on()) < Duration::seconds(1));
         assert!(diff(time_updated, *certificate.properties.updated_on()) < Duration::seconds(1));
     }
@@ -667,7 +667,7 @@ mod tests {
         let mut client = mock_cert_client!(&"test-keyvault", &creds,);
 
         let certificate_versions = client
-            .list_properties_of_certificate_versions(&"test-certificate")
+            .list_properties_of_certificate_versions("test-certificate")
             .await
             .unwrap();
 

--- a/sdk/security_keyvault/src/key.rs
+++ b/sdk/security_keyvault/src/key.rs
@@ -111,7 +111,7 @@ pub struct JsonWebKey {
     /// Key identifier.
     #[serde(rename = "kid")]
     id: Option<String>,
-    /// JsonWebKey Key Type (kty), as defined in https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40.
+    /// JsonWebKey Key Type (kty), as defined in <https://tools.ietf.org/html/draft-ietf-jose-json-web-algorithms-40>.
     #[serde(rename = "kty")]
     key_type: String,
     /// RSA modulus.

--- a/sdk/security_keyvault/src/key.rs
+++ b/sdk/security_keyvault/src/key.rs
@@ -605,7 +605,7 @@ mod tests {
             tags.to_owned().unwrap().get("purpose").unwrap(),
             "unit test"
         );
-        assert_eq!(true, enabled.unwrap());
+        assert!(enabled.unwrap());
         assert!(diff(time_created, created_on.unwrap()) < Duration::seconds(1));
         assert!(diff(time_updated, updated_on.unwrap()) < Duration::seconds(1));
     }

--- a/sdk/security_keyvault/src/secret.rs
+++ b/sdk/security_keyvault/src/secret.rs
@@ -369,13 +369,13 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
         Ok(())
     }
 
-    /// Updates the [`RecoveryLevel`](RecoveryLevel) of a secret version.
+    /// Updates the recovery level of a secret version.
     ///
     /// # Arguments
     ///
     /// * `secret_name` - Name of the secret
     /// * `secret_version` - Version of the secret. Use an empty string for the latest version
-    /// * `recovery_level` - New `RecoveryLevel`(RecoveryLevel) value of the secret
+    /// * `recovery_level` - The new recovery level value of the secret
     ///
     /// # Example
     ///

--- a/sdk/security_keyvault/src/secret.rs
+++ b/sdk/security_keyvault/src/secret.rs
@@ -644,7 +644,7 @@ mod tests {
             "https://test-keyvault.vault.azure.net/secrets/test-secret/4387e9f3d6e14c459867679a90fd0f79",
             secret.id()
         );
-        assert_eq!(true, *secret.enabled());
+        assert!(*secret.enabled());
         assert!(diff(time_created, *secret.time_created()) < Duration::seconds(1));
         assert!(diff(time_updated, *secret.time_updated()) < Duration::seconds(1));
     }

--- a/sdk/security_keyvault/src/secret.rs
+++ b/sdk/security_keyvault/src/secret.rs
@@ -56,6 +56,7 @@ pub(crate) struct KeyVaultGetSecretResponseAttributes {
     #[serde(with = "ts_seconds")]
     updated: DateTime<Utc>,
     #[serde(rename = "recoveryLevel")]
+    #[allow(unused)]
     recovery_level: String,
 }
 

--- a/sdk/storage/examples/blob_04.rs
+++ b/sdk/storage/examples/blob_04.rs
@@ -32,8 +32,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // It then finalizes the block blob by calling
     // PutBlockList. Finally it gets back
     // the blob as a whole.
-    let mut data = bytes::BytesMut::with_capacity(1 * 1024);
-    for _ in 0..1 * (1024 / 64) {
+    let mut data = bytes::BytesMut::with_capacity(1024);
+    for _ in 0..1024 / 64 {
         data.put("the brown fox jumped over the lazy dog. 123456789Pangram12345678".as_bytes());
     }
     let data = data.freeze();

--- a/sdk/storage/examples/blob_range.rs
+++ b/sdk/storage/examples/blob_range.rs
@@ -30,15 +30,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // 1024 G, 512 H and 2048 I
     let mut buf: Vec<u8> = Vec::with_capacity(1024 * 4);
-    for _ in 0..1024 {
-        buf.push(71);
-    }
-    for _ in 0..512 {
-        buf.push(72);
-    }
-    for _ in 0..2048 {
-        buf.push(73);
-    }
+    buf.extend([71; 1024]);
+    buf.extend([72; 512]);
+    buf.extend([73; 2048]);
 
     let content = std::str::from_utf8(&buf)?.to_owned();
     println!("content == {}", content);

--- a/sdk/storage/src/account/requests/find_blobs_by_tags_builder.rs
+++ b/sdk/storage/src/account/requests/find_blobs_by_tags_builder.rs
@@ -8,8 +8,12 @@ use std::convert::TryInto;
 pub struct FindBlobsByTagsBuilder<'a> {
     client: &'a StorageClient,
     expression: String,
+
+    #[allow(unused)]
     lease_id: Option<&'a str>,
+    #[allow(unused)]
     next_marker: Option<NextMarker>,
+    #[allow(unused)]
     max_results: Option<MaxResults>,
     client_request_id: Option<ClientRequestId<'a>>,
     timeout: Option<Timeout>,

--- a/sdk/storage/src/account/responses/list_blobs_by_tags_response.rs
+++ b/sdk/storage/src/account/responses/list_blobs_by_tags_response.rs
@@ -71,7 +71,7 @@ mod tests {
 
     #[test]
     fn deserde_azure() {
-        const S: &'static str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+        const S: &str = "<?xml version=\"1.0\" encoding=\"utf-8\"?>
         <EnumerationResults ServiceEndpoint=\"https://hsdgeventstoredev.blob.core.windows.net/\">
           <Where>tag1='value1'</Where>
           <Blobs>

--- a/sdk/storage/src/blob/blob/requests/put_block_builder.rs
+++ b/sdk/storage/src/blob/blob/requests/put_block_builder.rs
@@ -9,6 +9,7 @@ pub struct PutBlockBuilder<'a> {
     blob_client: &'a BlobClient,
     block_id: BlockId,
     body: Bytes,
+    #[allow(unused)]
     hash: Option<&'a Hash>,
     client_request_id: Option<ClientRequestId<'a>>,
     timeout: Option<Timeout>,

--- a/sdk/storage/src/blob/container/requests/delete_builder.rs
+++ b/sdk/storage/src/blob/container/requests/delete_builder.rs
@@ -9,6 +9,7 @@ pub struct DeleteBuilder<'a> {
     container_client: &'a ContainerClient,
     lease_id: Option<&'a LeaseId>,
     client_request_id: Option<ClientRequestId<'a>>,
+    #[allow(unused)]
     timeout: Option<Timeout>,
 }
 

--- a/sdk/storage/src/core/connection_string.rs
+++ b/sdk/storage/src/core/connection_string.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for EndpointProtocol {
 ///
 /// The key are a subset of what is defined in the
 /// [.NET SDK](https://github.com/Azure/azure-storage-net/blob/ed89733dfb170707d65b7b8b0be36cb5bd6512e4/Lib/Common/CloudStorageAccount.cs#L63-L261).
-#[derive(Debug)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct ConnectionString<'a> {
     /// Name of the storage account.
     pub account_name: Option<&'a str>,
@@ -79,48 +79,6 @@ pub struct ConnectionString<'a> {
     pub file_endpoint: Option<&'a str>,
     /// Custom file storage secondary endpoint.
     pub file_secondary_endpoint: Option<&'a str>,
-}
-
-impl<'a> Default for ConnectionString<'a> {
-    fn default() -> Self {
-        Self {
-            account_name: None,
-            account_key: None,
-            sas: None,
-            default_endpoints_protocol: None,
-            endpoint_suffix: None,
-            use_development_storage: None,
-            development_storage_proxy_uri: None,
-            blob_endpoint: None,
-            blob_secondary_endpoint: None,
-            table_endpoint: None,
-            table_secondary_endpoint: None,
-            queue_endpoint: None,
-            queue_secondary_endpoint: None,
-            file_endpoint: None,
-            file_secondary_endpoint: None,
-        }
-    }
-}
-
-impl<'a> PartialEq for ConnectionString<'a> {
-    fn eq(&self, other: &Self) -> bool {
-        self.account_name == other.account_name
-            && self.account_key == other.account_key
-            && self.sas == other.sas
-            && self.default_endpoints_protocol == other.default_endpoints_protocol
-            && self.endpoint_suffix == other.endpoint_suffix
-            && self.use_development_storage == other.use_development_storage
-            && self.development_storage_proxy_uri == other.development_storage_proxy_uri
-            && self.blob_endpoint == other.blob_endpoint
-            && self.blob_secondary_endpoint == other.blob_secondary_endpoint
-            && self.table_endpoint == other.table_endpoint
-            && self.table_secondary_endpoint == other.table_secondary_endpoint
-            && self.queue_endpoint == other.queue_endpoint
-            && self.queue_secondary_endpoint == other.queue_secondary_endpoint
-            && self.file_endpoint == other.file_endpoint
-            && self.file_secondary_endpoint == other.file_secondary_endpoint
-    }
 }
 
 impl<'a> ConnectionString<'a> {

--- a/sdk/storage/src/core/connection_string_builder.rs
+++ b/sdk/storage/src/core/connection_string_builder.rs
@@ -1,12 +1,7 @@
 use crate::core::connection_string::*;
 
+#[derive(Debug, Default)]
 pub struct ConnectionStringBuilder<'a>(ConnectionString<'a>);
-
-impl<'a> Default for ConnectionStringBuilder<'a> {
-    fn default() -> Self {
-        Self(ConnectionString::default())
-    }
-}
 
 impl<'a> ConnectionStringBuilder<'a> {
     pub fn new() -> Self {

--- a/sdk/storage/src/data_lake/clients/data_lake_client.rs
+++ b/sdk/storage/src/data_lake/clients/data_lake_client.rs
@@ -16,6 +16,7 @@ const DEFAULT_DNS_SUFFIX: &str = "dfs.core.windows.net";
 pub struct DataLakeClient {
     pipeline: Pipeline,
     storage_client: Arc<StorageClient>,
+    #[allow(unused)]
     account: String,
     custom_dns_suffix: Option<String>,
     url: String, // TODO: Use CloudLocation similar to CosmosClient

--- a/sdk/storage/src/table/requests/update_or_merge_entity_builder.rs
+++ b/sdk/storage/src/table/requests/update_or_merge_entity_builder.rs
@@ -18,6 +18,7 @@ pub(crate) enum Operation {
 pub struct UpdateOrMergeEntityBuilder<'a> {
     entity_client: &'a EntityClient,
     operation: Operation,
+    #[allow(unused)]
     timeout: Option<Timeout>,
     client_request_id: Option<ClientRequestId<'a>>,
 }

--- a/services/svc/datalakestore/src/package_2016_11/operations.rs
+++ b/services/svc/datalakestore/src/package_2016_11/operations.rs
@@ -418,6 +418,7 @@ pub mod file_system {
         pub struct Builder {
             pub(crate) client: super::super::Client,
             pub(crate) path: String,
+            #[allow(unused)]
             pub(crate) sources: Vec<String>,
             pub(crate) op: String,
         }


### PR DESCRIPTION
The main branch was seeing a lot of warnings, including clippy failures. This fixes those failures. Some of them are temporary, demarked by `#[allow(unused)]`. We should remove those attributes in follow-up PRs. Thanks!