### PR TITLE
x-ms-enum support

### DIFF
--- a/services/autorust/codegen/examples/gen_mgmt.rs
+++ b/services/autorust/codegen/examples/gen_mgmt.rs
@@ -18,6 +18,7 @@ const SKIP_SERVICES: &[&str] = &[
     "service-map",   // Ident "Ref:machine"
     "servicefabric", // https://github.com/Azure/azure-rest-api-specs/pull/11581 allOf mistakes and duplicate Operations_List
     "servicefabricmanagedclusters",
+    "web", // multiple duplicate `DnsType` and `SupportedTls` definitions
 ];
 
 const SKIP_SERVICE_TAGS: &[(&str, &str)] = &[

--- a/services/autorust/codegen/examples/gen_mgmt.rs
+++ b/services/autorust/codegen/examples/gen_mgmt.rs
@@ -8,17 +8,28 @@ const OUTPUT_FOLDER: &str = "../mgmt";
 const ONLY_SERVICES: &[&str] = &[];
 
 const SKIP_SERVICES: &[&str] = &[
+    "apimanagement",   // Vec of renamed enum BearerTokenSendingMethodsContract
+    "cdn",             // DeliveryRuleAction for struct and enum
+    "commerce",        // OfferTermInfo defined as struct and enum
+    "customproviders", // ProvisioningState namespace issues
+    "customerlockbox", // Multiple definitions of enum Status
     "datamigration",
+    "deviceupdate",               // ProvisioningState namespace issues
     "deviceprovisioningservices", // TODO #82 certificate_name used as parameter more than once
     "dnc",                        // https://github.com/Azure/azure-rest-api-specs/pull/11578 two ControllerDetails types
     "iotspaces",                  // no operations
+    "kubernetesconfiguration",    // ResourceIdentityType not found (renamed?)
     "m365securityandcompliance",  // can't find privateLinkServicesForO365ManagementActivityAPI.json
     "marketplace",
     "mixedreality",  // TODO #83 AccountKeyRegenerateRequest not generated
+    "network",       // Conflicting definitions of Direction, issues with Vec<renamed enum>
+    "scheduler",     // Duplicate definition of RecurrenceFrequency
+    "security",      // AadConnectivityState, ExternalSecuritySolutionKind defined as struct and enum
     "service-map",   // Ident "Ref:machine"
     "servicefabric", // https://github.com/Azure/azure-rest-api-specs/pull/11581 allOf mistakes and duplicate Operations_List
     "servicefabricmanagedclusters",
-    "web", // multiple duplicate `DnsType` and `SupportedTls` definitions
+    "storagecache", // ProvisioningStateType enum defined in cache namespace, should be top-level
+    "web", // CertificateProductType, ProvisioningState, CertificateOrderStatus defined in namespaces, should be top-level. Options with renamed enums.
 ];
 
 const SKIP_SERVICE_TAGS: &[(&str, &str)] = &[

--- a/services/autorust/codegen/examples/gen_svc.rs
+++ b/services/autorust/codegen/examples/gen_svc.rs
@@ -8,12 +8,12 @@ const OUTPUT_FOLDER: &str = "../svc";
 const ONLY_SERVICES: &[&str] = &[];
 
 const SKIP_SERVICES: &[&str] = &[
-    "eventgrid",               // multiple duplicate `MediaJobState` definitions
     "datalake-store",          // query param "sources" not used
     "machinelearningservices", // need to box inner errors
     "hdinsight",               // job_id appears multiple times https://github.com/Azure/azure-sdk-for-rust/issues/503
     "videoanalyzer",           // no operations
     "mediaservices",           // no operations
+    "synapse",                 // XXXPartitionOption redefined
 ];
 
 const SKIP_SERVICE_TAGS: &[(&str, &str)] = &[

--- a/services/autorust/codegen/examples/gen_svc.rs
+++ b/services/autorust/codegen/examples/gen_svc.rs
@@ -8,6 +8,7 @@ const OUTPUT_FOLDER: &str = "../svc";
 const ONLY_SERVICES: &[&str] = &[];
 
 const SKIP_SERVICES: &[&str] = &[
+    "eventgrid",               // multiple duplicate `MediaJobState` definitions
     "datalake-store",          // query param "sources" not used
     "machinelearningservices", // need to box inner errors
     "hdinsight",               // job_id appears multiple times https://github.com/Azure/azure-sdk-for-rust/issues/503

--- a/services/autorust/codegen/src/codegen.rs
+++ b/services/autorust/codegen/src/codegen.rs
@@ -65,6 +65,8 @@ impl CodeGen {
 pub enum Error {
     #[error("SpecError: {0}")]
     Spec(#[from] spec::Error),
+    #[error("creating code name for schema: {source}")]
+    CodeName { source: crate::identifier::Error },
     #[error("creating function name: {0}")]
     FunctionName(#[source] crate::identifier::Error),
     #[error("creating type name for schema ref: {0}")]

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -650,15 +650,3 @@ fn create_struct_field_code(
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use serde_json::json;
-
-    #[test]
-    fn test_enum_values_as_strings() {
-        let values = vec![json!("/"), json!("/keys")];
-        assert_eq!(enum_values_as_strings(&values), vec!["/", "/keys"]);
-    }
-}

--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -682,6 +682,7 @@ fn add_references_for_schema(list: &mut Vec<TypedReference>, schema: &Schema) {
     }
 }
 
+#[derive(Debug)]
 pub enum TypeName {
     Reference(String),
     Array(Box<TypeName>),
@@ -702,6 +703,9 @@ pub fn get_type_name_for_schema(schema: &SchemaCommon) -> Result<TypeName> {
             DataType::Array => {
                 let items = get_schema_array_items(schema)?;
                 let vec_items_typ = get_type_name_for_schema_ref(items)?;
+                if let TypeName::Reference(_) = vec_items_typ {
+                    //println!("vec_items_typ={:#?}\nitems={:#?}\nschema={:#?}", vec_items_typ, items, schema);
+                }
                 TypeName::Array(Box::new(vec_items_typ))
             }
             DataType::Integer => {


### PR DESCRIPTION
As per: https://github.com/Azure/azure-sdk-for-rust/issues/413

I implemented the improved naming of enums and values (where provided).  I have not implemented anything to support the `modelAsString` option.  Let me know if you think we need this.

I also added doc comments for enums.  Let me know if you don't want this!

Example diff of before/after from `KeyChain`:
![5dcb8a8a-eb6c-4868-8564-38bd286458de](https://user-images.githubusercontent.com/1869270/149600057-a701dbf8-cd83-4e1c-981f-b442c9d59cb2.jpg)

Example diff showing `RoleScope` definition, as per the issue example:
![7cb39b63-1061-4bba-b316-8f8ec52325ae](https://user-images.githubusercontent.com/1869270/149600105-c319991e-5682-41d9-847d-4ce0c299cd09.jpg)

