### PR TITLE
[Proposal] Error Handling

### DIFF
--- a/sdk/core/src/error.rs
+++ b/sdk/core/src/error.rs
@@ -1,0 +1,166 @@
+use std::{borrow::Cow, fmt::Display};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[macro_export]
+macro_rules! format_err {
+    ($kind:expr, $msg:literal $(,)?) => {{
+        // Handle $:literal as a special case to make cargo-expanded code more
+        // concise in the common case.
+        $crate::error::Error::new($kind, $msg)
+    }};
+    ($kind:expr, $msg:expr $(,)?) => {{
+        $crate::error::Error::new($kind, $msg)
+    }};
+    ($kind:expr, $msg:expr, $($arg:tt)*) => {{
+        $crate::error::Error::new($kind, format!($msg, $($arg)*))
+    }};
+}
+
+#[derive(Debug)]
+pub struct Error {
+    context: Context,
+}
+
+impl Error {
+    pub fn new<E>(kind: ErrorKind, error: E) -> Self
+    where
+        E: Into<Box<dyn std::error::Error + Send + Sync>>,
+    {
+        Self {
+            context: Context::Custom(Custom {
+                kind,
+                error: error.into(),
+            }),
+        }
+    }
+
+    pub fn with_message<C>(kind: ErrorKind, message: C) -> Self
+    where
+        C: Into<Cow<'static, str>>,
+    {
+        Self {
+            context: Context::Message {
+                kind,
+                message: message.into(),
+            },
+        }
+    }
+
+    pub fn kind(&self) -> ErrorKind {
+        match self.context {
+            Context::Simple(kind) => kind,
+            Context::Message { kind, .. } => kind,
+            Context::Custom(Custom { kind, .. }) => kind,
+            Context::Full(Custom { kind, .. }, _) => kind,
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.context {
+            Context::Custom(Custom { error, .. }) => Some(error.as_ref()),
+            Context::Full(Custom { error, .. }, _) => Some(error.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self {
+            context: Context::Simple(kind),
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.context {
+            Context::Simple(kind) => write!(f, "{}", kind),
+            Context::Message { kind, message } => write!(f, "{}: {}", kind, message),
+            Context::Custom(Custom { kind, error }) => write!(f, "{}: {}", kind, error),
+            Context::Full(Custom { kind, error }, message) => {
+                write!(f, "{}: {}\n{}", kind, message, error)
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Custom {
+    kind: ErrorKind,
+    error: Box<dyn std::error::Error + Send + Sync>,
+}
+
+#[derive(Debug)]
+enum Context {
+    Simple(ErrorKind),
+    Message {
+        kind: ErrorKind,
+        message: Cow<'static, str>,
+    },
+    Custom(Custom),
+    Full(Custom, Cow<'static, str>),
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum ErrorKind {
+    HttpStatus { status: u16 },
+    Encoding,
+    Other,
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorKind::HttpStatus { status } => write!(f, "HttpStatus({})", status),
+            ErrorKind::Encoding => write!(f, "Encoding"),
+            ErrorKind::Other => write!(f, "Other"),
+        }
+    }
+}
+
+pub trait ResultExt<T> {
+    fn context<C>(self, kind: ErrorKind, message: C) -> Result<T>
+    where
+        Self: Sized,
+        C: Into<Cow<'static, str>>;
+
+    fn with_context<F, C>(self, kind: ErrorKind, f: F) -> Result<T>
+    where
+        Self: Sized,
+        F: FnOnce() -> C,
+        C: Into<Cow<'static, str>>;
+}
+
+impl<T, E> ResultExt<T> for std::result::Result<T, E>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    fn context<C>(self, kind: ErrorKind, message: C) -> Result<T>
+    where
+        Self: Sized,
+        C: Into<Cow<'static, str>>,
+    {
+        self.map_err(|e| Error {
+            context: Context::Full(
+                Custom {
+                    error: Box::new(e),
+                    kind,
+                },
+                message.into(),
+            ),
+        })
+    }
+
+    fn with_context<F, C>(self, kind: ErrorKind, f: F) -> Result<T>
+    where
+        Self: Sized,
+        F: FnOnce() -> C,
+        C: Into<Cow<'static, str>>,
+    {
+        self.context(kind, f())
+    }
+}

--- a/sdk/core/src/error.rs
+++ b/sdk/core/src/error.rs
@@ -75,6 +75,28 @@ impl From<ErrorKind> for Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Self {
+            context: Context::Custom(Custom {
+                kind: ErrorKind::Io,
+                error: Box::new(error),
+            }),
+        }
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Self {
+            context: Context::Custom(Custom {
+                kind: ErrorKind::Deserialization,
+                error: Box::new(error),
+            }),
+        }
+    }
+}
+
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.context {
@@ -108,7 +130,9 @@ enum Context {
 #[derive(Copy, Clone, Debug)]
 pub enum ErrorKind {
     HttpStatus { status: u16 },
-    Encoding,
+    Io,
+    Serialization,
+    Deserialization,
     Other,
 }
 
@@ -116,7 +140,9 @@ impl Display for ErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ErrorKind::HttpStatus { status } => write!(f, "HttpStatus({})", status),
-            ErrorKind::Encoding => write!(f, "Encoding"),
+            ErrorKind::Io => write!(f, "Io"),
+            ErrorKind::Serialization => write!(f, "Serialization"),
+            ErrorKind::Deserialization => write!(f, "Deserialization"),
             ErrorKind::Other => write!(f, "Other"),
         }
     }

--- a/sdk/core/src/error.rs
+++ b/sdk/core/src/error.rs
@@ -74,11 +74,11 @@ pub struct Error<O> {
     context: Context<O>,
 }
 
-impl<O> Error<O> {
+impl<O: Clone + Copy> Error<O> {
     /// Create a new `Error` based on a specific error kind and an underlying error cause
-    pub fn new<ERR>(kind: ErrorKind<O>, error: ERR) -> Self
+    pub fn new<E>(kind: ErrorKind<O>, error: E) -> Self
     where
-        ERR: Into<Box<dyn std::error::Error + Send + Sync>>,
+        E: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
         Self {
             context: Context::Custom(Custom {
@@ -102,8 +102,8 @@ impl<O> Error<O> {
     }
 
     /// Get the `ErrorKind` of this `Error`
-    pub fn kind(&self) -> &ErrorKind<O> {
-        match &self.context {
+    pub fn kind(&self) -> ErrorKind<O> {
+        match self.context {
             Context::Simple(kind) => kind,
             Context::Message { kind, .. } => kind,
             Context::Custom(Custom { kind, .. }) => kind,
@@ -385,19 +385,19 @@ mod tests {
 
         let err = test_ensure(false).unwrap_err();
         assert_eq!(format!("{}", err), "predicate failed");
-        assert_eq!(*err.kind(), ErrorKind::Other);
+        assert_eq!(err.kind(), ErrorKind::Other);
 
         assert!(test_ensure(true).is_ok());
 
         let err = test_ensure_eq("foo", "bar").unwrap_err();
         assert_eq!(format!("{}", err), "predicate failed");
-        assert_eq!(*err.kind(), ErrorKind::Other);
+        assert_eq!(err.kind(), ErrorKind::Other);
 
         assert!(test_ensure_eq("foo", "foo").is_ok());
 
         let err = test_ensure_ne("foo", "foo").unwrap_err();
         assert_eq!(format!("{}", err), "predicate failed");
-        assert_eq!(*err.kind(), ErrorKind::Other);
+        assert_eq!(err.kind(), ErrorKind::Other);
 
         assert!(test_ensure_ne("foo", "bar").is_ok());
     }

--- a/sdk/core/src/error/azure_core_errors.rs
+++ b/sdk/core/src/error/azure_core_errors.rs
@@ -1,0 +1,44 @@
+use super::{Error, ErrorKind};
+
+impl<O: Copy> From<crate::errors::Error> for Error<O> {
+    fn from(err: crate::errors::Error) -> Error<O> {
+        match err {
+            crate::errors::Error::Json(e) => e.into(),
+            crate::errors::Error::Header(e) => Error::new(ErrorKind::DataConversion, e),
+            crate::errors::Error::Parse(e) => Error::new(ErrorKind::DataConversion, e),
+            crate::errors::Error::HeadersNotFound(hs) => Error::with_message(
+                ErrorKind::DataConversion,
+                format!("headers not found: {}", hs.join(", ")),
+            ),
+            crate::errors::Error::HeaderNotFound(h) => Error::with_message(
+                ErrorKind::DataConversion,
+                format!("header not found: {}", h),
+            ),
+            crate::errors::Error::Http(e) => e.into(),
+            crate::errors::Error::Stream(e) => Error::new(ErrorKind::Io, e),
+            crate::errors::Error::GetToken(e) => Error::new(ErrorKind::Credential, e),
+            crate::errors::Error::HttpPrepare(e) => e.into(),
+            crate::errors::Error::Other(e) => Error::new(ErrorKind::Other, e),
+        }
+    }
+}
+
+impl<O: Copy> From<crate::errors::HttpError> for Error<O> {
+    fn from(err: crate::errors::HttpError) -> Error<O> {
+        match err {
+            crate::HttpError::StatusCode { status, body } => Error::with_data(
+                ErrorKind::UnexpectedOperation {
+                    status: status.as_u16(),
+                },
+                "an unspecified and unexpected HTTP error occurred",
+                body,
+            ),
+            crate::HttpError::ExecuteRequest(e) => Error::new(ErrorKind::Io, e),
+            crate::HttpError::ReadBytes(e) => Error::new(ErrorKind::Io, e),
+            crate::HttpError::StreamReset(e) => Error::new(ErrorKind::Io, e),
+            crate::HttpError::Utf8(e) => Error::new(ErrorKind::DataConversion, e),
+            crate::HttpError::BuildResponse(e) => Error::new(ErrorKind::DataConversion, e),
+            crate::HttpError::BuildClientRequest(e) => Error::new(ErrorKind::Other, e),
+        }
+    }
+}

--- a/sdk/core/src/error/azure_core_errors.rs
+++ b/sdk/core/src/error/azure_core_errors.rs
@@ -26,12 +26,9 @@ impl From<crate::errors::Error> for Error {
 impl From<crate::errors::HttpError> for Error {
     fn from(err: crate::errors::HttpError) -> Error {
         match err {
-            crate::HttpError::StatusCode { status, body } => Error::with_data(
-                ErrorKind::HttpResponse {
-                    status: status.as_u16(),
-                },
-                "an unspecified and unexpected HTTP error occurred",
-                body,
+            crate::HttpError::StatusCode { status, ref body } => Error::new(
+                ErrorKind::http_response_from_body(status.as_u16(), body),
+                err,
             ),
             crate::HttpError::ExecuteRequest(e) => Error::new(ErrorKind::Io, e),
             crate::HttpError::ReadBytes(e) => Error::new(ErrorKind::Io, e),

--- a/sdk/core/src/error/azure_core_errors.rs
+++ b/sdk/core/src/error/azure_core_errors.rs
@@ -1,7 +1,7 @@
 use super::{Error, ErrorKind};
 
-impl<O: Copy> From<crate::errors::Error> for Error<O> {
-    fn from(err: crate::errors::Error) -> Error<O> {
+impl From<crate::errors::Error> for Error {
+    fn from(err: crate::errors::Error) -> Error {
         match err {
             crate::errors::Error::Json(e) => e.into(),
             crate::errors::Error::Header(e) => Error::new(ErrorKind::DataConversion, e),
@@ -23,11 +23,11 @@ impl<O: Copy> From<crate::errors::Error> for Error<O> {
     }
 }
 
-impl<O: Copy> From<crate::errors::HttpError> for Error<O> {
-    fn from(err: crate::errors::HttpError) -> Error<O> {
+impl From<crate::errors::HttpError> for Error {
+    fn from(err: crate::errors::HttpError) -> Error {
         match err {
             crate::HttpError::StatusCode { status, body } => Error::with_data(
-                ErrorKind::UnexpectedOperation {
+                ErrorKind::HttpResponse {
                     status: status.as_u16(),
                 },
                 "an unspecified and unexpected HTTP error occurred",

--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -1,0 +1,96 @@
+use crate::Response;
+
+/// An unsuccessful HTTP response
+#[derive(Debug)]
+pub struct HttpError {
+    status: u16,
+    error_code: Option<String>,
+    headers: std::collections::HashMap<String, String>,
+    body: String,
+}
+
+impl HttpError {
+    /// Create an error from an http response.
+    ///
+    /// This does not check whether the response was a success and should only be used with unsuccessul responses.
+    pub async fn new(response: Response) -> Self {
+        let status = response.status();
+        let mut error_code = get_error_code_from_header(&response);
+        let headers = response
+            .headers()
+            .into_iter()
+            // TODO: the following will panic if a non-UTF8 header value is sent back
+            // We should not panic but instead handle this gracefully
+            .map(|(n, v)| (n.as_str().to_owned(), v.to_str().unwrap().to_owned()))
+            .collect();
+        let body = response.into_body_string().await;
+        error_code = error_code.or_else(|| get_error_code_from_body(&body));
+        HttpError {
+            status: status.as_u16(),
+            headers,
+            error_code,
+            body,
+        }
+    }
+
+    /// Get a reference to the http error's status.
+    pub fn status(&self) -> u16 {
+        self.status
+    }
+
+    /// Get a reference to the http error's error code.
+    pub fn error_code(&self) -> Option<&str> {
+        self.error_code.as_deref()
+    }
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "HttpError")?;
+        writeln!(f, "\tStatus: {}", self.status)?;
+        writeln!(
+            f,
+            "\tError Code: {}",
+            self.error_code.as_deref().unwrap_or("unknown")
+        )?;
+        // TODO: sanitize body
+        writeln!(f, "\tBody: \"{}\"", self.body)?;
+        writeln!(f, "\tHeaders:")?;
+        // TODO: sanitize headers
+        for (k, v) in &self.headers {
+            writeln!(f, "\t\t{}:{}", k, v)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for HttpError {}
+
+/// Gets the error code if it's present in the headers
+///
+/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
+fn get_error_code_from_header(response: &Response) -> Option<String> {
+    Some(
+        response
+            .headers()
+            .get(http::header::HeaderName::from_static("x-ms-error-code"))?
+            .to_str()
+            .ok()?
+            .to_owned(),
+    )
+}
+
+/// Gets the error code if it's present in the body
+///
+/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
+pub(crate) fn get_error_code_from_body(body: &str) -> Option<String> {
+    Some(
+        serde_json::from_str::<serde_json::Value>(body)
+            .ok()?
+            .get("error")?
+            .get("code")?
+            .as_str()?
+            .to_owned(),
+    )
+}

--- a/sdk/core/src/error/hyperium_http.rs
+++ b/sdk/core/src/error/hyperium_http.rs
@@ -5,44 +5,44 @@ use http::method::InvalidMethod;
 use http::status::InvalidStatusCode;
 use http::uri::{InvalidUri, InvalidUriParts};
 
-impl<O: Copy> From<http::Error> for super::Error<O> {
-    fn from(err: http::Error) -> super::Error<O> {
+impl From<http::Error> for super::Error {
+    fn from(err: http::Error) -> super::Error {
         Error::new(ErrorKind::DataConversion, err)
     }
 }
 
-impl<O: Copy> From<InvalidHeaderName> for super::Error<O> {
-    fn from(err: InvalidHeaderName) -> super::Error<O> {
+impl From<InvalidHeaderName> for super::Error {
+    fn from(err: InvalidHeaderName) -> super::Error {
         Error::new(ErrorKind::DataConversion, err)
     }
 }
 
-impl<O: Copy> From<InvalidHeaderValue> for super::Error<O> {
-    fn from(err: InvalidHeaderValue) -> super::Error<O> {
+impl From<InvalidHeaderValue> for super::Error {
+    fn from(err: InvalidHeaderValue) -> super::Error {
         Error::new(ErrorKind::DataConversion, err)
     }
 }
 
-impl<O: Copy> From<InvalidMethod> for super::Error<O> {
-    fn from(err: InvalidMethod) -> super::Error<O> {
+impl From<InvalidMethod> for super::Error {
+    fn from(err: InvalidMethod) -> super::Error {
         Error::new(ErrorKind::DataConversion, err)
     }
 }
 
-impl<O: Copy> From<InvalidStatusCode> for super::Error<O> {
-    fn from(err: InvalidStatusCode) -> super::Error<O> {
+impl From<InvalidStatusCode> for super::Error {
+    fn from(err: InvalidStatusCode) -> super::Error {
         Error::new(ErrorKind::DataConversion, err)
     }
 }
 
-impl<O: Copy> From<InvalidUri> for super::Error<O> {
-    fn from(err: InvalidUri) -> super::Error<O> {
+impl From<InvalidUri> for super::Error {
+    fn from(err: InvalidUri) -> super::Error {
         Error::new(ErrorKind::DataConversion, err)
     }
 }
 
-impl<O: Copy> From<InvalidUriParts> for super::Error<O> {
-    fn from(err: InvalidUriParts) -> super::Error<O> {
+impl From<InvalidUriParts> for super::Error {
+    fn from(err: InvalidUriParts) -> super::Error {
         Error::new(ErrorKind::DataConversion, err)
     }
 }

--- a/sdk/core/src/error/hyperium_http.rs
+++ b/sdk/core/src/error/hyperium_http.rs
@@ -1,0 +1,48 @@
+use super::{Error, ErrorKind};
+
+use http::header::{InvalidHeaderName, InvalidHeaderValue};
+use http::method::InvalidMethod;
+use http::status::InvalidStatusCode;
+use http::uri::{InvalidUri, InvalidUriParts};
+
+impl<O: Copy> From<http::Error> for super::Error<O> {
+    fn from(err: http::Error) -> super::Error<O> {
+        Error::new(ErrorKind::DataConversion, err)
+    }
+}
+
+impl<O: Copy> From<InvalidHeaderName> for super::Error<O> {
+    fn from(err: InvalidHeaderName) -> super::Error<O> {
+        Error::new(ErrorKind::DataConversion, err)
+    }
+}
+
+impl<O: Copy> From<InvalidHeaderValue> for super::Error<O> {
+    fn from(err: InvalidHeaderValue) -> super::Error<O> {
+        Error::new(ErrorKind::DataConversion, err)
+    }
+}
+
+impl<O: Copy> From<InvalidMethod> for super::Error<O> {
+    fn from(err: InvalidMethod) -> super::Error<O> {
+        Error::new(ErrorKind::DataConversion, err)
+    }
+}
+
+impl<O: Copy> From<InvalidStatusCode> for super::Error<O> {
+    fn from(err: InvalidStatusCode) -> super::Error<O> {
+        Error::new(ErrorKind::DataConversion, err)
+    }
+}
+
+impl<O: Copy> From<InvalidUri> for super::Error<O> {
+    fn from(err: InvalidUri) -> super::Error<O> {
+        Error::new(ErrorKind::DataConversion, err)
+    }
+}
+
+impl<O: Copy> From<InvalidUriParts> for super::Error<O> {
+    fn from(err: InvalidUriParts) -> super::Error<O> {
+        Error::new(ErrorKind::DataConversion, err)
+    }
+}

--- a/sdk/core/src/error/macros.rs
+++ b/sdk/core/src/error/macros.rs
@@ -100,19 +100,19 @@ mod tests {
 
         let err = test_ensure(false).unwrap_err();
         assert_eq!(format!("{}", err), "predicate failed");
-        assert_eq!(err.kind(), ErrorKind::Other);
+        assert_eq!(err.kind(), &ErrorKind::Other);
 
         assert!(test_ensure(true).is_ok());
 
         let err = test_ensure_eq("foo", "bar").unwrap_err();
         assert_eq!(format!("{}", err), "predicate failed");
-        assert_eq!(err.kind(), ErrorKind::Other);
+        assert_eq!(err.kind(), &ErrorKind::Other);
 
         assert!(test_ensure_eq("foo", "foo").is_ok());
 
         let err = test_ensure_ne("foo", "foo").unwrap_err();
         assert_eq!(format!("{}", err), "predicate failed");
-        assert_eq!(err.kind(), ErrorKind::Other);
+        assert_eq!(err.kind(), &ErrorKind::Other);
 
         assert!(test_ensure_ne("foo", "bar").is_ok());
     }

--- a/sdk/core/src/error/macros.rs
+++ b/sdk/core/src/error/macros.rs
@@ -1,0 +1,119 @@
+/// A convenient way to create a new error using the normal formatting infrastructure
+#[macro_export]
+macro_rules! format_err {
+    ($kind:expr, $msg:literal $(,)?) => {{
+        // Handle $:literal as a special case to make cargo-expanded code more
+        // concise in the common case.
+        $crate::error::Error::new($kind, $msg)
+    }};
+    ($kind:expr, $msg:expr $(,)?) => {{
+        $crate::error::Error::new($kind, $msg)
+    }};
+    ($kind:expr, $msg:expr, $($arg:tt)*) => {{
+        $crate::error::Error::new($kind, format!($msg, $($arg)*))
+    }};
+}
+
+/// Return early with an error if a condition is not satisfied.
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $kind:expr, $msg:literal $(,)?) => {
+        if !$cond {
+            return ::std::result::Result::Err($crate::format_err!($kind, $msg));
+        }
+    };
+    ($cond:expr, $kind:expr, dicate $msg:expr $(,)?) => {
+        if !$cond {
+            return ::std::result::Result::Err($crate::format_err!($kind, $msg));
+        }
+    };
+    ($cond:expr, $kind:expr, dicate $msg:expr, $($arg:tt)*) => {
+        if !$cond {
+            return ::std::result::Result::Err($crate::format_err!($kind, $msg, $($arg)*));
+        }
+    };
+}
+
+/// Return early with an error if two expressions are not equal to each other.
+#[macro_export]
+macro_rules! ensure_eq {
+    ($left:expr, $right:expr, $kind:expr, $msg:literal $(,)?) => {
+        $crate::ensure!($left == $right, $kind, $msg);
+    };
+    ($left:expr, $right:expr, $kind:expr, dicate $msg:expr $(,)?) => {
+        $crate::ensure!($left == $right, $kind, $msg);
+    };
+    ($left:expr, $right:expr, $kind:expr, dicate $msg:expr, $($arg:tt)*) => {
+        $crate::ensure!($left == $right, $kind, $msg, $($arg)*);
+    };
+}
+
+/// Return early with an error if two expressions are equal to each other.
+#[macro_export]
+macro_rules! ensure_ne {
+    ($left:expr, $right:expr, $kind:expr, $msg:literal $(,)?) => {
+        $crate::ensure!($left != $right, $kind, $msg);
+    };
+    ($left:expr, $right:expr, $kind:expr, dicate $msg:expr $(,)?) => {
+        $crate::ensure!($left != $right, $kind, $msg);
+    };
+    ($left:expr, $right:expr, $kind:expr, dicate $msg:expr, $($arg:tt)*) => {
+        $crate::ensure!($left != $right, $kind, $msg, $($arg)*);
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::*;
+
+    #[derive(Debug, PartialEq, Copy, Clone)]
+    struct OperationError;
+
+    impl Display for OperationError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "OperationError")
+        }
+    }
+
+    #[derive(thiserror::Error, Debug)]
+    enum IntermediateError {
+        #[error("second error")]
+        Io(#[from] std::io::Error),
+    }
+
+    #[test]
+    fn ensure_works() {
+        fn test_ensure(predicate: bool) -> Result<(), OperationError> {
+            ensure!(predicate, ErrorKind::Other, "predicate failed");
+            Ok(())
+        }
+
+        fn test_ensure_eq(item1: &str, item2: &str) -> Result<(), OperationError> {
+            ensure_eq!(item1, item2, ErrorKind::Other, "predicate failed");
+            Ok(())
+        }
+
+        fn test_ensure_ne(item1: &str, item2: &str) -> Result<(), OperationError> {
+            ensure_ne!(item1, item2, ErrorKind::Other, "predicate failed");
+            Ok(())
+        }
+
+        let err = test_ensure(false).unwrap_err();
+        assert_eq!(format!("{}", err), "predicate failed");
+        assert_eq!(err.kind(), ErrorKind::Other);
+
+        assert!(test_ensure(true).is_ok());
+
+        let err = test_ensure_eq("foo", "bar").unwrap_err();
+        assert_eq!(format!("{}", err), "predicate failed");
+        assert_eq!(err.kind(), ErrorKind::Other);
+
+        assert!(test_ensure_eq("foo", "foo").is_ok());
+
+        let err = test_ensure_ne("foo", "foo").unwrap_err();
+        assert_eq!(format!("{}", err), "predicate failed");
+        assert_eq!(err.kind(), ErrorKind::Other);
+
+        assert!(test_ensure_ne("foo", "bar").is_ok());
+    }
+}

--- a/sdk/core/src/error/macros.rs
+++ b/sdk/core/src/error/macros.rs
@@ -83,17 +83,17 @@ mod tests {
 
     #[test]
     fn ensure_works() {
-        fn test_ensure(predicate: bool) -> Result<(), OperationError> {
+        fn test_ensure(predicate: bool) -> Result<()> {
             ensure!(predicate, ErrorKind::Other, "predicate failed");
             Ok(())
         }
 
-        fn test_ensure_eq(item1: &str, item2: &str) -> Result<(), OperationError> {
+        fn test_ensure_eq(item1: &str, item2: &str) -> Result<()> {
             ensure_eq!(item1, item2, ErrorKind::Other, "predicate failed");
             Ok(())
         }
 
-        fn test_ensure_ne(item1: &str, item2: &str) -> Result<(), OperationError> {
+        fn test_ensure_ne(item1: &str, item2: &str) -> Result<()> {
             ensure_ne!(item1, item2, ErrorKind::Other, "predicate failed");
             Ok(())
         }

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -234,8 +234,8 @@ impl Display for Error {
 
 /// An extention to the `Result` type that easy allows creating `Error` values from exsiting errors
 ///
-/// This trait should not be implemented on custom types and is meant for usage with `Result`
-pub trait ResultExt<T> {
+/// This trait cannot be implemented on custom types and is meant for usage with `Result`
+pub trait ResultExt<T>: private::Sealed {
     fn context<C>(self, kind: ErrorKind, message: C) -> Result<T>
     where
         Self: Sized,
@@ -246,6 +246,12 @@ pub trait ResultExt<T> {
         Self: Sized,
         F: FnOnce() -> C,
         C: Into<Cow<'static, str>>;
+}
+
+mod private {
+    pub trait Sealed {}
+
+    impl<T, E> Sealed for std::result::Result<T, E> where E: std::error::Error + Send + Sync + 'static {}
 }
 
 impl<T, E> ResultExt<T> for std::result::Result<T, E>

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -119,6 +119,11 @@ impl<O: Clone + Copy> Error<O> {
         }
     }
 
+    /// Consumes the error attempting to downcast the inner error as the type provided
+    pub fn into_downcast<T: std::error::Error + 'static>(self) -> Option<T> {
+        self.into_inner()?.downcast().ok().map(|t| *t)
+    }
+
     /// Returns a reference to the inner error wrapped by this error (if any).
     pub fn get_ref(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
         match &self.context {
@@ -128,13 +133,23 @@ impl<O: Clone + Copy> Error<O> {
         }
     }
 
+    /// Returns a reference to the inner error (if any) downcasted to the type provided
+    pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T> {
+        self.get_ref()?.downcast_ref()
+    }
+
     /// Returns a mutable reference to the inner error wrapped by this error (if any).
-    pub fn get_mut(&mut self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
+    pub fn get_mut(&mut self) -> Option<&mut (dyn std::error::Error + Send + Sync + 'static)> {
         match &mut self.context {
             Context::Custom(Custom { error, .. }) => Some(error.as_mut()),
             Context::Full(Custom { error, .. }, _) => Some(error.as_mut()),
             _ => None,
         }
+    }
+
+    /// Returns a mutable reference to the inner error (if any) downcasted to the type provided
+    pub fn downcast_mut<T: std::error::Error + 'static>(&mut self) -> Option<&mut T> {
+        self.get_mut()?.downcast_mut()
     }
 }
 

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -21,6 +21,9 @@ pub enum ErrorKind {
     DataConversion,
     /// An error getting an API credential token
     Credential,
+    #[cfg(feature = "mock_transport_framework")]
+    /// An error having to do with the mock framework
+    MockFramework,
     /// A catch all for other kinds of errors
     Other,
 }
@@ -38,6 +41,8 @@ impl Display for ErrorKind {
             ErrorKind::Io => write!(f, "Io"),
             ErrorKind::DataConversion => write!(f, "DataConversion"),
             ErrorKind::Credential => write!(f, "Credential"),
+            #[cfg(feature = "mock_transport_framework")]
+            ErrorKind::MockFramework => write!(f, "MockFramework"),
             ErrorKind::Other => write!(f, "Other"),
         }
     }

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -2,7 +2,7 @@ use http::StatusCode;
 #[cfg(feature = "enable_hyper")]
 use hyper::{self, body, Body};
 use std::cmp::PartialEq;
-use std::fmt::{Debug, Display};
+use std::fmt::Debug;
 
 /// A specialized `Result` type for this crate.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -44,9 +44,12 @@ pub enum Error {
     Other(#[source] Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
-impl<O: Display + Debug + Send + Sync + 'static> From<super::error::Error<O>> for Error {
-    fn from(err: super::error::Error<O>) -> Self {
-        Self::Other(Box::new(err))
+impl From<super::error::Error> for Error {
+    fn from(err: super::error::Error) -> Self {
+        match err.into_downcast() {
+            Ok(e) => e,
+            Err(e) => Self::Other(Box::new(e)),
+        }
     }
 }
 

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -17,6 +17,7 @@ mod macros;
 mod bytes_stream;
 mod constants;
 mod context;
+pub mod error;
 mod errors;
 mod http_client;
 mod models;
@@ -29,7 +30,6 @@ mod request_options;
 mod response;
 mod seekable_stream;
 mod sleep;
-pub mod error;
 
 pub mod auth;
 pub mod headers;

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -29,6 +29,7 @@ mod request_options;
 mod response;
 mod seekable_stream;
 mod sleep;
+pub mod error;
 
 pub mod auth;
 pub mod headers;

--- a/sdk/core/src/mock/mock_response.rs
+++ b/sdk/core/src/mock/mock_response.rs
@@ -3,7 +3,7 @@ use http::{header, HeaderMap, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-use crate::{collect_pinned_stream, BytesStream, Response, error};
+use crate::{collect_pinned_stream, error, BytesStream, Response};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct MockResponse {

--- a/sdk/core/src/mock/mock_response.rs
+++ b/sdk/core/src/mock/mock_response.rs
@@ -35,7 +35,7 @@ impl MockResponse {
 
     pub(crate) async fn duplicate(
         response: crate::Response,
-    ) -> Result<(crate::Response, Self), crate::StreamError> {
+    ) -> crate::error::Result<(crate::Response, Self)> {
         let (status_code, header_map, pinned_stream) = response.deconstruct();
         let response_bytes = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/core/src/mock/mock_response.rs
+++ b/sdk/core/src/mock/mock_response.rs
@@ -3,7 +3,7 @@ use http::{header, HeaderMap, StatusCode};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-use crate::{collect_pinned_stream, BytesStream, Response};
+use crate::{collect_pinned_stream, BytesStream, Response, error};
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct MockResponse {
@@ -35,9 +35,13 @@ impl MockResponse {
 
     pub(crate) async fn duplicate(
         response: crate::Response,
-    ) -> crate::error::Result<(crate::Response, Self)> {
+    ) -> error::Result<(crate::Response, Self)> {
+        use error::ResultExt;
         let (status_code, header_map, pinned_stream) = response.deconstruct();
-        let response_bytes = collect_pinned_stream(pinned_stream).await?;
+        let response_bytes = collect_pinned_stream(pinned_stream).await.context(
+            error::ErrorKind::Io,
+            "an error occurred fetching the next part of the byte stream",
+        )?;
 
         let response = Response::new(
             status_code,

--- a/sdk/core/src/mock/mod.rs
+++ b/sdk/core/src/mock/mod.rs
@@ -17,8 +17,6 @@ pub const TESTING_MODE_RECORD: &str = "RECORD";
 #[cfg(feature = "mock_transport_framework")]
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MockFrameworkError {
-    #[error("{0}: {1}")]
-    IOError(String, std::io::Error),
     #[error("{0}")]
     TransactionStorageError(String),
     #[error("{0}")]
@@ -35,6 +33,12 @@ pub(crate) enum MockFrameworkError {
     MismatchedRequestHTTPMethod(http::Method, http::Method),
     #[error("mismatched request body. Actual: {0:?}, Expected: {1:?}")]
     MismatchedRequestBody(Vec<u8>, Vec<u8>),
+}
+
+impl From<MockFrameworkError> for crate::error::Error {
+    fn from(err: MockFrameworkError) -> Self {
+        Self::new(crate::error::ErrorKind::MockFramework, err)
+    }
 }
 
 // Replace the default transport policy at runtime

--- a/sdk/core/src/mock/player_policy.rs
+++ b/sdk/core/src/mock/player_policy.rs
@@ -28,7 +28,7 @@ impl Policy for MockTransportPlayerPolicy {
         _ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
+    ) -> PolicyResult {
         // there must be no more policies
         assert_eq!(0, next.len());
 

--- a/sdk/core/src/mock/player_policy.rs
+++ b/sdk/core/src/mock/player_policy.rs
@@ -1,7 +1,7 @@
 use super::mock_response::MockResponse;
 use super::mock_transaction::MockTransaction;
 use crate::policies::{Policy, PolicyResult};
-use crate::{Context, Request, Response, TransportOptions};
+use crate::{Context, Request, TransportOptions};
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
@@ -57,10 +57,9 @@ impl Policy for MockTransportPlayerPolicy {
             .map(|p| p.to_string())
             .unwrap_or_else(String::new);
         if expected_uri != actual_uri {
-            return Err(Box::new(super::MockFrameworkError::MismatchedRequestUri(
-                actual_uri,
-                expected_uri,
-            )));
+            return Err(
+                super::MockFrameworkError::MismatchedRequestUri(actual_uri, expected_uri).into(),
+            );
         }
 
         // check if the passed request matches the one read from disk
@@ -84,12 +83,11 @@ impl Policy for MockTransportPlayerPolicy {
         // 1. There are no extra headers (in both the received and read request).
         // 2. Each header has the same value.
         if actual_headers.len() != expected_headers.len() {
-            return Err(Box::new(
-                super::MockFrameworkError::MismatchedRequestHeadersCount(
-                    actual_headers.len(),
-                    expected_headers.len(),
-                ),
-            ));
+            return Err(super::MockFrameworkError::MismatchedRequestHeadersCount(
+                actual_headers.len(),
+                expected_headers.len(),
+            )
+            .into());
         }
 
         for (actual_header_key, actual_header_value) in actual_headers.iter() {
@@ -101,23 +99,21 @@ impl Policy for MockTransportPlayerPolicy {
                 ))?;
 
             if actual_header_value != expected_header_value {
-                return Err(Box::new(
-                    super::MockFrameworkError::MismatchedRequestHeader(
-                        actual_header_key.as_str().to_owned(),
-                        actual_header_value.to_str().unwrap().to_owned(),
-                        expected_header_value.to_str().unwrap().to_owned(),
-                    ),
-                ));
+                return Err(super::MockFrameworkError::MismatchedRequestHeader(
+                    actual_header_key.as_str().to_owned(),
+                    actual_header_value.to_str().unwrap().to_owned(),
+                    expected_header_value.to_str().unwrap().to_owned(),
+                )
+                .into());
             }
         }
 
         if expected_request.method() != request.method() {
-            return Err(Box::new(
-                super::MockFrameworkError::MismatchedRequestHTTPMethod(
-                    expected_request.method(),
-                    request.method(),
-                ),
-            ));
+            return Err(super::MockFrameworkError::MismatchedRequestHTTPMethod(
+                expected_request.method(),
+                request.method(),
+            )
+            .into());
         }
 
         let actual_body = match request.body() {
@@ -131,10 +127,11 @@ impl Policy for MockTransportPlayerPolicy {
         };
 
         if actual_body != expected_body {
-            return Err(Box::new(super::MockFrameworkError::MismatchedRequestBody(
+            return Err(super::MockFrameworkError::MismatchedRequestBody(
                 actual_body.to_vec(),
                 expected_body.to_vec(),
-            )));
+            )
+            .into());
         }
 
         self.transaction.increment_number();

--- a/sdk/core/src/mock/recorder_policy.rs
+++ b/sdk/core/src/mock/recorder_policy.rs
@@ -1,7 +1,8 @@
 use super::mock_response::MockResponse;
 use super::MockTransaction;
+use crate::error::ResultExt;
 use crate::policies::{Policy, PolicyResult};
-use crate::{Context, Request, Response, TransportOptions};
+use crate::{Context, Request, TransportOptions};
 use std::io::Write;
 use std::sync::Arc;
 
@@ -45,9 +46,10 @@ impl Policy for MockTransportRecorderPolicy {
             let mut request_contents_stream = std::fs::File::create(&request_path).unwrap();
             request_contents_stream
                 .write_all(request_contents.as_str().as_bytes())
-                .map_err(|e| {
-                    super::MockFrameworkError::IOError("cannot write request file".into(), e)
-                })?;
+                .context(
+                    crate::error::ErrorKind::MockFramework,
+                    "cannot write request file",
+                )?;
         }
 
         let response = self
@@ -64,9 +66,10 @@ impl Policy for MockTransportRecorderPolicy {
             let mut response_contents_stream = std::fs::File::create(&response_path).unwrap();
             response_contents_stream
                 .write_all(response_contents.as_bytes())
-                .map_err(|e| {
-                    super::MockFrameworkError::IOError("cannot write response file".into(), e)
-                })?;
+                .context(
+                    crate::error::ErrorKind::MockFramework,
+                    "cannot write response file",
+                )?
         }
 
         self.transaction.increment_number();

--- a/sdk/core/src/mock/recorder_policy.rs
+++ b/sdk/core/src/mock/recorder_policy.rs
@@ -28,7 +28,7 @@ impl Policy for MockTransportRecorderPolicy {
         _ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
+    ) -> PolicyResult {
         // there must be no more policies
         assert_eq!(0, next.len());
 

--- a/sdk/core/src/pageable.rs
+++ b/sdk/core/src/pageable.rs
@@ -16,14 +16,14 @@ macro_rules! r#try {
 ///
 /// Internally uses the Azure specific continuation header to
 /// make repeated requests to Azure yielding a new page each time.
-pub struct Pageable<T> {
-    stream: std::pin::Pin<Box<dyn Stream<Item = crate::error::Result<T>>>>,
+pub struct Pageable<T, E> {
+    stream: std::pin::Pin<Box<dyn Stream<Item = Result<T, E>>>>,
 }
 
-impl<T: Continuable> Pageable<T> {
+impl<T: Continuable, E> Pageable<T, E> {
     pub fn new<F>(make_request: impl Fn(Option<String>) -> F + Clone + 'static) -> Self
     where
-        F: std::future::Future<Output = crate::error::Result<T>> + 'static,
+        F: std::future::Future<Output = Result<T, E>> + 'static,
     {
         let stream = unfold(State::Init, move |state: State| {
             let make_request = make_request.clone();
@@ -50,8 +50,8 @@ impl<T: Continuable> Pageable<T> {
     }
 }
 
-impl<T> Stream for Pageable<T> {
-    type Item = crate::error::Result<T>;
+impl<T, E> Stream for Pageable<T, E> {
+    type Item = Result<T, E>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -61,7 +61,7 @@ impl<T> Stream for Pageable<T> {
     }
 }
 
-impl<T> std::fmt::Debug for Pageable<T> {
+impl<T, O> std::fmt::Debug for Pageable<T, O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Pageable").finish_non_exhaustive()
     }

--- a/sdk/core/src/pageable.rs
+++ b/sdk/core/src/pageable.rs
@@ -17,13 +17,13 @@ macro_rules! r#try {
 /// Internally uses the Azure specific continuation header to
 /// make repeated requests to Azure yielding a new page each time.
 pub struct Pageable<T> {
-    stream: std::pin::Pin<Box<dyn Stream<Item = Result<T, crate::Error>>>>,
+    stream: std::pin::Pin<Box<dyn Stream<Item = crate::error::Result<T>>>>,
 }
 
 impl<T: Continuable> Pageable<T> {
     pub fn new<F>(make_request: impl Fn(Option<String>) -> F + Clone + 'static) -> Self
     where
-        F: std::future::Future<Output = Result<T, crate::Error>> + 'static,
+        F: std::future::Future<Output = crate::error::Result<T>> + 'static,
     {
         let stream = unfold(State::Init, move |state: State| {
             let make_request = make_request.clone();
@@ -51,7 +51,7 @@ impl<T: Continuable> Pageable<T> {
 }
 
 impl<T> Stream for Pageable<T> {
-    type Item = Result<T, crate::Error>;
+    type Item = crate::error::Result<T>;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -107,9 +107,9 @@ impl Pipeline {
     }
 
     pub async fn send(&self, ctx: &mut Context, request: &mut Request) -> Result<Response, Error> {
-        self.pipeline[0]
+        let res = self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
-            .await
-            .map_err(Error::Policy)
+            .await?;
+        Ok(res)
     }
 }

--- a/sdk/core/src/policies/custom_headers_policy.rs
+++ b/sdk/core/src/policies/custom_headers_policy.rs
@@ -1,5 +1,5 @@
 use crate::policies::{Policy, PolicyResult};
-use crate::{Context, Request, Response};
+use crate::{Context, Request};
 use http::header::HeaderMap;
 use std::sync::Arc;
 
@@ -22,7 +22,7 @@ impl Policy for CustomHeadersPolicy {
         ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
+    ) -> PolicyResult {
         if let Some(CustomHeaders(custom_headers)) = ctx.get::<CustomHeaders>() {
             custom_headers
                 .iter()

--- a/sdk/core/src/policies/mod.rs
+++ b/sdk/core/src/policies/mod.rs
@@ -6,13 +6,13 @@ mod transport;
 use crate::{Context, Request, Response};
 pub use custom_headers_policy::{CustomHeaders, CustomHeadersPolicy};
 pub use retry_policies::*;
-use std::error::Error;
 use std::sync::Arc;
 pub use telemetry_policy::*;
 pub use transport::*;
 
 /// A specialized `Result` type for policies.
-pub type PolicyResult<T> = Result<T, Box<dyn Error + Send + Sync>>;
+pub type PolicyResult = crate::error::Result<Response>;
+// pub type PolicyResult = Result<Response, Box<dyn Error + Send + Sync>>;
 
 /// A pipeline policy.
 ///
@@ -28,5 +28,5 @@ pub trait Policy: Send + Sync + std::fmt::Debug {
         ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response>;
+    ) -> PolicyResult;
 }

--- a/sdk/core/src/policies/retry_policies/no_retry.rs
+++ b/sdk/core/src/policies/retry_policies/no_retry.rs
@@ -1,4 +1,4 @@
-use crate::policies::{Policy, PolicyResult, Request, Response};
+use crate::policies::{Policy, PolicyResult, Request};
 use crate::Context;
 use std::sync::Arc;
 
@@ -17,7 +17,7 @@ impl Policy for NoRetryPolicy {
         ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
+    ) -> PolicyResult {
         // just call the following policies and bubble up the error
         next[0].send(ctx, request, &next[1..]).await
     }

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, ErrorKind};
-use crate::policies::{Policy, PolicyResult, Request};
+use crate::policies::{Policy, PolicyResult, Request, Response};
 use crate::sleep::sleep;
 use crate::Context;
 
@@ -61,13 +61,14 @@ where
                 }
                 Ok(response) => {
                     // Error status code
-                    let status = response.status();
-                    let body = response.into_body_string().await;
-                    let error = Error::with_data(
-                        ErrorKind::unexpected(status.as_u16()),
+                    let error = HttpError::new(response).await;
+                    let status = StatusCode::from_u16(error.status).unwrap();
+                    let error = Error::full(
+                        ErrorKind::http_response(status.as_u16()),
+                        error,
                         "server returned error status which will not be retried",
-                        body,
                     );
+
                     if !RETRY_STATUSES.contains(&status) {
                         log::error!(
                             "server returned error status which will not be retried: {}",
@@ -100,3 +101,79 @@ where
         }
     }
 }
+
+/// Gets the error code if it's present in the headers
+///
+/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
+fn get_error_code_from_header(response: &Response) -> Option<String> {
+    Some(
+        response
+            .headers()
+            .get(http::header::HeaderName::from_static("x-ms-error-code"))?
+            .to_str()
+            .ok()?
+            .to_owned(),
+    )
+}
+
+/// Gets the error code if it's present in the body
+///
+/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
+fn get_error_code_from_body(body: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct ErrorResponse {
+        error: InnerError,
+    }
+
+    #[derive(Deserialize)]
+    struct InnerError {
+        code: String,
+    }
+
+    Some(serde_json::from_str::<ErrorResponse>(body).ok()?.error.code)
+}
+
+/// An error type that packs all relevant data related to an HTTP response
+/// with an unsuccessful status code.
+#[derive(Debug)]
+struct HttpError {
+    status: u16,
+    error_code: Option<String>,
+    headers: std::collections::HashMap<String, String>,
+    body: String,
+}
+
+impl HttpError {
+    async fn new(response: Response) -> Self {
+        let status = response.status();
+        let mut error_code = get_error_code_from_header(&response);
+        let headers = response
+            .headers()
+            .into_iter()
+            // TODO: the following will panic if a non-UTF8 header value is sent back
+            // We should not panic but instead handle this gracefully
+            .map(|(n, v)| (n.as_str().to_owned(), v.to_str().unwrap().to_owned()))
+            .collect();
+        let body = response.into_body_string().await;
+        error_code = error_code.or_else(|| get_error_code_from_body(&body));
+        HttpError {
+            status: status.as_u16(),
+            headers,
+            error_code,
+            body,
+        }
+    }
+}
+
+impl std::fmt::Display for HttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpError")
+            .field("status", &self.status)
+            .field("error_code", &self.error_code)
+            .field("headers", &self.headers)
+            .field("body", &self.body)
+            .finish()
+    }
+}
+
+impl std::error::Error for HttpError {}

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -102,37 +102,6 @@ where
     }
 }
 
-/// Gets the error code if it's present in the headers
-///
-/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
-fn get_error_code_from_header(response: &Response) -> Option<String> {
-    Some(
-        response
-            .headers()
-            .get(http::header::HeaderName::from_static("x-ms-error-code"))?
-            .to_str()
-            .ok()?
-            .to_owned(),
-    )
-}
-
-/// Gets the error code if it's present in the body
-///
-/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
-fn get_error_code_from_body(body: &str) -> Option<String> {
-    #[derive(Deserialize)]
-    struct ErrorResponse {
-        error: InnerError,
-    }
-
-    #[derive(Deserialize)]
-    struct InnerError {
-        code: String,
-    }
-
-    Some(serde_json::from_str::<ErrorResponse>(body).ok()?.error.code)
-}
-
 /// An error type that packs all relevant data related to an HTTP response
 /// with an unsuccessful status code.
 #[derive(Debug)]
@@ -177,3 +146,34 @@ impl std::fmt::Display for HttpError {
 }
 
 impl std::error::Error for HttpError {}
+
+/// Gets the error code if it's present in the headers
+///
+/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
+fn get_error_code_from_header(response: &Response) -> Option<String> {
+    Some(
+        response
+            .headers()
+            .get(http::header::HeaderName::from_static("x-ms-error-code"))?
+            .to_str()
+            .ok()?
+            .to_owned(),
+    )
+}
+
+/// Gets the error code if it's present in the body
+///
+/// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
+fn get_error_code_from_body(body: &str) -> Option<String> {
+    #[derive(Deserialize)]
+    struct ErrorResponse {
+        error: InnerError,
+    }
+
+    #[derive(Deserialize)]
+    struct InnerError {
+        code: String,
+    }
+
+    Some(serde_json::from_str::<ErrorResponse>(body).ok()?.error.code)
+}

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -28,7 +28,7 @@ impl Policy for TransportPolicy {
         _ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
+    ) -> PolicyResult {
         // there must be no more policies
         assert_eq!(0, next.len());
 

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -86,11 +86,15 @@ impl std::fmt::Debug for Response {
 }
 
 /// Convenience function that transforms a `PinnedStream` in a `bytes::Bytes` struct by collecting all the chunks. It consumes the response stream.
-pub async fn collect_pinned_stream(mut pinned_stream: PinnedStream) -> Result<Bytes, StreamError> {
+pub async fn collect_pinned_stream(mut pinned_stream: PinnedStream) -> crate::error::Result<Bytes> {
+    use crate::error::ResultExt;
     let mut final_result = Vec::new();
 
     while let Some(res) = pinned_stream.next().await {
-        let res = res?;
+        let res = res.context(
+            crate::error::ErrorKind::Io,
+            "an error occurred fetching the next part of the byte stream",
+        )?;
         final_result.extend(&res);
     }
 

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -86,15 +86,11 @@ impl std::fmt::Debug for Response {
 }
 
 /// Convenience function that transforms a `PinnedStream` in a `bytes::Bytes` struct by collecting all the chunks. It consumes the response stream.
-pub async fn collect_pinned_stream(mut pinned_stream: PinnedStream) -> crate::error::Result<Bytes> {
-    use crate::error::ResultExt;
+pub async fn collect_pinned_stream(mut pinned_stream: PinnedStream) -> Result<Bytes, StreamError> {
     let mut final_result = Vec::new();
 
     while let Some(res) = pinned_stream.next().await {
-        let res = res.context(
-            crate::error::ErrorKind::Io,
-            "an error occurred fetching the next part of the byte stream",
-        )?;
+        let res = res?;
         final_result.extend(&res);
     }
 

--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -2,7 +2,7 @@ use crate::headers::{HEADER_DATE, HEADER_VERSION};
 use crate::resources::permission::AuthorizationToken;
 use crate::resources::ResourceType;
 use crate::TimeNonce;
-use azure_core::{Context, Policy, PolicyResult, Request, Response};
+use azure_core::{Context, Policy, PolicyResult, Request};
 use http::header::AUTHORIZATION;
 use http::HeaderValue;
 use ring::hmac;
@@ -43,14 +43,13 @@ impl Policy for AuthorizationPolicy {
         ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
+    ) -> PolicyResult {
         trace!("called AuthorizationPolicy::send. self == {:#?}", self);
 
-        if next.is_empty() {
-            return Err(Box::new(azure_core::PipelineError::InvalidTailPolicy(
-                "Authorization policies cannot be the last policy of a pipeline".to_owned(),
-            )));
-        }
+        assert!(
+            !next.is_empty(),
+            "Authorization policies cannot be the last policy of a pipeline"
+        );
 
         let time_nonce = TimeNonce::new();
 

--- a/sdk/data_cosmos/src/errors.rs
+++ b/sdk/data_cosmos/src/errors.rs
@@ -22,6 +22,12 @@ pub enum Error {
     InvalidHeaderValue(#[from] azure_core::HttpHeaderError),
 }
 
+impl From<azure_core::error::Error> for Error {
+    fn from(err: azure_core::error::Error) -> Self {
+        Self::Core(err.into())
+    }
+}
+
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Self::Core(azure_core::Error::Json(error))

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -94,7 +94,10 @@ pub struct CreateDatabaseResponse {
 impl CreateDatabaseResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
-        let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await?;
+        let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await.context(
+            azure_core::error::ErrorKind::Io,
+            "an error occurred fetching the next part of the byte stream",
+        )?;
 
         let res = || {
             crate::Result::Ok(Self {

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -57,8 +57,7 @@ impl CreateDatabaseBuilder {
                 .client
                 .pipeline()
                 .send(self.context.insert(ResourceType::Databases), &mut request)
-                .await
-                .context(ErrorKind::Other, "error when running pipeline")?;
+                .await?;
 
             CreateDatabaseResponse::try_from(response).await
         })

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -46,7 +46,7 @@ impl CreateDatabaseBuilder {
             };
 
             azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)
-                .with_context(ErrorKind::Serialization, || {
+                .with_context(ErrorKind::DataConversion, || {
                     format!(
                         "could not encode '{:?}' as an http header",
                         self.consistency_level
@@ -123,7 +123,7 @@ impl CreateDatabaseResponse {
         };
 
         res().context(
-            ErrorKind::Deserialization,
+            ErrorKind::DataConversion,
             "error converting headers to CreateDatabaseResponse",
         )
     }

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -35,7 +35,9 @@ impl ListDatabases {
         context: Context => Some(context),
     }
 
-    pub fn into_stream(self) -> Pageable<ListDatabasesResponse> {
+    pub fn into_stream(
+        self,
+    ) -> Pageable<ListDatabasesResponse, azure_core::error::Error<ListDatabasesError>> {
         let make_request = move |continuation: Option<String>| {
             let this = self.clone();
             let ctx = self.context.clone().unwrap_or_default();
@@ -100,7 +102,9 @@ pub struct ListDatabasesResponse {
 }
 
 impl ListDatabasesResponse {
-    pub(crate) async fn try_from(response: Response) -> azure_core::error::Result<Self> {
+    pub(crate) async fn try_from(
+        response: Response,
+    ) -> azure_core::error::Result<Self, ListDatabasesError> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body: bytes::Bytes = collect_pinned_stream(pinned_stream)
             .await
@@ -156,5 +160,14 @@ impl IntoIterator for ListDatabasesResponse {
 
     fn into_iter(self) -> Self::IntoIter {
         self.databases.into_iter()
+    }
+}
+
+#[derive(Debug)]
+pub enum ListDatabasesError {}
+
+impl std::fmt::Display for ListDatabasesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ListDataBasesError")
     }
 }

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -47,14 +47,14 @@ impl ListDatabases {
                     .prepare_request_pipeline("dbs", http::Method::GET);
 
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)
-                    .with_context(ErrorKind::Serialization, || {
+                    .with_context(ErrorKind::DataConversion, || {
                         format!(
                             "could not encode '{:?}' as an http header",
                             this.consistency_level
                         )
                     })?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)
-                    .with_context(ErrorKind::Serialization, || {
+                    .with_context(ErrorKind::DataConversion, || {
                         format!(
                             "could not encode '{:?}' as an http header",
                             this.max_item_count
@@ -63,7 +63,7 @@ impl ListDatabases {
 
                 if let Some(c) = continuation {
                     let h = http::HeaderValue::from_str(c.as_str())
-                        .with_context(ErrorKind::Serialization, || {
+                        .with_context(ErrorKind::DataConversion, || {
                             format!("could not encode '{:?}' as an http header", c)
                         })?;
                     request.headers_mut().append(headers::CONTINUATION, h);
@@ -141,7 +141,7 @@ impl ListDatabasesResponse {
         };
 
         res().context(
-            ErrorKind::Deserialization,
+            ErrorKind::DataConversion,
             "error converting headers to ListDatabasesResponse",
         )
     }

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -73,8 +73,7 @@ impl ListDatabases {
                     .client
                     .pipeline()
                     .send(ctx.clone().insert(ResourceType::Databases), &mut request)
-                    .await
-                    .context(ErrorKind::Other, "error when running pipeline")?;
+                    .await?;
 
                 ListDatabasesResponse::try_from(response).await
             }
@@ -163,7 +162,7 @@ impl IntoIterator for ListDatabasesResponse {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum ListDatabasesError {}
 
 impl std::fmt::Display for ListDatabasesError {

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -101,7 +101,10 @@ pub struct ListDatabasesResponse {
 impl ListDatabasesResponse {
     pub(crate) async fn try_from(response: Response) -> azure_core::error::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
-        let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await?;
+        let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await.context(
+            azure_core::error::ErrorKind::Io,
+            "an error occurred fetching the next part of the byte stream",
+        )?;
 
         #[derive(Deserialize, Debug)]
         pub struct Response {

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -35,9 +35,7 @@ impl ListDatabases {
         context: Context => Some(context),
     }
 
-    pub fn into_stream(
-        self,
-    ) -> Pageable<ListDatabasesResponse, azure_core::error::Error<ListDatabasesError>> {
+    pub fn into_stream(self) -> Pageable<ListDatabasesResponse, azure_core::error::Error> {
         let make_request = move |continuation: Option<String>| {
             let this = self.clone();
             let ctx = self.context.clone().unwrap_or_default();
@@ -101,13 +99,9 @@ pub struct ListDatabasesResponse {
 }
 
 impl ListDatabasesResponse {
-    pub(crate) async fn try_from(
-        response: Response,
-    ) -> azure_core::error::Result<Self, ListDatabasesError> {
+    pub(crate) async fn try_from(response: Response) -> azure_core::error::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
-        let body: bytes::Bytes = collect_pinned_stream(pinned_stream)
-            .await
-            .context(ErrorKind::Io, "failed to collect stream")?;
+        let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await?;
 
         #[derive(Deserialize, Debug)]
         pub struct Response {
@@ -159,14 +153,5 @@ impl IntoIterator for ListDatabasesResponse {
 
     fn into_iter(self) -> Self::IntoIter {
         self.databases.into_iter()
-    }
-}
-
-#[derive(Debug, Copy, Clone)]
-pub enum ListDatabasesError {}
-
-impl std::fmt::Display for ListDatabasesError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "ListDataBasesError")
     }
 }

--- a/sdk/storage/src/core/errors.rs
+++ b/sdk/storage/src/core/errors.rs
@@ -75,6 +75,12 @@ pub enum Error {
     InvalidHeaderValue(#[from] azure_core::HttpHeaderError),
 }
 
+impl From<azure_core::error::Error> for Error {
+    fn from(err: azure_core::error::Error) -> Self {
+        Self::CoreError(err.into())
+    }
+}
+
 impl From<azure_core::HttpError> for Error {
     fn from(error: azure_core::HttpError) -> Self {
         Self::CoreError(azure_core::Error::Http(error))

--- a/sdk/storage_datalake/src/bearer_token_authorization_policy.rs
+++ b/sdk/storage_datalake/src/bearer_token_authorization_policy.rs
@@ -1,4 +1,4 @@
-use azure_core::{Context, Policy, PolicyResult, Request, Response};
+use azure_core::{Context, Policy, PolicyResult, Request};
 use http::header::AUTHORIZATION;
 use http::HeaderValue;
 use std::sync::Arc;
@@ -22,12 +22,11 @@ impl Policy for BearerTokenAuthorizationPolicy {
         ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
-        if next.is_empty() {
-            return Err(Box::new(azure_core::PipelineError::InvalidTailPolicy(
-                "Authorization policies cannot be the last policy of a pipeline".to_owned(),
-            )));
-        }
+    ) -> PolicyResult {
+        assert!(
+            !next.is_empty(),
+            "Authorization policies cannot be the last policy of a pipeline"
+        );
 
         let auth_header_value = format!("Bearer {}", &self.bearer_token);
 

--- a/sdk/storage_datalake/src/operations/file_systems_list.rs
+++ b/sdk/storage_datalake/src/operations/file_systems_list.rs
@@ -8,7 +8,7 @@ use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 use std::pin::Pin;
 
-type ListFileSystems = Pin<Box<Pageable<ListFileSystemsResponse>>>;
+type ListFileSystems = Pin<Box<Pageable<ListFileSystemsResponse, azure_core::Error>>>;
 
 #[derive(Debug, Clone)]
 pub struct ListFileSystemsBuilder {

--- a/sdk/storage_datalake/src/operations/path_list.rs
+++ b/sdk/storage_datalake/src/operations/path_list.rs
@@ -13,7 +13,7 @@ use std::convert::TryInto;
 use std::pin::Pin;
 
 /// A future of a delete file response
-type ListPaths = Pin<Box<Pageable<ListPathsResponse>>>;
+type ListPaths = Pin<Box<Pageable<ListPathsResponse, azure_core::Error>>>;
 
 #[derive(Debug, Clone)]
 pub struct ListPathsBuilder {

--- a/sdk/storage_datalake/src/shared_key_authorization_policy.rs
+++ b/sdk/storage_datalake/src/shared_key_authorization_policy.rs
@@ -1,4 +1,4 @@
-use azure_core::{Context, Policy, PolicyResult, Request, Response};
+use azure_core::{Context, Policy, PolicyResult, Request};
 use azure_storage::core::storage_shared_key_credential::StorageSharedKeyCredential;
 use http::{HeaderMap, HeaderValue, Method};
 use ring::hmac;
@@ -26,12 +26,11 @@ impl Policy for SharedKeyAuthorizationPolicy {
         ctx: &Context,
         request: &mut Request,
         next: &[Arc<dyn Policy>],
-    ) -> PolicyResult<Response> {
-        if next.is_empty() {
-            return Err(Box::new(azure_core::PipelineError::InvalidTailPolicy(
-                "Authorization policies cannot be the last policy of a pipeline".to_owned(),
-            )));
-        }
+    ) -> PolicyResult {
+        assert!(
+            !next.is_empty(),
+            "Authorization policies cannot be the last policy of a pipeline"
+        );
 
         let headers_mut = request.headers_mut();
         headers_mut.append(


### PR DESCRIPTION
This is a proposal for a new form of error handling in the SDKs I have been working on with @yoshuawuyts. This is an attempt to reduce the large amount of errors into as compact a form as possible while still offering good ergonomics and quality error messages. 

In the grand scheme of things, this proposal is not a radical departure from the current approach taken, but is an attempt to rethink error handling from first principles. 

## The current approach

The current approach to error handling is to create a large, all-encompassing error type modeled as a Rust enum. This looks like this:

```rust
/// A general Azure error type.
#[non_exhaustive]
#[derive(Debug, thiserror::Error)]
pub enum Error {
    #[error("parse error")]
    Parse(#[from] ParseError),
    #[error("error getting token")]
    GetToken(#[source] Box<dyn std::error::Error + Send + Sync>),
    #[error("http error")]
    Http(#[from] HttpError),
    /// .... 
}
````

This approach does have some nice properties:
* The `thiserror` crate makes it pretty easy to declare new error variants together with how they are displayed to the user with minimal boiler plate and that conform to best practices for error types including provide an implementation for the `Error::source` method which shows what other error *caused* this error. 
* Error messages are relatively consistent (i.e., if two parsing errors can happen in two different SDKs, they'll largely have the same error message)
* More error types can be added without breaking existing user code (through the use of `non_exhaustive`. 
* Conversions from 3rd party error types to this error type are generally fairly easy.

However, this approach does have downsides:
* The specific variant of `Error` in question is tied directly to the underlying data or error cause. For example, in the code above, an `Error::Parse` must always have a corresponding `ParseError`. This encourages an ever expanding tree of errors. 
* Context dependent error messages are hard to add. Since the data associated with an error is directly tied to the error variant, it's hard to add additional context to errors that happen for unique reasons. For example,. say a parsing error when the key "foo" must have a value with the prefix "bar" - this happens only in one place in all the SDKs. If you want to display to the user this important context, you need to add a new variant to the `ParseError` type that explains this. This adds even more pressure for an ever expanding tree of error types.

The above list is not exhaustive but in general should give you the impression that the way we're modelling errors encourages error types with *lots* of variants and sub errors. This is exactly what we see in practice, where the error types in `azure_core` are bloated and often hard to keep track of. 

## What do we need?

Before getting into solutions, I'd like to briefly discuss the general needs we have from our errors. Errors are generally used for two things:
* Control flow (i.e., the user inspects the errors and writes code specifically to handle a certain error case)
* Error messages (i.e., the user just needs to display an error to the end user or developer consuming the library)  

The more important of these two for our purposes is likely error messages. While no doubt, users of the library will want to write code that inspects *some* errors and handles them in special ways, the large majority of errors will be propagated up the stack either through use of `?` or by panicking. 

Therefore, we need errors that can handle control flow but more importantly, encourage good error messages. 

The status quo provides ok error messages and excels at handling control flow, the exact opposite of our needs. 

## A proposed solution

This PR introduces a proposal for a new `Error` type that eventually will completely replace the current `Error` type (but that still works with it so that the transition does not need to happen all at once). 

This new error is based closely on [`std::io::Error`](https://doc.rust-lang.org/stable/std/io/struct.Error.html). Essentially the new error type wraps other errors and/or an error message along with an `ErrorKind` that roughly corresponds to the category of error being modeled. 

First, let's see how this new error handles control flow (arguably the weaker of its capabilities):

**Control Flow**

```rust
 match error.kind() {
     ErrorKind::UnexpectedOperation { status } if status == 503 => {
           // TODO: handle 503 errors specially
     }
     ErrorKind::Io => {
          if let Some(e) = error.downcast_ref::<std::io::Error>() {
               if e.kind() == std::io::ErrorKind::ConnectionAborted {
                   // TODO: handle an aborted connection
               }
          }
     }
     _ => return Err(error),
}
```

As you can see from this example, control flow is still very much possible, but does now rely on runtime downcasting for control flow of errors that we generally expect users to not have to handle. For example, in this case, the user wants to handle `ConnectionAborted` but we expect this to not be a super common use case as the SDK already does automatic retries and a policy will likely be there to handle offline scenarios in the general case. 

**NOTE**: the rest of this section is no longer true and has been removed from the design. 

~~The biggest difference with the current design is that the new `Error` is actually generic over some type that represents operation specific errors. For example, if we're dealing with an error in the Cosmos `create_database` operation, the error type would be `Error<CreateDatabaseError>`. The `CreateDatabaseError` would include all the documented cases specific to `CreateDatabase` - for example,  a bad request or a conflict. These errors are the ones we generally expect users to want to handle, and they are handled in a first class way:~~

```rust
 if let ErrorKind::Operation(CreateDatabaseError::Conflict) = error.kind() {
     /// TODO: handle conflict
}
```

**Error messages**

The new `Error` type comes with an improved ability to provide good error messages. The `Error` type conforms to best practices of the `std::error::Error` including providing a `source` for each error and displaying errors in such a way that plays nicely with ecosystem crates like `eyre` for displaying good error messages.

Included are conveniences like extensions to the `Result` type which allow for providing additional context to the error:

```rust
HeaderValue::from_str(&self.header).with_context(
    crate::error::ErrorKind::DataConversion,
    || {
        format!(
            "user agent '{}' cannot be serialized as an ascii-only HTTP header",
            self.header
        )
    },
)?;
```

### Comparison 

The new error type improves upon the old error type by not encouraging a growing tree of error types. It provides conveniences for providing good error messages while prioritizing a small error type that plays well with the ecosystem, provides good error messages, and provides control flow handling for cases where that handling is most likely needed. 