### PR TITLE
Upgrade examples to `stop-token@0.7.0`

### DIFF
--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -36,7 +36,7 @@ tokio = { version = "1", features = ["macros"] }
 hyper = "0.14"
 hyper-rustls = "0.23"
 reqwest = "0.11.0"
-stop-token = { version = "0.6.1", features = ["tokio"] }
+stop-token = { version = "0.7.0", features = ["tokio"] }
 
 [features]
 test_e2e = []

--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -20,7 +20,7 @@ async fn main() -> azure_data_cosmos::Result<()> {
     // Create a new database, and time out if it takes more than 1 second.
     let future = client.create_database("my_database").into_future();
     let deadline = Instant::now() + Duration::from_secs(1);
-    match future.until(deadline).await {
+    match future.timeout_at(deadline).await {
         Ok(Ok(r)) => println!("successful response: {:?}", r),
         Ok(Err(e)) => println!("request was made but failed: {:?}", e),
         Err(_) => println!("request timed out!"),
@@ -32,10 +32,10 @@ async fn main() -> azure_data_cosmos::Result<()> {
     for _ in 1..10 {
         let client = client.clone();
         // Clone the stop token for each request.
-        let stop = source.token();
+        let deadline = source.token();
         tokio::spawn(async move {
             let future = client.create_database("my_database").into_future();
-            match future.until(stop).await {
+            match future.timeout_at(deadline).await {
                 Ok(Ok(r)) => println!("successful response: {:?}", r),
                 Ok(Err(e)) => println!("request was made but failed: {:?}", e),
                 Err(_) => println!("request was cancelled!"),


### PR DESCRIPTION
Closes https://github.com/Azure/azure-sdk-for-rust/pull/617. This only affects examples, so we should merge this once CI passes. Thanks!