### PR TITLE
address clippy issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     name: Services Tests
     runs-on: ubuntu-20.04
     env:
-      RUSTFLAGS: -Dwarnings -Aunreachable-code -Aunused-assignments -Adead-code -Aclippy::new-without-default
+      RUSTFLAGS: -Dwarnings -Aunreachable-code -Aunused-assignments -Adead-code -Aclippy::new-without-default -Aclippy::unnecessary_to_owned
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/sdk/core/src/context.rs
+++ b/sdk/core/src/context.rs
@@ -66,8 +66,7 @@ impl Context {
     {
         self.type_map
             .get(&TypeId::of::<E>())
-            .map(|item| item.downcast_ref())
-            .flatten()
+            .and_then(|item| item.downcast_ref())
     }
 
     /// Returns the number of entities in the type map.

--- a/sdk/data_cosmos/examples/stored_proc_00.rs
+++ b/sdk/data_cosmos/examples/stored_proc_00.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .await?;
 
     println!("Response object:\n{:#?}", ret);
-    println!("Response as JSON:\n{}", ret.payload.to_string());
+    println!("Response as JSON:\n{}", ret.payload);
 
     Ok(())
 }

--- a/sdk/data_cosmos/examples/stored_proc_01.rs
+++ b/sdk/data_cosmos/examples/stored_proc_01.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     );
     println!(
         "Response as JSON:\n{}",
-        execute_stored_procedure_response.payload.to_string()
+        execute_stored_procedure_response.payload
     );
 
     let delete_stored_procedure_response = stored_procedure_client

