### PR TITLE
identity error cleanup

### DIFF
--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -69,7 +69,7 @@ pub async fn perform(
         .body(encoded)
         .send()
         .await
-        .map_err(|e| ClientCredentialError::RequestError(Box::new(e)))?;
+        .map_err(|e| ClientCredentialError::Request(Box::new(e)))?;
 
     if !response.status().is_success() {
         return Err(ClientCredentialError::UnsuccessfulResponse(
@@ -81,7 +81,7 @@ pub async fn perform(
     let b = response
         .text()
         .await
-        .map_err(|e| ClientCredentialError::RequestError(Box::new(e)))?;
+        .map_err(|e| ClientCredentialError::Request(Box::new(e)))?;
 
     serde_json::from_str::<LoginResponse>(&b)
         .map_err(|_| ClientCredentialError::InvalidResponseBody(b))
@@ -100,6 +100,6 @@ pub enum ClientCredentialError {
     #[error("The supplied tenant id could not be url encoded: {0}")]
     InvalidTenantId(String),
     /// An error occurred when trying to make a request
-    #[error("An error occurred when trying to make a request: {0}")]
-    RequestError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("An error occurred when trying to make a request")]
+    Request(#[source] Box<dyn std::error::Error + Send + Sync>),
 }

--- a/sdk/identity/src/device_code_flow/device_code_responses.rs
+++ b/sdk/identity/src/device_code_flow/device_code_responses.rs
@@ -74,7 +74,7 @@ pub enum DeviceCodeError {
     ExpiredToken(DeviceCodeErrorResponse),
     /// The authorization response returned an unrecognized error
     #[error("unrecognized device code error response error kind: {0}")]
-    UnrecognizedError(DeviceCodeErrorResponse),
+    UnrecognizedResponse(DeviceCodeErrorResponse),
     /// The supplied tenant id could not be url encoded
     #[error("the supplied tenant id could not be url encoded: {0}")]
     InvalidTenantId(String),
@@ -85,8 +85,8 @@ pub enum DeviceCodeError {
     #[error("the http response body could not be turned into a device code response: {0}")]
     InvalidResponseBody(String),
     /// An error occurred when trying to make a request
-    #[error("an error occurred when trying to make a request: {0}")]
-    RequestError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("an error occurred when trying to make a request")]
+    Request(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
 /// Expected responses while polling the /token endpoint.
@@ -127,7 +127,7 @@ impl TryInto<DeviceCodeResponse> for String {
                             "expired_token" => {
                                 Err(DeviceCodeError::ExpiredToken(device_code_error_response))
                             }
-                            _ => Err(DeviceCodeError::UnrecognizedError(
+                            _ => Err(DeviceCodeError::UnrecognizedResponse(
                                 device_code_error_response,
                             )),
                         }

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -47,7 +47,7 @@ where
         .body(encoded)
         .send()
         .await
-        .map_err(|e| DeviceCodeError::RequestError(Box::new(e)))?;
+        .map_err(|e| DeviceCodeError::Request(Box::new(e)))?;
 
     if !response.status().is_success() {
         return Err(DeviceCodeError::UnsuccessfulResponse(
@@ -58,7 +58,7 @@ where
     let s = response
         .text()
         .await
-        .map_err(|e| DeviceCodeError::RequestError(Box::new(e)))?;
+        .map_err(|e| DeviceCodeError::Request(Box::new(e)))?;
 
     serde_json::from_str::<DeviceCodePhaseOneResponse>(&s)
         // we need to capture some variables that will be useful in
@@ -145,7 +145,7 @@ impl<'a> DeviceCodePhaseOneResponse<'a> {
                         .body(encoded)
                         .send()
                         .await
-                        .map_err(|e| DeviceCodeError::RequestError(Box::new(e)))
+                        .map_err(|e| DeviceCodeError::Request(Box::new(e)))
                     {
                         Ok(result) => result,
                         Err(error) => return Some((Err(error), NextState::Finish)),
@@ -154,7 +154,7 @@ impl<'a> DeviceCodePhaseOneResponse<'a> {
                     let result = match result
                         .text()
                         .await
-                        .map_err(|e| DeviceCodeError::RequestError(Box::new(e)))
+                        .map_err(|e| DeviceCodeError::Request(Box::new(e)))
                     {
                         Ok(result) => result,
                         Err(error) => return Some((Err(error), NextState::Finish)),

--- a/sdk/identity/src/errors.rs
+++ b/sdk/identity/src/errors.rs
@@ -1,5 +1,5 @@
 //! Errors specific to identity services.
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::fmt;
 
 /// Errors specific to identity services
@@ -7,42 +7,32 @@ use std::fmt;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// An error getting credentials from the Azure CLI
-    #[error("Error getting token credentials from Azure CLI: {0}")]
-    AzureCliCredentialError(#[from] crate::token_credentials::AzureCliCredentialError),
+    #[error("Error getting token credentials from Azure CLI")]
+    AzureCliCredential(#[from] crate::token_credentials::AzureCliCredentialError),
     /// An error getting credentials through the client secrect token credential flow
-    #[error("Client secret credentials error: {0}")]
-    ClientSecretCredentialError(#[from] crate::token_credentials::ClientSecretCredentialError),
+    #[error("Client secret credentials error")]
+    ClientSecretCredential(#[from] crate::token_credentials::ClientSecretCredentialError),
     /// An error getting credentials from the environment
-    #[error("Error getting environment credential: {0}")]
-    EnvironmentCredentialError(#[from] crate::token_credentials::EnvironmentCredentialError),
+    #[error("Error getting environment credential")]
+    EnvironmentCredential(#[from] crate::token_credentials::EnvironmentCredentialError),
     /// An error getting managed identity credentials
-    #[error("Error getting managed identity credential: {0}")]
-    ManagedIdentityCredentialError(
-        #[from] crate::token_credentials::ManagedIdentityCredentialError,
-    ),
+    #[error("Error getting managed identity credential")]
+    ManagedIdentityCredential(#[from] crate::token_credentials::ManagedIdentityCredentialError),
     /// An error using the default token credential flow
-    #[error("Error getting default credential: {0}")]
+    #[error("Error getting default credential")]
     DefaultAzureCredentialError(#[from] crate::token_credentials::DefaultAzureCredentialError),
     /// An error getting a refresh token
-    #[error("Error refreshing token: {0}")]
-    RefreshTokenError(#[from] crate::refresh_token::Error),
+    #[error("Error refreshing token")]
+    RefreshToken(#[from] crate::refresh_token::Error),
     /// An error performing the device code flow
-    #[error("Error performing the device code flow: {0}")]
-    DeviceCodeError(#[from] crate::device_code_flow::DeviceCodeError),
+    #[error("Error performing the device code flow")]
+    DeviceCode(#[from] crate::device_code_flow::DeviceCodeError),
     /// An error performing the device code flow
-    #[error("Error performing the device code flow: {0}")]
-    ClientCredentialError(#[from] crate::client_credentials_flow::ClientCredentialError),
+    #[error("Error performing the device code flow")]
+    ClientCredential(#[from] crate::client_credentials_flow::ClientCredentialError),
     /// An unrecognized error response from an identity service.
     #[error("Error response from service: {0}")]
     ErrorResponse(String),
-}
-
-/// An HTTP error response from the identity service.
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
-pub(crate) enum ErrorResponse {
-    /// An unrecognized error response from an identity service.
-    GenericError { error_description: String },
 }
 
 /// Error Token

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -72,12 +72,12 @@ impl DefaultAzureCredentialBuilder {
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum DefaultAzureCredentialError {
-    #[error("Error getting token credential from Azure CLI: {0}")]
-    AzureCliCredentialError(#[from] super::AzureCliCredentialError),
-    #[error("Error getting environment credential: {0}")]
-    EnvironmentCredentialError(#[from] super::EnvironmentCredentialError),
-    #[error("Error getting managed identity credential: {0}")]
-    ManagedIdentityCredentialError(#[from] super::ManagedIdentityCredentialError),
+    #[error("Error getting token credential from Azure CLI")]
+    AzureCliCredential(#[source] super::AzureCliCredentialError),
+    #[error("Error getting environment credential")]
+    EnvironmentCredential(#[source] super::EnvironmentCredentialError),
+    #[error("Error getting managed identity credential")]
+    ManagedIdentityCredential(#[source] super::ManagedIdentityCredentialError),
     #[error(
         "Multiple errors were encountered while attempting to authenticate:\n{}",
         format_aggregate_error(.0)
@@ -104,15 +104,15 @@ impl TokenCredential for DefaultAzureCredentialEnum {
             DefaultAzureCredentialEnum::Environment(credential) => credential
                 .get_token(resource)
                 .await
-                .map_err(DefaultAzureCredentialError::EnvironmentCredentialError),
+                .map_err(DefaultAzureCredentialError::EnvironmentCredential),
             DefaultAzureCredentialEnum::ManagedIdentity(credential) => credential
                 .get_token(resource)
                 .await
-                .map_err(DefaultAzureCredentialError::ManagedIdentityCredentialError),
+                .map_err(DefaultAzureCredentialError::ManagedIdentityCredential),
             DefaultAzureCredentialEnum::AzureCli(credential) => credential
                 .get_token(resource)
                 .await
-                .map_err(DefaultAzureCredentialError::AzureCliCredentialError),
+                .map_err(DefaultAzureCredentialError::AzureCliCredential),
         }
     }
 }

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -41,16 +41,16 @@ pub enum EnvironmentCredentialError {
         "Missing tenant id set in {} environment variable",
         AZURE_TENANT_ID_ENV_KEY
     )]
-    MissingTenantId(std::env::VarError),
+    MissingTenantId(#[source] std::env::VarError),
     #[error(
         "Missing client id set in {} environment variable",
         AZURE_CLIENT_ID_ENV_KEY
     )]
-    MissingClientId(std::env::VarError),
+    MissingClientId(#[source] std::env::VarError),
     #[error("No valid environment credential providers")]
     NoValid,
     #[error(transparent)]
-    ClientSecretCredentialError(super::ClientSecretCredentialError),
+    ClientSecretCredential(super::ClientSecretCredentialError),
 }
 
 #[async_trait::async_trait]
@@ -78,7 +78,7 @@ impl TokenCredential for EnvironmentCredential {
             return credential
                 .get_token(resource)
                 .await
-                .map_err(EnvironmentCredentialError::ClientSecretCredentialError);
+                .map_err(EnvironmentCredentialError::ClientSecretCredential);
         } else if username.is_ok() && password.is_ok() {
             // Could use multiple if-let with #![feature(let_chains)] once stabilised - see https://github.com/rust-lang/rust/issues/53667
             // TODO: username & password credential


### PR DESCRIPTION
- remove `Error` suffix in case names
- specify `#[source] ` if it is one
- do not print source in message