### PR TITLE
add blob_container.exists()

### DIFF
--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -2,7 +2,7 @@ use crate::blob::requests::*;
 use crate::prelude::*;
 use crate::BA512Range;
 use azure_core::prelude::*;
-use azure_core::HttpClient;
+use azure_core::{HttpClient, HttpError};
 use azure_storage::core::clients::StorageCredentials;
 use azure_storage::core::prelude::*;
 use azure_storage::core::shared_access_signature::{
@@ -12,6 +12,7 @@ use azure_storage::core::shared_access_signature::{
 use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
+use http::StatusCode;
 use std::sync::Arc;
 use url::Url;
 
@@ -208,6 +209,26 @@ impl BlobClient {
     ) -> crate::Result<(Request<Bytes>, url::Url)> {
         self.container_client
             .prepare_request(url, method, http_header_adder, request_body)
+    }
+
+    pub async fn exists(&self) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
+        let result = self.get_properties().execute().await.map(|_| true);
+
+        if let Err(err) = &result {
+            if let Some(err) = err.downcast_ref::<HttpError>() {
+                if matches!(
+                    err,
+                    HttpError::StatusCode {
+                        status: StatusCode::NOT_FOUND,
+                        ..
+                    }
+                ) {
+                    return Ok(false);
+                }
+            }
+        }
+
+        result
     }
 }
 


### PR DESCRIPTION
Similar functions exist for other SDKs, which wrap calls to getting the
blob properties.

* [python](https://github.com/Azure/azure-sdk-for-python/blob/a968613f6debc0da3d86fb64c31bf7aaa2d737f2/sdk/storage/azure-storage-blob/azure/storage/blob/_blob_client.py#L1134-L1159)
* [dotnet](https://github.com/Azure/azure-sdk-for-net/blob/68ddcee4d9e19ce83056ecc3c7839ef0fdecdf03/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs#L4144-L4164)
* [golang](https://github.com/Azure/azure-sdk-for-go/blob/52ad1c9e349078f275e121bab06202d1ea95924b/storage/blob.go#L125-L138)

Implementation notes:
* This most closely matches the python version in implementaiton.
* The Result type (<bool, Box<Error + Send + Sync>>) is ugly, but it's the same result type as the underlying `get_properties()` call.  Once `get_properties()` gets updated to use crate::Result, this should get updated to be the same.