### PR TITLE
move BA512Range to storage_blobs

### DIFF
--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -146,15 +146,6 @@ pub enum HttpError {
     StreamResetError(StreamError),
 }
 
-/// An error caused by a range not being 512-byte aligned.
-#[derive(Debug, PartialEq, thiserror::Error)]
-pub enum Not512ByteAlignedError {
-    #[error("start range not 512-byte aligned: {0}")]
-    StartRange(u64),
-    #[error("end range not 512-byte aligned: {0}")]
-    EndRange(u64),
-}
-
 /// An error caused by invalid permissions.
 #[derive(Debug, thiserror::Error)]
 pub enum PermissionError {
@@ -165,17 +156,6 @@ pub enum PermissionError {
         received_token: char,
         supported_tokens: Vec<char>,
     },
-}
-
-/// An error caused by a range not being 512-byte aligned or by a parse failure.
-#[derive(Debug, PartialEq, thiserror::Error)]
-pub enum Parse512AlignedError {
-    #[error("split not found")]
-    SplitNotFound,
-    #[error("parse int error: {0}")]
-    ParseIntError(#[from] std::num::ParseIntError),
-    #[error("not 512 byte aligned error: {0}")]
-    Not512ByteAlignedError(#[from] Not512ByteAlignedError),
 }
 
 /// An error caused by failure to traverse a data structure.

--- a/sdk/core/src/request_options/mod.rs
+++ b/sdk/core/src/request_options/mod.rs
@@ -1,5 +1,4 @@
 mod activity_id;
-mod ba512_range;
 mod client_request_id;
 mod content_disposition;
 mod content_encoding;
@@ -31,7 +30,6 @@ mod timeout;
 mod user_agent;
 
 pub use activity_id::ActivityId;
-pub use ba512_range::BA512Range;
 pub use client_request_id::ClientRequestId;
 pub use content_disposition::ContentDisposition;
 pub use content_encoding::ContentEncoding;

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -1,4 +1,3 @@
-use super::BA512Range;
 use crate::{AddAsHeader, ParsingError};
 use http::request::Builder;
 use std::convert::From;
@@ -22,15 +21,6 @@ impl Range {
 
     pub fn is_empty(&self) -> bool {
         self.end == self.start
-    }
-}
-
-impl<'a> From<&'a BA512Range> for Range {
-    fn from(ba: &'a BA512Range) -> Range {
-        Range {
-            start: ba.start(),
-            end: ba.end(),
-        }
     }
 }
 

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -29,6 +29,7 @@ serde_json = "1.0"
 serde-xml-rs = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
 url = "2.2"
+thiserror = "1.0"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/sdk/storage_blobs/examples/put_page_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_page_blob_00.rs
@@ -2,7 +2,7 @@
 extern crate log;
 use azure_core::prelude::*;
 use azure_storage::core::prelude::*;
-use azure_storage_blobs::prelude::*;
+use azure_storage_blobs::{prelude::*, BA512Range};
 use bytes::Bytes;
 use std::error::Error;
 

--- a/sdk/storage_blobs/src/ba512_range.rs
+++ b/sdk/storage_blobs/src/ba512_range.rs
@@ -1,6 +1,6 @@
-use super::range::Range;
-use crate::AddAsHeader;
-use crate::{Not512ByteAlignedError, Parse512AlignedError};
+use crate::{AddAsHeader, Not512ByteAlignedError, Parse512AlignedError};
+use azure_core::prelude::Range;
+use azure_core::{HttpHeaderError, Request};
 use http::request::Builder;
 use std::convert::TryFrom;
 use std::fmt;
@@ -67,10 +67,7 @@ impl AddAsHeader for BA512Range {
         builder.header(http::header::RANGE, &format!("{}", self))
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
+    fn add_as_header2(&self, request: &mut Request) -> Result<(), HttpHeaderError> {
         request.headers_mut().append(
             http::header::RANGE,
             http::HeaderValue::from_str(&self.to_string())?,
@@ -98,6 +95,15 @@ impl FromStr for BA512Range {
 impl fmt::Display for BA512Range {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "bytes={}-{}", self.start, self.end)
+    }
+}
+
+impl<'a> From<&'a BA512Range> for Range {
+    fn from(ba: &'a BA512Range) -> Range {
+        Range {
+            start: ba.start(),
+            end: ba.end(),
+        }
     }
 }
 

--- a/sdk/storage_blobs/src/blob/requests/clear_page_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/clear_page_builder.rs
@@ -1,5 +1,6 @@
 use crate::blob::responses::ClearPageResponse;
 use crate::prelude::*;
+use crate::BA512Range;
 use azure_core::headers::{
     add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_TYPE, PAGE_WRITE,
 };

--- a/sdk/storage_blobs/src/blob/requests/update_page_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/update_page_builder.rs
@@ -1,5 +1,6 @@
 use crate::blob::responses::UpdatePageResponse;
 use crate::prelude::*;
+use crate::BA512Range;
 use azure_core::headers::{add_mandatory_header, add_optional_header, add_optional_header_ref};
 use azure_core::headers::{BLOB_TYPE, PAGE_WRITE};
 use azure_core::prelude::*;

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -1,5 +1,6 @@
 use crate::blob::requests::*;
 use crate::prelude::*;
+use crate::BA512Range;
 use azure_core::prelude::*;
 use azure_core::HttpClient;
 use azure_storage::core::clients::StorageCredentials;

--- a/sdk/storage_blobs/src/errors.rs
+++ b/sdk/storage_blobs/src/errors.rs
@@ -1,0 +1,19 @@
+/// An error caused by a range not being 512-byte aligned.
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum Not512ByteAlignedError {
+    #[error("start range not 512-byte aligned: {0}")]
+    StartRange(u64),
+    #[error("end range not 512-byte aligned: {0}")]
+    EndRange(u64),
+}
+
+/// An error caused by a range not being 512-byte aligned or by a parse failure.
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum Parse512AlignedError {
+    #[error("split not found")]
+    SplitNotFound,
+    #[error("parse int error: {0}")]
+    ParseIntError(#[from] std::num::ParseIntError),
+    #[error("not 512 byte aligned error: {0}")]
+    Not512ByteAlignedError(#[from] Not512ByteAlignedError),
+}

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -8,6 +8,7 @@ extern crate azure_core;
 pub use azure_storage::{Error, Result};
 
 mod access_tier;
+mod ba512_range;
 #[allow(clippy::module_inception)]
 pub mod blob;
 mod blob_content_md5;
@@ -17,6 +18,7 @@ mod condition_append_position;
 mod condition_max_size;
 pub mod container;
 mod delete_snapshot_method;
+mod errors;
 mod hash;
 mod headers;
 mod incomplete_vector;
@@ -26,11 +28,13 @@ mod version_id;
 
 pub use access_tier::AccessTier;
 use azure_core::{AddAsHeader, AppendToUrlQuery};
+pub use ba512_range::BA512Range;
 pub use blob_content_md5::BlobContentMD5;
 pub use block_id::BlockId;
 pub use condition_append_position::ConditionAppendPosition;
 pub use condition_max_size::ConditionMaxSize;
 pub use delete_snapshot_method::DeleteSnapshotsMethod;
+pub use errors::*;
 pub use hash::Hash;
 use http::request::Builder;
 pub use snapshot::Snapshot;

--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -2,12 +2,12 @@
 #[macro_use]
 extern crate log;
 
-use azure_core::prelude::*;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::{
     blob::BlockListType,
     container::{Container, PublicAccess},
     prelude::*,
+    BA512Range,
 };
 use bytes::Bytes;
 use chrono::{FixedOffset, Utc};


### PR DESCRIPTION
This moves `BA512Range` and two supporting errors out of core to storage_blobs.