### PR TITLE
drop Error suffix from cases

### DIFF
--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -27,38 +27,29 @@ pub enum HttpHeaderError {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("pipeline error: {0}")]
-    PipelineError(#[from] PipelineError),
+    Pipeline(#[from] PipelineError),
     #[error("policy error: {0}")]
-    PolicyError(Box<dyn std::error::Error + Send + Sync>),
+    Policy(Box<dyn std::error::Error + Send + Sync>),
     #[error("parsing error: {0}")]
-    ParsingError(#[from] ParsingError),
+    Parsing(#[from] ParsingError),
     #[error("error getting token: {0}")]
-    GetTokenError(Box<dyn std::error::Error + Send + Sync>),
+    GetToken(Box<dyn std::error::Error + Send + Sync>),
     #[error("http error: {0}")]
-    HttpError(#[from] HttpError),
+    Http(#[from] HttpError),
     #[error("to str error: {0}")]
-    ToStrError(#[from] http::header::ToStrError),
+    ToStr(#[from] http::header::ToStrError),
     #[error("header error: {0}")]
-    HeaderError(#[from] HttpHeaderError),
+    Header(#[from] HttpHeaderError),
     #[error("header not found: {0}")]
     HeaderNotFound(String),
     #[error("at least one of these headers must be present: {0:?}")]
     HeadersNotFound(Vec<String>),
-    #[error(
-        "the expected query parameter {} was not found in the provided Url: {:?}",
-        expected_parameter,
-        url
-    )]
-    UrlQueryParameterNotFound {
-        expected_parameter: String,
-        url: url::Url,
-    },
     #[error("error preparing HTTP request: {0}")]
-    HttpPrepareError(#[from] http::Error),
+    HttpPrepare(#[from] http::Error),
     #[error(transparent)]
-    StreamError(#[from] StreamError),
+    Stream(#[from] StreamError),
     #[error("JSON error: {0}")]
-    JsonError(#[from] serde_json::Error),
+    Json(#[from] serde_json::Error),
     #[error("Other error: {0}")]
     Other(Box<dyn std::error::Error + Send + Sync + 'static>),
 }

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -156,7 +156,7 @@ where
 {
     get_str_from_headers(headers, key)?
         .parse()
-        .map_err(|e: T::Err| Error::ParsingError(e.into()))
+        .map_err(|e: T::Err| Error::Parsing(e.into()))
 }
 
 pub fn get_option_from_headers<T>(headers: &HeaderMap, key: &str) -> Result<Option<T>>
@@ -169,7 +169,7 @@ where
             header
                 .to_str()?
                 .parse()
-                .map_err(|e: T::Err| Error::ParsingError(e.into()))?,
+                .map_err(|e: T::Err| Error::Parsing(e.into()))?,
         )),
         None => Ok(None),
     }

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -110,6 +110,6 @@ impl Pipeline {
         self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
             .await
-            .map_err(Error::PolicyError)
+            .map_err(Error::Policy)
     }
 }

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -24,25 +24,25 @@ pub enum Error {
 
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
-        Self::Core(azure_core::Error::JsonError(error))
+        Self::Core(azure_core::Error::Json(error))
     }
 }
 
 impl From<azure_core::StreamError> for Error {
     fn from(error: azure_core::StreamError) -> Self {
-        Self::Core(azure_core::Error::StreamError(error))
+        Self::Core(azure_core::Error::Stream(error))
     }
 }
 
 impl From<azure_core::HttpError> for Error {
     fn from(error: azure_core::HttpError) -> Self {
-        Self::Core(azure_core::Error::HttpError(error))
+        Self::Core(azure_core::Error::Http(error))
     }
 }
 
 impl From<http::Error> for Error {
     fn from(error: http::Error) -> Self {
-        Self::Core(azure_core::Error::HttpPrepareError(error))
+        Self::Core(azure_core::Error::HttpPrepare(error))
     }
 }
 

--- a/sdk/identity/src/token_credentials/cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/cli_credentials.rs
@@ -129,7 +129,7 @@ impl azure_core::auth::TokenCredential for AzureCliCredential {
     ) -> Result<azure_core::auth::TokenResponse, azure_core::Error> {
         TokenCredential::get_token(self, resource)
             .await
-            .map_err(|error| azure_core::Error::GetTokenError(Box::new(error)))
+            .map_err(|error| azure_core::Error::GetToken(Box::new(error)))
     }
 }
 

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -181,6 +181,6 @@ impl azure_core::auth::TokenCredential for ClientSecretCredential {
     ) -> Result<azure_core::auth::TokenResponse, azure_core::Error> {
         TokenCredential::get_token(self, resource)
             .await
-            .map_err(|error| azure_core::Error::GetTokenError(Box::new(error)))
+            .map_err(|error| azure_core::Error::GetToken(Box::new(error)))
     }
 }

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -167,7 +167,7 @@ impl azure_core::auth::TokenCredential for DefaultAzureCredential {
     ) -> Result<azure_core::auth::TokenResponse, azure_core::Error> {
         TokenCredential::get_token(self, resource)
             .await
-            .map_err(|error| azure_core::Error::GetTokenError(Box::new(error)))
+            .map_err(|error| azure_core::Error::GetToken(Box::new(error)))
     }
 }
 

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -97,6 +97,6 @@ impl azure_core::auth::TokenCredential for EnvironmentCredential {
     ) -> Result<azure_core::auth::TokenResponse, azure_core::Error> {
         TokenCredential::get_token(self, resource)
             .await
-            .map_err(|error| azure_core::Error::GetTokenError(Box::new(error)))
+            .map_err(|error| azure_core::Error::GetToken(Box::new(error)))
     }
 }

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -90,7 +90,7 @@ impl azure_core::auth::TokenCredential for ImdsManagedIdentityCredential {
     ) -> Result<azure_core::auth::TokenResponse, azure_core::Error> {
         TokenCredential::get_token(self, resource)
             .await
-            .map_err(|error| azure_core::Error::GetTokenError(Box::new(error)))
+            .map_err(|error| azure_core::Error::GetToken(Box::new(error)))
     }
 }
 

--- a/sdk/identity/src/token_credentials/mod.rs
+++ b/sdk/identity/src/token_credentials/mod.rs
@@ -40,6 +40,6 @@ where
     ) -> Result<azure_core::auth::TokenResponse, azure_core::Error> {
         TokenCredential::get_token(self, resource)
             .await
-            .map_err(|error| azure_core::Error::GetTokenError(Box::new(error)))
+            .map_err(|error| azure_core::Error::GetToken(Box::new(error)))
     }
 }

--- a/sdk/storage/src/core/errors.rs
+++ b/sdk/storage/src/core/errors.rs
@@ -77,7 +77,7 @@ pub enum Error {
 
 impl From<azure_core::HttpError> for Error {
     fn from(error: azure_core::HttpError) -> Self {
-        Self::CoreError(azure_core::Error::HttpError(error))
+        Self::CoreError(azure_core::Error::Http(error))
     }
 }
 


### PR DESCRIPTION
I'd like to drop the "Error" suffix currently used in many of the error cases. This starts with just `azure_core::Error`.

Instead of `Error::HeaderError`, it is more succinct `Error:Header`.

If this looks good, I can create more PRs for the others.