### PR TITLE
fix rustls support for data tables and storage blobs

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -23,9 +23,9 @@ http = "0.2"
 hyper = { version = "0.14", optional = true }
 hyper-rustls = { version = "0.22", optional = true }
 log = "0.4"
-oauth2 = { version = "4.0", default_features=false }
+oauth2 = { version = "4.0", default-features=false }
 rand = "0.8"
-reqwest = { version = "0.11", features = ["stream"], default_features=false, optional = true }
+reqwest = { version = "0.11", features = ["stream"], default-features=false, optional = true }
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.1.0", default-features=false}
-azure_storage = { path = "../storage", version = "0.1.0", default-features=false}
+azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"]}
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0" }
-azure_storage = { path = "../storage", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0", default-features=false}
+azure_storage = { path = "../storage", version = "0.1.0", default-features=false}
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
@@ -32,6 +32,7 @@ url = "2.2"
 tokio = { version = "1.0", features = ["full"] }
 
 [features]
+default = ["enable_reqwest"]
 test_e2e = []
 enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls", "azure_storage/enable_reqwest_rustls"]

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0" }
-azure_storage = { path = "../storage", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0", default-features=false }
+azure_storage = { path = "../storage", version = "0.1.0", default-features=false }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
@@ -37,6 +37,7 @@ azure_identity = { path = "../identity" }
 reqwest = "0.11"
 
 [features]
+default = ["enable_reqwest"]
 test_e2e = []
 enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls", "azure_storage/enable_reqwest_rustls"]

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.1.0", default-features=false }
-azure_storage = { path = "../storage", version = "0.1.0", default-features=false }
+azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"] }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0" }
-azure_storage = { path = "../storage", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0", default-features=false }
+azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"] }
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
@@ -31,6 +31,7 @@ url = "2.2"
 tokio = { version = "1.0", features = ["full"] }
 
 [features]
+default = ["enable_reqwest"]
 test_e2e = []
 enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls", "azure_storage/enable_reqwest_rustls"]


### PR DESCRIPTION
* Adds `default-features = false` to the recently split out data_tables & storage_blobs crates.  This fixes targeting MUSL without using OpenSSL.
* Normalizes default features to "default-features", which is the recommendation from cargo docs (ref: https://doc.rust-lang.org/cargo/reference/features.html#dependency-features )