### PR TITLE
Add azurite_workaround feature to storage_blobs

### DIFF
--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -41,5 +41,6 @@ oauth2 = { version = "4.0.0", default-features = false }
 [features]
 default = ["enable_reqwest"]
 test_e2e = []
+azurite_workaround = []
 enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls", "azure_storage/enable_reqwest_rustls"]


### PR DESCRIPTION
This was missing from Cargo.toml, yet the feature is defined in the
code.

```
% rg azurite_workaround
Cargo.toml
44:azurite_workaround = []

src/blob/mod.rs
34:#[cfg(feature = "azurite_workaround")]
127:    #[cfg(not(feature = "azurite_workaround"))]
131:    #[cfg(feature = "azurite_workaround")]
202:        #[cfg(not(feature = "azurite_workaround"))]
213:        #[cfg(feature = "azurite_workaround")]

src/blob/responses/delete_blob_response.rs
5:#[cfg(not(feature = "azurite_workaround"))]
12:#[cfg(feature = "azurite_workaround")]
```