### PR TITLE
Downgrade log line from debug to trace

### DIFF
--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -415,7 +415,7 @@ impl StorageAccountClient {
             request.body(azure_core::EMPTY_BODY)
         }?;
 
-        debug!("using request == {:#?}", request);
+        trace!("using request == {:#?}", request);
 
         Ok((request, url))
     }


### PR DESCRIPTION
This statement logs the entire request body, which can be fairly large. I think it should at least be moved down to trace level -- or, if it's not useful to end users, removed.