### PR TITLE
Fix the new `IntoFuture` signature

### DIFF
--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -75,7 +75,7 @@ impl CreateCollectionBuilder {
 impl std::future::IntoFuture for CreateCollectionBuilder {
     type IntoFuture = CreateCollection;
     type Output = <CreateCollection as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -68,7 +68,7 @@ impl CreateDatabaseBuilder {
 impl std::future::IntoFuture for CreateDatabaseBuilder {
     type IntoFuture = CreateDatabase;
     type Output = <CreateDatabase as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -103,7 +103,7 @@ impl<D: Serialize + CosmosEntity + Send + 'static> std::future::IntoFuture
 {
     type IntoFuture = CreateDocument;
     type Output = <CreateDocument as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -92,7 +92,7 @@ pub type CreateOrReplaceAttachment =
 impl std::future::IntoFuture for CreateOrReplaceAttachmentBuilder {
     type IntoFuture = CreateOrReplaceAttachment;
     type Output = <CreateOrReplaceAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -98,7 +98,7 @@ pub type CreateOrReplaceSlugAttachment =
 impl std::future::IntoFuture for CreateOrReplaceSlugAttachmentBuilder {
     type IntoFuture = CreateOrReplaceSlugAttachment;
     type Output = <CreateOrReplaceSlugAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -94,7 +94,7 @@ pub type CreateOrReplaceTrigger =
 impl std::future::IntoFuture for CreateOrReplaceTriggerBuilder {
     type IntoFuture = CreateOrReplaceTrigger;
     type Output = <CreateOrReplaceTrigger as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -76,7 +76,7 @@ pub type CreateOrReplaceUserDefinedFunction =
 impl std::future::IntoFuture for CreateOrReplaceUserDefinedFunctionBuilder {
     type IntoFuture = CreateOrReplaceUserDefinedFunction;
     type Output = <CreateOrReplaceUserDefinedFunction as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -79,7 +79,7 @@ pub type CreatePermission = futures::future::BoxFuture<'static, crate::Result<Pe
 impl std::future::IntoFuture for CreatePermissionBuilder {
     type IntoFuture = CreatePermission;
     type Output = <CreatePermission as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -64,7 +64,7 @@ impl CreateStoredProcedureBuilder {
 impl std::future::IntoFuture for CreateStoredProcedureBuilder {
     type IntoFuture = CreateStoredProcedure;
     type Output = <CreateStoredProcedure as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -58,7 +58,7 @@ pub type CreateUser = futures::future::BoxFuture<'static, crate::Result<UserResp
 impl std::future::IntoFuture for CreateUserBuilder {
     type IntoFuture = CreateUser;
     type Output = <CreateUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -68,7 +68,7 @@ pub type DeleteAttachment =
 impl std::future::IntoFuture for DeleteAttachmentBuilder {
     type IntoFuture = DeleteAttachment;
     type Output = <DeleteAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -55,7 +55,7 @@ pub type DeleteCollection =
 impl std::future::IntoFuture for DeleteCollectionBuilder {
     type IntoFuture = DeleteCollection;
     type Output = <DeleteCollection as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -56,7 +56,7 @@ pub type DeleteDatabase =
 impl std::future::IntoFuture for DeleteDatabaseBuilder {
     type IntoFuture = DeleteDatabase;
     type Output = <DeleteDatabase as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -75,7 +75,7 @@ pub type DeleteDocument =
 impl std::future::IntoFuture for DeleteDocumentBuilder {
     type IntoFuture = DeleteDocument;
     type Output = <DeleteDocument as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -56,7 +56,7 @@ pub type DeletePermission =
 impl std::future::IntoFuture for DeletePermissionBuilder {
     type IntoFuture = DeletePermission;
     type Output = <DeletePermission as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -56,7 +56,7 @@ pub type DeleteStoredProcedure =
 impl std::future::IntoFuture for DeleteStoredProcedureBuilder {
     type IntoFuture = DeleteStoredProcedure;
     type Output = <DeleteStoredProcedure as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -57,7 +57,7 @@ pub type DeleteTrigger = futures::future::BoxFuture<'static, crate::Result<Delet
 impl std::future::IntoFuture for DeleteTriggerBuilder {
     type IntoFuture = DeleteTrigger;
     type Output = <DeleteTrigger as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -51,7 +51,7 @@ pub type DeleteUser = futures::future::BoxFuture<'static, crate::Result<DeleteUs
 impl std::future::IntoFuture for DeleteUserBuilder {
     type IntoFuture = DeleteUser;
     type Output = <DeleteUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -56,7 +56,7 @@ impl DeleteUserDefinedFunctionBuilder {
 impl std::future::IntoFuture for DeleteUserDefinedFunctionBuilder {
     type IntoFuture = DeleteUserDefinedFunction;
     type Output = <DeleteUserDefinedFunction as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -65,7 +65,7 @@ impl GetAttachmentBuilder {
 impl std::future::IntoFuture for GetAttachmentBuilder {
     type IntoFuture = GetAttachment;
     type Output = <GetAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -57,7 +57,7 @@ pub type GetCollection = futures::future::BoxFuture<'static, crate::Result<GetCo
 impl std::future::IntoFuture for GetCollectionBuilder {
     type IntoFuture = GetCollection;
     type Output = <GetCollection as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -58,7 +58,7 @@ pub type GetDatabase = futures::future::BoxFuture<'static, crate::Result<GetData
 impl std::future::IntoFuture for GetDatabaseBuilder {
     type IntoFuture = GetDatabase;
     type Output = <GetDatabase as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -71,7 +71,7 @@ pub type GetPartitionKeyRanges =
 impl std::future::IntoFuture for GetPartitionKeyRangesBuilder {
     type IntoFuture = GetPartitionKeyRanges;
     type Output = <GetPartitionKeyRanges as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -52,7 +52,7 @@ pub type GetPermission = futures::future::BoxFuture<'static, crate::Result<Permi
 impl std::future::IntoFuture for GetPermissionBuilder {
     type IntoFuture = GetPermission;
     type Output = <GetPermission as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/get_user.rs
+++ b/sdk/data_cosmos/src/operations/get_user.rs
@@ -51,7 +51,7 @@ pub type GetUser = futures::future::BoxFuture<'static, crate::Result<UserRespons
 impl std::future::IntoFuture for GetUserBuilder {
     type IntoFuture = GetUser;
     type Output = <GetUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -71,7 +71,7 @@ pub type ReplaceCollection =
 impl std::future::IntoFuture for ReplaceCollectionBuilder {
     type IntoFuture = ReplaceCollection;
     type Output = <ReplaceCollection as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -97,7 +97,7 @@ pub type ReplaceDocument =
 impl<D: Serialize + Send + 'static> std::future::IntoFuture for ReplaceDocumentBuilder<D> {
     type IntoFuture = ReplaceDocument;
     type Output = <ReplaceDocument as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -74,7 +74,7 @@ pub type ReplacePermission = futures::future::BoxFuture<'static, crate::Result<P
 impl std::future::IntoFuture for ReplacePermissionBuilder {
     type IntoFuture = ReplacePermission;
     type Output = <ReplacePermission as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -63,7 +63,7 @@ impl ReplaceStoredProcedureBuilder {
 impl std::future::IntoFuture for ReplaceStoredProcedureBuilder {
     type IntoFuture = ReplaceStoredProcedure;
     type Output = <ReplaceStoredProcedure as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -61,7 +61,7 @@ pub type ReplaceUser = futures::future::BoxFuture<'static, crate::Result<UserRes
 impl std::future::IntoFuture for ReplaceUserBuilder {
     type IntoFuture = ReplaceUser;
     type Output = <ReplaceUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::Future {
+    fn into_future(self) -> Self::IntoFuture {
         Self::into_future(self)
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/Azure/azure-sdk-for-rust/pull/686. One of the downsides of not having CI run on unstable changes is that if you forget something the compiler doesn't catch it. I forgot to update the return type 😅 . This should fix it proper. Thanks!