### PR TITLE
Turn on 'test_e2e' feature for rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "editor.formatOnSave": true
+    "editor.formatOnSave": true,
+    "rust-analyzer.cargo.features": [
+        "test_e2e"
+    ]
 }


### PR DESCRIPTION
For rust-analyzer users this will show enable rust-analyzer features in e2e tests