### PR TITLE
Use the new `IntoFuture` signature on nightly

### DIFF
--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -73,7 +73,7 @@ impl CreateCollectionBuilder {
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateCollectionBuilder {
-    type Future = CreateCollection;
+    type IntoFuture = CreateCollection;
     type Output = <CreateCollection as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -66,7 +66,7 @@ impl CreateDatabaseBuilder {
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateDatabaseBuilder {
-    type Future = CreateDatabase;
+    type IntoFuture = CreateDatabase;
     type Output = <CreateDatabase as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -101,7 +101,7 @@ pub type CreateDocument =
 impl<D: Serialize + CosmosEntity + Send + 'static> std::future::IntoFuture
     for CreateDocumentBuilder<D>
 {
-    type Future = CreateDocument;
+    type IntoFuture = CreateDocument;
     type Output = <CreateDocument as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -90,7 +90,7 @@ pub type CreateOrReplaceAttachment =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateOrReplaceAttachmentBuilder {
-    type Future = CreateOrReplaceAttachment;
+    type IntoFuture = CreateOrReplaceAttachment;
     type Output = <CreateOrReplaceAttachment as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -96,7 +96,7 @@ pub type CreateOrReplaceSlugAttachment =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateOrReplaceSlugAttachmentBuilder {
-    type Future = CreateOrReplaceSlugAttachment;
+    type IntoFuture = CreateOrReplaceSlugAttachment;
     type Output = <CreateOrReplaceSlugAttachment as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -92,7 +92,7 @@ pub type CreateOrReplaceTrigger =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateOrReplaceTriggerBuilder {
-    type Future = CreateOrReplaceTrigger;
+    type IntoFuture = CreateOrReplaceTrigger;
     type Output = <CreateOrReplaceTrigger as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -74,7 +74,7 @@ pub type CreateOrReplaceUserDefinedFunction =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateOrReplaceUserDefinedFunctionBuilder {
-    type Future = CreateOrReplaceUserDefinedFunction;
+    type IntoFuture = CreateOrReplaceUserDefinedFunction;
     type Output = <CreateOrReplaceUserDefinedFunction as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -77,7 +77,7 @@ pub type CreatePermission = futures::future::BoxFuture<'static, crate::Result<Pe
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreatePermissionBuilder {
-    type Future = CreatePermission;
+    type IntoFuture = CreatePermission;
     type Output = <CreatePermission as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -62,7 +62,7 @@ impl CreateStoredProcedureBuilder {
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateStoredProcedureBuilder {
-    type Future = CreateStoredProcedure;
+    type IntoFuture = CreateStoredProcedure;
     type Output = <CreateStoredProcedure as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -56,7 +56,7 @@ pub type CreateUser = futures::future::BoxFuture<'static, crate::Result<UserResp
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateUserBuilder {
-    type Future = CreateUser;
+    type IntoFuture = CreateUser;
     type Output = <CreateUser as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -66,7 +66,7 @@ pub type DeleteAttachment =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteAttachmentBuilder {
-    type Future = DeleteAttachment;
+    type IntoFuture = DeleteAttachment;
     type Output = <DeleteAttachment as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -53,7 +53,7 @@ pub type DeleteCollection =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteCollectionBuilder {
-    type Future = DeleteCollection;
+    type IntoFuture = DeleteCollection;
     type Output = <DeleteCollection as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -54,7 +54,7 @@ pub type DeleteDatabase =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteDatabaseBuilder {
-    type Future = DeleteDatabase;
+    type IntoFuture = DeleteDatabase;
     type Output = <DeleteDatabase as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -73,7 +73,7 @@ pub type DeleteDocument =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteDocumentBuilder {
-    type Future = DeleteDocument;
+    type IntoFuture = DeleteDocument;
     type Output = <DeleteDocument as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -54,7 +54,7 @@ pub type DeletePermission =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeletePermissionBuilder {
-    type Future = DeletePermission;
+    type IntoFuture = DeletePermission;
     type Output = <DeletePermission as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -54,7 +54,7 @@ pub type DeleteStoredProcedure =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteStoredProcedureBuilder {
-    type Future = DeleteStoredProcedure;
+    type IntoFuture = DeleteStoredProcedure;
     type Output = <DeleteStoredProcedure as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -55,7 +55,7 @@ pub type DeleteTrigger = futures::future::BoxFuture<'static, crate::Result<Delet
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteTriggerBuilder {
-    type Future = DeleteTrigger;
+    type IntoFuture = DeleteTrigger;
     type Output = <DeleteTrigger as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -49,7 +49,7 @@ pub type DeleteUser = futures::future::BoxFuture<'static, crate::Result<DeleteUs
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteUserBuilder {
-    type Future = DeleteUser;
+    type IntoFuture = DeleteUser;
     type Output = <DeleteUser as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -54,7 +54,7 @@ impl DeleteUserDefinedFunctionBuilder {
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteUserDefinedFunctionBuilder {
-    type Future = DeleteUserDefinedFunction;
+    type IntoFuture = DeleteUserDefinedFunction;
     type Output = <DeleteUserDefinedFunction as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -63,7 +63,7 @@ impl GetAttachmentBuilder {
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetAttachmentBuilder {
-    type Future = GetAttachment;
+    type IntoFuture = GetAttachment;
     type Output = <GetAttachment as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -55,7 +55,7 @@ pub type GetCollection = futures::future::BoxFuture<'static, crate::Result<GetCo
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetCollectionBuilder {
-    type Future = GetCollection;
+    type IntoFuture = GetCollection;
     type Output = <GetCollection as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -56,7 +56,7 @@ pub type GetDatabase = futures::future::BoxFuture<'static, crate::Result<GetData
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetDatabaseBuilder {
-    type Future = GetDatabase;
+    type IntoFuture = GetDatabase;
     type Output = <GetDatabase as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -69,7 +69,7 @@ pub type GetPartitionKeyRanges =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetPartitionKeyRangesBuilder {
-    type Future = GetPartitionKeyRanges;
+    type IntoFuture = GetPartitionKeyRanges;
     type Output = <GetPartitionKeyRanges as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -50,7 +50,7 @@ pub type GetPermission = futures::future::BoxFuture<'static, crate::Result<Permi
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetPermissionBuilder {
-    type Future = GetPermission;
+    type IntoFuture = GetPermission;
     type Output = <GetPermission as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/get_user.rs
+++ b/sdk/data_cosmos/src/operations/get_user.rs
@@ -49,7 +49,7 @@ pub type GetUser = futures::future::BoxFuture<'static, crate::Result<UserRespons
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetUserBuilder {
-    type Future = GetUser;
+    type IntoFuture = GetUser;
     type Output = <GetUser as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -69,7 +69,7 @@ pub type ReplaceCollection =
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for ReplaceCollectionBuilder {
-    type Future = ReplaceCollection;
+    type IntoFuture = ReplaceCollection;
     type Output = <ReplaceCollection as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -95,7 +95,7 @@ pub type ReplaceDocument =
 
 #[cfg(feature = "into_future")]
 impl<D: Serialize + Send + 'static> std::future::IntoFuture for ReplaceDocumentBuilder<D> {
-    type Future = ReplaceDocument;
+    type IntoFuture = ReplaceDocument;
     type Output = <ReplaceDocument as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -72,7 +72,7 @@ pub type ReplacePermission = futures::future::BoxFuture<'static, crate::Result<P
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for ReplacePermissionBuilder {
-    type Future = ReplacePermission;
+    type IntoFuture = ReplacePermission;
     type Output = <ReplacePermission as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -61,7 +61,7 @@ impl ReplaceStoredProcedureBuilder {
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for ReplaceStoredProcedureBuilder {
-    type Future = ReplaceStoredProcedure;
+    type IntoFuture = ReplaceStoredProcedure;
     type Output = <ReplaceStoredProcedure as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -59,7 +59,7 @@ pub type ReplaceUser = futures::future::BoxFuture<'static, crate::Result<UserRes
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for ReplaceUserBuilder {
-    type Future = ReplaceUser;
+    type IntoFuture = ReplaceUser;
     type Output = <ReplaceUser as std::future::Future>::Output;
     fn into_future(self) -> Self::Future {
         Self::into_future(self)


### PR DESCRIPTION
We changed the signature of `IntoFuture` on nightly in https://github.com/rust-lang/rust/pull/94818. It appears there are no nightly releases with this change yet, but once there are (which shouldn't be more than a few days away) we should merge this to match the new signature. Thanks!