--- a/sdk/security_keyvault/src/key.rs
+++ b/sdk/security_keyvault/src/key.rs
@@ -468,7 +468,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
         let mut request_body = Map::new();
         request_body.insert(
             "value".to_owned(),
-            Value::String(base64::encode(decrypt_parameters.ciphertext.to_owned())),
+            Value::String(base64::encode(&decrypt_parameters.ciphertext)),
         );
 
         let algorithm = match decrypt_parameters.decrypt_parameters_encryption {

--- a/sdk/storage_blobs/examples/stream_blob_01.rs
+++ b/sdk/storage_blobs/examples/stream_blob_01.rs
@@ -39,9 +39,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-fn get_blob_stream<'_>(
-    blob_client: &'_ BlobClient,
-) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>> + '_
+fn get_blob_stream<'a>(
+    blob_client: &'a BlobClient,
+) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>> + 'a
 {
     let stream = blob_client.get().stream(1024);
     stream

--- a/sdk/storage_blobs/examples/stream_blob_01.rs
+++ b/sdk/storage_blobs/examples/stream_blob_01.rs
@@ -39,9 +39,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-fn get_blob_stream<'a>(
-    blob_client: &'a BlobClient,
-) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>> + 'a
+fn get_blob_stream(
+    blob_client: &BlobClient,
+) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>>
 {
     let stream = blob_client.get().stream(1024);
     stream

--- a/sdk/storage_blobs/examples/stream_blob_01.rs
+++ b/sdk/storage_blobs/examples/stream_blob_01.rs
@@ -39,9 +39,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
-fn get_blob_stream(
-    blob_client: &BlobClient,
-) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>>
+fn get_blob_stream<'_>(
+    blob_client: &'_ BlobClient,
+) -> impl futures::Stream<Item = Result<GetBlobResponse, Box<dyn std::error::Error + Send + Sync>>> + '_
 {
     let stream = blob_client.get().stream(1024);
     stream

--- a/sdk/storage_blobs/src/delete_snapshot_method.rs
+++ b/sdk/storage_blobs/src/delete_snapshot_method.rs
@@ -14,7 +14,7 @@ impl AddAsHeader for DeleteSnapshotsMethod {
     ) -> Result<(), azure_core::HttpHeaderError> {
         request.headers_mut().append(
             azure_core::headers::DELETE_SNAPSHOTS,
-            http::header::HeaderValue::from_str(&self.to_string())?,
+            http::header::HeaderValue::from_str(self.as_ref())?,
         );
 
         Ok(())

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -82,7 +82,7 @@ impl AddAsHeader for RehydratePriority {
     ) -> std::result::Result<(), azure_core::HttpHeaderError> {
         request.headers_mut().append(
             headers::REHYDRATE_PRIORITY,
-            http::header::HeaderValue::from_str(&self.to_string())?,
+            http::header::HeaderValue::from_str(self.as_ref())?,
         );
 
         Ok(())

--- a/sdk/storage_queues/examples/queue_create.rs
+++ b/sdk/storage_queues/examples/queue_create.rs
@@ -53,9 +53,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let response = queue.get_metadata().execute().await?;
     println!("response == {:#?}", response);
 
-    // create two queue stored access policies
-    let mut queue_stored_acess_policies = Vec::new();
-    queue_stored_acess_policies.push(
+    // use two queue stored access policies
+    let queue_stored_acess_policies = vec![
         QueueStoredAccessPolicy::new(
             "first_sap_read_process",
             Utc::now() - Duration::hours(1),
@@ -63,15 +62,13 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         )
         .enable_read()
         .enable_process(),
-    );
-    queue_stored_acess_policies.push(
         QueueStoredAccessPolicy::new(
             "sap_admin",
             Utc::now() - chrono::Duration::hours(1),
             Utc::now() + chrono::Duration::hours(5),
         )
         .enable_all(),
-    );
+    ];
 
     let response = queue
         .set_acl()

--- a/services/autorust/codegen/examples/multiple_versions.rs
+++ b/services/autorust/codegen/examples/multiple_versions.rs
@@ -11,7 +11,7 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 fn main() -> Result<()> {
     println!("CONTROL PLANE");
     check(&get_mgmt_readmes()?)?;
-    println!("");
+    println!();
     println!("DATA PLANE");
     check(&get_svc_readmes()?)?;
     Ok(())
@@ -32,7 +32,7 @@ fn check(readmes: &[SpecReadme]) -> Result<()> {
                         for version in versions {
                             println!("  {}", version);
                         }
-                        tags = tags + 1;
+                        tags += 1;
                         services.insert(readme.spec());
                     }
                 }
@@ -41,7 +41,7 @@ fn check(readmes: &[SpecReadme]) -> Result<()> {
             }
         }
     }
-    println!("");
+    println!();
     println!("{} tags", tags);
     println!("{} services:", services.len());
     for service in services {

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -114,7 +114,7 @@ impl SchemaGen {
     }
 
     fn default(&self) -> Option<&str> {
-        self.schema.common.default.as_ref().map(|v| v.as_str()).flatten()
+        self.schema.common.default.as_ref().and_then(|v| v.as_str())
     }
 
     /// If the type should implement Default

--- a/services/autorust/codegen/src/config_parser.rs
+++ b/services/autorust/codegen/src/config_parser.rs
@@ -210,7 +210,7 @@ pub fn to_mod_name(feature_name: &str) -> String {
     if starts_with_number(&name) {
         name = format!("v{}", &name);
     }
-    name.replace("-", "_").replace(".", "_").to_lowercase()
+    name.replace('-', "_").replace('.', "_").to_lowercase()
 }
 
 #[cfg(test)]

--- a/services/autorust/codegen/src/identifier.rs
+++ b/services/autorust/codegen/src/identifier.rs
@@ -61,17 +61,17 @@ pub fn ident(text: &str) -> Result<TokenStream, Error> {
 }
 
 fn remove_spaces(text: &str) -> String {
-    text.replace(" ", "")
+    text.replace(' ', "")
 }
 
 /// replace special characters with underscores
 fn replace_special_chars(text: &str) -> String {
-    let mut txt = text.replace(".", "_");
-    txt = txt.replace(",", "_");
-    txt = txt.replace("-", "_");
-    txt = txt.replace("/", "_");
-    txt = txt.replace("*", "_");
-    txt = txt.replace(":", "_");
+    let mut txt = text.replace('.', "_");
+    txt = txt.replace(',', "_");
+    txt = txt.replace('-', "_");
+    txt = txt.replace('/', "_");
+    txt = txt.replace('*', "_");
+    txt = txt.replace(':', "_");
     txt
 }
 

--- a/services/autorust/codegen/src/lib.rs
+++ b/services/autorust/codegen/src/lib.rs
@@ -226,7 +226,7 @@ pub fn get_svc_readmes() -> Result<Vec<SpecReadme>> {
 }
 
 fn get_service_name(spec_name: &str) -> String {
-    spec_name.replace("azure", "").replace("_", "").replace("-", "").to_lowercase()
+    spec_name.replace("azure", "").replace('_', "").replace('-', "").to_lowercase()
 }
 
 #[cfg(test)]

--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -110,7 +110,8 @@ impl Spec {
         let mut versions: Vec<_> = self
             .docs()
             .values()
-            .filter(|doc| !doc.paths().is_empty()).flat_map(|api| &api.consumes)
+            .filter(|doc| !doc.paths().is_empty())
+            .flat_map(|api| &api.consumes)
             .collect();
         versions.sort_unstable();
         versions

--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -68,7 +68,7 @@ impl Spec {
         let file_path = file_path.as_ref();
         if !docs.contains_key(file_path) {
             let doc = openapi::parse(&file_path)?;
-            let ref_files = openapi::get_reference_file_paths(&file_path.to_path_buf(), &doc);
+            let ref_files = openapi::get_reference_file_paths(file_path, &doc);
             docs.insert(PathBuf::from(file_path), doc);
             for ref_file in ref_files {
                 let child_path = path::join(&file_path, &ref_file).map_err(|source| Error::PathJoin { source })?;
@@ -110,9 +110,7 @@ impl Spec {
         let mut versions: Vec<_> = self
             .docs()
             .values()
-            .filter(|doc| !doc.paths().is_empty())
-            .map(|api| &api.consumes)
-            .flatten()
+            .filter(|doc| !doc.paths().is_empty()).flat_map(|api| &api.consumes)
             .collect();
         versions.sort_unstable();
         versions

--- a/services/autorust/openapi/src/reference.rs
+++ b/services/autorust/openapi/src/reference.rs
@@ -126,7 +126,7 @@ impl Serialize for Reference {
     where
         S: Serializer,
     {
-        let mut str = self.file.clone().unwrap_or_else(String::new);
+        let mut str = self.file.clone().unwrap_or_default();
         let path = &self.path.join("/");
         if !path.is_empty() {
             str.push_str("#/");


### PR DESCRIPTION
This PR addresses clippy issues that break the build starting in 1.59.0.  

Note, this adds to the set of warnings that are ignored in the services code, specifically [unnecessary_to_owned](https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned)