### PR TITLE
 Add partition key support to DocumentClient.get_document 

### DIFF
--- a/sdk/data_cosmos/src/clients/document_client.rs
+++ b/sdk/data_cosmos/src/clients/document_client.rs
@@ -69,7 +69,7 @@ impl DocumentClient {
     {
         let mut request = self.prepare_request_pipeline_with_document_name(http::Method::GET);
 
-        options.decorate_request(&mut request)?;
+        options.decorate_request(&mut request, self.partition_key_serialized())?;   
 
         let response = self
             .cosmos_client()

--- a/sdk/data_cosmos/src/clients/document_client.rs
+++ b/sdk/data_cosmos/src/clients/document_client.rs
@@ -69,7 +69,7 @@ impl DocumentClient {
     {
         let mut request = self.prepare_request_pipeline_with_document_name(http::Method::GET);
 
-        options.decorate_request(&mut request, self.partition_key_serialized())?;   
+        options.decorate_request(&mut request, self.partition_key_serialized())?;
 
         let response = self
             .cosmos_client()

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -33,10 +33,19 @@ impl GetDocumentOptions {
         if_modified_since: DateTime<Utc> => Some(IfModifiedSince::new(if_modified_since)),
     }
 
-    pub(crate) fn decorate_request(&self, request: &mut HttpRequest) -> crate::Result<()> {
+    pub(crate) fn decorate_request(
+        &self, 
+        request: &mut HttpRequest,
+        serialized_partition_key: &str,
+    ) -> crate::Result<()> {
         azure_core::headers::add_optional_header2(&self.if_match_condition, request)?;
         azure_core::headers::add_optional_header2(&self.if_modified_since, request)?;
         azure_core::headers::add_optional_header2(&self.consistency_level, request)?;
+        
+        crate::cosmos_entity::add_as_partition_key_header_serialized2(
+            serialized_partition_key,
+            request,
+        );
 
         request.set_body(azure_core::EMPTY_BODY.into());
 

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -34,14 +34,14 @@ impl GetDocumentOptions {
     }
 
     pub(crate) fn decorate_request(
-        &self, 
+        &self,
         request: &mut HttpRequest,
         serialized_partition_key: &str,
     ) -> crate::Result<()> {
         azure_core::headers::add_optional_header2(&self.if_match_condition, request)?;
         azure_core::headers::add_optional_header2(&self.if_modified_since, request)?;
         azure_core::headers::add_optional_header2(&self.consistency_level, request)?;
-        
+
         crate::cosmos_entity::add_as_partition_key_header_serialized2(
             serialized_partition_key,
             request,


### PR DESCRIPTION
All item operations should act on partition keys.
The implementation is copied from delete_document.