### PR TITLE
rename ParsingError to ParseError

### DIFF
--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -31,7 +31,7 @@ pub enum Error {
     #[error("policy error: {0}")]
     Policy(Box<dyn std::error::Error + Send + Sync>),
     #[error("parsing error: {0}")]
-    Parsing(#[from] ParsingError),
+    Parsing(#[from] ParseError),
     #[error("error getting token: {0}")]
     GetToken(Box<dyn std::error::Error + Send + Sync>),
     #[error("http error: {0}")]
@@ -62,7 +62,7 @@ type HttpClientError = reqwest::Error;
 /// An error caused by a failure to parse data.
 #[non_exhaustive]
 #[derive(Debug, PartialEq, thiserror::Error)]
-pub enum ParsingError {
+pub enum ParseError {
     #[error("unknown variant of {item} found: \"{variant}\"")]
     UnknownVariant { item: &'static str, variant: String },
     #[error("expected token \"{token}\" not found when parsing {item} from \"{full}\"")]
@@ -201,7 +201,7 @@ pub enum TraversingError {
     #[error("generic parse error: {0}")]
     GenericParseError(String),
     #[error("parsing error: {0:?}")]
-    ParsingError(#[from] ParsingError),
+    ParseError(#[from] ParseError),
 }
 
 /// Extract the headers and body from a `hyper` HTTP response.

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -72,15 +72,15 @@ pub enum ParseError {
         full: String,
     },
     #[error("error parsing int: {0}")]
-    ParseIntError(#[from] std::num::ParseIntError),
+    Int(#[from] std::num::ParseIntError),
     #[error("error parsing uuid: {0}")]
-    ParseUuidError(#[from] uuid::Error),
+    Uuid(#[from] uuid::Error),
     #[error("error parsing date time: {0}")]
-    ParseDateTimeError(#[from] chrono::ParseError),
+    DateTime(#[from] chrono::ParseError),
     #[error("error parsing a float: {0}")]
-    ParseFloatError(#[from] std::num::ParseFloatError),
+    Float(#[from] std::num::ParseFloatError),
     #[error("error parsing bool: {0}")]
-    ParseBoolError(#[from] std::str::ParseBoolError),
+    Bool(#[from] std::str::ParseBoolError),
 }
 
 /// An unexpected value.

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -179,18 +179,18 @@ pub fn parse_date_from_str(
     date: &str,
     fmt: &str,
 ) -> std::result::Result<DateTime<FixedOffset>, ParseError> {
-    DateTime::parse_from_str(date, fmt).map_err(ParseError::ParseDateTimeError)
+    DateTime::parse_from_str(date, fmt).map_err(ParseError::DateTime)
 }
 
 pub fn parse_date_from_rfc2822(
     date: &str,
 ) -> std::result::Result<DateTime<FixedOffset>, ParseError> {
-    DateTime::parse_from_rfc2822(date).map_err(ParseError::ParseDateTimeError)
+    DateTime::parse_from_rfc2822(date).map_err(ParseError::DateTime)
 }
 
 pub fn parse_int<F>(s: &str) -> std::result::Result<F, ParseError>
 where
     F: FromStr<Err = std::num::ParseIntError>,
 {
-    FromStr::from_str(s).map_err(ParseError::ParseIntError)
+    FromStr::from_str(s).map_err(ParseError::Int)
 }

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -152,7 +152,7 @@ pub fn get_str_from_headers<'a>(headers: &'a HeaderMap, key: &str) -> Result<&'a
 pub fn get_from_headers<T: std::str::FromStr>(headers: &HeaderMap, key: &str) -> Result<T>
 where
     T: std::str::FromStr,
-    T::Err: Into<ParsingError>,
+    T::Err: Into<ParseError>,
 {
     get_str_from_headers(headers, key)?
         .parse()
@@ -162,7 +162,7 @@ where
 pub fn get_option_from_headers<T>(headers: &HeaderMap, key: &str) -> Result<Option<T>>
 where
     T: std::str::FromStr,
-    T::Err: Into<ParsingError>,
+    T::Err: Into<ParseError>,
 {
     match headers.get(key) {
         Some(header) => Ok(Some(
@@ -178,19 +178,19 @@ where
 pub fn parse_date_from_str(
     date: &str,
     fmt: &str,
-) -> std::result::Result<DateTime<FixedOffset>, ParsingError> {
-    DateTime::parse_from_str(date, fmt).map_err(ParsingError::ParseDateTimeError)
+) -> std::result::Result<DateTime<FixedOffset>, ParseError> {
+    DateTime::parse_from_str(date, fmt).map_err(ParseError::ParseDateTimeError)
 }
 
 pub fn parse_date_from_rfc2822(
     date: &str,
-) -> std::result::Result<DateTime<FixedOffset>, ParsingError> {
-    DateTime::parse_from_rfc2822(date).map_err(ParsingError::ParseDateTimeError)
+) -> std::result::Result<DateTime<FixedOffset>, ParseError> {
+    DateTime::parse_from_rfc2822(date).map_err(ParseError::ParseDateTimeError)
 }
 
-pub fn parse_int<F>(s: &str) -> std::result::Result<F, ParsingError>
+pub fn parse_int<F>(s: &str) -> std::result::Result<F, ParseError>
 where
     F: FromStr<Err = std::num::ParseIntError>,
 {
-    FromStr::from_str(s).map_err(ParsingError::ParseIntError)
+    FromStr::from_str(s).map_err(ParseError::ParseIntError)
 }

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -81,19 +81,19 @@ macro_rules! create_enum {
 
         impl $crate::parsing::FromStringOptional<$name> for $name {
             fn from_str_optional(s : &str) -> ::std::result::Result<$name, $crate::TraversingError> {
-                s.parse::<$name>().map_err(|e| { $crate::TraversingError::ParsingError(e) })
+                s.parse::<$name>().map_err(|e| { $crate::TraversingError::ParseError(e) })
             }
         }
 
         impl ::std::str::FromStr for $name {
-            type Err = $crate::ParsingError;
+            type Err = $crate::ParseError;
 
-            fn from_str(s: &str) -> ::std::result::Result<$name, $crate::ParsingError> {
+            fn from_str(s: &str) -> ::std::result::Result<$name, $crate::ParseError> {
                 match s {
                     $(
                         $value => Ok($name::$variant),
                     )*
-                    _ => Err($crate::ParsingError::UnknownVariant {
+                    _ => Err($crate::ParseError::UnknownVariant {
                         item: stringify!($name),
                         variant: s.to_owned()
                     })
@@ -148,7 +148,7 @@ macro_rules! create_enum {
 
 #[cfg(test)]
 mod test {
-    use crate::ParsingError;
+    use crate::ParseError;
     create_enum!(Colors, (Black, "Black"), (White, "White"), (Red, "Red"));
     create_enum!(ColorsMonochrome, (Black, "Black"), (White, "White"));
 
@@ -188,7 +188,7 @@ mod test {
         let err = "Red".parse::<ColorsMonochrome>().unwrap_err();
         assert_eq!(
             err,
-            ParsingError::UnknownVariant {
+            ParseError::UnknownVariant {
                 item: "ColorsMonochrome",
                 variant: "Red".to_string()
             }

--- a/sdk/core/src/request_options/content_range.rs
+++ b/sdk/core/src/request_options/content_range.rs
@@ -1,4 +1,4 @@
-use crate::ParsingError;
+use crate::ParseError;
 use std::fmt;
 use std::str::FromStr;
 
@@ -38,11 +38,11 @@ impl ContentRange {
 }
 
 impl FromStr for ContentRange {
-    type Err = ParsingError;
+    type Err = ParseError;
     fn from_str(s: &str) -> Result<ContentRange, Self::Err> {
         let remaining = s
             .strip_prefix(PREFIX)
-            .ok_or_else(|| ParsingError::TokenNotFound {
+            .ok_or_else(|| ParseError::TokenNotFound {
                 item: "ContentRange",
                 token: PREFIX.to_owned(),
                 full: s.into(),
@@ -53,7 +53,7 @@ impl FromStr for ContentRange {
 
         let mut split_at_slash = split_at_dash
             .next()
-            .ok_or_else(|| ParsingError::TokenNotFound {
+            .ok_or_else(|| ParseError::TokenNotFound {
                 item: "ContentRange",
                 token: "-".to_owned(),
                 full: s.into(),
@@ -63,7 +63,7 @@ impl FromStr for ContentRange {
         let end = split_at_slash.next().unwrap().parse()?;
         let total_length = split_at_slash
             .next()
-            .ok_or_else(|| ParsingError::TokenNotFound {
+            .ok_or_else(|| ParseError::TokenNotFound {
                 item: "ContentRange",
                 token: "/".to_owned(),
                 full: s.into(),
@@ -111,7 +111,7 @@ mod test {
         let err = "something else".parse::<ContentRange>().unwrap_err();
         assert_eq!(
             err,
-            ParsingError::TokenNotFound {
+            ParseError::TokenNotFound {
                 item: "ContentRange",
                 token: "bytes ".to_string(),
                 full: "something else".to_string()
@@ -124,7 +124,7 @@ mod test {
         let err = "bytes 100".parse::<ContentRange>().unwrap_err();
         assert_eq!(
             err,
-            ParsingError::TokenNotFound {
+            ParseError::TokenNotFound {
                 item: "ContentRange",
                 token: "-".to_string(),
                 full: "bytes 100".to_string()
@@ -137,7 +137,7 @@ mod test {
         let err = "bytes 100-500".parse::<ContentRange>().unwrap_err();
         assert_eq!(
             err,
-            ParsingError::TokenNotFound {
+            ParseError::TokenNotFound {
                 item: "ContentRange",
                 token: "/".to_string(),
                 full: "bytes 100-500".to_string()

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -1,5 +1,5 @@
 use super::BA512Range;
-use crate::{AddAsHeader, ParsingError};
+use crate::{AddAsHeader, ParseError};
 use http::request::Builder;
 use std::convert::From;
 use std::fmt;
@@ -62,11 +62,11 @@ impl From<std::ops::Range<usize>> for Range {
 }
 
 impl FromStr for Range {
-    type Err = ParsingError;
+    type Err = ParseError;
     fn from_str(s: &str) -> Result<Range, Self::Err> {
         let v = s.split('/').collect::<Vec<&str>>();
         if v.len() != 2 {
-            return Err(ParsingError::TokenNotFound {
+            return Err(ParseError::TokenNotFound {
                 item: "Range",
                 token: "/".to_owned(),
                 full: s.to_owned(),
@@ -136,7 +136,7 @@ mod test {
     #[test]
     fn test_range_parse_panic_1() {
         let err = "abba/2000".parse::<Range>().unwrap_err();
-        assert!(matches!(err, ParsingError::ParseIntError(_)));
+        assert!(matches!(err, ParseError::ParseIntError(_)));
     }
 
     #[test]
@@ -144,7 +144,7 @@ mod test {
         let err = "1000-2000".parse::<Range>().unwrap_err();
         assert_eq!(
             err,
-            ParsingError::TokenNotFound {
+            ParseError::TokenNotFound {
                 item: "Range",
                 token: "/".to_string(),
                 full: "1000-2000".to_string()

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -136,7 +136,7 @@ mod test {
     #[test]
     fn test_range_parse_panic_1() {
         let err = "abba/2000".parse::<Range>().unwrap_err();
-        assert!(matches!(err, ParseError::ParseIntError(_)));
+        assert!(matches!(err, ParseError::Int(_)));
     }
 
     #[test]

--- a/sdk/cosmos/src/errors.rs
+++ b/sdk/cosmos/src/errors.rs
@@ -11,13 +11,13 @@ pub enum Error {
     Core(#[from] azure_core::Error),
     /// An error related to parsing
     #[error(transparent)]
-    ParsingError(#[from] ParsingError),
+    ParseError(#[from] ParseError),
     #[error("conversion to `{0}` failed because at lease one element is raw")]
     ElementIsRaw(String),
     #[error("error parsing authorization token: {0}")]
-    AuthorizationTokenParsing(#[from] crate::resources::permission::AuthorizationTokenParsingError),
+    AuthorizationTokenParsing(#[from] crate::resources::permission::AuthorizationTokenParseError),
     #[error("error parsing permission token: {0}")]
-    PermissionTokenParsing(#[from] crate::resources::permission::PermissionTokenParsingError),
+    PermissionTokenParsing(#[from] crate::resources::permission::PermissionTokenParseError),
     #[error("error writing the header value: {0}")]
     InvalidHeaderValue(#[from] azure_core::HttpHeaderError),
 }
@@ -50,14 +50,14 @@ impl From<http::Error> for Error {
 ///
 /// Most issues are already defined in `azure_core`
 #[derive(Debug, thiserror::Error)]
-pub enum ParsingError {
+pub enum ParseError {
     #[error(transparent)]
-    Core(azure_core::ParsingError),
+    Core(azure_core::ParseError),
     #[error("Resource quota parsing error: {0}")]
-    ParseResourceQuotaError(#[from] crate::resource_quota::ResourceQuotaParsingError),
+    ParseResourceQuotaError(#[from] crate::resource_quota::ResourceQuotaParseError),
 }
 
-impl<T: Into<azure_core::ParsingError>> From<T> for ParsingError {
+impl<T: Into<azure_core::ParseError>> From<T> for ParseError {
     fn from(error: T) -> Self {
         Self::Core(error.into())
     }

--- a/sdk/cosmos/src/headers/from_headers.rs
+++ b/sdk/cosmos/src/headers/from_headers.rs
@@ -1,5 +1,5 @@
 use crate::errors::Error;
-use crate::errors::ParsingError;
+use crate::errors::ParseError;
 use crate::headers::*;
 use crate::resource_quota::resource_quotas_from_str;
 use crate::resources::document::IndexingDirective;
@@ -38,14 +38,14 @@ pub(crate) fn resource_quota_from_headers(
     headers: &HeaderMap,
 ) -> Result<Vec<ResourceQuota>, Error> {
     let s = get_str_from_headers(headers, HEADER_RESOURCE_QUOTA)?;
-    resource_quotas_from_str(s).map_err(|e| Error::ParsingError(e.into()))
+    resource_quotas_from_str(s).map_err(|e| Error::ParseError(e.into()))
 }
 
 pub(crate) fn resource_usage_from_headers(
     headers: &HeaderMap,
 ) -> Result<Vec<ResourceQuota>, Error> {
     let s = get_str_from_headers(headers, HEADER_RESOURCE_USAGE)?;
-    resource_quotas_from_str(s).map_err(|e| Error::ParsingError(e.into()))
+    resource_quotas_from_str(s).map_err(|e| Error::ParseError(e.into()))
 }
 
 pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64, Error> {
@@ -109,7 +109,7 @@ pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u
     Ok(if s == "-1" {
         0
     } else {
-        parse_int(s).map_err(ParsingError::Core)?
+        parse_int(s).map_err(ParseError::Core)?
     })
 }
 
@@ -165,7 +165,7 @@ fn _date_from_headers(headers: &HeaderMap, header_name: &str) -> Result<DateTime
     // For example: Wed, 15 Jan 2020 23:39:44.369 GMT
     let date = date.replace("GMT", "+0000");
     let date =
-        parse_date_from_str(&date, "%a, %e %h %Y %H:%M:%S%.f %z").map_err(ParsingError::Core)?;
+        parse_date_from_str(&date, "%a, %e %h %Y %H:%M:%S%.f %z").map_err(ParseError::Core)?;
     let date = DateTime::from_utc(date.naive_utc(), Utc);
     Ok(date)
 }
@@ -186,7 +186,7 @@ fn get_str_from_headers<'a>(headers: &'a HeaderMap, key: &str) -> Result<&'a str
 fn get_from_headers<T: std::str::FromStr>(headers: &HeaderMap, key: &str) -> Result<T, Error>
 where
     T: std::str::FromStr,
-    T::Err: Into<azure_core::ParsingError>,
+    T::Err: Into<azure_core::ParseError>,
 {
     Ok(headers::get_from_headers(headers, key)?)
 }
@@ -194,7 +194,7 @@ where
 fn get_option_from_headers<T>(headers: &HeaderMap, key: &str) -> Result<Option<T>, Error>
 where
     T: std::str::FromStr,
-    T::Err: Into<azure_core::ParsingError>,
+    T::Err: Into<azure_core::ParseError>,
 {
     Ok(headers::get_option_from_headers(headers, key)?)
 }

--- a/sdk/cosmos/src/resource_quota.rs
+++ b/sdk/cosmos/src/resource_quota.rs
@@ -39,19 +39,19 @@ const AUTH_POLICY_ELEMENTS: &str = "authPolicyElements=";
 /// Parse a collection of [`ResourceQuota`] from a string
 pub(crate) fn resource_quotas_from_str(
     s: &str,
-) -> Result<Vec<ResourceQuota>, ResourceQuotaParsingError> {
+) -> Result<Vec<ResourceQuota>, ResourceQuotaParseError> {
     debug!("resource_quotas_from_str(\"{}\") called", s);
     let tokens: Vec<&str> = s.split(';').collect();
     let mut v = Vec::with_capacity(tokens.len());
 
     let parseu64 = |s| {
-        str::parse(s).map_err(|e| ResourceQuotaParsingError::NumberParseError {
+        str::parse(s).map_err(|e| ResourceQuotaParseError::NumberParseError {
             string: s.to_owned(),
             error: e,
         })
     };
     let parsei64 = |s| {
-        str::parse(s).map_err(|e| ResourceQuotaParsingError::NumberParseError {
+        str::parse(s).map_err(|e| ResourceQuotaParseError::NumberParseError {
             string: s.to_owned(),
             error: e,
         })
@@ -89,7 +89,7 @@ pub(crate) fn resource_quotas_from_str(
         } else if let Some(stripped) = token.strip_prefix(AUTH_POLICY_ELEMENTS) {
             v.push(ResourceQuota::AuthPolicyElements(parseu64(stripped)?));
         } else {
-            return Err(ResourceQuotaParsingError::UnrecognizedPart {
+            return Err(ResourceQuotaParseError::UnrecognizedPart {
                 part: token.to_string(),
                 full_string: s.to_owned(),
             });
@@ -102,7 +102,7 @@ pub(crate) fn resource_quotas_from_str(
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum ResourceQuotaParsingError {
+pub enum ResourceQuotaParseError {
     #[error(
         "resource quota has an unrecognized part - part: \"{}\" full string: \"{}\"",
         part,

--- a/sdk/cosmos/src/resources/document/indexing_directive.rs
+++ b/sdk/cosmos/src/resources/document/indexing_directive.rs
@@ -1,5 +1,5 @@
 use crate::headers;
-use azure_core::ParsingError;
+use azure_core::ParseError;
 use http::request::Builder;
 use std::fmt;
 
@@ -25,14 +25,14 @@ impl<'a> From<&'a IndexingDirective> for &'a str {
 }
 
 impl std::str::FromStr for IndexingDirective {
-    type Err = ParsingError;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "Default" => Ok(IndexingDirective::Default),
             "Exclude" => Ok(IndexingDirective::Exclude),
             "Include" => Ok(IndexingDirective::Include),
-            _ => Err(ParsingError::UnknownVariant {
+            _ => Err(ParseError::UnknownVariant {
                 item: "IndexingDirective",
                 variant: s.to_owned(),
             }),

--- a/sdk/cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/cosmos/src/resources/permission/authorization_token.rs
@@ -18,7 +18,7 @@ impl AuthorizationToken {
     /// The token is *not* verified to be valid.
     pub fn primary_from_base64(
         base64_encoded: &str,
-    ) -> Result<AuthorizationToken, AuthorizationTokenParsingError> {
+    ) -> Result<AuthorizationToken, AuthorizationTokenParseError> {
         let key = base64::decode(base64_encoded)?;
         Ok(AuthorizationToken::Primary(key))
     }
@@ -32,7 +32,7 @@ impl AuthorizationToken {
 #[allow(missing_docs)]
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
-pub enum AuthorizationTokenParsingError {
+pub enum AuthorizationTokenParseError {
     #[error("the authorization token was not properly base64 encoded: {0}")]
     InvalidBase64Encoding(#[from] base64::DecodeError),
 }

--- a/sdk/cosmos/src/resources/permission/mod.rs
+++ b/sdk/cosmos/src/resources/permission/mod.rs
@@ -7,11 +7,11 @@ mod permission_response;
 mod permission_token;
 
 pub use authorization_token::AuthorizationToken;
-pub use authorization_token::AuthorizationTokenParsingError;
+pub use authorization_token::AuthorizationTokenParseError;
 pub use permission::{Permission, PermissionMode};
 pub(crate) use permission_response::PermissionResponse;
 pub use permission_token::PermissionToken;
-pub use permission_token::PermissionTokenParsingError;
+pub use permission_token::PermissionTokenParseError;
 
 use crate::headers;
 use azure_core::AddAsHeader;

--- a/sdk/cosmos/tests/setup.rs
+++ b/sdk/cosmos/tests/setup.rs
@@ -1,4 +1,4 @@
-use crate::permission::AuthorizationTokenParsingError;
+use crate::permission::AuthorizationTokenParseError;
 use azure_cosmos::prelude::*;
 
 #[cfg(not(feature = "mock_transport_framework"))]
@@ -15,7 +15,7 @@ fn get_account() -> String {
     std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!")
 }
 
-fn get_authorization_token() -> Result<AuthorizationToken, AuthorizationTokenParsingError> {
+fn get_authorization_token() -> Result<AuthorizationToken, AuthorizationTokenParseError> {
     let key =
         std::env::var("COSMOS_MASTER_KEY").expect("Set env variable COSMOS_MASTER_KEY first!");
 

--- a/sdk/storage/src/core/connection_string.rs
+++ b/sdk/storage/src/core/connection_string.rs
@@ -22,7 +22,7 @@ pub enum ConnectionStringError {
     #[error("Unexpected key '{}'", key)]
     UnexpectedKey { key: String },
     #[error("Parsing error: {}", msg)]
-    ParsingError { msg: String },
+    ParseError { msg: String },
     #[error("Unsupported protocol {}", protocol)]
     UnsupportedProtocol { protocol: String },
 }
@@ -107,12 +107,12 @@ impl<'a> ConnectionString<'a> {
             let mut kv = kv_pair_str.trim().split('=');
             let k = match kv.next() {
                 Some(k) if k.chars().all(char::is_whitespace) => {
-                    return Err(ConnectionStringError::ParsingError {
+                    return Err(ConnectionStringError::ParseError {
                         msg: "No key found".to_owned(),
                     })
                 }
                 None => {
-                    return Err(ConnectionStringError::ParsingError {
+                    return Err(ConnectionStringError::ParseError {
                         msg: "No key found".to_owned(),
                     })
                 }
@@ -147,7 +147,7 @@ impl<'a> ConnectionString<'a> {
                     "true" => use_development_storage = Some(true),
                     "false" => use_development_storage = Some(false),
                     _ => {
-                        return Err(ConnectionStringError::ParsingError {
+                        return Err(ConnectionStringError::ParseError {
                             msg: format!(
                         "Unexpected value for {}: {}. Please specify either 'true' or 'false'.",
                         USE_DEVELOPMENT_STORAGE_KEY_NAME, v),
@@ -200,7 +200,7 @@ mod tests {
         ));
         assert!(matches!(
             ConnectionString::new("="),
-            Err(ConnectionStringError::ParsingError { msg: _ })
+            Err(ConnectionStringError::ParseError { msg: _ })
         ));
         assert!(matches!(
             ConnectionString::new("x=123;"),

--- a/sdk/storage/src/core/errors.rs
+++ b/sdk/storage/src/core/errors.rs
@@ -9,7 +9,7 @@ pub enum Error {
     #[error(transparent)]
     CoreError(#[from] azure_core::Error),
     #[error("Parsing error: {0}")]
-    ParsingError(#[from] azure_core::ParsingError),
+    ParseError(#[from] azure_core::ParseError),
     #[error("Permission error: {0}")]
     PermissionError(#[from] azure_core::PermissionError),
     #[error("Parse bool error: {0}")]


### PR DESCRIPTION
And trims `Parse` and `Error` from `azure_core::ParseError`.