### PR TITLE
Fix wrong definition of certificate authority

### DIFF
--- a/sdk/iot_hub/src/service/resources/identity.rs
+++ b/sdk/iot_hub/src/service/resources/identity.rs
@@ -55,11 +55,8 @@ pub struct X509ThumbPrint {
 /// AuthenticationType of a module or device.
 #[derive(Serialize, Debug, Deserialize, PartialEq)]
 pub enum AuthenticationType {
-    /// Authentication using certificate
-    #[serde(rename = "certificate")]
-    Certificate,
     /// Authentication using a certificate authority.
-    #[serde(rename = "Authority")]
+    #[serde(rename = "certificateAuthority")]
     Authority,
     /// The device or module is not authenticated.
     #[serde(rename = "none")]


### PR DESCRIPTION
The pre-commit implementation does not work, if a device is created with Authority type, a device with a SAS is created instead.
From azure-iot-sdk-python: "Possible values include: 'sas', 'selfSigned', 'certificateAuthority', 'none'".
With this fix, creating a device and modules with Authority type does work.