### PR TITLE
Better header insertion handling

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -25,6 +25,29 @@ pub trait AddAsHeader {
     ) -> Result<(), crate::errors::HttpHeaderError>;
 }
 
+impl<T> AddAsHeader for Option<T>
+where
+    T: AddAsHeader,
+{
+    fn add_as_header(&self, builder: Builder) -> Builder {
+        if let Some(h) = self {
+            h.add_as_header(builder)
+        } else {
+            builder
+        }
+    }
+
+    fn add_as_header2(
+        &self,
+        request: &mut crate::Request,
+    ) -> Result<(), crate::errors::HttpHeaderError> {
+        if let Some(h) = self {
+            h.add_as_header2(request)?;
+        }
+        Ok(())
+    }
+}
+
 #[must_use]
 pub fn add_optional_header_ref<T: AddAsHeader>(item: &Option<&T>, mut builder: Builder) -> Builder {
     if let Some(item) = item {

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -1,4 +1,7 @@
-use crate::SeekableStream;
+use crate::{
+    error::{ErrorKind, ResultExt},
+    AddAsHeader, SeekableStream,
+};
 use http::{HeaderMap, Method, Uri};
 use std::fmt::Debug;
 
@@ -52,6 +55,14 @@ impl Request {
 
     pub fn method(&self) -> Method {
         self.method.clone()
+    }
+
+    pub fn insert_header<T: AddAsHeader + Debug>(&mut self, h: &T) -> crate::error::Result<()> {
+        h.add_as_header2(self)
+            .with_context(ErrorKind::DataConversion, || {
+                format!("could not encode '{:?}' as an http header", h)
+            })?;
+        Ok(())
     }
 
     pub fn headers(&self) -> &HeaderMap {

--- a/sdk/core/src/request_options/continuation.rs
+++ b/sdk/core/src/request_options/continuation.rs
@@ -1,18 +1,22 @@
 use crate::{headers, AddAsHeader};
 use http::request::Builder;
 
-#[derive(Debug, Clone, Copy)]
-pub struct Continuation<'a>(&'a str);
+#[derive(Debug, Clone)]
+pub struct Continuation(String);
 
-impl<'a> Continuation<'a> {
-    pub fn new(c: &'a str) -> Self {
+impl Continuation {
+    pub fn new(c: String) -> Self {
         Self(c)
+    }
+
+    pub fn into_raw(self) -> String {
+        self.0
     }
 }
 
-impl AddAsHeader for Continuation<'_> {
+impl AddAsHeader for Continuation {
     fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::CONTINUATION, self.0)
+        builder.header(headers::CONTINUATION, &self.0)
     }
 
     fn add_as_header2(
@@ -21,7 +25,7 @@ impl AddAsHeader for Continuation<'_> {
     ) -> Result<(), crate::errors::HttpHeaderError> {
         request
             .headers_mut()
-            .append(headers::CONTINUATION, http::HeaderValue::from_str(self.0)?);
+            .append(headers::CONTINUATION, http::HeaderValue::from_str(&self.0)?);
 
         Ok(())
     }

--- a/sdk/core/src/request_options/next_marker.rs
+++ b/sdk/core/src/request_options/next_marker.rs
@@ -1,5 +1,7 @@
 use crate::{AppendToUrlQuery, Error, HttpHeaderError};
 
+use super::Continuation;
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NextMarker(String);
 
@@ -44,6 +46,12 @@ impl NextMarker {
 impl AppendToUrlQuery for NextMarker {
     fn append_to_url_query(&self, url: &mut url::Url) {
         url.query_pairs_mut().append_pair("marker", &self.0);
+    }
+}
+
+impl From<Continuation> for NextMarker {
+    fn from(next_marker: Continuation) -> Self {
+        Self::new(next_marker.into_raw())
     }
 }
 

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -45,9 +45,7 @@ impl CreateDatabaseBuilder {
                 id: self.database_name.as_str(),
             };
 
-            if let Some(ref h) = self.consistency_level {
-                request.insert_header(h)?;
-            }
+            request.insert_header(&self.consistency_level)?;
             request.set_body(bytes::Bytes::from(serde_json::to_string(&body)?).into());
 
             let response = self

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -45,13 +45,9 @@ impl CreateDatabaseBuilder {
                 id: self.database_name.as_str(),
             };
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)
-                .with_context(ErrorKind::DataConversion, || {
-                    format!(
-                        "could not encode '{:?}' as an http header",
-                        self.consistency_level
-                    )
-                })?;
+            if let Some(ref h) = self.consistency_level {
+                request.insert_header(h)?;
+            }
             request.set_body(bytes::Bytes::from(serde_json::to_string(&body)?).into());
 
             let response = self

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -65,9 +65,7 @@ impl ListAttachmentsBuilder {
                     &mut request,
                 );
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -41,9 +41,7 @@ impl ListCollectionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -5,7 +5,7 @@ use crate::ResourceQuota;
 use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use azure_core::prelude::*;
 use azure_core::Response as HttpResponse;
-use azure_core::{collect_pinned_stream, headers, Pageable};
+use azure_core::{collect_pinned_stream, Pageable};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
@@ -33,7 +33,7 @@ impl ListCollectionsBuilder {
     }
 
     pub fn into_stream(self) -> ListCollections {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
@@ -41,10 +41,8 @@ impl ListCollectionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(c) = continuation {
-                    let h = http::HeaderValue::from_str(c.as_str())
-                        .map_err(azure_core::HttpHeaderError::InvalidHeaderValue)?;
-                    request.headers_mut().append(headers::CONTINUATION, h);
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
                 }
 
                 let response = this

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -41,13 +41,9 @@ impl ListDatabasesBuilder {
                 let mut request = this
                     .client
                     .prepare_request_pipeline("dbs", http::Method::GET);
-                if let Some(ref h) = this.consistency_level {
-                    request.insert_header(h)?;
-                }
+                request.insert_header(&this.consistency_level)?;
                 request.insert_header(&this.max_item_count)?;
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -48,9 +48,7 @@ impl ListPermissionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -3,9 +3,7 @@ use crate::prelude::*;
 use crate::resources::Permission;
 use crate::resources::ResourceType;
 use azure_core::collect_pinned_stream;
-use azure_core::headers::{
-    self, continuation_token_from_headers_optional, session_token_from_headers,
-};
+use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use azure_core::prelude::*;
 use azure_core::{Pageable, Response as HttpResponse};
 
@@ -34,7 +32,7 @@ impl ListPermissionsBuilder {
     }
 
     pub fn into_stream(self) -> ListPermissions {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
@@ -50,10 +48,8 @@ impl ListPermissionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(c) = continuation {
-                    let h = http::HeaderValue::from_str(c.as_str())
-                        .map_err(azure_core::HttpHeaderError::InvalidHeaderValue)?;
-                    request.headers_mut().append(headers::CONTINUATION, h);
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
                 }
 
                 let response = this

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -4,7 +4,6 @@ use crate::resources::ResourceType;
 use crate::resources::StoredProcedure;
 use crate::ResourceQuota;
 use azure_core::collect_pinned_stream;
-use azure_core::headers;
 use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
 use azure_core::prelude::*;
 use azure_core::{Pageable, Response as HttpResponse};
@@ -35,7 +34,7 @@ impl ListStoredProceduresBuilder {
     }
 
     pub fn into_stream(self) -> ListStoredProcedures {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
@@ -51,10 +50,8 @@ impl ListStoredProceduresBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(c) = continuation {
-                    let h = http::HeaderValue::from_str(c.as_str())
-                        .map_err(azure_core::HttpHeaderError::InvalidHeaderValue)?;
-                    request.headers_mut().append(headers::CONTINUATION, h);
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
                 }
 
                 let response = this

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -50,9 +50,7 @@ impl ListStoredProceduresBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -54,9 +54,7 @@ impl ListTriggersBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -7,7 +7,7 @@ use azure_core::collect_pinned_stream;
 use azure_core::headers::{
     continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
 };
-use azure_core::{headers, prelude::*, Pageable, Response as HttpResponse};
+use azure_core::{prelude::*, Pageable, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
@@ -38,7 +38,7 @@ impl ListUserDefinedFunctionsBuilder {
     }
 
     pub fn into_stream(self) -> ListUserDefinedFunctions {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
@@ -55,10 +55,8 @@ impl ListUserDefinedFunctionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(c) = continuation {
-                    let h = http::HeaderValue::from_str(c.as_str())
-                        .map_err(azure_core::HttpHeaderError::InvalidHeaderValue)?;
-                    request.headers_mut().append(headers::CONTINUATION, h);
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
                 }
 
                 let response = this

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -55,9 +55,7 @@ impl ListUserDefinedFunctionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -1,13 +1,14 @@
 use crate::headers::from_headers::{activity_id_from_headers, request_charge_from_headers};
 use crate::prelude::*;
 use crate::resources::User;
+use azure_core::prelude::Continuation;
 use azure_core::{
     collect_pinned_stream,
     headers::{continuation_token_from_headers_optional, session_token_from_headers},
     prelude::MaxItemCount,
     Response as HttpResponse, SessionToken,
 };
-use azure_core::{headers, Context, Continuable, Pageable};
+use azure_core::{Context, Continuable, Pageable};
 
 #[derive(Debug, Clone)]
 pub struct ListUsersBuilder {
@@ -34,7 +35,7 @@ impl ListUsersBuilder {
     }
 
     pub fn into_stream(self) -> ListUsers {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
@@ -46,11 +47,9 @@ impl ListUsersBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(c) = continuation {
-                    let h = http::HeaderValue::from_str(c.as_str())
-                        .map_err(azure_core::HttpHeaderError::InvalidHeaderValue)?;
-                    request.headers_mut().append(headers::CONTINUATION, h);
-                }
+                if let Some(ref c) = continuation {
+ request.insert_header(c)?;
+}
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -47,9 +47,7 @@ impl ListUsersBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
- request.insert_header(c)?;
-}
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -111,9 +111,7 @@ impl QueryDocumentsBuilder {
                     );
                 }
 
-                if let Some(ref c) = continuation {
- request.insert_header(c)?;
-}
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -6,8 +6,7 @@ use crate::resources::ResourceType;
 use crate::ResourceQuota;
 use azure_core::collect_pinned_stream;
 use azure_core::headers::{
-    self, continuation_token_from_headers_optional, item_count_from_headers,
-    session_token_from_headers,
+    continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
 };
 use azure_core::prelude::*;
 use azure_core::Pageable;
@@ -72,7 +71,7 @@ impl QueryDocumentsBuilder {
     where
         T: DeserializeOwned,
     {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
@@ -112,11 +111,9 @@ impl QueryDocumentsBuilder {
                     );
                 }
 
-                if let Some(c) = continuation {
-                    let h = http::HeaderValue::from_str(c.as_str())
-                        .map_err(azure_core::HttpHeaderError::InvalidHeaderValue)?;
-                    request.headers_mut().append(headers::CONTINUATION, h);
-                }
+                if let Some(ref c) = continuation {
+ request.insert_header(c)?;
+}
 
                 let response = this
                     .client

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -672,7 +672,7 @@ impl ServiceClient {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let query_builder = iot_hub.query();
     /// ```
-    pub fn query(&self) -> QueryBuilder<'_, '_> {
+    pub fn query(&self) -> QueryBuilder<'_> {
         QueryBuilder::new(self)
     }
 

--- a/sdk/iot_hub/src/service/requests/query_builder.rs
+++ b/sdk/iot_hub/src/service/requests/query_builder.rs
@@ -16,13 +16,13 @@ struct QueryBody {
 }
 
 /// Builder for creating queries
-pub struct QueryBuilder<'a, 'b> {
+pub struct QueryBuilder<'a> {
     service_client: &'a ServiceClient,
     max_item_count: MaxItemCount,
-    continuation: Option<Continuation<'b>>,
+    continuation: Option<Continuation>,
 }
 
-impl<'a, 'b> QueryBuilder<'a, 'b> {
+impl<'a> QueryBuilder<'a> {
     /// Create a new query struct
     pub(crate) fn new(service_client: &'a ServiceClient) -> Self {
         Self {
@@ -33,7 +33,7 @@ impl<'a, 'b> QueryBuilder<'a, 'b> {
     }
 
     azure_core::setters! {
-        continuation: &'b str => Some(Continuation::new(continuation)),
+        continuation: String => Some(Continuation::new(continuation)),
         max_item_count: i32 => MaxItemCount::new(max_item_count),
     }
 

--- a/sdk/storage_datalake/src/operations/file_systems_list.rs
+++ b/sdk/storage_datalake/src/operations/file_systems_list.rs
@@ -43,7 +43,7 @@ impl ListFileSystemsBuilder {
     }
 
     pub fn into_stream(self) -> ListFileSystems {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone().unwrap_or_default();
 

--- a/sdk/storage_datalake/src/operations/path_list.rs
+++ b/sdk/storage_datalake/src/operations/path_list.rs
@@ -54,7 +54,7 @@ impl ListPathsBuilder {
     }
 
     pub fn into_stream(self) -> ListPaths {
-        let make_request = move |continuation: Option<String>| {
+        let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
             let ctx = self.context.clone();
 


### PR DESCRIPTION
*Worked on with @yoshuawuyts 🎉*

Better handling of how we add headers to requests.

### Before

```rust
azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)
   .with_context(ErrorKind::DataConversion, || {
      format!(
        "could not encode '{:?}' as an http header",
        self.consistency_level
       )
   })?;
```

### After

```rust
request.insert_header(&self.consistency_level)?;
```

*This PR is best reviewed commit by commit.*
