### PR TITLE
revert back to "azure_core"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,10 @@ jobs:
         if: matrix.rust == 'stable'
 
       - name: check core for wasm
-        run: cargo check -p azure_base --target=wasm32-unknown-unknown
+        run: cargo check -p azure_core --target=wasm32-unknown-unknown
 
       # - name: check core for hyper
-      #   run: cargo check -p azure_base --no-default-features --features enable_hyper
+      #   run: cargo check -p azure_core --no-default-features --features enable_hyper
 
       - name: sdk tests
         run: cargo test --all --features mock_transport_framework

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core"
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "azure_base"
+name = "azure_core"
 version = "0.1.0"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
@@ -7,7 +7,7 @@ authors = ["Microsoft Corp."]
 license = "MIT"
 repository = "https://github.com/azure/azure-sdk-for-rust"
 homepage = "https://github.com/azure/azure-sdk-for-rust"
-documentation = "https://docs.rs/azure_base"
+documentation = "https://docs.rs/azure_core"
 keywords = ["sdk", "azure", "rest", "iot", "cloud"]
 categories = ["api-bindings"]
 edition = "2018"

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -8,5 +8,5 @@ To set this crate as a dependency, add this to your Cargo.toml
 
 ```toml
 [dependencies]
-azure_core = { version = "0.1.0", git = "https://github.com/Azure/azure-sdk-for-rust" }
+azure_core = "0.1"
 ```

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -5,7 +5,7 @@
 ///
 /// In other words. The following macro call:
 /// ```
-/// # #[macro_use] extern crate azure_base;
+/// # #[macro_use] extern crate azure_core;
 /// struct MyStruct<'a> { foo: Option<&'a str> };
 /// impl <'a> MyStruct<'a> {
 ///     setters! { foo: &'a str => Some(foo), }
@@ -55,7 +55,7 @@ macro_rules! setters {
 
 /// The following macro invocation:
 /// ```
-/// # #[macro_use] extern crate azure_base;
+/// # #[macro_use] extern crate azure_core;
 /// create_enum!(Words, (Pollo, "Pollo"), (Bianco, "Bianco"), (Giallo, "Giallo"));
 /// ```
 /// Turns into a struct where each variant can be turned into and construct from the corresponding string.

--- a/sdk/core/src/options.rs
+++ b/sdk/core/src/options.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 /// You can override default options and even add your own per-call or per-retry policies:
 ///
 /// ```
-/// use azure_base::{ClientOptions, RetryOptions, TelemetryOptions};
+/// use azure_core::{ClientOptions, RetryOptions, TelemetryOptions};
 /// let options: ClientOptions = ClientOptions::default()
 ///     .retry(RetryOptions::default().max_retries(10u32))
 ///     .telemetry(TelemetryOptions::default().application_id("my-application"));

--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1" }
 ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"

--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0" }
 ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0", default-features=false}
-azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"]}
+azure_core = { path = "../core", version = "0.1", default-features=false}
+azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"]}
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0", default-features=false}
+azure_core = { path = "../core", version = "0.1.0", default-features=false}
 azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"]}
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_identity"
-version = "0.1.0"
+version = "0.1.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure identity helper crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"], default-features = false }
-azure_core = { package = "azure_base", path = "../core", version = "0.1", default-features = false }
+azure_core = { path = "../core", version = "0.1", default-features = false }
 oauth2 = { version = "4.0.0", default-features = false }
 url = "2.2"
 futures = "0.3"

--- a/sdk/identity/README.md
+++ b/sdk/identity/README.md
@@ -1,6 +1,6 @@
-# Azure SDK for Rust - Azure OAuth2 Crate
+# Azure SDK for Rust - Azure Identity Crate
 
- Azure OAuth2 helper crate for the unofficial Microsoft Azure SDK for Rust. This crate is part of a collection of crates: for more information please refer to [https://github.com/azure/azure-sdk-for-rust](https://github.com/azure/azure-sdk-for-rust).
+ Azure Identity crate for the unofficial Microsoft Azure SDK for Rust. This crate is part of a collection of crates: for more information please refer to [https://github.com/azure/azure-sdk-for-rust](https://github.com/azure/azure-sdk-for-rust).
 This crate provides mechanisms for several ways to authenticate against Azure
 
 For example, to authenticate using the client credential flow, you can do the following:
@@ -51,5 +51,5 @@ To set this crate as a dependency, add this to your Cargo.toml
 
 ```toml
 [dependencies]
-azure_identity = { version = "0.1.0", git = "https://github.com/Azure/azure-sdk-for-rust" }
+azure_identity = "0.1"
 ```

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Microsoft Corp."]
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0" }
 base64 = "0.13"
 bytes = "1.0"
 chrono = "0.4"

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Microsoft Corp."]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1" }
 base64 = "0.13"
 bytes = "1.0"
 chrono = "0.4"

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0" }
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1" }
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1" }
 ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0" }
 ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0" }
 
 [dev-dependencies]
 oauth2 = "4.0.0"

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -22,11 +22,11 @@ serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-azure_core = { path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1" }
 
 [dev-dependencies]
 oauth2 = "4.0.0"
-azure_identity = { path = "../identity" }
+azure_identity = { path = "../identity", version = "0.1" }
 mockito = "0.30"
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["full"] }

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0", default-features=false }
+azure_core = { path = "../core", version = "0.1.0", default-features=false }
 ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.1.0", default-features=false }
+azure_core = { path = "../core", version = "0.1", default-features=false }
 ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"
@@ -35,7 +35,7 @@ once_cell = "1.7"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }
 env_logger = "0.9"
