### PR TITLE
move to hmac instead of ring for hmac calculation

### DIFF
--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -17,7 +17,6 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.1" }
-ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"
 http = "0.2"
@@ -29,6 +28,9 @@ url = "2.2"
 uuid = { version = "0.8", features = ["v4"] }
 thiserror = "1.0"
 bytes = "1.0"
+hmac = "0.12"
+sha2 = "0.10"
+
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -3,9 +3,10 @@ use crate::resources::permission::AuthorizationToken;
 use crate::resources::ResourceType;
 use crate::TimeNonce;
 use azure_core::{Context, Policy, PolicyResult, Request};
+use hmac::{Hmac, Mac};
 use http::header::AUTHORIZATION;
 use http::HeaderValue;
-use ring::hmac;
+use sha2::Sha256;
 use std::borrow::Cow;
 use std::sync::Arc;
 use url::form_urlencoded;
@@ -228,10 +229,11 @@ fn string_to_sign(
 /// encoded and returned to the caller. Possibile optimization: profile if the HMAC struct
 /// initialization is expensive and, if so, cache it somehow to avoid recreating it at every
 /// request.
-fn encode_str_to_sign(str_to_sign: &str, key: &[u8]) -> String {
-    let key = hmac::Key::new(ring::hmac::HMAC_SHA256, key);
-    let sig = hmac::sign(&key, str_to_sign.as_bytes());
-    base64::encode(sig.as_ref())
+fn encode_str_to_sign(data: &str, key: &[u8]) -> String {
+    let mut hmac = Hmac::<Sha256>::new_from_slice(key).unwrap();
+    hmac.update(data.as_bytes());
+    let signature = hmac.finalize().into_bytes();
+    base64::encode(&signature)
 }
 
 #[cfg(test)]

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -16,11 +16,12 @@ edition = "2018"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.1" }
-ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"
 log = "0.4"
 url = "2.2"
+hmac = "0.12"
+sha2 = "0.10"
 
 [dev-dependencies]
 futures = "0.3"

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.1", default-features=false }
-ring = "0.16"
 base64 = "0.13"
 chrono = "0.4"
 http = "0.2"
@@ -31,6 +30,8 @@ bytes = "1.0"
 RustyXML = "0.3"
 thiserror = "1.0"
 once_cell = "1.7"
+hmac = "0.12"
+sha2 = "0.10"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -1,6 +1,7 @@
 use crate::headers::CONTENT_MD5;
 use crate::{
     core::{ConnectionString, No},
+    hmac::sign,
     shared_access_signature::account_sas::{
         AccountSharedAccessSignatureBuilder, ClientAccountSharedAccessSignature,
     },
@@ -13,7 +14,6 @@ use http::{
     method::Method,
     request::{Builder, Request},
 };
-use ring::hmac;
 use std::sync::Arc;
 use url::Url;
 
@@ -450,20 +450,10 @@ fn generate_authorization(
     // debug!("\nstr_to_sign == {:?}\n", str_to_sign);
     // debug!("str_to_sign == {}", str_to_sign);
 
-    let auth = encode_str_to_sign(&str_to_sign, key);
+    let auth = sign(&str_to_sign, key).unwrap();
     // debug!("auth == {:?}", auth);
 
     format!("SharedKey {}:{}", account, auth)
-}
-
-fn encode_str_to_sign(str_to_sign: &str, hmac_key: &str) -> String {
-    let key = hmac::Key::new(ring::hmac::HMAC_SHA256, &base64::decode(hmac_key).unwrap());
-    let sig = hmac::sign(&key, str_to_sign.as_bytes());
-
-    // let res = hmac.result();
-    // debug!("{:?}", res.code());
-
-    base64::encode(sig.as_ref())
 }
 
 fn add_if_exists<K: AsHeaderName>(h: &HeaderMap, key: K) -> &str {

--- a/sdk/storage/src/core/errors.rs
+++ b/sdk/storage/src/core/errors.rs
@@ -73,6 +73,8 @@ pub enum Error {
     HeadersNotFound(Vec<String>),
     #[error("error writing the header value: {0}")]
     InvalidHeaderValue(#[from] azure_core::HttpHeaderError),
+    #[error("error generating hmac: {0}")]
+    Hmac(#[from] hmac::digest::InvalidLength),
 }
 
 impl From<azure_core::error::Error> for Error {

--- a/sdk/storage/src/core/hmac.rs
+++ b/sdk/storage/src/core/hmac.rs
@@ -1,0 +1,11 @@
+use crate::Result;
+use base64::encode;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+
+pub fn sign(data: &str, key: &str) -> Result<String> {
+    let mut hmac = Hmac::<Sha256>::new_from_slice(&base64::decode(key)?)?;
+    hmac.update(data.as_bytes());
+    let signature = hmac.finalize().into_bytes();
+    Ok(encode(&signature))
+}

--- a/sdk/storage/src/core/mod.rs
+++ b/sdk/storage/src/core/mod.rs
@@ -4,6 +4,7 @@ mod connection_string_builder;
 mod copy_id;
 mod copy_progress;
 mod errors;
+pub mod hmac;
 mod into_azure_path;
 mod macros;
 pub mod prelude;

--- a/sdk/storage/src/core/shared_access_signature/account_sas.rs
+++ b/sdk/storage/src/core/shared_access_signature/account_sas.rs
@@ -1,5 +1,6 @@
 use crate::core::{
-    shared_access_signature::{format_date, format_form, sign, SasProtocol, SasToken},
+    hmac::sign,
+    shared_access_signature::{format_date, format_form, SasProtocol, SasToken},
     No, ToAssign,
 };
 use chrono::{DateTime, Utc};
@@ -170,7 +171,7 @@ impl AccountSharedAccessSignature {
                     self.signed_version,
                 );
 
-                sign(&self.key, &string_to_sign)
+                sign(&string_to_sign, &self.key).unwrap()
             }
             _ => {
                 // TODO: support other version tags?

--- a/sdk/storage/src/core/shared_access_signature/mod.rs
+++ b/sdk/storage/src/core/shared_access_signature/mod.rs
@@ -1,5 +1,4 @@
 use chrono::{DateTime, Utc};
-use ring::hmac;
 use std::fmt;
 use url::form_urlencoded;
 
@@ -8,12 +7,6 @@ pub mod service_sas;
 
 pub trait SasToken {
     fn token(&self) -> String;
-}
-
-pub(crate) fn sign(key: &str, data: &str) -> String {
-    let key = hmac::Key::new(ring::hmac::HMAC_SHA256, &base64::decode(key).unwrap());
-    let sig_bytes = hmac::sign(&key, data.as_bytes());
-    base64::encode(&sig_bytes)
 }
 
 pub(crate) fn format_date(d: DateTime<Utc>) -> String {

--- a/sdk/storage/src/core/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/core/shared_access_signature/service_sas.rs
@@ -1,4 +1,7 @@
-use crate::core::shared_access_signature::{format_date, format_form, sign, SasProtocol, SasToken};
+use crate::{
+    core::shared_access_signature::{format_date, format_form, SasProtocol, SasToken},
+    hmac,
+};
 use chrono::{DateTime, Utc};
 use std::{fmt, marker::PhantomData};
 
@@ -128,7 +131,7 @@ impl BlobSharedAccessSignature {
             "".to_string(), // rsct
         ];
 
-        sign(&self.key, &content.join("\n"))
+        hmac::sign(&content.join("\n"), &self.key).unwrap()
     }
 }
 

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -28,7 +28,6 @@ serde_json = "1.0"
 serde-xml-rs = "0.5"
 uuid = { version = "0.8", features = ["v4"] }
 url = "2.2"
-ring = "0.16"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }

--- a/sdk/storage_datalake/src/shared_key_authorization_policy.rs
+++ b/sdk/storage_datalake/src/shared_key_authorization_policy.rs
@@ -1,7 +1,6 @@
 use azure_core::{Context, Policy, PolicyResult, Request};
-use azure_storage::core::storage_shared_key_credential::StorageSharedKeyCredential;
+use azure_storage::{core::storage_shared_key_credential::StorageSharedKeyCredential, hmac::sign};
 use http::{HeaderMap, HeaderValue, Method};
-use ring::hmac;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,7 +74,7 @@ fn generate_authorization(
     // println!("\nstr_to_sign == {:?}\n", str_to_sign);
     // debug!("str_to_sign == {}", str_to_sign);
 
-    let auth = encode_str_to_sign(&str_to_sign, shared_key);
+    let auth = sign(&str_to_sign, shared_key).unwrap();
     // debug!("auth == {:?}", auth);
 
     format!("SharedKey {}:{}", storage_account_name, auth)
@@ -221,14 +220,4 @@ fn lexy_sort<'a>(
     v_values.sort();
 
     v_values
-}
-
-fn encode_str_to_sign(str_to_sign: &str, hmac_key: &str) -> String {
-    let key = hmac::Key::new(ring::hmac::HMAC_SHA256, &base64::decode(hmac_key).unwrap());
-    let sig = hmac::sign(&key, str_to_sign.as_bytes());
-
-    // let res = hmac.result();
-    // debug!("{:?}", res.code());
-
-    base64::encode(sig.as_ref())
 }


### PR DESCRIPTION
As #657 identifies, multiple crates depend on ring.  This PR replaces the use of `ring` with the `hmac` and `sha256`, as we implicitly use `sha256` from the `oauth2` crates in `core`, `identity`, `storage_blobs`, and `security_keyvault`.