### PR TITLE
Force operationalinsight query result rows to serde_json::Value.

### DIFF
--- a/services/autorust/codegen/examples/gen_svc.rs
+++ b/services/autorust/codegen/examples/gen_svc.rs
@@ -27,11 +27,18 @@ const SKIP_SERVICE_TAGS: &[(&str, &str)] = &[
     ("storagedatalake", "package-2019-10"),
 ];
 
-const INVALID_TYPE_WORKAROUND: &[(&str, &str, &str)] = &[(
-    "../../../azure-rest-api-specs/specification/applicationinsights/data-plane/Microsoft.Insights/preview/v1/AppInsights.json",
-    "table",
-    "rows",
-)];
+const INVALID_TYPE_WORKAROUND: &[(&str, &str, &str)] = &[
+    (
+        "../../../azure-rest-api-specs/specification/applicationinsights/data-plane/Microsoft.Insights/preview/v1/AppInsights.json",
+        "table",
+        "rows",
+    ),
+    (
+        "../../../azure-rest-api-specs/specification/operationalinsights/data-plane/Microsoft.OperationalInsights/stable/v1/OperationalInsights.json",
+        "table",
+        "rows",
+    ),
+];
 
 const FIX_CASE_PROPERTIES: &[&str] = &["BatchServiceClient", "BatchService"];
 

--- a/services/svc/operationalinsights/src/v1/models.rs
+++ b/services/svc/operationalinsights/src/v1/models.rs
@@ -21,7 +21,7 @@ pub struct QueryResults {
 pub struct Table {
     pub name: String,
     pub columns: Vec<Column>,
-    pub rows: Vec<Vec<String>>,
+    pub rows: serde_json::Value,
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Column {


### PR DESCRIPTION
This uses the machinery introduced in #399 and addresses the same problem in operational insights. The current `Vec<Vec<String>>` as derived from the OpenAPI spec is misguided, since the returned result can contain e.g. booleans.