### PR TITLE
add license for services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __queuestorage__
 .idea/
 *.iml
 *.bat
+*.ps1

--- a/services/autorust/codegen/src/cargo_toml.rs
+++ b/services/autorust/codegen/src/cargo_toml.rs
@@ -22,6 +22,8 @@ pub fn create(crate_name: &str, feature_mod_names: &[(String, String)], path: &P
 name = "{}"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = {{ path = "../../../sdk/core", version = "0.1", default-features = false }}

--- a/services/mgmt/activedirectory/Cargo.toml
+++ b/services/mgmt/activedirectory/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_activedirectory"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/addons/Cargo.toml
+++ b/services/mgmt/addons/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_addons"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/adhybridhealthservice/Cargo.toml
+++ b/services/mgmt/adhybridhealthservice/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_adhybridhealthservice"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/adp/Cargo.toml
+++ b/services/mgmt/adp/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_adp"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/advisor/Cargo.toml
+++ b/services/mgmt/advisor/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_advisor"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/agrifood/Cargo.toml
+++ b/services/mgmt/agrifood/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_agrifood"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/alertsmanagement/Cargo.toml
+++ b/services/mgmt/alertsmanagement/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_alertsmanagement"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/analysisservices/Cargo.toml
+++ b/services/mgmt/analysisservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_analysisservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/apimanagement/Cargo.toml
+++ b/services/mgmt/apimanagement/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_apimanagement"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/appconfiguration/Cargo.toml
+++ b/services/mgmt/appconfiguration/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_appconfiguration"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/applicationinsights/Cargo.toml
+++ b/services/mgmt/applicationinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_applicationinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/appplatform/Cargo.toml
+++ b/services/mgmt/appplatform/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_appplatform"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/arcdata/Cargo.toml
+++ b/services/mgmt/arcdata/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_arcdata"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/attestation/Cargo.toml
+++ b/services/mgmt/attestation/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_attestation"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/authorization/Cargo.toml
+++ b/services/mgmt/authorization/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_authorization"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/automanage/Cargo.toml
+++ b/services/mgmt/automanage/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_automanage"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/automation/Cargo.toml
+++ b/services/mgmt/automation/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_automation"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/baremetalinfrastructure/Cargo.toml
+++ b/services/mgmt/baremetalinfrastructure/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_baremetalinfrastructure"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/batch/Cargo.toml
+++ b/services/mgmt/batch/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_batch"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/billing/Cargo.toml
+++ b/services/mgmt/billing/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_billing"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/blockchain/Cargo.toml
+++ b/services/mgmt/blockchain/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_blockchain"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/blueprint/Cargo.toml
+++ b/services/mgmt/blueprint/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_blueprint"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/botservice/Cargo.toml
+++ b/services/mgmt/botservice/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_botservice"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/cdn/Cargo.toml
+++ b/services/mgmt/cdn/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_cdn"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/changeanalysis/Cargo.toml
+++ b/services/mgmt/changeanalysis/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_changeanalysis"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/chaos/Cargo.toml
+++ b/services/mgmt/chaos/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_chaos"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/cloudshell/Cargo.toml
+++ b/services/mgmt/cloudshell/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_cloudshell"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/cognitiveservices/Cargo.toml
+++ b/services/mgmt/cognitiveservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_cognitiveservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/commerce/Cargo.toml
+++ b/services/mgmt/commerce/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_commerce"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/communication/Cargo.toml
+++ b/services/mgmt/communication/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_communication"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/compute/Cargo.toml
+++ b/services/mgmt/compute/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_compute"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/confidentialledger/Cargo.toml
+++ b/services/mgmt/confidentialledger/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_confidentialledger"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/confluent/Cargo.toml
+++ b/services/mgmt/confluent/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_confluent"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/connectedvmware/Cargo.toml
+++ b/services/mgmt/connectedvmware/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_connectedvmware"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/consumption/Cargo.toml
+++ b/services/mgmt/consumption/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_consumption"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/containerinstance/Cargo.toml
+++ b/services/mgmt/containerinstance/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_containerinstance"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/containerregistry/Cargo.toml
+++ b/services/mgmt/containerregistry/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_containerregistry"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/containerservice/Cargo.toml
+++ b/services/mgmt/containerservice/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_containerservice"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/cosmosdb/Cargo.toml
+++ b/services/mgmt/cosmosdb/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_cosmosdb"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/costmanagement/Cargo.toml
+++ b/services/mgmt/costmanagement/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_costmanagement"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/cpim/Cargo.toml
+++ b/services/mgmt/cpim/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_cpim"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/customerinsights/Cargo.toml
+++ b/services/mgmt/customerinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_customerinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/customerlockbox/Cargo.toml
+++ b/services/mgmt/customerlockbox/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_customerlockbox"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/customproviders/Cargo.toml
+++ b/services/mgmt/customproviders/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_customproviders"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/data/Cargo.toml
+++ b/services/mgmt/data/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_data"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/databox/Cargo.toml
+++ b/services/mgmt/databox/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_databox"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/databoxedge/Cargo.toml
+++ b/services/mgmt/databoxedge/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_databoxedge"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/databricks/Cargo.toml
+++ b/services/mgmt/databricks/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_databricks"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/datacatalog/Cargo.toml
+++ b/services/mgmt/datacatalog/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_datacatalog"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/datadog/Cargo.toml
+++ b/services/mgmt/datadog/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_datadog"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/datafactory/Cargo.toml
+++ b/services/mgmt/datafactory/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_datafactory"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/datalakeanalytics/Cargo.toml
+++ b/services/mgmt/datalakeanalytics/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_datalakeanalytics"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/datalakestore/Cargo.toml
+++ b/services/mgmt/datalakestore/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_datalakestore"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/dataprotection/Cargo.toml
+++ b/services/mgmt/dataprotection/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_dataprotection"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/datashare/Cargo.toml
+++ b/services/mgmt/datashare/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_datashare"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/deploymentmanager/Cargo.toml
+++ b/services/mgmt/deploymentmanager/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_deploymentmanager"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/desktopvirtualization/Cargo.toml
+++ b/services/mgmt/desktopvirtualization/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_desktopvirtualization"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/deviceupdate/Cargo.toml
+++ b/services/mgmt/deviceupdate/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_deviceupdate"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/devops/Cargo.toml
+++ b/services/mgmt/devops/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_devops"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/devspaces/Cargo.toml
+++ b/services/mgmt/devspaces/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_devspaces"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/devtestlabs/Cargo.toml
+++ b/services/mgmt/devtestlabs/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_devtestlabs"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/dfp/Cargo.toml
+++ b/services/mgmt/dfp/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_dfp"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/digitaltwins/Cargo.toml
+++ b/services/mgmt/digitaltwins/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_digitaltwins"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/dns/Cargo.toml
+++ b/services/mgmt/dns/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_dns"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/domainservices/Cargo.toml
+++ b/services/mgmt/domainservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_domainservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/edgeorder/Cargo.toml
+++ b/services/mgmt/edgeorder/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_edgeorder"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/edgeorderpartner/Cargo.toml
+++ b/services/mgmt/edgeorderpartner/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_edgeorderpartner"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/elastic/Cargo.toml
+++ b/services/mgmt/elastic/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_elastic"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/engagementfabric/Cargo.toml
+++ b/services/mgmt/engagementfabric/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_engagementfabric"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/enterpriseknowledgegraph/Cargo.toml
+++ b/services/mgmt/enterpriseknowledgegraph/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_enterpriseknowledgegraph"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/eventgrid/Cargo.toml
+++ b/services/mgmt/eventgrid/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_eventgrid"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/eventhub/Cargo.toml
+++ b/services/mgmt/eventhub/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_eventhub"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/extendedlocation/Cargo.toml
+++ b/services/mgmt/extendedlocation/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_extendedlocation"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/fluidrelay/Cargo.toml
+++ b/services/mgmt/fluidrelay/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_fluidrelay"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/frontdoor/Cargo.toml
+++ b/services/mgmt/frontdoor/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_frontdoor"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/guestconfiguration/Cargo.toml
+++ b/services/mgmt/guestconfiguration/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_guestconfiguration"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hanaon/Cargo.toml
+++ b/services/mgmt/hanaon/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hanaon"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hardwaresecuritymodules/Cargo.toml
+++ b/services/mgmt/hardwaresecuritymodules/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hardwaresecuritymodules"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hdinsight/Cargo.toml
+++ b/services/mgmt/hdinsight/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hdinsight"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/healthbot/Cargo.toml
+++ b/services/mgmt/healthbot/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_healthbot"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/healthcareapis/Cargo.toml
+++ b/services/mgmt/healthcareapis/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_healthcareapis"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hybridcompute/Cargo.toml
+++ b/services/mgmt/hybridcompute/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hybridcompute"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hybridconnectivity/Cargo.toml
+++ b/services/mgmt/hybridconnectivity/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hybridconnectivity"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hybriddatamanager/Cargo.toml
+++ b/services/mgmt/hybriddatamanager/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hybriddatamanager"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hybridkubernetes/Cargo.toml
+++ b/services/mgmt/hybridkubernetes/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hybridkubernetes"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/hybridnetwork/Cargo.toml
+++ b/services/mgmt/hybridnetwork/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_hybridnetwork"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/imagebuilder/Cargo.toml
+++ b/services/mgmt/imagebuilder/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_imagebuilder"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/intune/Cargo.toml
+++ b/services/mgmt/intune/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_intune"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/iotcentral/Cargo.toml
+++ b/services/mgmt/iotcentral/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_iotcentral"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/iothub/Cargo.toml
+++ b/services/mgmt/iothub/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_iothub"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/keyvault/Cargo.toml
+++ b/services/mgmt/keyvault/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_keyvault"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/kubernetesconfiguration/Cargo.toml
+++ b/services/mgmt/kubernetesconfiguration/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_kubernetesconfiguration"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/kusto/Cargo.toml
+++ b/services/mgmt/kusto/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_kusto"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/labservices/Cargo.toml
+++ b/services/mgmt/labservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_labservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/loadtestservice/Cargo.toml
+++ b/services/mgmt/loadtestservice/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_loadtestservice"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/logic/Cargo.toml
+++ b/services/mgmt/logic/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_logic"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/logz/Cargo.toml
+++ b/services/mgmt/logz/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_logz"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/machinelearning/Cargo.toml
+++ b/services/mgmt/machinelearning/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_machinelearning"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/machinelearningcompute/Cargo.toml
+++ b/services/mgmt/machinelearningcompute/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_machinelearningcompute"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/machinelearningexperimentation/Cargo.toml
+++ b/services/mgmt/machinelearningexperimentation/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_machinelearningexperimentation"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/machinelearningservices/Cargo.toml
+++ b/services/mgmt/machinelearningservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_machinelearningservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/maintenance/Cargo.toml
+++ b/services/mgmt/maintenance/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_maintenance"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/managednetwork/Cargo.toml
+++ b/services/mgmt/managednetwork/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_managednetwork"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/managedservices/Cargo.toml
+++ b/services/mgmt/managedservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_managedservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/managementgroups/Cargo.toml
+++ b/services/mgmt/managementgroups/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_managementgroups"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/managementpartner/Cargo.toml
+++ b/services/mgmt/managementpartner/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_managementpartner"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/maps/Cargo.toml
+++ b/services/mgmt/maps/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_maps"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/mariadb/Cargo.toml
+++ b/services/mgmt/mariadb/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_mariadb"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/marketplacenotifications/Cargo.toml
+++ b/services/mgmt/marketplacenotifications/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_marketplacenotifications"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/marketplaceordering/Cargo.toml
+++ b/services/mgmt/marketplaceordering/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_marketplaceordering"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/mediaservices/Cargo.toml
+++ b/services/mgmt/mediaservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_mediaservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/migrate/Cargo.toml
+++ b/services/mgmt/migrate/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_migrate"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/migrateprojects/Cargo.toml
+++ b/services/mgmt/migrateprojects/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_migrateprojects"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/monitor/Cargo.toml
+++ b/services/mgmt/monitor/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_monitor"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/msi/Cargo.toml
+++ b/services/mgmt/msi/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_msi"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/mysql/Cargo.toml
+++ b/services/mgmt/mysql/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_mysql"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/netapp/Cargo.toml
+++ b/services/mgmt/netapp/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_netapp"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/network/Cargo.toml
+++ b/services/mgmt/network/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_network"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/notificationhubs/Cargo.toml
+++ b/services/mgmt/notificationhubs/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_notificationhubs"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/oep/Cargo.toml
+++ b/services/mgmt/oep/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_oep"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/operationalinsights/Cargo.toml
+++ b/services/mgmt/operationalinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_operationalinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/operationsmanagement/Cargo.toml
+++ b/services/mgmt/operationsmanagement/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_operationsmanagement"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/orbital/Cargo.toml
+++ b/services/mgmt/orbital/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_orbital"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/peering/Cargo.toml
+++ b/services/mgmt/peering/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_peering"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/policyinsights/Cargo.toml
+++ b/services/mgmt/policyinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_policyinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/portal/Cargo.toml
+++ b/services/mgmt/portal/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_portal"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/postgresql/Cargo.toml
+++ b/services/mgmt/postgresql/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_postgresql"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/postgresqlhsc/Cargo.toml
+++ b/services/mgmt/postgresqlhsc/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_postgresqlhsc"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/powerbidedicated/Cargo.toml
+++ b/services/mgmt/powerbidedicated/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_powerbidedicated"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/powerbiembedded/Cargo.toml
+++ b/services/mgmt/powerbiembedded/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_powerbiembedded"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/powerbiprivatelinks/Cargo.toml
+++ b/services/mgmt/powerbiprivatelinks/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_powerbiprivatelinks"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/powerplatform/Cargo.toml
+++ b/services/mgmt/powerplatform/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_powerplatform"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/privatedns/Cargo.toml
+++ b/services/mgmt/privatedns/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_privatedns"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/providerhub/Cargo.toml
+++ b/services/mgmt/providerhub/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_providerhub"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/purview/Cargo.toml
+++ b/services/mgmt/purview/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_purview"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/quantum/Cargo.toml
+++ b/services/mgmt/quantum/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_quantum"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/quota/Cargo.toml
+++ b/services/mgmt/quota/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_quota"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/recoveryservices/Cargo.toml
+++ b/services/mgmt/recoveryservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_recoveryservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/recoveryservicesbackup/Cargo.toml
+++ b/services/mgmt/recoveryservicesbackup/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_recoveryservicesbackup"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/recoveryservicessiterecovery/Cargo.toml
+++ b/services/mgmt/recoveryservicessiterecovery/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_recoveryservicessiterecovery"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/redhatopenshift/Cargo.toml
+++ b/services/mgmt/redhatopenshift/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_redhatopenshift"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/redis/Cargo.toml
+++ b/services/mgmt/redis/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_redis"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/redisenterprise/Cargo.toml
+++ b/services/mgmt/redisenterprise/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_redisenterprise"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/relay/Cargo.toml
+++ b/services/mgmt/relay/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_relay"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/reservations/Cargo.toml
+++ b/services/mgmt/reservations/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_reservations"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/resourceconnector/Cargo.toml
+++ b/services/mgmt/resourceconnector/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_resourceconnector"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/resourcegraph/Cargo.toml
+++ b/services/mgmt/resourcegraph/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_resourcegraph"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/resourcehealth/Cargo.toml
+++ b/services/mgmt/resourcehealth/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_resourcehealth"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/resourcemover/Cargo.toml
+++ b/services/mgmt/resourcemover/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_resourcemover"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/resources/Cargo.toml
+++ b/services/mgmt/resources/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_resources"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/saas/Cargo.toml
+++ b/services/mgmt/saas/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_saas"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/scheduler/Cargo.toml
+++ b/services/mgmt/scheduler/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_scheduler"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/search/Cargo.toml
+++ b/services/mgmt/search/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_search"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/security/Cargo.toml
+++ b/services/mgmt/security/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_security"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/securityandcompliance/Cargo.toml
+++ b/services/mgmt/securityandcompliance/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_securityandcompliance"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/securityinsights/Cargo.toml
+++ b/services/mgmt/securityinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_securityinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/serialconsole/Cargo.toml
+++ b/services/mgmt/serialconsole/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_serialconsole"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/servicebus/Cargo.toml
+++ b/services/mgmt/servicebus/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_servicebus"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/servicefabricmesh/Cargo.toml
+++ b/services/mgmt/servicefabricmesh/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_servicefabricmesh"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/servicelinker/Cargo.toml
+++ b/services/mgmt/servicelinker/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_servicelinker"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/signalr/Cargo.toml
+++ b/services/mgmt/signalr/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_signalr"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/softwareplan/Cargo.toml
+++ b/services/mgmt/softwareplan/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_softwareplan"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/solutions/Cargo.toml
+++ b/services/mgmt/solutions/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_solutions"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/sql/Cargo.toml
+++ b/services/mgmt/sql/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_sql"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/sqlvirtualmachine/Cargo.toml
+++ b/services/mgmt/sqlvirtualmachine/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_sqlvirtualmachine"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/stack/Cargo.toml
+++ b/services/mgmt/stack/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_stack"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/storage/Cargo.toml
+++ b/services/mgmt/storage/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_storage"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/storagecache/Cargo.toml
+++ b/services/mgmt/storagecache/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_storagecache"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/storageimportexport/Cargo.toml
+++ b/services/mgmt/storageimportexport/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_storageimportexport"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/storagepool/Cargo.toml
+++ b/services/mgmt/storagepool/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_storagepool"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/storagesync/Cargo.toml
+++ b/services/mgmt/storagesync/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_storagesync"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/storsimple1200series/Cargo.toml
+++ b/services/mgmt/storsimple1200series/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_storsimple1200series"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/storsimple8000series/Cargo.toml
+++ b/services/mgmt/storsimple8000series/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_storsimple8000series"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/streamanalytics/Cargo.toml
+++ b/services/mgmt/streamanalytics/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_streamanalytics"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/subscription/Cargo.toml
+++ b/services/mgmt/subscription/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_subscription"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/support/Cargo.toml
+++ b/services/mgmt/support/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_support"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/synapse/Cargo.toml
+++ b/services/mgmt/synapse/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_synapse"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/testbase/Cargo.toml
+++ b/services/mgmt/testbase/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_testbase"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/timeseriesinsights/Cargo.toml
+++ b/services/mgmt/timeseriesinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_timeseriesinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/trafficmanager/Cargo.toml
+++ b/services/mgmt/trafficmanager/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_trafficmanager"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/vi/Cargo.toml
+++ b/services/mgmt/vi/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_vi"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/videoanalyzer/Cargo.toml
+++ b/services/mgmt/videoanalyzer/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_videoanalyzer"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/visualstudio/Cargo.toml
+++ b/services/mgmt/visualstudio/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_visualstudio"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/vmware/Cargo.toml
+++ b/services/mgmt/vmware/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_vmware"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/vmwarecloudsimple/Cargo.toml
+++ b/services/mgmt/vmwarecloudsimple/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_vmwarecloudsimple"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/web/Cargo.toml
+++ b/services/mgmt/web/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_web"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/webpubsub/Cargo.toml
+++ b/services/mgmt/webpubsub/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_webpubsub"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/windowsesu/Cargo.toml
+++ b/services/mgmt/windowsesu/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_windowsesu"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/windowsiot/Cargo.toml
+++ b/services/mgmt/windowsiot/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_windowsiot"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/mgmt/workloadmonitor/Cargo.toml
+++ b/services/mgmt/workloadmonitor/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_mgmt_workloadmonitor"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/appconfiguration/Cargo.toml
+++ b/services/svc/appconfiguration/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_appconfiguration"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/applicationinsights/Cargo.toml
+++ b/services/svc/applicationinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_applicationinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/attestation/Cargo.toml
+++ b/services/svc/attestation/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_attestation"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/batch/Cargo.toml
+++ b/services/svc/batch/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_batch"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/blobstorage/Cargo.toml
+++ b/services/svc/blobstorage/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_blobstorage"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/confidentialledger/Cargo.toml
+++ b/services/svc/confidentialledger/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_confidentialledger"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/containerregistry/Cargo.toml
+++ b/services/svc/containerregistry/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_containerregistry"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/cosmosdb/Cargo.toml
+++ b/services/svc/cosmosdb/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_cosmosdb"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/datalakeanalytics/Cargo.toml
+++ b/services/svc/datalakeanalytics/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_datalakeanalytics"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/deviceprovisioningservices/Cargo.toml
+++ b/services/svc/deviceprovisioningservices/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_deviceprovisioningservices"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/deviceupdate/Cargo.toml
+++ b/services/svc/deviceupdate/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_deviceupdate"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/digitaltwins/Cargo.toml
+++ b/services/svc/digitaltwins/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_digitaltwins"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/eventgrid/Cargo.toml
+++ b/services/svc/eventgrid/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_eventgrid"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/filestorage/Cargo.toml
+++ b/services/svc/filestorage/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_filestorage"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/graphrbac/Cargo.toml
+++ b/services/svc/graphrbac/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_graphrbac"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/imds/Cargo.toml
+++ b/services/svc/imds/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_imds"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/iotcentral/Cargo.toml
+++ b/services/svc/iotcentral/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_iotcentral"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/keyvault/Cargo.toml
+++ b/services/svc/keyvault/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_keyvault"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/loadtestservice/Cargo.toml
+++ b/services/svc/loadtestservice/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_loadtestservice"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/marketplacecatalog/Cargo.toml
+++ b/services/svc/marketplacecatalog/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_marketplacecatalog"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/mixedreality/Cargo.toml
+++ b/services/svc/mixedreality/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_mixedreality"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/monitor/Cargo.toml
+++ b/services/svc/monitor/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_monitor"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/operationalinsights/Cargo.toml
+++ b/services/svc/operationalinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_operationalinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/purview/Cargo.toml
+++ b/services/svc/purview/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_purview"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/quantum/Cargo.toml
+++ b/services/svc/quantum/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_quantum"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/queuestorage/Cargo.toml
+++ b/services/svc/queuestorage/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_queuestorage"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/schemaregistry/Cargo.toml
+++ b/services/svc/schemaregistry/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_schemaregistry"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/servicefabric/Cargo.toml
+++ b/services/svc/servicefabric/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_servicefabric"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/storagedatalake/Cargo.toml
+++ b/services/svc/storagedatalake/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_storagedatalake"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/synapse/Cargo.toml
+++ b/services/svc/synapse/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_synapse"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/timeseriesinsights/Cargo.toml
+++ b/services/svc/timeseriesinsights/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_timeseriesinsights"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }

--- a/services/svc/webpubsub/Cargo.toml
+++ b/services/svc/webpubsub/Cargo.toml
@@ -3,6 +3,8 @@
 name = "azure_svc_webpubsub"
 version = "0.1.0"
 edition = "2018"
+license = "MIT"
+description = "generated REST API bindings"
 
 [dependencies]
 azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }


### PR DESCRIPTION
This is required for publishing. Without it, this error happens:

```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error: missing or empty metadata fields: description, license. Please see https://doc.rust-lang.org/cargo/reference/manifest.html for how to upload metadata
```