-azure_identity = { path = "../identity" }
+azure_identity = { path = "../identity", version = "0.1" }
 reqwest = "0.11"
 
 [features]

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0", default-features=false }
-azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"] }
+azure_core = { path = "../core", version = "0.1", default-features=false }
+azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"] }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
@@ -34,7 +34,7 @@ thiserror = "1.0"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.9"
-azure_identity = { path = "../identity" }
+azure_identity = { path = "../identity", version = "0.1" }
 reqwest = "0.11"
 oauth2 = { version = "4.0.0", default-features = false }
 

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0", default-features=false }
+azure_core = { path = "../core", version = "0.1.0", default-features=false }
 azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"] }
 base64 = "0.13"
 bytes = "1.0"

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1.0" }
 azure_storage = { path = "../storage", version = "0.1.0" }
 base64 = "0.13"
 bytes = "1.0"

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.1.0" }
-azure_storage = { path = "../storage", version = "0.1.0" }
+azure_core = { path = "../core", version = "0.1" }
+azure_storage = { path = "../storage", version = "0.1" }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
@@ -32,7 +32,7 @@ ring = "0.16"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
-azure_identity = { path = "../identity", version = "0.1.0" }
+azure_identity = { path = "../identity", version = "0.1" }
 
 [features]
 default = ["enable_reqwest"]

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1.0", default-features=false }
-azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"] }
+azure_core = { path = "../core", version = "0.1", default-features=false }
+azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"] }
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../core", version = "0.1.0", default-features=false }
+azure_core = { path = "../core", version = "0.1.0", default-features=false }
 azure_storage = { path = "../storage", version = "0.1.0", default-features=false, features=["account"] }
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/services/README.md
+++ b/services/README.md
@@ -30,14 +30,14 @@ cargo run --package azure_mgmt_storage --example storage_account_list
 ```
 
 ## Dependencies
-These creates depend on `azure_core` and `azure_identity`. They are not yet published to [crates.io](https://crates.io/). See the [milestones](https://github.com/Azure/azure-sdk-for-rust/milestones) to see what is left before that happens. Here is an example of adding `azure_svc_batch` as a dependency.
+These crates depend on `azure_core` and `azure_identity`. Here is an example of adding `azure_svc_batch` as a dependency.
 
 ``` toml
 [dependencies]
 tokio = { version = "1.0", features = ["macros"] }
-azure_core = { git = "https://github.com/Azure/azure-sdk-for-rust" }
-azure_identity = { git = "https://github.com/Azure/azure-sdk-for-rust" }
-azure_svc_batch = { git = "https://github.com/Azure/azure-sdk-for-rust" }
+azure_core = "0.1"
+azure_identity = "0.1"
+azure_svc_batch = "0.1"
 ```
 
 Each crate may support several [API versions](api-versions.md).

--- a/services/autorust/codegen/src/cargo_toml.rs
+++ b/services/autorust/codegen/src/cargo_toml.rs
@@ -24,7 +24,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = {{ package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }}
+azure_core = {{ path = "../../../sdk/core", version = "0.1.0", default-features = false }}
 serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/autorust/codegen/src/cargo_toml.rs
+++ b/services/autorust/codegen/src/cargo_toml.rs
@@ -24,7 +24,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = {{ path = "../../../sdk/core", version = "0.1.0", default-features = false }}
+azure_core = {{ path = "../../../sdk/core", version = "0.1", default-features = false }}
 serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = "1.0"
 bytes = "1.0"
@@ -34,7 +34,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = {{ path = "../../../sdk/identity", version = "0.1.0" }}
+azure_identity = {{ path = "../../../sdk/identity", version = "0.1" }}
 tokio = {{ version = "1.0", features = ["macros"] }}
 
 [package.metadata.docs.rs]

--- a/services/mgmt/activedirectory/Cargo.toml
+++ b/services/mgmt/activedirectory/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/activedirectory/Cargo.toml
+++ b/services/mgmt/activedirectory/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/addons/Cargo.toml
+++ b/services/mgmt/addons/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/addons/Cargo.toml
+++ b/services/mgmt/addons/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/adhybridhealthservice/Cargo.toml
+++ b/services/mgmt/adhybridhealthservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/adhybridhealthservice/Cargo.toml
+++ b/services/mgmt/adhybridhealthservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/adp/Cargo.toml
+++ b/services/mgmt/adp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/adp/Cargo.toml
+++ b/services/mgmt/adp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/advisor/Cargo.toml
+++ b/services/mgmt/advisor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/advisor/Cargo.toml
+++ b/services/mgmt/advisor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/agrifood/Cargo.toml
+++ b/services/mgmt/agrifood/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/agrifood/Cargo.toml
+++ b/services/mgmt/agrifood/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/alertsmanagement/Cargo.toml
+++ b/services/mgmt/alertsmanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/alertsmanagement/Cargo.toml
+++ b/services/mgmt/alertsmanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/analysisservices/Cargo.toml
+++ b/services/mgmt/analysisservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/analysisservices/Cargo.toml
+++ b/services/mgmt/analysisservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/apimanagement/Cargo.toml
+++ b/services/mgmt/apimanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/apimanagement/Cargo.toml
+++ b/services/mgmt/apimanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/appconfiguration/Cargo.toml
+++ b/services/mgmt/appconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/appconfiguration/Cargo.toml
+++ b/services/mgmt/appconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/applicationinsights/Cargo.toml
+++ b/services/mgmt/applicationinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/applicationinsights/Cargo.toml
+++ b/services/mgmt/applicationinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/appplatform/Cargo.toml
+++ b/services/mgmt/appplatform/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/appplatform/Cargo.toml
+++ b/services/mgmt/appplatform/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/arcdata/Cargo.toml
+++ b/services/mgmt/arcdata/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/arcdata/Cargo.toml
+++ b/services/mgmt/arcdata/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/attestation/Cargo.toml
+++ b/services/mgmt/attestation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/attestation/Cargo.toml
+++ b/services/mgmt/attestation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/authorization/Cargo.toml
+++ b/services/mgmt/authorization/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/authorization/Cargo.toml
+++ b/services/mgmt/authorization/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/automanage/Cargo.toml
+++ b/services/mgmt/automanage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/automanage/Cargo.toml
+++ b/services/mgmt/automanage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/automation/Cargo.toml
+++ b/services/mgmt/automation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/automation/Cargo.toml
+++ b/services/mgmt/automation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/baremetalinfrastructure/Cargo.toml
+++ b/services/mgmt/baremetalinfrastructure/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/baremetalinfrastructure/Cargo.toml
+++ b/services/mgmt/baremetalinfrastructure/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/batch/Cargo.toml
+++ b/services/mgmt/batch/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/batch/Cargo.toml
+++ b/services/mgmt/batch/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/billing/Cargo.toml
+++ b/services/mgmt/billing/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/billing/Cargo.toml
+++ b/services/mgmt/billing/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/blockchain/Cargo.toml
+++ b/services/mgmt/blockchain/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/blockchain/Cargo.toml
+++ b/services/mgmt/blockchain/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/blueprint/Cargo.toml
+++ b/services/mgmt/blueprint/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/blueprint/Cargo.toml
+++ b/services/mgmt/blueprint/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/botservice/Cargo.toml
+++ b/services/mgmt/botservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/botservice/Cargo.toml
+++ b/services/mgmt/botservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cdn/Cargo.toml
+++ b/services/mgmt/cdn/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cdn/Cargo.toml
+++ b/services/mgmt/cdn/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/changeanalysis/Cargo.toml
+++ b/services/mgmt/changeanalysis/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/changeanalysis/Cargo.toml
+++ b/services/mgmt/changeanalysis/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/chaos/Cargo.toml
+++ b/services/mgmt/chaos/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/chaos/Cargo.toml
+++ b/services/mgmt/chaos/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cloudshell/Cargo.toml
+++ b/services/mgmt/cloudshell/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cloudshell/Cargo.toml
+++ b/services/mgmt/cloudshell/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cognitiveservices/Cargo.toml
+++ b/services/mgmt/cognitiveservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cognitiveservices/Cargo.toml
+++ b/services/mgmt/cognitiveservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/commerce/Cargo.toml
+++ b/services/mgmt/commerce/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/commerce/Cargo.toml
+++ b/services/mgmt/commerce/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/communication/Cargo.toml
+++ b/services/mgmt/communication/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/communication/Cargo.toml
+++ b/services/mgmt/communication/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/compute/Cargo.toml
+++ b/services/mgmt/compute/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/compute/Cargo.toml
+++ b/services/mgmt/compute/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/confidentialledger/Cargo.toml
+++ b/services/mgmt/confidentialledger/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/confidentialledger/Cargo.toml
+++ b/services/mgmt/confidentialledger/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/confluent/Cargo.toml
+++ b/services/mgmt/confluent/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/confluent/Cargo.toml
+++ b/services/mgmt/confluent/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/connectedvmware/Cargo.toml
+++ b/services/mgmt/connectedvmware/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/connectedvmware/Cargo.toml
+++ b/services/mgmt/connectedvmware/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/consumption/Cargo.toml
+++ b/services/mgmt/consumption/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/consumption/Cargo.toml
+++ b/services/mgmt/consumption/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/containerinstance/Cargo.toml
+++ b/services/mgmt/containerinstance/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/containerinstance/Cargo.toml
+++ b/services/mgmt/containerinstance/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/containerregistry/Cargo.toml
+++ b/services/mgmt/containerregistry/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/containerregistry/Cargo.toml
+++ b/services/mgmt/containerregistry/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/containerservice/Cargo.toml
+++ b/services/mgmt/containerservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/containerservice/Cargo.toml
+++ b/services/mgmt/containerservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cosmosdb/Cargo.toml
+++ b/services/mgmt/cosmosdb/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cosmosdb/Cargo.toml
+++ b/services/mgmt/cosmosdb/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/costmanagement/Cargo.toml
+++ b/services/mgmt/costmanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/costmanagement/Cargo.toml
+++ b/services/mgmt/costmanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cpim/Cargo.toml
+++ b/services/mgmt/cpim/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cpim/Cargo.toml
+++ b/services/mgmt/cpim/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/customerinsights/Cargo.toml
+++ b/services/mgmt/customerinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/customerinsights/Cargo.toml
+++ b/services/mgmt/customerinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/customerlockbox/Cargo.toml
+++ b/services/mgmt/customerlockbox/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/customerlockbox/Cargo.toml
+++ b/services/mgmt/customerlockbox/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/customproviders/Cargo.toml
+++ b/services/mgmt/customproviders/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/customproviders/Cargo.toml
+++ b/services/mgmt/customproviders/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/data/Cargo.toml
+++ b/services/mgmt/data/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/data/Cargo.toml
+++ b/services/mgmt/data/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/databox/Cargo.toml
+++ b/services/mgmt/databox/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/databox/Cargo.toml
+++ b/services/mgmt/databox/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/databoxedge/Cargo.toml
+++ b/services/mgmt/databoxedge/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/databoxedge/Cargo.toml
+++ b/services/mgmt/databoxedge/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/databricks/Cargo.toml
+++ b/services/mgmt/databricks/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/databricks/Cargo.toml
+++ b/services/mgmt/databricks/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datacatalog/Cargo.toml
+++ b/services/mgmt/datacatalog/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datacatalog/Cargo.toml
+++ b/services/mgmt/datacatalog/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datadog/Cargo.toml
+++ b/services/mgmt/datadog/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datadog/Cargo.toml
+++ b/services/mgmt/datadog/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datafactory/Cargo.toml
+++ b/services/mgmt/datafactory/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datafactory/Cargo.toml
+++ b/services/mgmt/datafactory/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datalakeanalytics/Cargo.toml
+++ b/services/mgmt/datalakeanalytics/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datalakeanalytics/Cargo.toml
+++ b/services/mgmt/datalakeanalytics/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datalakestore/Cargo.toml
+++ b/services/mgmt/datalakestore/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datalakestore/Cargo.toml
+++ b/services/mgmt/datalakestore/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dataprotection/Cargo.toml
+++ b/services/mgmt/dataprotection/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dataprotection/Cargo.toml
+++ b/services/mgmt/dataprotection/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datashare/Cargo.toml
+++ b/services/mgmt/datashare/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datashare/Cargo.toml
+++ b/services/mgmt/datashare/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/deploymentmanager/Cargo.toml
+++ b/services/mgmt/deploymentmanager/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/deploymentmanager/Cargo.toml
+++ b/services/mgmt/deploymentmanager/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/desktopvirtualization/Cargo.toml
+++ b/services/mgmt/desktopvirtualization/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/desktopvirtualization/Cargo.toml
+++ b/services/mgmt/desktopvirtualization/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/deviceupdate/Cargo.toml
+++ b/services/mgmt/deviceupdate/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/deviceupdate/Cargo.toml
+++ b/services/mgmt/deviceupdate/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/devops/Cargo.toml
+++ b/services/mgmt/devops/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/devops/Cargo.toml
+++ b/services/mgmt/devops/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/devspaces/Cargo.toml
+++ b/services/mgmt/devspaces/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/devspaces/Cargo.toml
+++ b/services/mgmt/devspaces/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/devtestlabs/Cargo.toml
+++ b/services/mgmt/devtestlabs/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/devtestlabs/Cargo.toml
+++ b/services/mgmt/devtestlabs/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dfp/Cargo.toml
+++ b/services/mgmt/dfp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dfp/Cargo.toml
+++ b/services/mgmt/dfp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/digitaltwins/Cargo.toml
+++ b/services/mgmt/digitaltwins/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/digitaltwins/Cargo.toml
+++ b/services/mgmt/digitaltwins/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dns/Cargo.toml
+++ b/services/mgmt/dns/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dns/Cargo.toml
+++ b/services/mgmt/dns/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/domainservices/Cargo.toml
+++ b/services/mgmt/domainservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/domainservices/Cargo.toml
+++ b/services/mgmt/domainservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/edgeorder/Cargo.toml
+++ b/services/mgmt/edgeorder/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/edgeorder/Cargo.toml
+++ b/services/mgmt/edgeorder/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/edgeorderpartner/Cargo.toml
+++ b/services/mgmt/edgeorderpartner/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/edgeorderpartner/Cargo.toml
+++ b/services/mgmt/edgeorderpartner/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/elastic/Cargo.toml
+++ b/services/mgmt/elastic/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/elastic/Cargo.toml
+++ b/services/mgmt/elastic/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/engagementfabric/Cargo.toml
+++ b/services/mgmt/engagementfabric/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/engagementfabric/Cargo.toml
+++ b/services/mgmt/engagementfabric/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/enterpriseknowledgegraph/Cargo.toml
+++ b/services/mgmt/enterpriseknowledgegraph/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/enterpriseknowledgegraph/Cargo.toml
+++ b/services/mgmt/enterpriseknowledgegraph/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/eventgrid/Cargo.toml
+++ b/services/mgmt/eventgrid/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/eventgrid/Cargo.toml
+++ b/services/mgmt/eventgrid/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/eventhub/Cargo.toml
+++ b/services/mgmt/eventhub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/eventhub/Cargo.toml
+++ b/services/mgmt/eventhub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/extendedlocation/Cargo.toml
+++ b/services/mgmt/extendedlocation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/extendedlocation/Cargo.toml
+++ b/services/mgmt/extendedlocation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/fluidrelay/Cargo.toml
+++ b/services/mgmt/fluidrelay/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/fluidrelay/Cargo.toml
+++ b/services/mgmt/fluidrelay/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/frontdoor/Cargo.toml
+++ b/services/mgmt/frontdoor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/frontdoor/Cargo.toml
+++ b/services/mgmt/frontdoor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/guestconfiguration/Cargo.toml
+++ b/services/mgmt/guestconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/guestconfiguration/Cargo.toml
+++ b/services/mgmt/guestconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hanaon/Cargo.toml
+++ b/services/mgmt/hanaon/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hanaon/Cargo.toml
+++ b/services/mgmt/hanaon/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hardwaresecuritymodules/Cargo.toml
+++ b/services/mgmt/hardwaresecuritymodules/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hardwaresecuritymodules/Cargo.toml
+++ b/services/mgmt/hardwaresecuritymodules/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hdinsight/Cargo.toml
+++ b/services/mgmt/hdinsight/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hdinsight/Cargo.toml
+++ b/services/mgmt/hdinsight/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/healthbot/Cargo.toml
+++ b/services/mgmt/healthbot/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/healthbot/Cargo.toml
+++ b/services/mgmt/healthbot/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/healthcareapis/Cargo.toml
+++ b/services/mgmt/healthcareapis/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/healthcareapis/Cargo.toml
+++ b/services/mgmt/healthcareapis/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridcompute/Cargo.toml
+++ b/services/mgmt/hybridcompute/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridcompute/Cargo.toml
+++ b/services/mgmt/hybridcompute/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridconnectivity/Cargo.toml
+++ b/services/mgmt/hybridconnectivity/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridconnectivity/Cargo.toml
+++ b/services/mgmt/hybridconnectivity/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybriddatamanager/Cargo.toml
+++ b/services/mgmt/hybriddatamanager/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybriddatamanager/Cargo.toml
+++ b/services/mgmt/hybriddatamanager/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridkubernetes/Cargo.toml
+++ b/services/mgmt/hybridkubernetes/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridkubernetes/Cargo.toml
+++ b/services/mgmt/hybridkubernetes/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridnetwork/Cargo.toml
+++ b/services/mgmt/hybridnetwork/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridnetwork/Cargo.toml
+++ b/services/mgmt/hybridnetwork/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/imagebuilder/Cargo.toml
+++ b/services/mgmt/imagebuilder/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/imagebuilder/Cargo.toml
+++ b/services/mgmt/imagebuilder/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/intune/Cargo.toml
+++ b/services/mgmt/intune/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/intune/Cargo.toml
+++ b/services/mgmt/intune/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/iotcentral/Cargo.toml
+++ b/services/mgmt/iotcentral/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/iotcentral/Cargo.toml
+++ b/services/mgmt/iotcentral/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/iothub/Cargo.toml
+++ b/services/mgmt/iothub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/iothub/Cargo.toml
+++ b/services/mgmt/iothub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/keyvault/Cargo.toml
+++ b/services/mgmt/keyvault/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/keyvault/Cargo.toml
+++ b/services/mgmt/keyvault/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/kubernetesconfiguration/Cargo.toml
+++ b/services/mgmt/kubernetesconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/kubernetesconfiguration/Cargo.toml
+++ b/services/mgmt/kubernetesconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/kusto/Cargo.toml
+++ b/services/mgmt/kusto/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/kusto/Cargo.toml
+++ b/services/mgmt/kusto/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/labservices/Cargo.toml
+++ b/services/mgmt/labservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/labservices/Cargo.toml
+++ b/services/mgmt/labservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/loadtestservice/Cargo.toml
+++ b/services/mgmt/loadtestservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/loadtestservice/Cargo.toml
+++ b/services/mgmt/loadtestservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/logic/Cargo.toml
+++ b/services/mgmt/logic/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/logic/Cargo.toml
+++ b/services/mgmt/logic/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/logz/Cargo.toml
+++ b/services/mgmt/logz/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/logz/Cargo.toml
+++ b/services/mgmt/logz/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearning/Cargo.toml
+++ b/services/mgmt/machinelearning/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearning/Cargo.toml
+++ b/services/mgmt/machinelearning/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearningcompute/Cargo.toml
+++ b/services/mgmt/machinelearningcompute/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearningcompute/Cargo.toml
+++ b/services/mgmt/machinelearningcompute/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearningexperimentation/Cargo.toml
+++ b/services/mgmt/machinelearningexperimentation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearningexperimentation/Cargo.toml
+++ b/services/mgmt/machinelearningexperimentation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearningservices/Cargo.toml
+++ b/services/mgmt/machinelearningservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearningservices/Cargo.toml
+++ b/services/mgmt/machinelearningservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/maintenance/Cargo.toml
+++ b/services/mgmt/maintenance/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/maintenance/Cargo.toml
+++ b/services/mgmt/maintenance/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managednetwork/Cargo.toml
+++ b/services/mgmt/managednetwork/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managednetwork/Cargo.toml
+++ b/services/mgmt/managednetwork/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managedservices/Cargo.toml
+++ b/services/mgmt/managedservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managedservices/Cargo.toml
+++ b/services/mgmt/managedservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managementgroups/Cargo.toml
+++ b/services/mgmt/managementgroups/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managementgroups/Cargo.toml
+++ b/services/mgmt/managementgroups/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managementpartner/Cargo.toml
+++ b/services/mgmt/managementpartner/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managementpartner/Cargo.toml
+++ b/services/mgmt/managementpartner/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/maps/Cargo.toml
+++ b/services/mgmt/maps/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/maps/Cargo.toml
+++ b/services/mgmt/maps/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/mariadb/Cargo.toml
+++ b/services/mgmt/mariadb/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/mariadb/Cargo.toml
+++ b/services/mgmt/mariadb/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/marketplacenotifications/Cargo.toml
+++ b/services/mgmt/marketplacenotifications/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/marketplacenotifications/Cargo.toml
+++ b/services/mgmt/marketplacenotifications/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/marketplaceordering/Cargo.toml
+++ b/services/mgmt/marketplaceordering/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/marketplaceordering/Cargo.toml
+++ b/services/mgmt/marketplaceordering/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/mediaservices/Cargo.toml
+++ b/services/mgmt/mediaservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/mediaservices/Cargo.toml
+++ b/services/mgmt/mediaservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/migrate/Cargo.toml
+++ b/services/mgmt/migrate/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/migrate/Cargo.toml
+++ b/services/mgmt/migrate/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/migrateprojects/Cargo.toml
+++ b/services/mgmt/migrateprojects/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/migrateprojects/Cargo.toml
+++ b/services/mgmt/migrateprojects/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/monitor/Cargo.toml
+++ b/services/mgmt/monitor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/monitor/Cargo.toml
+++ b/services/mgmt/monitor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/msi/Cargo.toml
+++ b/services/mgmt/msi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/msi/Cargo.toml
+++ b/services/mgmt/msi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/mysql/Cargo.toml
+++ b/services/mgmt/mysql/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/mysql/Cargo.toml
+++ b/services/mgmt/mysql/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/netapp/Cargo.toml
+++ b/services/mgmt/netapp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/netapp/Cargo.toml
+++ b/services/mgmt/netapp/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/network/Cargo.toml
+++ b/services/mgmt/network/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/network/Cargo.toml
+++ b/services/mgmt/network/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/notificationhubs/Cargo.toml
+++ b/services/mgmt/notificationhubs/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/notificationhubs/Cargo.toml
+++ b/services/mgmt/notificationhubs/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/oep/Cargo.toml
+++ b/services/mgmt/oep/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/oep/Cargo.toml
+++ b/services/mgmt/oep/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/operationalinsights/Cargo.toml
+++ b/services/mgmt/operationalinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/operationalinsights/Cargo.toml
+++ b/services/mgmt/operationalinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/operationsmanagement/Cargo.toml
+++ b/services/mgmt/operationsmanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/operationsmanagement/Cargo.toml
+++ b/services/mgmt/operationsmanagement/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/orbital/Cargo.toml
+++ b/services/mgmt/orbital/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/orbital/Cargo.toml
+++ b/services/mgmt/orbital/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/peering/Cargo.toml
+++ b/services/mgmt/peering/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/peering/Cargo.toml
+++ b/services/mgmt/peering/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/policyinsights/Cargo.toml
+++ b/services/mgmt/policyinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/policyinsights/Cargo.toml
+++ b/services/mgmt/policyinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/portal/Cargo.toml
+++ b/services/mgmt/portal/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/portal/Cargo.toml
+++ b/services/mgmt/portal/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/postgresql/Cargo.toml
+++ b/services/mgmt/postgresql/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/postgresql/Cargo.toml
+++ b/services/mgmt/postgresql/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/postgresqlhsc/Cargo.toml
+++ b/services/mgmt/postgresqlhsc/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/postgresqlhsc/Cargo.toml
+++ b/services/mgmt/postgresqlhsc/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerbidedicated/Cargo.toml
+++ b/services/mgmt/powerbidedicated/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerbidedicated/Cargo.toml
+++ b/services/mgmt/powerbidedicated/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerbiembedded/Cargo.toml
+++ b/services/mgmt/powerbiembedded/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerbiembedded/Cargo.toml
+++ b/services/mgmt/powerbiembedded/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerbiprivatelinks/Cargo.toml
+++ b/services/mgmt/powerbiprivatelinks/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerbiprivatelinks/Cargo.toml
+++ b/services/mgmt/powerbiprivatelinks/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerplatform/Cargo.toml
+++ b/services/mgmt/powerplatform/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerplatform/Cargo.toml
+++ b/services/mgmt/powerplatform/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/privatedns/Cargo.toml
+++ b/services/mgmt/privatedns/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/privatedns/Cargo.toml
+++ b/services/mgmt/privatedns/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/providerhub/Cargo.toml
+++ b/services/mgmt/providerhub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/providerhub/Cargo.toml
+++ b/services/mgmt/providerhub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/purview/Cargo.toml
+++ b/services/mgmt/purview/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/purview/Cargo.toml
+++ b/services/mgmt/purview/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/quantum/Cargo.toml
+++ b/services/mgmt/quantum/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/quantum/Cargo.toml
+++ b/services/mgmt/quantum/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/quota/Cargo.toml
+++ b/services/mgmt/quota/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/quota/Cargo.toml
+++ b/services/mgmt/quota/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/recoveryservices/Cargo.toml
+++ b/services/mgmt/recoveryservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/recoveryservices/Cargo.toml
+++ b/services/mgmt/recoveryservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/recoveryservicesbackup/Cargo.toml
+++ b/services/mgmt/recoveryservicesbackup/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/recoveryservicesbackup/Cargo.toml
+++ b/services/mgmt/recoveryservicesbackup/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/recoveryservicessiterecovery/Cargo.toml
+++ b/services/mgmt/recoveryservicessiterecovery/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/recoveryservicessiterecovery/Cargo.toml
+++ b/services/mgmt/recoveryservicessiterecovery/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/redhatopenshift/Cargo.toml
+++ b/services/mgmt/redhatopenshift/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/redhatopenshift/Cargo.toml
+++ b/services/mgmt/redhatopenshift/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/redis/Cargo.toml
+++ b/services/mgmt/redis/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/redis/Cargo.toml
+++ b/services/mgmt/redis/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/redisenterprise/Cargo.toml
+++ b/services/mgmt/redisenterprise/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/redisenterprise/Cargo.toml
+++ b/services/mgmt/redisenterprise/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/relay/Cargo.toml
+++ b/services/mgmt/relay/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/relay/Cargo.toml
+++ b/services/mgmt/relay/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/reservations/Cargo.toml
+++ b/services/mgmt/reservations/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/reservations/Cargo.toml
+++ b/services/mgmt/reservations/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourceconnector/Cargo.toml
+++ b/services/mgmt/resourceconnector/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourceconnector/Cargo.toml
+++ b/services/mgmt/resourceconnector/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourcegraph/Cargo.toml
+++ b/services/mgmt/resourcegraph/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourcegraph/Cargo.toml
+++ b/services/mgmt/resourcegraph/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourcehealth/Cargo.toml
+++ b/services/mgmt/resourcehealth/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourcehealth/Cargo.toml
+++ b/services/mgmt/resourcehealth/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourcemover/Cargo.toml
+++ b/services/mgmt/resourcemover/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourcemover/Cargo.toml
+++ b/services/mgmt/resourcemover/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resources/Cargo.toml
+++ b/services/mgmt/resources/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resources/Cargo.toml
+++ b/services/mgmt/resources/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/saas/Cargo.toml
+++ b/services/mgmt/saas/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/saas/Cargo.toml
+++ b/services/mgmt/saas/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/scheduler/Cargo.toml
+++ b/services/mgmt/scheduler/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/scheduler/Cargo.toml
+++ b/services/mgmt/scheduler/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/search/Cargo.toml
+++ b/services/mgmt/search/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/search/Cargo.toml
+++ b/services/mgmt/search/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/security/Cargo.toml
+++ b/services/mgmt/security/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/security/Cargo.toml
+++ b/services/mgmt/security/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/securityandcompliance/Cargo.toml
+++ b/services/mgmt/securityandcompliance/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/securityandcompliance/Cargo.toml
+++ b/services/mgmt/securityandcompliance/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/securityinsights/Cargo.toml
+++ b/services/mgmt/securityinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/securityinsights/Cargo.toml
+++ b/services/mgmt/securityinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/serialconsole/Cargo.toml
+++ b/services/mgmt/serialconsole/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/serialconsole/Cargo.toml
+++ b/services/mgmt/serialconsole/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicebus/Cargo.toml
+++ b/services/mgmt/servicebus/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/servicebus/Cargo.toml
+++ b/services/mgmt/servicebus/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicefabricmesh/Cargo.toml
+++ b/services/mgmt/servicefabricmesh/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/servicefabricmesh/Cargo.toml
+++ b/services/mgmt/servicefabricmesh/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicelinker/Cargo.toml
+++ b/services/mgmt/servicelinker/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/servicelinker/Cargo.toml
+++ b/services/mgmt/servicelinker/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/signalr/Cargo.toml
+++ b/services/mgmt/signalr/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/signalr/Cargo.toml
+++ b/services/mgmt/signalr/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/softwareplan/Cargo.toml
+++ b/services/mgmt/softwareplan/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/softwareplan/Cargo.toml
+++ b/services/mgmt/softwareplan/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/solutions/Cargo.toml
+++ b/services/mgmt/solutions/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/solutions/Cargo.toml
+++ b/services/mgmt/solutions/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/sql/Cargo.toml
+++ b/services/mgmt/sql/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/sql/Cargo.toml
+++ b/services/mgmt/sql/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/sqlvirtualmachine/Cargo.toml
+++ b/services/mgmt/sqlvirtualmachine/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/sqlvirtualmachine/Cargo.toml
+++ b/services/mgmt/sqlvirtualmachine/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/stack/Cargo.toml
+++ b/services/mgmt/stack/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/stack/Cargo.toml
+++ b/services/mgmt/stack/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storage/Cargo.toml
+++ b/services/mgmt/storage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storage/Cargo.toml
+++ b/services/mgmt/storage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storagecache/Cargo.toml
+++ b/services/mgmt/storagecache/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storagecache/Cargo.toml
+++ b/services/mgmt/storagecache/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storageimportexport/Cargo.toml
+++ b/services/mgmt/storageimportexport/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storageimportexport/Cargo.toml
+++ b/services/mgmt/storageimportexport/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storagepool/Cargo.toml
+++ b/services/mgmt/storagepool/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storagepool/Cargo.toml
+++ b/services/mgmt/storagepool/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storagesync/Cargo.toml
+++ b/services/mgmt/storagesync/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storagesync/Cargo.toml
+++ b/services/mgmt/storagesync/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storsimple1200series/Cargo.toml
+++ b/services/mgmt/storsimple1200series/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storsimple1200series/Cargo.toml
+++ b/services/mgmt/storsimple1200series/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storsimple8000series/Cargo.toml
+++ b/services/mgmt/storsimple8000series/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storsimple8000series/Cargo.toml
+++ b/services/mgmt/storsimple8000series/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/streamanalytics/Cargo.toml
+++ b/services/mgmt/streamanalytics/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/streamanalytics/Cargo.toml
+++ b/services/mgmt/streamanalytics/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/subscription/Cargo.toml
+++ b/services/mgmt/subscription/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/subscription/Cargo.toml
+++ b/services/mgmt/subscription/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/support/Cargo.toml
+++ b/services/mgmt/support/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/support/Cargo.toml
+++ b/services/mgmt/support/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/synapse/Cargo.toml
+++ b/services/mgmt/synapse/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/synapse/Cargo.toml
+++ b/services/mgmt/synapse/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/testbase/Cargo.toml
+++ b/services/mgmt/testbase/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/testbase/Cargo.toml
+++ b/services/mgmt/testbase/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/timeseriesinsights/Cargo.toml
+++ b/services/mgmt/timeseriesinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/timeseriesinsights/Cargo.toml
+++ b/services/mgmt/timeseriesinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/trafficmanager/Cargo.toml
+++ b/services/mgmt/trafficmanager/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/trafficmanager/Cargo.toml
+++ b/services/mgmt/trafficmanager/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/vi/Cargo.toml
+++ b/services/mgmt/vi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/vi/Cargo.toml
+++ b/services/mgmt/vi/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/videoanalyzer/Cargo.toml
+++ b/services/mgmt/videoanalyzer/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/videoanalyzer/Cargo.toml
+++ b/services/mgmt/videoanalyzer/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/visualstudio/Cargo.toml
+++ b/services/mgmt/visualstudio/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/visualstudio/Cargo.toml
+++ b/services/mgmt/visualstudio/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/vmware/Cargo.toml
+++ b/services/mgmt/vmware/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/vmware/Cargo.toml
+++ b/services/mgmt/vmware/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/vmwarecloudsimple/Cargo.toml
+++ b/services/mgmt/vmwarecloudsimple/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/vmwarecloudsimple/Cargo.toml
+++ b/services/mgmt/vmwarecloudsimple/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/web/Cargo.toml
+++ b/services/mgmt/web/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/web/Cargo.toml
+++ b/services/mgmt/web/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/webpubsub/Cargo.toml
+++ b/services/mgmt/webpubsub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/webpubsub/Cargo.toml
+++ b/services/mgmt/webpubsub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/windowsesu/Cargo.toml
+++ b/services/mgmt/windowsesu/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/windowsesu/Cargo.toml
+++ b/services/mgmt/windowsesu/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/windowsiot/Cargo.toml
+++ b/services/mgmt/windowsiot/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/windowsiot/Cargo.toml
+++ b/services/mgmt/windowsiot/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/mgmt/workloadmonitor/Cargo.toml
+++ b/services/mgmt/workloadmonitor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/workloadmonitor/Cargo.toml
+++ b/services/mgmt/workloadmonitor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/appconfiguration/Cargo.toml
+++ b/services/svc/appconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/appconfiguration/Cargo.toml
+++ b/services/svc/appconfiguration/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/applicationinsights/Cargo.toml
+++ b/services/svc/applicationinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/applicationinsights/Cargo.toml
+++ b/services/svc/applicationinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/attestation/Cargo.toml
+++ b/services/svc/attestation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/attestation/Cargo.toml
+++ b/services/svc/attestation/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/batch/Cargo.toml
+++ b/services/svc/batch/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/batch/Cargo.toml
+++ b/services/svc/batch/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/blobstorage/Cargo.toml
+++ b/services/svc/blobstorage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/blobstorage/Cargo.toml
+++ b/services/svc/blobstorage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/confidentialledger/Cargo.toml
+++ b/services/svc/confidentialledger/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/confidentialledger/Cargo.toml
+++ b/services/svc/confidentialledger/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/containerregistry/Cargo.toml
+++ b/services/svc/containerregistry/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/containerregistry/Cargo.toml
+++ b/services/svc/containerregistry/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/cosmosdb/Cargo.toml
+++ b/services/svc/cosmosdb/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/cosmosdb/Cargo.toml
+++ b/services/svc/cosmosdb/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/datalakeanalytics/Cargo.toml
+++ b/services/svc/datalakeanalytics/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/datalakeanalytics/Cargo.toml
+++ b/services/svc/datalakeanalytics/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/deviceprovisioningservices/Cargo.toml
+++ b/services/svc/deviceprovisioningservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/deviceprovisioningservices/Cargo.toml
+++ b/services/svc/deviceprovisioningservices/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/deviceupdate/Cargo.toml
+++ b/services/svc/deviceupdate/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/deviceupdate/Cargo.toml
+++ b/services/svc/deviceupdate/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/digitaltwins/Cargo.toml
+++ b/services/svc/digitaltwins/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/digitaltwins/Cargo.toml
+++ b/services/svc/digitaltwins/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/eventgrid/Cargo.toml
+++ b/services/svc/eventgrid/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/eventgrid/Cargo.toml
+++ b/services/svc/eventgrid/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/filestorage/Cargo.toml
+++ b/services/svc/filestorage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/filestorage/Cargo.toml
+++ b/services/svc/filestorage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/graphrbac/Cargo.toml
+++ b/services/svc/graphrbac/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/graphrbac/Cargo.toml
+++ b/services/svc/graphrbac/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/imds/Cargo.toml
+++ b/services/svc/imds/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/imds/Cargo.toml
+++ b/services/svc/imds/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/iotcentral/Cargo.toml
+++ b/services/svc/iotcentral/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/iotcentral/Cargo.toml
+++ b/services/svc/iotcentral/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/keyvault/Cargo.toml
+++ b/services/svc/keyvault/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/keyvault/Cargo.toml
+++ b/services/svc/keyvault/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/loadtestservice/Cargo.toml
+++ b/services/svc/loadtestservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/loadtestservice/Cargo.toml
+++ b/services/svc/loadtestservice/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/marketplacecatalog/Cargo.toml
+++ b/services/svc/marketplacecatalog/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/marketplacecatalog/Cargo.toml
+++ b/services/svc/marketplacecatalog/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/mixedreality/Cargo.toml
+++ b/services/svc/mixedreality/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/mixedreality/Cargo.toml
+++ b/services/svc/mixedreality/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/monitor/Cargo.toml
+++ b/services/svc/monitor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/monitor/Cargo.toml
+++ b/services/svc/monitor/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/operationalinsights/Cargo.toml
+++ b/services/svc/operationalinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/operationalinsights/Cargo.toml
+++ b/services/svc/operationalinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/purview/Cargo.toml
+++ b/services/svc/purview/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/purview/Cargo.toml
+++ b/services/svc/purview/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/quantum/Cargo.toml
+++ b/services/svc/quantum/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/quantum/Cargo.toml
+++ b/services/svc/quantum/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/queuestorage/Cargo.toml
+++ b/services/svc/queuestorage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/queuestorage/Cargo.toml
+++ b/services/svc/queuestorage/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/schemaregistry/Cargo.toml
+++ b/services/svc/schemaregistry/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/schemaregistry/Cargo.toml
+++ b/services/svc/schemaregistry/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/servicefabric/Cargo.toml
+++ b/services/svc/servicefabric/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/servicefabric/Cargo.toml
+++ b/services/svc/servicefabric/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/storagedatalake/Cargo.toml
+++ b/services/svc/storagedatalake/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/storagedatalake/Cargo.toml
+++ b/services/svc/storagedatalake/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/synapse/Cargo.toml
+++ b/services/svc/synapse/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/synapse/Cargo.toml
+++ b/services/svc/synapse/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/timeseriesinsights/Cargo.toml
+++ b/services/svc/timeseriesinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/timeseriesinsights/Cargo.toml
+++ b/services/svc/timeseriesinsights/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]

--- a/services/svc/webpubsub/Cargo.toml
+++ b/services/svc/webpubsub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { package = "azure_base", path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/webpubsub/Cargo.toml
+++ b/services/svc/webpubsub/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1.0", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"
@@ -15,7 +15,7 @@ url = "2.2"
 futures = "0.3"
 
 [dev-dependencies]
-azure_identity = { path = "../../../sdk/identity", version = "0.1.0" }
+azure_identity = { path = "../../../sdk/identity", version = "0.1" }
 tokio = { version = "1.0", features = ["macros"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
- This changes the core crate back to `azure_core`.
- Bumps `azure_core` & `azure_identity` to 0.1.1.
- Relaxes the service crates to depend on `0.1` instead of `0.1.0`.