### PR TITLE
[datalake] Remove `Box::pin` where Pageable is returned

### DIFF
--- a/sdk/storage_datalake/src/operations/file_systems_list.rs
+++ b/sdk/storage_datalake/src/operations/file_systems_list.rs
@@ -6,9 +6,8 @@ use azure_core::{
 };
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
-use std::pin::Pin;
 
-type ListFileSystems = Pin<Box<Pageable<ListFileSystemsResponse, azure_core::Error>>>;
+type ListFileSystems = Pageable<ListFileSystemsResponse, azure_core::Error>;
 
 #[derive(Debug, Clone)]
 pub struct ListFileSystemsBuilder {
@@ -79,7 +78,7 @@ impl ListFileSystemsBuilder {
             }
         };
 
-        Box::pin(Pageable::new(make_request))
+        Pageable::new(make_request)
     }
 }
 

--- a/sdk/storage_datalake/src/operations/path_list.rs
+++ b/sdk/storage_datalake/src/operations/path_list.rs
@@ -10,10 +10,9 @@ use azure_core::{
 };
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
-use std::pin::Pin;
 
 /// A future of a delete file response
-type ListPaths = Pin<Box<Pageable<ListPathsResponse, azure_core::Error>>>;
+type ListPaths = Pageable<ListPathsResponse, azure_core::Error>;
 
 #[derive(Debug, Clone)]
 pub struct ListPathsBuilder {
@@ -92,7 +91,7 @@ impl ListPathsBuilder {
             }
         };
 
-        Box::pin(Pageable::new(make_request))
+        Pageable::new(make_request)
     }
 }
 


### PR DESCRIPTION
After #668 we no longer need to wrap the return of `into_stream` in `Box::pin`. This PR removes all such occurrences from the datalake crate.

@thovoll @yoshuawuyts 