### PR TITLE
Better header handling

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -7,9 +7,7 @@ pub use utilities::*;
 
 /// View a type as an HTTP header.
 ///
-/// Ad interim we require two functions: `add_as_header` and `add_as_header2`. Make sure
-/// your implementations are functionally equivalent between the two. In other words, the
-/// effect should be the same regardless of which function the SDK calls.
+/// Ad interim there are two default functions: `add_as_header` and `add_to_request`.
 ///
 /// While not restricted by the type system, please add HTTP headers only. In particular, do not
 /// interact with the body of the request.
@@ -20,11 +18,11 @@ pub trait Header {
     fn name(&self) -> &'static str;
     fn value(&self) -> String;
 
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         builder.header(self.name(), self.value())
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut crate::Request,
     ) -> Result<(), crate::errors::HttpHeaderError> {
@@ -51,7 +49,7 @@ where
             .expect("tried to get optional header when None")
     }
 
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         if let Some(h) = self {
             builder.header(h.name(), h.value())
         } else {
@@ -59,7 +57,7 @@ where
         }
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut crate::Request,
     ) -> Result<(), crate::errors::HttpHeaderError> {
@@ -75,7 +73,7 @@ where
 #[must_use]
 pub fn add_optional_header_ref<T: Header>(item: &Option<&T>, mut builder: Builder) -> Builder {
     if let Some(item) = item {
-        builder = item.add_as_header(builder);
+        builder = item.add_to_builder(builder);
     }
     builder
 }
@@ -83,7 +81,7 @@ pub fn add_optional_header_ref<T: Header>(item: &Option<&T>, mut builder: Builde
 #[must_use]
 pub fn add_optional_header<T: Header>(item: &Option<T>, mut builder: Builder) -> Builder {
     if let Some(item) = item {
-        builder = item.add_as_header(builder);
+        builder = item.add_to_builder(builder);
     }
     builder
 }
@@ -93,21 +91,21 @@ pub fn add_optional_header2<T: Header>(
     request: &mut crate::Request,
 ) -> Result<(), crate::errors::HttpHeaderError> {
     if let Some(item) = item {
-        item.add_as_header2(request)?
+        item.add_to_request(request)?
     }
     Ok(())
 }
 
 #[must_use]
 pub fn add_mandatory_header<T: Header>(item: &T, builder: Builder) -> Builder {
-    item.add_as_header(builder)
+    item.add_to_builder(builder)
 }
 
 pub fn add_mandatory_header2<T: Header>(
     item: &T,
     request: &mut crate::Request,
 ) -> Result<(), crate::errors::HttpHeaderError> {
-    item.add_as_header2(request)
+    item.add_to_request(request)
 }
 
 pub const ACCOUNT_KIND: &str = "x-ms-account-kind";

--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -50,21 +50,6 @@ where
 pub trait Header {
     fn name(&self) -> HeaderName;
     fn value(&self) -> HeaderValue;
-
-    fn add_to_builder(&self, builder: Builder) -> Builder {
-        builder.header(self.name().as_str(), self.value().as_str())
-    }
-
-    fn add_to_request(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().insert(
-            self.name(),
-            http::HeaderValue::from_str(&self.value().as_str())?,
-        );
-        Ok(())
-    }
 }
 
 /// A collection of headers
@@ -202,7 +187,7 @@ impl From<&HeaderValue> for http::header::HeaderValue {
 #[must_use]
 pub fn add_optional_header_ref<T: Header>(item: &Option<&T>, mut builder: Builder) -> Builder {
     if let Some(item) = item {
-        builder = item.add_to_builder(builder);
+        builder = builder.header(item.name().as_str(), item.value().as_str())
     }
     builder
 }
@@ -210,7 +195,7 @@ pub fn add_optional_header_ref<T: Header>(item: &Option<&T>, mut builder: Builde
 #[must_use]
 pub fn add_optional_header<T: Header>(item: &Option<T>, mut builder: Builder) -> Builder {
     if let Some(item) = item {
-        builder = item.add_to_builder(builder);
+        builder = builder.header(item.name().as_str(), item.value().as_str())
     }
     builder
 }
@@ -230,21 +215,28 @@ pub fn add_optional_header2<T: Header>(
     request: &mut crate::Request,
 ) -> Result<(), crate::errors::HttpHeaderError> {
     if let Some(item) = item {
-        item.add_to_request(request)?
+        request.headers_mut().insert(
+            item.name(),
+            http::HeaderValue::from_str(&item.value().as_str())?,
+        );
     }
     Ok(())
 }
 
 #[must_use]
 pub fn add_mandatory_header<T: Header>(item: &T, builder: Builder) -> Builder {
-    item.add_to_builder(builder)
+    builder.header(item.name().as_str(), item.value().as_str())
 }
 
 pub fn add_mandatory_header2<T: Header>(
     item: &T,
     request: &mut crate::Request,
 ) -> Result<(), crate::errors::HttpHeaderError> {
-    item.add_to_request(request)
+    request.headers_mut().insert(
+        item.name(),
+        http::HeaderValue::from_str(&item.value().as_str())?,
+    );
+    Ok(())
 }
 
 pub const ACCOUNT_KIND: &str = "x-ms-account-kind";

--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -187,6 +187,12 @@ impl From<String> for HeaderValue {
     }
 }
 
+impl From<&String> for HeaderValue {
+    fn from(s: &String) -> Self {
+        Self(std::borrow::Cow::Owned(s.clone()))
+    }
+}
+
 impl From<&HeaderValue> for http::header::HeaderValue {
     fn from(n: &HeaderValue) -> Self {
         http::header::HeaderValue::from_bytes(n.as_str().as_bytes()).unwrap()

--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -56,14 +56,6 @@ impl Headers {
         self.0.insert(key.into(), value.into());
     }
 
-    pub fn append<K, V>(&mut self, key: K, value: V)
-    where
-        K: Into<HeaderName>,
-        V: Into<HeaderValue>,
-    {
-        self.0.insert(key.into(), value.into());
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)> {
         self.0.iter()
     }

--- a/sdk/core/src/http_client.rs
+++ b/sdk/core/src/http_client.rs
@@ -149,8 +149,8 @@ impl HttpClient for reqwest::Client {
     ) -> Result<crate::Response, HttpError> {
         let url = url::Url::parse(&request.uri().to_string())?;
         let mut reqwest_request = self.request(request.method(), url);
-        for header in request.headers() {
-            reqwest_request = reqwest_request.header(header.0, header.1);
+        for (name, value) in request.headers().iter() {
+            reqwest_request = reqwest_request.header(name, value);
         }
 
         // We clone the body since we need to give ownership of it to Reqwest.

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -39,7 +39,6 @@ pub mod parsing;
 pub mod prelude;
 pub mod util;
 
-use headers::*;
 use uuid::Uuid;
 
 pub use bytes_stream::*;
@@ -47,7 +46,7 @@ pub use constants::*;
 pub use context::Context;
 pub use errors::*;
 #[doc(inline)]
-pub use headers::AddAsHeader;
+pub use headers::Header;
 pub use http_client::{new_http_client, to_json, HttpClient};
 pub use models::*;
 pub use options::*;

--- a/sdk/core/src/mock/mock_request.rs
+++ b/sdk/core/src/mock/mock_request.rs
@@ -1,5 +1,5 @@
 use crate::{Body, Request};
-use http::{HeaderMap, Method, Uri};
+use http::{Method, Uri};
 use serde::de::Visitor;
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use serde::{Deserialize, Deserializer};
@@ -78,19 +78,15 @@ impl<'de> Visitor<'de> for RequestVisitor {
 
         let body = base64::decode(&body.1).map_err(serde::de::Error::custom)?;
 
-        let mut hm = HeaderMap::new();
+        let mut hm = std::collections::HashMap::new();
         for (k, v) in headers.1.into_iter() {
-            hm.append(
-                http::header::HeaderName::from_lowercase(k.as_bytes())
-                    .map_err(serde::de::Error::custom)?,
-                http::HeaderValue::from_str(&v).map_err(serde::de::Error::custom)?,
-            );
+            hm.insert(k.to_owned().into(), v.into());
         }
 
         Ok(Self::Value {
             uri: Uri::from_str(uri.1).expect("expected a valid uri"),
             method: Method::from_str(method.1).expect("expected a valid HTTP method"),
-            headers: hm,
+            headers: hm.into(),
             body: bytes::Bytes::from(body).into(),
         })
     }
@@ -104,9 +100,9 @@ impl Serialize for Request {
         let mut hm = std::collections::BTreeMap::new();
         for (h, v) in self.headers().iter() {
             if h.as_str().to_lowercase() == "authorization" {
-                hm.insert(h.to_string(), "<<STRIPPED>>");
+                hm.insert(h.as_str(), "<<STRIPPED>>");
             } else {
-                hm.insert(h.to_string(), v.to_str().unwrap());
+                hm.insert(h.as_str(), v.as_str());
             }
         }
 

--- a/sdk/core/src/mock/player_policy.rs
+++ b/sdk/core/src/mock/player_policy.rs
@@ -101,8 +101,8 @@ impl Policy for MockTransportPlayerPolicy {
             if actual_header_value != expected_header_value {
                 return Err(super::MockFrameworkError::MismatchedRequestHeader(
                     actual_header_key.as_str().to_owned(),
-                    actual_header_value.to_str().unwrap().to_owned(),
-                    expected_header_value.to_str().unwrap().to_owned(),
+                    actual_header_value.as_str().to_owned(),
+                    expected_header_value.as_str().to_owned(),
                 )
                 .into());
             }

--- a/sdk/core/src/policies/custom_headers_policy.rs
+++ b/sdk/core/src/policies/custom_headers_policy.rs
@@ -1,14 +1,14 @@
+use crate::headers::Headers;
 use crate::policies::{Policy, PolicyResult};
 use crate::{Context, Request};
-use http::header::HeaderMap;
 use std::sync::Arc;
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct CustomHeaders(pub HeaderMap);
+#[derive(Debug, Clone)]
+pub struct CustomHeaders(Headers);
 
-impl From<HeaderMap> for CustomHeaders {
-    fn from(header_map: HeaderMap) -> Self {
-        Self(header_map)
+impl From<Headers> for CustomHeaders {
+    fn from(h: Headers) -> Self {
+        Self(h)
     }
 }
 
@@ -34,7 +34,7 @@ impl Policy for CustomHeadersPolicy {
                     );
                     request
                         .headers_mut()
-                        .insert(header_name, header_value.to_owned());
+                        .insert(header_name.clone(), header_value.clone());
                 });
         }
 

--- a/sdk/core/src/prelude.rs
+++ b/sdk/core/src/prelude.rs
@@ -1,4 +1,4 @@
 //! The Azure Core prelude.
 
 pub use crate::request_options::*;
-pub use crate::{AddAsHeader, AppendToUrlQuery, Context, Continuable};
+pub use crate::{Header, AppendToUrlQuery, Context, Continuable};

--- a/sdk/core/src/prelude.rs
+++ b/sdk/core/src/prelude.rs
@@ -1,4 +1,4 @@
 //! The Azure Core prelude.
 
 pub use crate::request_options::*;
-pub use crate::{Header, AppendToUrlQuery, Context, Continuable};
+pub use crate::{AppendToUrlQuery, Context, Continuable, Header};

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -1,4 +1,4 @@
-use crate::headers::{Header, Headers};
+use crate::headers::{AsHeaders, Header, Headers};
 use crate::{
     error::{ErrorKind, ResultExt},
     SeekableStream,
@@ -66,31 +66,10 @@ impl Request {
         Ok(())
     }
 
-    pub fn maybe_insert_header<T: Header + Debug>(
-        &mut self,
-        header: Option<&T>,
-    ) -> crate::error::Result<()> {
-        if let Some(h) = header {
-            self.insert_header(h)?;
+    pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) {
+        for (name, value) in headers.as_headers() {
+            self.headers_mut().insert(name, value)
         }
-        Ok(())
-    }
-
-    pub fn insert_headers<T: Header + Debug>(&mut self, headers: &[T]) -> crate::error::Result<()> {
-        for header in headers {
-            self.insert_header(header)?;
-        }
-        Ok(())
-    }
-
-    pub fn maybe_insert_headers<T: Header + Debug>(
-        &mut self,
-        headers: Option<&[T]>,
-    ) -> crate::error::Result<()> {
-        if let Some(hs) = headers {
-            self.insert_headers(hs)?;
-        }
-        Ok(())
     }
 
     pub fn headers(&self) -> &Headers {

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -66,9 +66,29 @@ impl Request {
         Ok(())
     }
 
+    pub fn maybe_insert_header<T: Header + Debug>(
+        &mut self,
+        header: Option<&T>,
+    ) -> crate::error::Result<()> {
+        if let Some(h) = header {
+            self.insert_header(h)?;
+        }
+        Ok(())
+    }
+
     pub fn insert_headers<T: Header + Debug>(&mut self, headers: &[T]) -> crate::error::Result<()> {
         for header in headers {
             self.insert_header(header)?;
+        }
+        Ok(())
+    }
+
+    pub fn maybe_insert_headers<T: Header + Debug>(
+        &mut self,
+        headers: Option<&[T]>,
+    ) -> crate::error::Result<()> {
+        if let Some(hs) = headers {
+            self.insert_headers(hs)?;
         }
         Ok(())
     }

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -1,8 +1,5 @@
-use crate::headers::{AsHeaders, Header, Headers};
-use crate::{
-    error::{ErrorKind, ResultExt},
-    SeekableStream,
-};
+use crate::headers::{AsHeaders, Headers};
+use crate::SeekableStream;
 use http::{Method, Uri};
 use std::fmt::Debug;
 
@@ -56,14 +53,6 @@ impl Request {
 
     pub fn method(&self) -> Method {
         self.method.clone()
-    }
-
-    pub fn insert_header<T: Header + Debug>(&mut self, h: &T) -> crate::error::Result<()> {
-        h.add_to_request(self)
-            .with_context(ErrorKind::DataConversion, || {
-                format!("could not encode '{:?}' as an http header", h)
-            })?;
-        Ok(())
     }
 
     pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) {

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -58,7 +58,7 @@ impl Request {
     }
 
     pub fn insert_header<T: Header + Debug>(&mut self, h: &T) -> crate::error::Result<()> {
-        h.add_as_header2(self)
+        h.add_to_request(self)
             .with_context(ErrorKind::DataConversion, || {
                 format!("could not encode '{:?}' as an http header", h)
             })?;

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{ErrorKind, ResultExt},
-    AddAsHeader, SeekableStream,
+    Header, SeekableStream,
 };
 use http::{HeaderMap, Method, Uri};
 use std::fmt::Debug;
@@ -57,7 +57,7 @@ impl Request {
         self.method.clone()
     }
 
-    pub fn insert_header<T: AddAsHeader + Debug>(&mut self, h: &T) -> crate::error::Result<()> {
+    pub fn insert_header<T: Header + Debug>(&mut self, h: &T) -> crate::error::Result<()> {
         h.add_as_header2(self)
             .with_context(ErrorKind::DataConversion, || {
                 format!("could not encode '{:?}' as an http header", h)

--- a/sdk/core/src/request_options/activity_id.rs
+++ b/sdk/core/src/request_options/activity_id.rs
@@ -1,5 +1,4 @@
-use crate::{headers, AddAsHeader};
-use http::request::Builder;
+use crate::{headers, Header};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ActivityId<'a>(&'a str);
@@ -10,18 +9,12 @@ impl<'a> ActivityId<'a> {
     }
 }
 
-impl<'a> AddAsHeader for ActivityId<'a> {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::ACTIVITY_ID, self.0)
+impl<'a> Header for ActivityId<'a> {
+    fn name(&self) -> &'static str {
+        headers::ACTIVITY_ID
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request
-            .headers_mut()
-            .append(headers::ACTIVITY_ID, http::HeaderValue::from_str(self.0)?);
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }

--- a/sdk/core/src/request_options/activity_id.rs
+++ b/sdk/core/src/request_options/activity_id.rs
@@ -1,4 +1,4 @@
-use crate::{headers, Header};
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ActivityId<'a>(&'a str);
@@ -10,11 +10,11 @@ impl<'a> ActivityId<'a> {
 }
 
 impl<'a> Header for ActivityId<'a> {
-    fn name(&self) -> &'static str {
-        headers::ACTIVITY_ID
+    fn name(&self) -> headers::HeaderName {
+        headers::ACTIVITY_ID.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/client_request_id.rs
+++ b/sdk/core/src/request_options/client_request_id.rs
@@ -23,11 +23,11 @@ impl From<&str> for ClientRequestId {
 }
 
 impl Header for ClientRequestId {
-    fn name(&self) -> &'static str {
-        headers::CLIENT_REQUEST_ID
+    fn name(&self) -> headers::HeaderName {
+        headers::CLIENT_REQUEST_ID.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/client_request_id.rs
+++ b/sdk/core/src/request_options/client_request_id.rs
@@ -1,6 +1,5 @@
-use crate::headers::*;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::headers;
+use crate::Header;
 
 #[derive(Debug, Clone)]
 pub struct ClientRequestId(String);
@@ -23,19 +22,12 @@ impl From<&str> for ClientRequestId {
     }
 }
 
-impl AddAsHeader for ClientRequestId {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(CLIENT_REQUEST_ID, &self.0)
+impl Header for ClientRequestId {
+    fn name(&self) -> &'static str {
+        headers::CLIENT_REQUEST_ID
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request
-            .headers_mut()
-            .append(CLIENT_REQUEST_ID, http::HeaderValue::from_str(&self.0)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }

--- a/sdk/core/src/request_options/content_disposition.rs
+++ b/sdk/core/src/request_options/content_disposition.rs
@@ -1,5 +1,4 @@
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentDisposition<'a>(&'a str);
@@ -13,20 +12,12 @@ where
     }
 }
 
-impl<'a> AddAsHeader for ContentDisposition<'a> {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(http::header::CONTENT_DISPOSITION, self.0)
+impl<'a> Header for ContentDisposition<'a> {
+    fn name(&self) -> &'static str {
+        http::header::CONTENT_DISPOSITION.as_str()
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            http::header::CONTENT_DISPOSITION,
-            http::HeaderValue::from_str(self.0)?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }

--- a/sdk/core/src/request_options/content_disposition.rs
+++ b/sdk/core/src/request_options/content_disposition.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentDisposition<'a>(&'a str);
@@ -13,11 +13,11 @@ where
 }
 
 impl<'a> Header for ContentDisposition<'a> {
-    fn name(&self) -> &'static str {
-        http::header::CONTENT_DISPOSITION.as_str()
+    fn name(&self) -> headers::HeaderName {
+        http::header::CONTENT_DISPOSITION.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/content_encoding.rs
+++ b/sdk/core/src/request_options/content_encoding.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentEncoding<'a>(&'a str);
@@ -13,11 +13,11 @@ where
 }
 
 impl<'a> Header for ContentEncoding<'a> {
-    fn name(&self) -> &'static str {
-        http::header::CONTENT_ENCODING.as_str()
+    fn name(&self) -> headers::HeaderName {
+        http::header::CONTENT_ENCODING.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/content_encoding.rs
+++ b/sdk/core/src/request_options/content_encoding.rs
@@ -1,5 +1,4 @@
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentEncoding<'a>(&'a str);
@@ -13,20 +12,12 @@ where
     }
 }
 
-impl<'a> AddAsHeader for ContentEncoding<'a> {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(http::header::CONTENT_ENCODING, self.0)
+impl<'a> Header for ContentEncoding<'a> {
+    fn name(&self) -> &'static str {
+        http::header::CONTENT_ENCODING.as_str()
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            http::header::CONTENT_ENCODING,
-            http::HeaderValue::from_str(self.0)?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }

--- a/sdk/core/src/request_options/content_language.rs
+++ b/sdk/core/src/request_options/content_language.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentLanguage<'a>(&'a str);
@@ -13,11 +13,11 @@ where
 }
 
 impl<'a> Header for ContentLanguage<'a> {
-    fn name(&self) -> &'static str {
-        http::header::CONTENT_LANGUAGE.as_str()
+    fn name(&self) -> headers::HeaderName {
+        http::header::CONTENT_LANGUAGE.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/content_language.rs
+++ b/sdk/core/src/request_options/content_language.rs
@@ -1,5 +1,4 @@
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentLanguage<'a>(&'a str);
@@ -13,20 +12,12 @@ where
     }
 }
 
-impl<'a> AddAsHeader for ContentLanguage<'a> {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(http::header::CONTENT_LANGUAGE, self.0)
+impl<'a> Header for ContentLanguage<'a> {
+    fn name(&self) -> &'static str {
+        http::header::CONTENT_LANGUAGE.as_str()
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            http::header::CONTENT_LANGUAGE,
-            http::HeaderValue::from_str(self.0)?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }

--- a/sdk/core/src/request_options/content_length.rs
+++ b/sdk/core/src/request_options/content_length.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentLength(i32);
@@ -10,12 +10,12 @@ impl ContentLength {
 }
 
 impl Header for ContentLength {
-    fn name(&self) -> &'static str {
-        http::header::CONTENT_LENGTH.as_str()
+    fn name(&self) -> headers::HeaderName {
+        http::header::CONTENT_LENGTH.into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         let count = if self.0 < 0 { -1 } else { self.0 };
-        format!("{}", count)
+        format!("{}", count).into()
     }
 }

--- a/sdk/core/src/request_options/content_length.rs
+++ b/sdk/core/src/request_options/content_length.rs
@@ -1,5 +1,4 @@
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 
 #[derive(Debug, Clone, Copy)]
 pub struct ContentLength(i32);
@@ -10,26 +9,13 @@ impl ContentLength {
     }
 }
 
-impl AddAsHeader for ContentLength {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        if self.0 <= 0 {
-            builder.header(http::header::CONTENT_LENGTH, -1)
-        } else {
-            builder.header(http::header::CONTENT_LENGTH, self.0)
-        }
+impl Header for ContentLength {
+    fn name(&self) -> &'static str {
+        http::header::CONTENT_LENGTH.as_str()
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        if self.0 >= 0 {
-            let (header_name, header_value) = (http::header::CONTENT_LENGTH, self.0);
-            request
-                .headers_mut()
-                .append(header_name, http::HeaderValue::from(header_value));
-        };
-
-        Ok(())
+    fn value(&self) -> String {
+        let count = if self.0 < 0 { -1 } else { self.0 };
+        format!("{}", count)
     }
 }

--- a/sdk/core/src/request_options/content_type.rs
+++ b/sdk/core/src/request_options/content_type.rs
@@ -1,5 +1,4 @@
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContentType<'a>(&'a str);
@@ -23,20 +22,12 @@ where
     }
 }
 
-impl<'a> AddAsHeader for ContentType<'a> {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(http::header::CONTENT_TYPE, self.0)
+impl<'a> Header for ContentType<'a> {
+    fn name(&self) -> &'static str {
+        http::header::CONTENT_TYPE.as_str()
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            http::header::CONTENT_TYPE,
-            http::HeaderValue::from_str(self.0)?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }

--- a/sdk/core/src/request_options/content_type.rs
+++ b/sdk/core/src/request_options/content_type.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContentType<'a>(&'a str);
@@ -23,11 +23,11 @@ where
 }
 
 impl<'a> Header for ContentType<'a> {
-    fn name(&self) -> &'static str {
-        http::header::CONTENT_TYPE.as_str()
+    fn name(&self) -> headers::HeaderName {
+        http::header::CONTENT_TYPE.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/continuation.rs
+++ b/sdk/core/src/request_options/continuation.rs
@@ -14,11 +14,11 @@ impl Continuation {
 }
 
 impl Header for Continuation {
-    fn name(&self) -> &'static str {
-        headers::CONTINUATION
+    fn name(&self) -> headers::HeaderName {
+        headers::CONTINUATION.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/continuation.rs
+++ b/sdk/core/src/request_options/continuation.rs
@@ -1,5 +1,4 @@
-use crate::{headers, AddAsHeader};
-use http::request::Builder;
+use crate::{headers, Header};
 
 #[derive(Debug, Clone)]
 pub struct Continuation(String);
@@ -14,19 +13,12 @@ impl Continuation {
     }
 }
 
-impl AddAsHeader for Continuation {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::CONTINUATION, &self.0)
+impl Header for Continuation {
+    fn name(&self) -> &'static str {
+        headers::CONTINUATION
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request
-            .headers_mut()
-            .append(headers::CONTINUATION, http::HeaderValue::from_str(&self.0)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }

--- a/sdk/core/src/request_options/if_match_condition.rs
+++ b/sdk/core/src/request_options/if_match_condition.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 use http::header::{IF_MATCH, IF_NONE_MATCH};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -8,17 +8,18 @@ pub enum IfMatchCondition {
 }
 
 impl Header for IfMatchCondition {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         match self {
-            IfMatchCondition::Match(_) => IF_MATCH.as_str(),
-            IfMatchCondition::NotMatch(_) => IF_NONE_MATCH.as_str(),
+            IfMatchCondition::Match(_) => IF_MATCH.into(),
+            IfMatchCondition::NotMatch(_) => IF_NONE_MATCH.into(),
         }
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self.clone() {
             IfMatchCondition::Match(etag) => etag,
             IfMatchCondition::NotMatch(etag) => etag,
         }
+        .into()
     }
 }

--- a/sdk/core/src/request_options/if_match_condition.rs
+++ b/sdk/core/src/request_options/if_match_condition.rs
@@ -1,6 +1,5 @@
-use crate::AddAsHeader;
+use crate::Header;
 use http::header::{IF_MATCH, IF_NONE_MATCH};
-use http::request::Builder;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IfMatchCondition {
@@ -8,27 +7,18 @@ pub enum IfMatchCondition {
     NotMatch(String),
 }
 
-impl AddAsHeader for IfMatchCondition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+impl Header for IfMatchCondition {
+    fn name(&self) -> &'static str {
         match self {
-            IfMatchCondition::Match(etag) => builder.header(IF_MATCH, etag),
-            IfMatchCondition::NotMatch(etag) => builder.header(IF_NONE_MATCH, etag),
+            IfMatchCondition::Match(_) => IF_MATCH.as_str(),
+            IfMatchCondition::NotMatch(_) => IF_NONE_MATCH.as_str(),
         }
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            IfMatchCondition::Match(etag) => (IF_MATCH, etag),
-            IfMatchCondition::NotMatch(etag) => (IF_NONE_MATCH, etag),
-        };
-
-        request
-            .headers_mut()
-            .append(header_name, http::HeaderValue::from_str(header_value)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        match self.clone() {
+            IfMatchCondition::Match(etag) => etag,
+            IfMatchCondition::NotMatch(etag) => etag,
+        }
     }
 }

--- a/sdk/core/src/request_options/if_modified_since.rs
+++ b/sdk/core/src/request_options/if_modified_since.rs
@@ -1,7 +1,5 @@
-use crate::AddAsHeader;
+use crate::Header;
 use chrono::{DateTime, Utc};
-use http::header::IF_MODIFIED_SINCE;
-use http::request::Builder;
 
 #[derive(Debug, Clone, Copy)]
 pub struct IfModifiedSince(DateTime<Utc>);
@@ -12,20 +10,12 @@ impl IfModifiedSince {
     }
 }
 
-impl AddAsHeader for IfModifiedSince {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(IF_MODIFIED_SINCE, self.0.to_rfc2822())
+impl Header for IfModifiedSince {
+    fn name(&self) -> &'static str {
+        http::header::IF_MODIFIED_SINCE.as_str()
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            IF_MODIFIED_SINCE,
-            http::HeaderValue::from_str(&self.0.to_rfc2822())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_rfc2822()
     }
 }

--- a/sdk/core/src/request_options/if_modified_since.rs
+++ b/sdk/core/src/request_options/if_modified_since.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, Copy)]
@@ -11,11 +11,11 @@ impl IfModifiedSince {
 }
 
 impl Header for IfModifiedSince {
-    fn name(&self) -> &'static str {
-        http::header::IF_MODIFIED_SINCE.as_str()
+    fn name(&self) -> headers::HeaderName {
+        http::header::IF_MODIFIED_SINCE.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_rfc2822()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_rfc2822().into()
     }
 }

--- a/sdk/core/src/request_options/if_modified_since_condition.rs
+++ b/sdk/core/src/request_options/if_modified_since_condition.rs
@@ -1,7 +1,6 @@
-use crate::AddAsHeader;
+use crate::Header;
 use chrono::{DateTime, Utc};
 use http::header::{IF_MODIFIED_SINCE, IF_UNMODIFIED_SINCE};
-use http::request::Builder;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum IfModifiedSinceCondition {
@@ -9,37 +8,18 @@ pub enum IfModifiedSinceCondition {
     Unmodified(DateTime<Utc>),
 }
 
-impl AddAsHeader for IfModifiedSinceCondition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+impl Header for IfModifiedSinceCondition {
+    fn name(&self) -> &'static str {
         match self {
-            IfModifiedSinceCondition::Modified(date) => {
-                builder.header(IF_MODIFIED_SINCE, &date.to_rfc2822() as &str)
-            }
-            IfModifiedSinceCondition::Unmodified(date) => {
-                builder.header(IF_UNMODIFIED_SINCE, &date.to_rfc2822() as &str)
-            }
+            IfModifiedSinceCondition::Modified(_) => IF_MODIFIED_SINCE.as_str(),
+            IfModifiedSinceCondition::Unmodified(_) => IF_UNMODIFIED_SINCE.as_str(),
         }
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
+    fn value(&self) -> String {
         match self {
-            IfModifiedSinceCondition::Modified(date) => {
-                request.headers_mut().append(
-                    IF_MODIFIED_SINCE,
-                    http::HeaderValue::from_str(&date.to_rfc2822() as &str)?,
-                );
-            }
-            IfModifiedSinceCondition::Unmodified(date) => {
-                request.headers_mut().append(
-                    IF_UNMODIFIED_SINCE,
-                    http::HeaderValue::from_str(&date.to_rfc2822() as &str)?,
-                );
-            }
+            IfModifiedSinceCondition::Modified(date) => date.to_rfc2822(),
+            IfModifiedSinceCondition::Unmodified(date) => date.to_rfc2822(),
         }
-
-        Ok(())
     }
 }

--- a/sdk/core/src/request_options/if_modified_since_condition.rs
+++ b/sdk/core/src/request_options/if_modified_since_condition.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 use chrono::{DateTime, Utc};
 use http::header::{IF_MODIFIED_SINCE, IF_UNMODIFIED_SINCE};
 
@@ -9,17 +9,18 @@ pub enum IfModifiedSinceCondition {
 }
 
 impl Header for IfModifiedSinceCondition {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         match self {
-            IfModifiedSinceCondition::Modified(_) => IF_MODIFIED_SINCE.as_str(),
-            IfModifiedSinceCondition::Unmodified(_) => IF_UNMODIFIED_SINCE.as_str(),
+            IfModifiedSinceCondition::Modified(_) => IF_MODIFIED_SINCE.into(),
+            IfModifiedSinceCondition::Unmodified(_) => IF_UNMODIFIED_SINCE.into(),
         }
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self {
             IfModifiedSinceCondition::Modified(date) => date.to_rfc2822(),
             IfModifiedSinceCondition::Unmodified(date) => date.to_rfc2822(),
         }
+        .into()
     }
 }

--- a/sdk/core/src/request_options/if_source_match_condition.rs
+++ b/sdk/core/src/request_options/if_source_match_condition.rs
@@ -1,5 +1,4 @@
-use crate::headers;
-use crate::Header;
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IfSourceMatchCondition {
@@ -8,17 +7,19 @@ pub enum IfSourceMatchCondition {
 }
 
 impl Header for IfSourceMatchCondition {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         match self {
             IfSourceMatchCondition::Match(_) => headers::SOURCE_IF_MATCH,
             IfSourceMatchCondition::NotMatch(_) => headers::SOURCE_IF_NONE_MATCH,
         }
+        .into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self.clone() {
             IfSourceMatchCondition::Match(etag) => etag,
             IfSourceMatchCondition::NotMatch(etag) => etag,
         }
+        .into()
     }
 }

--- a/sdk/core/src/request_options/if_source_match_condition.rs
+++ b/sdk/core/src/request_options/if_source_match_condition.rs
@@ -1,6 +1,5 @@
-use crate::headers::*;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::headers;
+use crate::Header;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IfSourceMatchCondition {
@@ -8,27 +7,18 @@ pub enum IfSourceMatchCondition {
     NotMatch(String),
 }
 
-impl AddAsHeader for IfSourceMatchCondition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+impl Header for IfSourceMatchCondition {
+    fn name(&self) -> &'static str {
         match self {
-            IfSourceMatchCondition::Match(etag) => builder.header(SOURCE_IF_MATCH, etag),
-            IfSourceMatchCondition::NotMatch(etag) => builder.header(SOURCE_IF_NONE_MATCH, etag),
+            IfSourceMatchCondition::Match(_) => headers::SOURCE_IF_MATCH,
+            IfSourceMatchCondition::NotMatch(_) => headers::SOURCE_IF_NONE_MATCH,
         }
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            IfSourceMatchCondition::Match(etag) => (SOURCE_IF_MATCH, etag),
-            IfSourceMatchCondition::NotMatch(etag) => (SOURCE_IF_NONE_MATCH, etag),
-        };
-
-        request
-            .headers_mut()
-            .append(header_name, http::HeaderValue::from_str(header_value)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        match self.clone() {
+            IfSourceMatchCondition::Match(etag) => etag,
+            IfSourceMatchCondition::NotMatch(etag) => etag,
+        }
     }
 }

--- a/sdk/core/src/request_options/if_source_modified_since_condition.rs
+++ b/sdk/core/src/request_options/if_source_modified_since_condition.rs
@@ -1,5 +1,4 @@
-use crate::headers;
-use crate::Header;
+use crate::headers::{self, Header};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -9,17 +8,19 @@ pub enum IfSourceModifiedSinceCondition {
 }
 
 impl Header for IfSourceModifiedSinceCondition {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         match self {
             IfSourceModifiedSinceCondition::Modified(_) => headers::SOURCE_IF_MODIFIED_SINCE,
             IfSourceModifiedSinceCondition::Unmodified(_) => headers::SOURCE_IF_UNMODIFIED_SINCE,
         }
+        .into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self {
             IfSourceModifiedSinceCondition::Modified(date) => date.to_rfc2822(),
             IfSourceModifiedSinceCondition::Unmodified(date) => date.to_rfc2822(),
         }
+        .into()
     }
 }

--- a/sdk/core/src/request_options/if_source_modified_since_condition.rs
+++ b/sdk/core/src/request_options/if_source_modified_since_condition.rs
@@ -1,7 +1,6 @@
-use crate::headers::*;
-use crate::AddAsHeader;
+use crate::headers;
+use crate::Header;
 use chrono::{DateTime, Utc};
-use http::request::Builder;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum IfSourceModifiedSinceCondition {
@@ -9,35 +8,18 @@ pub enum IfSourceModifiedSinceCondition {
     Unmodified(DateTime<Utc>),
 }
 
-impl AddAsHeader for IfSourceModifiedSinceCondition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+impl Header for IfSourceModifiedSinceCondition {
+    fn name(&self) -> &'static str {
         match self {
-            IfSourceModifiedSinceCondition::Modified(date) => {
-                builder.header(SOURCE_IF_MODIFIED_SINCE, &date.to_rfc2822() as &str)
-            }
-            IfSourceModifiedSinceCondition::Unmodified(date) => {
-                builder.header(SOURCE_IF_UNMODIFIED_SINCE, &date.to_rfc2822() as &str)
-            }
+            IfSourceModifiedSinceCondition::Modified(_) => headers::SOURCE_IF_MODIFIED_SINCE,
+            IfSourceModifiedSinceCondition::Unmodified(_) => headers::SOURCE_IF_UNMODIFIED_SINCE,
         }
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            IfSourceModifiedSinceCondition::Modified(date) => {
-                (SOURCE_IF_MODIFIED_SINCE, date.to_rfc2822())
-            }
-            IfSourceModifiedSinceCondition::Unmodified(date) => {
-                (SOURCE_IF_UNMODIFIED_SINCE, date.to_rfc2822())
-            }
-        };
-
-        request
-            .headers_mut()
-            .append(header_name, http::HeaderValue::from_str(&header_value)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        match self {
+            IfSourceModifiedSinceCondition::Modified(date) => date.to_rfc2822(),
+            IfSourceModifiedSinceCondition::Unmodified(date) => date.to_rfc2822(),
+        }
     }
 }

--- a/sdk/core/src/request_options/lease.rs
+++ b/sdk/core/src/request_options/lease.rs
@@ -1,5 +1,4 @@
-use crate::headers::*;
-use crate::Header;
+use crate::headers::{self, Header};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -21,11 +20,11 @@ impl std::str::FromStr for LeaseId {
 }
 
 impl Header for LeaseId {
-    fn name(&self) -> &'static str {
-        LEASE_ID
+    fn name(&self) -> headers::HeaderName {
+        headers::LEASE_ID.into()
     }
 
-    fn value(&self) -> String {
-        format!("{}", self.0)
+    fn value(&self) -> headers::HeaderValue {
+        format!("{}", self.0).into()
     }
 }

--- a/sdk/core/src/request_options/lease.rs
+++ b/sdk/core/src/request_options/lease.rs
@@ -1,6 +1,5 @@
 use crate::headers::*;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -21,19 +20,12 @@ impl std::str::FromStr for LeaseId {
     }
 }
 
-impl AddAsHeader for LeaseId {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(LEASE_ID, &format!("{}", self.0))
+impl Header for LeaseId {
+    fn name(&self) -> &'static str {
+        LEASE_ID
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request
-            .headers_mut()
-            .append(LEASE_ID, http::HeaderValue::from_str(&self.0.to_string())?);
-
-        Ok(())
+    fn value(&self) -> String {
+        format!("{}", self.0)
     }
 }

--- a/sdk/core/src/request_options/lease_break_period.rs
+++ b/sdk/core/src/request_options/lease_break_period.rs
@@ -1,6 +1,5 @@
 use crate::headers::*;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy)]
@@ -12,20 +11,12 @@ impl From<Duration> for LeaseBreakPeriod {
     }
 }
 
-impl AddAsHeader for LeaseBreakPeriod {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(LEASE_BREAK_PERIOD, &format!("{}", self.0.as_secs()))
+impl Header for LeaseBreakPeriod {
+    fn name(&self) -> &'static str {
+        LEASE_BREAK_PERIOD
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            LEASE_BREAK_PERIOD,
-            http::HeaderValue::from(self.0.as_secs()),
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        format!("{}", self.0.as_secs())
     }
 }

--- a/sdk/core/src/request_options/lease_break_period.rs
+++ b/sdk/core/src/request_options/lease_break_period.rs
@@ -1,5 +1,4 @@
-use crate::headers::*;
-use crate::Header;
+use crate::headers::{self, Header};
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy)]
@@ -12,11 +11,11 @@ impl From<Duration> for LeaseBreakPeriod {
 }
 
 impl Header for LeaseBreakPeriod {
-    fn name(&self) -> &'static str {
-        LEASE_BREAK_PERIOD
+    fn name(&self) -> headers::HeaderName {
+        headers::LEASE_BREAK_PERIOD.into()
     }
 
-    fn value(&self) -> String {
-        format!("{}", self.0.as_secs())
+    fn value(&self) -> headers::HeaderValue {
+        format!("{}", self.0.as_secs()).into()
     }
 }

--- a/sdk/core/src/request_options/lease_duration.rs
+++ b/sdk/core/src/request_options/lease_duration.rs
@@ -1,6 +1,5 @@
 use crate::headers::*;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -9,30 +8,18 @@ pub enum LeaseDuration {
     Seconds(u8),
 }
 
-impl AddAsHeader for LeaseDuration {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        match self {
-            LeaseDuration::Infinite => builder.header(LEASE_DURATION, "-1"),
-            LeaseDuration::Seconds(seconds) => {
-                builder.header(LEASE_DURATION, &format!("{}", seconds))
-            }
-        }
+impl Header for LeaseDuration {
+    fn name(&self) -> &'static str {
+        LEASE_DURATION
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            LeaseDuration::Infinite => (LEASE_DURATION, -1),
-            LeaseDuration::Seconds(seconds) => (LEASE_DURATION, *seconds as i32),
-        };
-
-        request
-            .headers_mut()
-            .append(header_name, http::HeaderValue::from(header_value));
-
-        Ok(())
+    fn value(&self) -> String {
+        match self {
+            LeaseDuration::Infinite => "-1".to_owned(),
+            LeaseDuration::Seconds(seconds) => {
+                format!("{}", seconds)
+            }
+        }
     }
 }
 

--- a/sdk/core/src/request_options/lease_duration.rs
+++ b/sdk/core/src/request_options/lease_duration.rs
@@ -1,5 +1,4 @@
-use crate::headers::*;
-use crate::Header;
+use crate::headers::{self, Header};
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -9,17 +8,18 @@ pub enum LeaseDuration {
 }
 
 impl Header for LeaseDuration {
-    fn name(&self) -> &'static str {
-        LEASE_DURATION
+    fn name(&self) -> headers::HeaderName {
+        headers::LEASE_DURATION.into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self {
             LeaseDuration::Infinite => "-1".to_owned(),
             LeaseDuration::Seconds(seconds) => {
                 format!("{}", seconds)
             }
         }
+        .into()
     }
 }
 

--- a/sdk/core/src/request_options/max_item_count.rs
+++ b/sdk/core/src/request_options/max_item_count.rs
@@ -1,5 +1,4 @@
-use crate::headers;
-use crate::Header;
+use crate::headers::{self, Header};
 
 /// The max number of items in the collection
 #[derive(Debug, Clone, Copy)]
@@ -13,12 +12,12 @@ impl MaxItemCount {
 }
 
 impl Header for MaxItemCount {
-    fn name(&self) -> &'static str {
-        headers::MAX_ITEM_COUNT
+    fn name(&self) -> headers::HeaderName {
+        headers::MAX_ITEM_COUNT.into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         let count = if self.0 <= 0 { -1 } else { self.0 };
-        format!("{}", count)
+        format!("{}", count).into()
     }
 }

--- a/sdk/core/src/request_options/max_item_count.rs
+++ b/sdk/core/src/request_options/max_item_count.rs
@@ -1,6 +1,5 @@
 use crate::headers;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 
 /// The max number of items in the collection
 #[derive(Debug, Clone, Copy)]
@@ -13,29 +12,13 @@ impl MaxItemCount {
     }
 }
 
-impl AddAsHeader for MaxItemCount {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        if self.0 <= 0 {
-            builder.header(headers::MAX_ITEM_COUNT, -1)
-        } else {
-            builder.header(headers::MAX_ITEM_COUNT, self.0)
-        }
+impl Header for MaxItemCount {
+    fn name(&self) -> &'static str {
+        headers::MAX_ITEM_COUNT
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        let (header_name, header_value) = if self.0 <= 0 {
-            (headers::MAX_ITEM_COUNT, -1)
-        } else {
-            (headers::MAX_ITEM_COUNT, self.0)
-        };
-
-        request
-            .headers_mut()
-            .append(header_name, http::HeaderValue::from(header_value));
-
-        Ok(())
+    fn value(&self) -> String {
+        let count = if self.0 <= 0 { -1 } else { self.0 };
+        format!("{}", count)
     }
 }

--- a/sdk/core/src/request_options/metadata.rs
+++ b/sdk/core/src/request_options/metadata.rs
@@ -1,4 +1,4 @@
-use crate::AddAsHeader;
+use crate::Header;
 use bytes::Bytes;
 use http::request::Builder;
 use http::HeaderMap;
@@ -45,7 +45,15 @@ impl Metadata {
     }
 }
 
-impl AddAsHeader for &Metadata {
+impl Header for &Metadata {
+    fn name(&self) -> &'static str {
+        todo!("Handle multiple headers")
+    }
+
+    fn value(&self) -> String {
+        todo!("Handle multiple headers")
+    }
+
     fn add_as_header(&self, builder: Builder) -> Builder {
         let mut builder = builder;
 

--- a/sdk/core/src/request_options/metadata.rs
+++ b/sdk/core/src/request_options/metadata.rs
@@ -54,7 +54,7 @@ impl Header for &Metadata {
         todo!("Handle multiple headers")
     }
 
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         let mut builder = builder;
 
         for (key, val) in self.0.iter() {
@@ -64,7 +64,7 @@ impl Header for &Metadata {
         builder
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut crate::Request,
     ) -> Result<(), crate::errors::HttpHeaderError> {

--- a/sdk/core/src/request_options/proposed_lease_id.rs
+++ b/sdk/core/src/request_options/proposed_lease_id.rs
@@ -1,6 +1,5 @@
 use super::LeaseId;
-use crate::{headers, AddAsHeader};
-use http::request::Builder;
+use crate::{headers, Header};
 
 #[derive(Debug, Clone, Copy)]
 pub struct ProposedLeaseId(LeaseId);
@@ -11,20 +10,12 @@ impl From<LeaseId> for ProposedLeaseId {
     }
 }
 
-impl AddAsHeader for ProposedLeaseId {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::PROPOSED_LEASE_ID, &format!("{}", self.0))
+impl Header for ProposedLeaseId {
+    fn name(&self) -> &'static str {
+        headers::PROPOSED_LEASE_ID
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            crate::PROPOSED_LEASE_ID,
-            http::HeaderValue::from_str(&format!("{}", self.0))?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        format!("{}", self.0)
     }
 }

--- a/sdk/core/src/request_options/proposed_lease_id.rs
+++ b/sdk/core/src/request_options/proposed_lease_id.rs
@@ -11,11 +11,11 @@ impl From<LeaseId> for ProposedLeaseId {
 }
 
 impl Header for ProposedLeaseId {
-    fn name(&self) -> &'static str {
-        headers::PROPOSED_LEASE_ID
+    fn name(&self) -> headers::HeaderName {
+        headers::PROPOSED_LEASE_ID.into()
     }
 
-    fn value(&self) -> String {
-        format!("{}", self.0)
+    fn value(&self) -> headers::HeaderValue {
+        format!("{}", self.0).into()
     }
 }

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -1,4 +1,5 @@
-use crate::{Header, ParseError};
+use crate::headers::{self, Header};
+use crate::ParseError;
 use http::request::Builder;
 use std::convert::From;
 use std::fmt;
@@ -80,11 +81,11 @@ impl fmt::Display for Range {
 }
 
 impl<'a> Header for Range {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         todo!("Handle multiple headers")
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         todo!("Handle multiple headers")
     }
 

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -104,13 +104,13 @@ impl<'a> Header for Range {
         &self,
         request: &mut crate::Request,
     ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
+        request.headers_mut().insert(
             "x-ms-range",
             http::HeaderValue::from_str(&format!("{}", self))?,
         );
 
         if self.len() < 1024 * 1024 * 4 {
-            request.headers_mut().append(
+            request.headers_mut().insert(
                 "x-ms-range-get-content-crc64",
                 http::HeaderValue::from_str("true")?,
             );

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -90,7 +90,7 @@ impl<'a> Header for Range {
 
     // here we ask for the CRC64 value if we can (that is,
     // if the range is smaller than 4MB).
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         let builder = builder.header("x-ms-range", &format!("{}", self));
         if self.len() < 1024 * 1024 * 4 {
             builder.header("x-ms-range-get-content-crc64", "true")
@@ -99,7 +99,7 @@ impl<'a> Header for Range {
         }
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut crate::Request,
     ) -> Result<(), crate::errors::HttpHeaderError> {

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -1,4 +1,4 @@
-use crate::{AddAsHeader, ParseError};
+use crate::{Header, ParseError};
 use http::request::Builder;
 use std::convert::From;
 use std::fmt;
@@ -79,7 +79,15 @@ impl fmt::Display for Range {
     }
 }
 
-impl<'a> AddAsHeader for Range {
+impl<'a> Header for Range {
+    fn name(&self) -> &'static str {
+        todo!("Handle multiple headers")
+    }
+
+    fn value(&self) -> String {
+        todo!("Handle multiple headers")
+    }
+
     // here we ask for the CRC64 value if we can (that is,
     // if the range is smaller than 4MB).
     fn add_as_header(&self, builder: Builder) -> Builder {

--- a/sdk/core/src/request_options/sequence_number.rs
+++ b/sdk/core/src/request_options/sequence_number.rs
@@ -1,5 +1,5 @@
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::headers;
+use crate::Header;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct SequenceNumber(u64);
@@ -16,20 +16,12 @@ impl From<u64> for SequenceNumber {
     }
 }
 
-impl AddAsHeader for SequenceNumber {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(crate::BLOB_SEQUENCE_NUMBER, &format!("{}", self.0))
+impl Header for SequenceNumber {
+    fn name(&self) -> &'static str {
+        headers::BLOB_SEQUENCE_NUMBER
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            crate::BLOB_SEQUENCE_NUMBER,
-            http::HeaderValue::from_str(&format!("{}", self.0))?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_string()
     }
 }

--- a/sdk/core/src/request_options/sequence_number.rs
+++ b/sdk/core/src/request_options/sequence_number.rs
@@ -1,5 +1,4 @@
-use crate::headers;
-use crate::Header;
+use crate::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct SequenceNumber(u64);
@@ -17,11 +16,11 @@ impl From<u64> for SequenceNumber {
 }
 
 impl Header for SequenceNumber {
-    fn name(&self) -> &'static str {
-        headers::BLOB_SEQUENCE_NUMBER
+    fn name(&self) -> headers::HeaderName {
+        headers::BLOB_SEQUENCE_NUMBER.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_string()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_string().into()
     }
 }

--- a/sdk/core/src/request_options/sequence_number_condition.rs
+++ b/sdk/core/src/request_options/sequence_number_condition.rs
@@ -1,6 +1,5 @@
 use crate::headers::*;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::Header;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SequenceNumberCondition {
@@ -9,35 +8,20 @@ pub enum SequenceNumberCondition {
     Equal(u64),
 }
 
-impl AddAsHeader for SequenceNumberCondition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+impl Header for SequenceNumberCondition {
+    fn name(&self) -> &'static str {
         match self {
-            SequenceNumberCondition::Equal(val) => {
-                builder.header(IF_SEQUENCE_NUMBER_EQ, &val.to_string() as &str)
-            }
-            SequenceNumberCondition::LessOrEqual(val) => {
-                builder.header(IF_SEQUENCE_NUMBER_LE, &val.to_string() as &str)
-            }
-            SequenceNumberCondition::Less(val) => {
-                builder.header(IF_SEQUENCE_NUMBER_LT, &val.to_string() as &str)
-            }
+            SequenceNumberCondition::Equal(_) => IF_SEQUENCE_NUMBER_EQ,
+            SequenceNumberCondition::LessOrEqual(_) => IF_SEQUENCE_NUMBER_LE,
+            SequenceNumberCondition::Less(_) => IF_SEQUENCE_NUMBER_LT,
         }
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        let (header_name, val) = match self {
-            SequenceNumberCondition::Equal(val) => (IF_SEQUENCE_NUMBER_EQ, val),
-            SequenceNumberCondition::LessOrEqual(val) => (IF_SEQUENCE_NUMBER_LE, val),
-            SequenceNumberCondition::Less(val) => (IF_SEQUENCE_NUMBER_LT, val),
-        };
-
-        request
-            .headers_mut()
-            .append(header_name, http::HeaderValue::from_str(&val.to_string())?);
-
-        Ok(())
+    fn value(&self) -> String {
+        match self {
+            SequenceNumberCondition::Equal(val) => val.to_string(),
+            SequenceNumberCondition::LessOrEqual(val) => val.to_string(),
+            SequenceNumberCondition::Less(val) => val.to_string(),
+        }
     }
 }

--- a/sdk/core/src/request_options/sequence_number_condition.rs
+++ b/sdk/core/src/request_options/sequence_number_condition.rs
@@ -1,5 +1,4 @@
-use crate::headers::*;
-use crate::Header;
+use crate::{headers, Header};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SequenceNumberCondition {
@@ -9,19 +8,21 @@ pub enum SequenceNumberCondition {
 }
 
 impl Header for SequenceNumberCondition {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         match self {
-            SequenceNumberCondition::Equal(_) => IF_SEQUENCE_NUMBER_EQ,
-            SequenceNumberCondition::LessOrEqual(_) => IF_SEQUENCE_NUMBER_LE,
-            SequenceNumberCondition::Less(_) => IF_SEQUENCE_NUMBER_LT,
+            SequenceNumberCondition::Equal(_) => headers::IF_SEQUENCE_NUMBER_EQ,
+            SequenceNumberCondition::LessOrEqual(_) => headers::IF_SEQUENCE_NUMBER_LE,
+            SequenceNumberCondition::Less(_) => headers::IF_SEQUENCE_NUMBER_LT,
         }
+        .into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self {
             SequenceNumberCondition::Equal(val) => val.to_string(),
             SequenceNumberCondition::LessOrEqual(val) => val.to_string(),
             SequenceNumberCondition::Less(val) => val.to_string(),
         }
+        .into()
     }
 }

--- a/sdk/core/src/request_options/source_lease_id.rs
+++ b/sdk/core/src/request_options/source_lease_id.rs
@@ -1,6 +1,5 @@
-use crate::headers::*;
-use crate::AddAsHeader;
-use http::request::Builder;
+use crate::headers;
+use crate::Header;
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -21,20 +20,12 @@ impl std::str::FromStr for SourceLeaseId {
     }
 }
 
-impl AddAsHeader for SourceLeaseId {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(SOURCE_LEASE_ID, &format!("{}", self.0))
+impl Header for SourceLeaseId {
+    fn name(&self) -> &'static str {
+        headers::SOURCE_LEASE_ID
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request.headers_mut().append(
-            SOURCE_LEASE_ID,
-            http::HeaderValue::from_str(&format!("{}", self.0))?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_string()
     }
 }

--- a/sdk/core/src/request_options/source_lease_id.rs
+++ b/sdk/core/src/request_options/source_lease_id.rs
@@ -1,5 +1,4 @@
-use crate::headers;
-use crate::Header;
+use crate::headers::{self, Header};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -21,11 +20,11 @@ impl std::str::FromStr for SourceLeaseId {
 }
 
 impl Header for SourceLeaseId {
-    fn name(&self) -> &'static str {
-        headers::SOURCE_LEASE_ID
+    fn name(&self) -> headers::HeaderName {
+        headers::SOURCE_LEASE_ID.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_string()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_string().into()
     }
 }

--- a/sdk/core/src/request_options/user_agent.rs
+++ b/sdk/core/src/request_options/user_agent.rs
@@ -1,4 +1,4 @@
-use crate::Header;
+use crate::headers::{self, Header};
 use http::header;
 
 #[derive(Debug, Clone, Copy)]
@@ -11,11 +11,11 @@ impl<'a> UserAgent<'a> {
 }
 
 impl<'a> Header for UserAgent<'a> {
-    fn name(&self) -> &'static str {
-        header::USER_AGENT.as_str()
+    fn name(&self) -> headers::HeaderName {
+        header::USER_AGENT.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_string()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }

--- a/sdk/core/src/request_options/user_agent.rs
+++ b/sdk/core/src/request_options/user_agent.rs
@@ -1,6 +1,5 @@
-use crate::AddAsHeader;
-use http::header::USER_AGENT;
-use http::request::Builder;
+use crate::Header;
+use http::header;
 
 #[derive(Debug, Clone, Copy)]
 pub struct UserAgent<'a>(&'a str);
@@ -11,19 +10,12 @@ impl<'a> UserAgent<'a> {
     }
 }
 
-impl<'a> AddAsHeader for UserAgent<'a> {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(USER_AGENT, self.0)
+impl<'a> Header for UserAgent<'a> {
+    fn name(&self) -> &'static str {
+        header::USER_AGENT.as_str()
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut crate::Request,
-    ) -> Result<(), crate::errors::HttpHeaderError> {
-        request
-            .headers_mut()
-            .append(USER_AGENT, http::HeaderValue::from_str(self.0)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_string()
     }
 }

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -1,7 +1,7 @@
+use azure_core::headers::{HeaderName, HeaderValue, Headers};
 use azure_core::prelude::*;
 use azure_core::CustomHeaders;
 use azure_data_cosmos::prelude::*;
-use http::{HeaderMap, HeaderValue};
 use std::error::Error;
 
 #[tokio::main]
@@ -30,9 +30,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     // Next we create a CustomHeaders type and insert it into the context allowing us to insert custom headers.
     let custom_headers: CustomHeaders = {
-        let mut custom_headers = HeaderMap::new();
-        custom_headers.insert("MyCoolHeader", HeaderValue::from_static("CORS maybe?"));
-        custom_headers.into()
+        let mut custom_headers = std::collections::HashMap::<HeaderName, HeaderValue>::new();
+        custom_headers.insert("MyCoolHeader".into(), "CORS maybe?".into());
+        let hs: Headers = custom_headers.into();
+        hs.into()
     };
 
     context.insert(custom_headers);

--- a/sdk/data_cosmos/src/consistency_level.rs
+++ b/sdk/data_cosmos/src/consistency_level.rs
@@ -143,11 +143,11 @@ impl Header for ConsistencyLevel {
         Ok(())
     }
 
-    fn name(&self) -> &'static str {
+    fn name(&self) -> azure_core::headers::HeaderName {
         todo!()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> azure_core::headers::HeaderValue {
         todo!()
     }
 }

--- a/sdk/data_cosmos/src/consistency_level.rs
+++ b/sdk/data_cosmos/src/consistency_level.rs
@@ -126,7 +126,7 @@ impl Header for ConsistencyLevel {
         &self,
         request: &mut azure_core::Request,
     ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
+        request.headers_mut().insert(
             headers::HEADER_CONSISTENCY_LEVEL,
             http::header::HeaderValue::from_str(self.to_consistency_level_header())?,
         );
@@ -134,7 +134,7 @@ impl Header for ConsistencyLevel {
         // if we have a Session consistency level we make sure to pass
         // the x-ms-session-token header too.
         if let ConsistencyLevel::Session(session_token) = self {
-            request.headers_mut().append(
+            request.headers_mut().insert(
                 headers::HEADER_SESSION_TOKEN,
                 http::header::HeaderValue::from_str(session_token)?,
             );

--- a/sdk/data_cosmos/src/consistency_level.rs
+++ b/sdk/data_cosmos/src/consistency_level.rs
@@ -107,7 +107,7 @@ where
 }
 
 impl Header for ConsistencyLevel {
-    fn add_as_header(&self, builder: request::Builder) -> request::Builder {
+    fn add_to_builder(&self, builder: request::Builder) -> request::Builder {
         let builder = builder.header(
             headers::HEADER_CONSISTENCY_LEVEL,
             self.to_consistency_level_header(),
@@ -122,7 +122,7 @@ impl Header for ConsistencyLevel {
         }
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut azure_core::Request,
     ) -> Result<(), azure_core::HttpHeaderError> {

--- a/sdk/data_cosmos/src/consistency_level.rs
+++ b/sdk/data_cosmos/src/consistency_level.rs
@@ -1,7 +1,7 @@
 use crate::headers;
 use crate::operations::*;
 use crate::resources::user::UserResponse;
-use azure_core::AddAsHeader;
+use azure_core::Header;
 use http::request;
 use serde::de::DeserializeOwned;
 
@@ -106,7 +106,7 @@ where
     }
 }
 
-impl AddAsHeader for ConsistencyLevel {
+impl Header for ConsistencyLevel {
     fn add_as_header(&self, builder: request::Builder) -> request::Builder {
         let builder = builder.header(
             headers::HEADER_CONSISTENCY_LEVEL,
@@ -141,5 +141,13 @@ impl AddAsHeader for ConsistencyLevel {
         }
 
         Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        todo!()
+    }
+
+    fn value(&self) -> String {
+        todo!()
     }
 }

--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -44,7 +44,9 @@ impl CreateCollectionBuilder {
         Box::pin(async move {
             let mut request = self.client.prepare_collections_pipeline(http::Method::POST);
             azure_core::headers::add_optional_header2(&self.offer, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let collection = CreateCollectionBody {
                 id: &self.collection_name,

--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -43,7 +43,7 @@ impl CreateCollectionBuilder {
     pub fn into_future(self) -> CreateCollection {
         Box::pin(async move {
             let mut request = self.client.prepare_collections_pipeline(http::Method::POST);
-            azure_core::headers::add_optional_header2(&self.offer, &mut request)?;
+            request.insert_headers(&self.offer);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -45,9 +45,7 @@ impl CreateDatabaseBuilder {
                 id: self.database_name.as_str(),
             };
 
-            if let Some(ref h) = self.consistency_level {
-                request.insert_header(h)?;
-            }
+            request.insert_header(&self.consistency_level)?;
             request.set_body(bytes::Bytes::from(serde_json::to_string(&body)?).into());
 
             let response = self

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -45,7 +45,7 @@ impl CreateDatabaseBuilder {
                 id: self.database_name.as_str(),
             };
 
-            request.insert_header(&self.consistency_level)?;
+            request.insert_headers(&self.consistency_level);
             request.set_body(bytes::Bytes::from(serde_json::to_string(&body)?).into());
 
             let response = self

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -45,7 +45,9 @@ impl CreateDatabaseBuilder {
                 id: self.database_name.as_str(),
             };
 
-            request.insert_headers(&self.consistency_level);
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             request.set_body(bytes::Bytes::from(serde_json::to_string(&body)?).into());
 
             let response = self

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -45,7 +45,9 @@ impl CreateDatabaseBuilder {
                 id: self.database_name.as_str(),
             };
 
-            request.insert_header(&self.consistency_level)?;
+            if let Some(ref h) = self.consistency_level {
+                request.insert_header(h)?;
+            }
             request.set_body(bytes::Bytes::from(serde_json::to_string(&body)?).into());
 
             let response = self

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -73,7 +73,9 @@ impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {
             add_as_partition_key_header_serialized2(&partition_key, &mut request);
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
             azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             azure_core::headers::add_mandatory_header2(&self.is_upsert, &mut request)?;
             azure_core::headers::add_mandatory_header2(&self.indexing_directive, &mut request)?;
             azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -71,14 +71,14 @@ impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {
             let mut request = self.client.prepare_doc_request_pipeline(http::Method::POST);
 
             add_as_partition_key_header_serialized2(&partition_key, &mut request);
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
+            request.insert_headers(&self.if_match_condition);
+            request.insert_headers(&self.if_modified_since);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
-            azure_core::headers::add_mandatory_header2(&self.is_upsert, &mut request)?;
-            azure_core::headers::add_mandatory_header2(&self.indexing_directive, &mut request)?;
-            azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;
+            request.insert_headers(&self.is_upsert);
+            request.insert_headers(&self.indexing_directive);
+            request.insert_headers(&self.allow_tentative_writes);
 
             request.set_body(bytes::Bytes::from(serialized).into());
             let response = self

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -49,7 +49,9 @@ impl CreateOrReplaceAttachmentBuilder {
                     .prepare_pipeline_with_attachment_name(http::Method::PUT)
             };
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut req)?;
+            if let Some(cl) = &self.consistency_level {
+                req.insert_headers(cl);
+            }
             crate::cosmos_entity::add_as_partition_key_header_serialized2(
                 self.client.document_client().partition_key_serialized(),
                 &mut req,

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -54,7 +54,9 @@ impl CreateOrReplaceSlugAttachmentBuilder {
             };
 
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut req)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut req)?;
+            if let Some(cl) = &self.consistency_level {
+                req.insert_headers(cl);
+            }
 
             crate::cosmos_entity::add_as_partition_key_header_serialized2(
                 self.client.document_client().partition_key_serialized(),

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -46,45 +46,45 @@ impl CreateOrReplaceSlugAttachmentBuilder {
 
     pub fn into_future(self) -> CreateOrReplaceSlugAttachment {
         Box::pin(async move {
-            let mut req = if self.is_create {
+            let mut request = if self.is_create {
                 self.client.prepare_pipeline(http::Method::POST)
             } else {
                 self.client
                     .prepare_pipeline_with_attachment_name(http::Method::PUT)
             };
 
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut req)?;
+            request.insert_headers(&self.if_match_condition);
             if let Some(cl) = &self.consistency_level {
-                req.insert_headers(cl);
+                request.insert_headers(cl);
             }
 
             crate::cosmos_entity::add_as_partition_key_header_serialized2(
                 self.client.document_client().partition_key_serialized(),
-                &mut req,
+                &mut request,
             );
             let body = self.body;
-            req.headers_mut().insert(
+            request.headers_mut().insert(
                 http::header::CONTENT_TYPE,
                 http::HeaderValue::from_str(self.content_type.as_deref().unwrap_or("text/plain"))
                     .unwrap(),
             );
 
-            req.headers_mut().insert(
+            request.headers_mut().insert(
                 "Slug",
                 http::HeaderValue::from_str(self.client.attachment_name()).unwrap(),
             );
-            req.headers_mut().insert(
+            request.headers_mut().insert(
                 http::header::CONTENT_LENGTH,
                 http::HeaderValue::from_str(&format!("{}", body.len())).unwrap(),
             );
 
-            req.set_body(body.into());
+            request.set_body(body.into());
             let response = self
                 .client
                 .pipeline()
                 .send(
                     self.context.clone().insert(ResourceType::Attachments),
-                    &mut req,
+                    &mut request,
                 )
                 .await?;
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -53,7 +53,9 @@ impl CreateOrReplaceTriggerBuilder {
                     .prepare_pipeline_with_trigger_name(http::Method::PUT)
             };
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             #[derive(Debug, Deserialize, Serialize)]
             struct Request<'a> {

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -42,7 +42,7 @@ impl CreateOrReplaceUserDefinedFunctionBuilder {
                     .prepare_pipeline_with_user_defined_function_name(http::Method::PUT),
             };
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -42,7 +42,9 @@ impl CreateOrReplaceUserDefinedFunctionBuilder {
                     .prepare_pipeline_with_user_defined_function_name(http::Method::PUT),
             };
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             #[derive(Debug, Serialize)]
             struct Request<'a> {

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -40,7 +40,9 @@ impl CreatePermissionBuilder {
                 http::Method::POST,
             );
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             azure_core::headers::add_optional_header2(&self.expiry_seconds, &mut request)?;
 
             #[derive(Serialize, Deserialize)]

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -43,7 +43,7 @@ impl CreatePermissionBuilder {
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
-            azure_core::headers::add_optional_header2(&self.expiry_seconds, &mut request)?;
+            request.insert_headers(&self.expiry_seconds);
 
             #[derive(Serialize, Deserialize)]
             struct RequestBody<'x> {

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -33,7 +33,9 @@ impl CreateStoredProcedureBuilder {
         Box::pin(async move {
             let mut req = self.client.prepare_request_pipeline(http::Method::POST);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut req)?;
+            if let Some(cl) = &self.consistency_level {
+                req.insert_headers(cl);
+            }
 
             #[derive(Debug, Serialize)]
             struct Request<'a> {

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -32,7 +32,9 @@ impl CreateUserBuilder {
                 http::Method::POST,
             );
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             let body = CreateUserBody {
                 id: self.client.user_name(),
             };

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -40,7 +40,9 @@ impl DeleteAttachmentBuilder {
 
             // add trait headers
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             crate::cosmos_entity::add_as_partition_key_header_serialized2(
                 self.client.document_client().partition_key_serialized(),

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -39,7 +39,7 @@ impl DeleteAttachmentBuilder {
                 .prepare_pipeline_with_attachment_name(http::Method::DELETE);
 
             // add trait headers
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
+            request.insert_headers(&self.if_match_condition);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -31,7 +31,7 @@ impl DeleteCollectionBuilder {
                 .client
                 .prepare_request_with_collection_name(http::Method::DELETE);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -31,7 +31,9 @@ impl DeleteCollectionBuilder {
                 .client
                 .prepare_request_with_collection_name(http::Method::DELETE);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -29,7 +29,9 @@ impl DeleteDatabaseBuilder {
     pub fn into_future(self) -> DeleteDatabase {
         Box::pin(async move {
             let mut request = self.client.prepare_pipeline(http::Method::DELETE);
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -42,12 +42,12 @@ impl DeleteDocumentBuilder {
                 .client
                 .prepare_request_pipeline_with_document_name(http::Method::DELETE);
 
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
-if let Some(cl) = &self.consistency_level {
+            request.insert_headers(&self.if_match_condition);
+            request.insert_headers(&self.if_modified_since);
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
-            azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;
+            request.insert_headers(&self.allow_tentative_writes);
 
             crate::cosmos_entity::add_as_partition_key_header_serialized2(
                 self.client.partition_key_serialized(),

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -44,7 +44,9 @@ impl DeleteDocumentBuilder {
 
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
             azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;
 
             crate::cosmos_entity::add_as_partition_key_header_serialized2(

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -32,7 +32,9 @@ impl DeletePermissionBuilder {
                 .client
                 .prepare_request_with_permission_name(http::Method::DELETE);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -32,7 +32,7 @@ impl DeletePermissionBuilder {
                 .client
                 .prepare_request_with_permission_name(http::Method::DELETE);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -32,7 +32,9 @@ impl DeleteStoredProcedureBuilder {
                 .client
                 .prepare_pipeline_with_stored_procedure_name(http::Method::DELETE);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -32,7 +32,7 @@ impl DeleteStoredProcedureBuilder {
                 .client
                 .prepare_pipeline_with_stored_procedure_name(http::Method::DELETE);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -34,7 +34,7 @@ impl DeleteTriggerBuilder {
                 .client
                 .prepare_pipeline_with_trigger_name(http::Method::DELETE);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -34,7 +34,9 @@ impl DeleteTriggerBuilder {
                 .client
                 .prepare_pipeline_with_trigger_name(http::Method::DELETE);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -28,7 +28,9 @@ impl DeleteUserBuilder {
             let mut request = self
                 .client
                 .prepare_request_with_user_name(http::Method::DELETE);
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             request.set_body(bytes::Bytes::from_static(&[]).into());
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -28,7 +28,7 @@ impl DeleteUserBuilder {
             let mut request = self
                 .client
                 .prepare_request_with_user_name(http::Method::DELETE);
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
             request.set_body(bytes::Bytes::from_static(&[]).into());

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -34,7 +34,9 @@ impl DeleteUserDefinedFunctionBuilder {
                 .client
                 .prepare_pipeline_with_user_defined_function_name(http::Method::DELETE);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -34,7 +34,7 @@ impl DeleteUserDefinedFunctionBuilder {
                 .client
                 .prepare_pipeline_with_user_defined_function_name(http::Method::DELETE);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -60,7 +60,9 @@ impl ExecuteStoredProcedureBuilder {
                 crate::cosmos_entity::add_as_partition_key_header_serialized2(pk, &mut request)
             }
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;
 
             let body = if let Some(parameters) = self.parameters.as_ref() {

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -60,10 +60,10 @@ impl ExecuteStoredProcedureBuilder {
                 crate::cosmos_entity::add_as_partition_key_header_serialized2(pk, &mut request)
             }
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
-            azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;
+            request.insert_headers(&self.allow_tentative_writes);
 
             let body = if let Some(parameters) = self.parameters.as_ref() {
                 Bytes::from(parameters.to_json())

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -40,8 +40,8 @@ impl GetAttachmentBuilder {
                 .client
                 .prepare_pipeline_with_attachment_name(http::Method::GET);
 
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-if let Some(cl) = &self.consistency_level {
+            request.insert_headers(&self.if_match_condition);
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -41,7 +41,9 @@ impl GetAttachmentBuilder {
                 .prepare_pipeline_with_attachment_name(http::Method::GET);
 
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             crate::cosmos_entity::add_as_partition_key_header_serialized2(
                 self.client.document_client().partition_key_serialized(),

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -34,7 +34,9 @@ impl GetCollectionBuilder {
                 .client
                 .prepare_request_with_collection_name(http::Method::GET);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -31,7 +31,9 @@ impl GetDatabaseBuilder {
     pub fn into_future(self) -> GetDatabase {
         Box::pin(async move {
             let mut request = self.client.prepare_pipeline(http::Method::GET);
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -49,7 +49,9 @@ impl GetDocumentBuilder {
 
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
             azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             request.set_body(azure_core::EMPTY_BODY.into());
 

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -47,8 +47,8 @@ impl GetDocumentBuilder {
                 .client
                 .prepare_request_pipeline_with_document_name(http::Method::GET);
 
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
+            request.insert_headers(&self.if_match_condition);
+            request.insert_headers(&self.if_modified_since);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -43,9 +43,9 @@ impl GetPartitionKeyRangesBuilder {
                 http::Method::GET,
             );
 
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
-if let Some(cl) = &self.consistency_level {
+            request.insert_headers(&self.if_match_condition);
+            request.insert_headers(&self.if_modified_since);
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -45,7 +45,9 @@ impl GetPartitionKeyRangesBuilder {
 
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
             azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -29,7 +29,7 @@ impl GetPermissionBuilder {
                 .client
                 .prepare_request_with_permission_name(http::Method::GET);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -29,7 +29,9 @@ impl GetPermissionBuilder {
                 .client
                 .prepare_request_with_permission_name(http::Method::GET);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/get_user.rs
+++ b/sdk/data_cosmos/src/operations/get_user.rs
@@ -28,7 +28,9 @@ impl GetUserBuilder {
                 .client
                 .prepare_request_with_user_name(http::Method::GET);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             request.set_body(bytes::Bytes::from_static(&[]).into());
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -65,9 +65,7 @@ impl ListAttachmentsBuilder {
                     &mut request,
                 );
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -65,7 +65,7 @@ impl ListAttachmentsBuilder {
                     &mut request,
                 );
 
-                request.insert_header(&continuation)?;
+                request.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -57,7 +57,9 @@ impl ListAttachmentsBuilder {
                 );
 
                 azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.a_im, &mut request)?;
                 crate::cosmos_entity::add_as_partition_key_header_serialized2(

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -65,7 +65,9 @@ impl ListAttachmentsBuilder {
                     &mut request,
                 );
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -56,12 +56,12 @@ impl ListAttachmentsBuilder {
                     http::Method::GET,
                 );
 
-                azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
+                request.insert_headers(&this.if_match_condition);
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
-                azure_core::headers::add_mandatory_header2(&this.a_im, &mut request)?;
+                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.a_im);
                 crate::cosmos_entity::add_as_partition_key_header_serialized2(
                     this.client.partition_key_serialized(),
                     &mut request,

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -38,7 +38,9 @@ impl ListCollectionsBuilder {
             let ctx = self.context.clone();
             async move {
                 let mut request = this.client.prepare_collections_pipeline(http::Method::GET);
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
                 request.insert_headers(&continuation);

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -41,7 +41,9 @@ impl ListCollectionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -41,9 +41,7 @@ impl ListCollectionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -41,7 +41,7 @@ impl ListCollectionsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
+                request.insert_headers(&this.max_item_count);
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -41,7 +41,7 @@ impl ListCollectionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                request.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -41,9 +41,9 @@ impl ListDatabasesBuilder {
                 let mut request = this
                     .client
                     .prepare_request_pipeline("dbs", http::Method::GET);
-                request.insert_header(&this.consistency_level)?;
-                request.insert_header(&this.max_item_count)?;
-                request.insert_header(&continuation)?;
+                request.insert_headers(&this.consistency_level);
+                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -41,13 +41,9 @@ impl ListDatabasesBuilder {
                 let mut request = this
                     .client
                     .prepare_request_pipeline("dbs", http::Method::GET);
-                if let Some(ref h) = this.consistency_level {
-                    request.insert_header(h)?;
-                }
+                request.insert_header(&this.consistency_level)?;
                 request.insert_header(&this.max_item_count)?;
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -41,7 +41,9 @@ impl ListDatabasesBuilder {
                 let mut request = this
                     .client
                     .prepare_request_pipeline("dbs", http::Method::GET);
-                request.insert_headers(&this.consistency_level);
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 request.insert_headers(&this.max_item_count);
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -41,9 +41,13 @@ impl ListDatabasesBuilder {
                 let mut request = this
                     .client
                     .prepare_request_pipeline("dbs", http::Method::GET);
-                request.insert_header(&this.consistency_level)?;
+                if let Some(ref h) = this.consistency_level {
+                    request.insert_header(h)?;
+                }
                 request.insert_header(&this.max_item_count)?;
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -58,7 +58,9 @@ impl ListDocumentsBuilder {
                 );
 
                 azure_core::headers::add_optional_header2(&this.if_match_condition, &mut req)?;
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut req)?;
+                if let Some(cl) = &this.consistency_level {
+                    req.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut req)?;
                 azure_core::headers::add_mandatory_header2(&this.a_im, &mut req)?;
                 azure_core::headers::add_optional_header2(&this.partition_range_id, &mut req)?;

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -57,17 +57,14 @@ impl ListDocumentsBuilder {
                     http::Method::GET,
                 );
 
-                azure_core::headers::add_optional_header2(&this.if_match_condition, &mut req)?;
+                req.insert_headers(&this.if_match_condition);
                 if let Some(cl) = &this.consistency_level {
                     req.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut req)?;
-                azure_core::headers::add_mandatory_header2(&this.a_im, &mut req)?;
-                azure_core::headers::add_optional_header2(&this.partition_range_id, &mut req)?;
-
-                if let Some(ref c) = continuation {
-                    req.insert_header(c)?;
-                }
+                req.insert_headers(&this.max_item_count);
+                req.insert_headers(&this.a_im);
+                req.insert_headers(&this.partition_range_id);
+                req.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -48,7 +48,7 @@ impl ListPermissionsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
+                request.insert_headers(&this.max_item_count);
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -48,9 +48,7 @@ impl ListPermissionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -45,7 +45,9 @@ impl ListPermissionsBuilder {
                     http::Method::GET,
                 );
 
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
                 request.insert_headers(&continuation);

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -48,7 +48,9 @@ impl ListPermissionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -48,7 +48,7 @@ impl ListPermissionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                request.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -50,7 +50,7 @@ impl ListStoredProceduresBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
+                request.insert_headers(&this.max_item_count);
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -50,7 +50,9 @@ impl ListStoredProceduresBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -50,9 +50,7 @@ impl ListStoredProceduresBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -50,7 +50,7 @@ impl ListStoredProceduresBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                request.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -47,7 +47,9 @@ impl ListStoredProceduresBuilder {
                     http::Method::GET,
                 );
 
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
                 request.insert_headers(&continuation);

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -51,7 +51,9 @@ impl ListTriggersBuilder {
                 );
 
                 azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
                 request.insert_headers(&continuation);

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -54,7 +54,7 @@ impl ListTriggersBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                request.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -50,11 +50,11 @@ impl ListTriggersBuilder {
                     http::Method::GET,
                 );
 
-                azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
+                request.insert_headers(&this.if_match_condition);
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
+                request.insert_headers(&this.max_item_count);
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -54,7 +54,9 @@ impl ListTriggersBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -54,9 +54,7 @@ impl ListTriggersBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -52,7 +52,9 @@ impl ListUserDefinedFunctionsBuilder {
                 );
 
                 azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
                 request.insert_headers(&continuation);

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -55,7 +55,9 @@ impl ListUserDefinedFunctionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -55,9 +55,7 @@ impl ListUserDefinedFunctionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
-                }
+                request.insert_header(&continuation)?;
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -55,7 +55,7 @@ impl ListUserDefinedFunctionsBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                request.insert_headers(&continuation);
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -51,11 +51,11 @@ impl ListUserDefinedFunctionsBuilder {
                     http::Method::GET,
                 );
 
-                azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
+                request.insert_headers(&this.if_match_condition);
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
+                request.insert_headers(&this.max_item_count);
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -50,7 +50,7 @@ impl ListUsersBuilder {
                 request.insert_headers(&this.max_item_count);
 
                 if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
+                    request.insert_headers(c)?;
                 }
 
                 let response = this

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -44,7 +44,9 @@ impl ListUsersBuilder {
                     http::Method::GET,
                 );
 
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
                 if let Some(ref c) = continuation {

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -47,7 +47,7 @@ impl ListUsersBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
+                request.insert_headers(&this.max_item_count);
 
                 if let Some(ref c) = continuation {
                     request.insert_header(c)?;

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -47,7 +47,9 @@ impl ListUsersBuilder {
                 azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -94,16 +94,13 @@ impl QueryDocumentsBuilder {
                     http::HeaderValue::from_str("application/query+json").unwrap(),
                 );
 
-                azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
-                azure_core::headers::add_optional_header2(&this.if_modified_since, &mut request)?;
+                request.insert_headers(&this.if_match_condition);
+                request.insert_headers(&this.if_modified_since);
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
-                azure_core::headers::add_mandatory_header2(
-                    &this.query_cross_partition,
-                    &mut request,
-                )?;
+                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.query_cross_partition);
 
                 request.set_body(bytes::Bytes::from(serde_json::to_string(&this.query)?).into());
                 if let Some(partition_key_serialized) = this.partition_key_serialized.as_ref() {

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -96,7 +96,9 @@ impl QueryDocumentsBuilder {
 
                 azure_core::headers::add_optional_header2(&this.if_match_condition, &mut request)?;
                 azure_core::headers::add_optional_header2(&this.if_modified_since, &mut request)?;
-                azure_core::headers::add_optional_header2(&this.consistency_level, &mut request)?;
+                if let Some(cl) = &this.consistency_level {
+                    request.insert_headers(cl);
+                }
                 azure_core::headers::add_mandatory_header2(&this.max_item_count, &mut request)?;
                 azure_core::headers::add_mandatory_header2(
                     &this.query_cross_partition,

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -111,7 +111,9 @@ impl QueryDocumentsBuilder {
                     );
                 }
 
-                request.insert_header(&continuation)?;
+                if let Some(ref c) = continuation {
+                    request.insert_header(c)?;
+                }
 
                 let response = this
                     .client

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -111,7 +111,7 @@ impl QueryDocumentsBuilder {
                 }
 
                 if let Some(ref c) = continuation {
-                    request.insert_header(c)?;
+                    request.insert_headers(c)?;
                 }
 
                 let response = this

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -39,7 +39,9 @@ impl ReplaceCollectionBuilder {
                 .client
                 .prepare_request_with_collection_name(http::Method::PUT);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
 
             let collection = ReplaceCollectionBody {
                 id: self.client.collection_name(),

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -39,7 +39,7 @@ impl ReplaceCollectionBuilder {
                 .client
                 .prepare_request_with_collection_name(http::Method::PUT);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
 

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -65,13 +65,13 @@ impl<D: Serialize + Send + 'static> ReplaceDocumentBuilder<D> {
                 .unwrap_or_else(|| self.client.partition_key_serialized());
             add_as_partition_key_header_serialized2(partition_key, &mut request);
 
-            azure_core::headers::add_mandatory_header2(&self.indexing_directive, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
+            request.insert_headers(&self.indexing_directive);
+            request.insert_headers(&self.if_match_condition);
+            request.insert_headers(&self.if_modified_since);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
-            azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;
+            request.insert_headers(&self.allow_tentative_writes);
 
             let serialized = azure_core::to_json(&self.document)?;
             request.set_body(serialized.into());

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -68,7 +68,9 @@ impl<D: Serialize + Send + 'static> ReplaceDocumentBuilder<D> {
             azure_core::headers::add_mandatory_header2(&self.indexing_directive, &mut request)?;
             azure_core::headers::add_optional_header2(&self.if_match_condition, &mut request)?;
             azure_core::headers::add_optional_header2(&self.if_modified_since, &mut request)?;
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+            if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             azure_core::headers::add_mandatory_header2(&self.allow_tentative_writes, &mut request)?;
 
             let serialized = azure_core::to_json(&self.document)?;

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -35,7 +35,9 @@ impl ReplacePermissionBuilder {
                 .client
                 .prepare_request_with_permission_name(http::Method::PUT);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             azure_core::headers::add_optional_header2(&self.expiry_seconds, &mut request)?;
 
             #[derive(Serialize, Deserialize)]

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -35,10 +35,10 @@ impl ReplacePermissionBuilder {
                 .client
                 .prepare_request_with_permission_name(http::Method::PUT);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
-            azure_core::headers::add_optional_header2(&self.expiry_seconds, &mut request)?;
+            request.insert_headers(&self.expiry_seconds);
 
             #[derive(Serialize, Deserialize)]
             struct RequestBody<'x> {

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -32,7 +32,9 @@ impl ReplaceStoredProcedureBuilder {
                 .client
                 .prepare_pipeline_with_stored_procedure_name(http::Method::PUT);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut req)?;
+            if let Some(cl) = &self.consistency_level {
+                req.insert_headers(cl);
+            }
 
             #[derive(Debug, Serialize)]
             struct Request<'a> {

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -30,7 +30,9 @@ impl ReplaceUserBuilder {
                 .client
                 .prepare_request_with_user_name(http::Method::PUT);
 
-            azure_core::headers::add_optional_header2(&self.consistency_level, &mut request)?;
+if let Some(cl) = &self.consistency_level {
+                request.insert_headers(cl);
+            }
             let body = ReplaceUserBody {
                 id: &self.user_name,
             };

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -30,7 +30,7 @@ impl ReplaceUserBuilder {
                 .client
                 .prepare_request_with_user_name(http::Method::PUT);
 
-if let Some(cl) = &self.consistency_level {
+            if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }
             let body = ReplaceUserBody {

--- a/sdk/data_cosmos/src/resources/collection/offer.rs
+++ b/sdk/data_cosmos/src/resources/collection/offer.rs
@@ -1,6 +1,5 @@
 use crate::headers;
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 /// The collection performance level.
 ///
@@ -17,35 +16,20 @@ pub enum Offer {
     S3,
 }
 
-impl AddAsHeader for Offer {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+impl Header for Offer {
+    fn name(&self) -> &'static str {
         match self {
-            Offer::Throughput(throughput) => {
-                builder.header(headers::HEADER_OFFER_THROUGHPUT, *throughput)
-            }
-            Offer::S1 => builder.header(headers::HEADER_OFFER_TYPE, "S1"),
-            Offer::S2 => builder.header(headers::HEADER_OFFER_TYPE, "S2"),
-            Offer::S3 => builder.header(headers::HEADER_OFFER_TYPE, "S3"),
+            Offer::Throughput(_) => headers::HEADER_OFFER_THROUGHPUT,
+            _ => headers::HEADER_OFFER_TYPE,
         }
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            Offer::Throughput(throughput) => {
-                (headers::HEADER_OFFER_THROUGHPUT, throughput.to_string())
-            }
-            Offer::S1 => (headers::HEADER_OFFER_TYPE, "S1".to_owned()),
-            Offer::S2 => (headers::HEADER_OFFER_TYPE, "S2".to_owned()),
-            Offer::S3 => (headers::HEADER_OFFER_TYPE, "S3".to_owned()),
-        };
-
-        request.headers_mut().append(
-            header_name,
-            http::header::HeaderValue::from_str(&header_value)?,
-        );
-        Ok(())
+    fn value(&self) -> String {
+        match self {
+            Offer::Throughput(throughput) => throughput.to_string(),
+            Offer::S1 => "S1".to_owned(),
+            Offer::S2 => "S2".to_owned(),
+            Offer::S3 => "S3".to_owned(),
+        }
     }
 }

--- a/sdk/data_cosmos/src/resources/collection/offer.rs
+++ b/sdk/data_cosmos/src/resources/collection/offer.rs
@@ -17,19 +17,21 @@ pub enum Offer {
 }
 
 impl Header for Offer {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> azure_core::headers::HeaderName {
         match self {
             Offer::Throughput(_) => headers::HEADER_OFFER_THROUGHPUT,
             _ => headers::HEADER_OFFER_TYPE,
         }
+        .into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> azure_core::headers::HeaderValue {
         match self {
             Offer::Throughput(throughput) => throughput.to_string(),
             Offer::S1 => "S1".to_owned(),
             Offer::S2 => "S2".to_owned(),
             Offer::S3 => "S3".to_owned(),
         }
+        .into()
     }
 }

--- a/sdk/data_cosmos/src/resources/document/indexing_directive.rs
+++ b/sdk/data_cosmos/src/resources/document/indexing_directive.rs
@@ -77,7 +77,7 @@ impl azure_core::Header for IndexingDirective {
             IndexingDirective::Include => (headers::HEADER_INDEXING_DIRECTIVE, "Include"),
         };
 
-        request.headers_mut().append(
+        request.headers_mut().insert(
             header_name,
             http::header::HeaderValue::from_str(header_value)?,
         );

--- a/sdk/data_cosmos/src/resources/document/indexing_directive.rs
+++ b/sdk/data_cosmos/src/resources/document/indexing_directive.rs
@@ -1,6 +1,5 @@
-use crate::headers;
+use azure_core::headers::{self, AsHeaders};
 use azure_core::ParseError;
-use http::request::Builder;
 use std::fmt;
 
 /// Whether the resource should be included in the index.
@@ -46,41 +45,22 @@ impl fmt::Display for IndexingDirective {
     }
 }
 
-impl azure_core::Header for IndexingDirective {
-    fn name(&self) -> azure_core::headers::HeaderName {
-        todo!()
-    }
+impl AsHeaders for IndexingDirective {
+    type Iter = std::vec::IntoIter<(headers::HeaderName, headers::HeaderValue)>;
 
-    fn value(&self) -> azure_core::headers::HeaderValue {
-        todo!()
-    }
-
-    fn add_to_builder(&self, builder: Builder) -> Builder {
+    fn as_headers(&self) -> Self::Iter {
         match self {
-            IndexingDirective::Default => builder,
-            IndexingDirective::Exclude => {
-                builder.header(headers::HEADER_INDEXING_DIRECTIVE, "Exclude")
-            }
-            IndexingDirective::Include => {
-                builder.header(headers::HEADER_INDEXING_DIRECTIVE, "Include")
-            }
+            IndexingDirective::Default => vec![].into_iter(),
+            IndexingDirective::Exclude => vec![(
+                crate::headers::HEADER_INDEXING_DIRECTIVE.into(),
+                "Exclude".into(),
+            )]
+            .into_iter(),
+            IndexingDirective::Include => vec![(
+                crate::headers::HEADER_INDEXING_DIRECTIVE.into(),
+                "Include".into(),
+            )]
+            .into_iter(),
         }
-    }
-
-    fn add_to_request(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            IndexingDirective::Default => return Ok(()),
-            IndexingDirective::Exclude => (headers::HEADER_INDEXING_DIRECTIVE, "Exclude"),
-            IndexingDirective::Include => (headers::HEADER_INDEXING_DIRECTIVE, "Include"),
-        };
-
-        request.headers_mut().insert(
-            header_name,
-            http::header::HeaderValue::from_str(header_value)?,
-        );
-        Ok(())
     }
 }

--- a/sdk/data_cosmos/src/resources/document/indexing_directive.rs
+++ b/sdk/data_cosmos/src/resources/document/indexing_directive.rs
@@ -47,11 +47,11 @@ impl fmt::Display for IndexingDirective {
 }
 
 impl azure_core::Header for IndexingDirective {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> azure_core::headers::HeaderName {
         todo!()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> azure_core::headers::HeaderValue {
         todo!()
     }
 

--- a/sdk/data_cosmos/src/resources/document/indexing_directive.rs
+++ b/sdk/data_cosmos/src/resources/document/indexing_directive.rs
@@ -55,7 +55,7 @@ impl azure_core::Header for IndexingDirective {
         todo!()
     }
 
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         match self {
             IndexingDirective::Default => builder,
             IndexingDirective::Exclude => {
@@ -67,7 +67,7 @@ impl azure_core::Header for IndexingDirective {
         }
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut azure_core::Request,
     ) -> Result<(), azure_core::HttpHeaderError> {

--- a/sdk/data_cosmos/src/resources/document/indexing_directive.rs
+++ b/sdk/data_cosmos/src/resources/document/indexing_directive.rs
@@ -46,7 +46,15 @@ impl fmt::Display for IndexingDirective {
     }
 }
 
-impl azure_core::AddAsHeader for IndexingDirective {
+impl azure_core::Header for IndexingDirective {
+    fn name(&self) -> &'static str {
+        todo!()
+    }
+
+    fn value(&self) -> String {
+        todo!()
+    }
+
     fn add_as_header(&self, builder: Builder) -> Builder {
         match self {
             IndexingDirective::Default => builder,

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -168,7 +168,7 @@ impl Header for ChangeFeed {
     ) -> Result<(), azure_core::HttpHeaderError> {
         match self {
             Self::Incremental => {
-                request.headers_mut().append(
+                request.headers_mut().insert(
                     headers::HEADER_A_IM,
                     http::header::HeaderValue::from_str("Incremental feed")?,
                 );

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -11,7 +11,7 @@ pub use query::{Param, Query};
 use super::Resource;
 use crate::headers;
 
-use azure_core::AddAsHeader;
+use azure_core::Header;
 use http::header::HeaderMap;
 use http::request::Builder;
 use serde::de::DeserializeOwned;
@@ -82,24 +82,13 @@ impl QueryCrossPartition {
     }
 }
 
-impl AddAsHeader for QueryCrossPartition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(
-            headers::HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION,
-            self.as_bool_str(),
-        )
+impl Header for QueryCrossPartition {
+    fn name(&self) -> &'static str {
+        headers::HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            headers::HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION,
-            http::header::HeaderValue::from_str(self.as_bool_str())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.as_bool_str().to_owned()
     }
 }
 
@@ -120,24 +109,13 @@ impl ParallelizeCrossPartition {
     }
 }
 
-impl AddAsHeader for ParallelizeCrossPartition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(
-            headers::HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY,
-            self.as_bool_str(),
-        )
+impl Header for ParallelizeCrossPartition {
+    fn name(&self) -> &'static str {
+        headers::HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            headers::HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY,
-            http::header::HeaderValue::from_str(self.as_bool_str())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.as_bool_str().to_owned()
     }
 }
 
@@ -158,21 +136,13 @@ impl IsUpsert {
     }
 }
 
-impl AddAsHeader for IsUpsert {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::HEADER_DOCUMENTDB_IS_UPSERT, self.as_bool_str())
+impl Header for IsUpsert {
+    fn name(&self) -> &'static str {
+        headers::HEADER_DOCUMENTDB_IS_UPSERT
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            headers::HEADER_DOCUMENTDB_IS_UPSERT,
-            http::header::HeaderValue::from_str(self.as_bool_str())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.as_bool_str().to_owned()
     }
 }
 
@@ -184,7 +154,7 @@ pub enum ChangeFeed {
     None,
 }
 
-impl AddAsHeader for ChangeFeed {
+impl Header for ChangeFeed {
     fn add_as_header(&self, builder: Builder) -> Builder {
         match self {
             Self::Incremental => builder.header(headers::HEADER_A_IM, "Incremental feed"),
@@ -207,6 +177,14 @@ impl AddAsHeader for ChangeFeed {
         }
         Ok(())
     }
+
+    fn name(&self) -> &'static str {
+        todo!()
+    }
+
+    fn value(&self) -> String {
+        todo!()
+    }
 }
 
 /// Whether to allow tenative writes allowance
@@ -226,21 +204,13 @@ impl TentativeWritesAllowance {
     }
 }
 
-impl AddAsHeader for TentativeWritesAllowance {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::HEADER_ALLOW_MULTIPLE_WRITES, self.as_bool_str())
+impl Header for TentativeWritesAllowance {
+    fn name(&self) -> &'static str {
+        headers::HEADER_ALLOW_MULTIPLE_WRITES
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            headers::HEADER_ALLOW_MULTIPLE_WRITES,
-            http::header::HeaderValue::from_str(self.as_bool_str())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.as_bool_str().to_owned()
     }
 }
 
@@ -255,20 +225,12 @@ impl PartitionRangeId {
     }
 }
 
-impl AddAsHeader for PartitionRangeId {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::HEADER_DOCUMENTDB_PARTITIONRANGEID, &self.0)
+impl Header for PartitionRangeId {
+    fn name(&self) -> &'static str {
+        headers::HEADER_DOCUMENTDB_PARTITIONRANGEID
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            headers::HEADER_DOCUMENTDB_PARTITIONRANGEID,
-            http::header::HeaderValue::from_str(&self.0)?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.clone()
     }
 }

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -11,9 +11,9 @@ pub use query::{Param, Query};
 use super::Resource;
 use crate::headers;
 
+use azure_core::headers::{AsHeaders, HeaderName, HeaderValue};
 use azure_core::Header;
 use http::header::HeaderMap;
-use http::request::Builder;
 use serde::de::DeserializeOwned;
 
 /// User-defined content in JSON format.
@@ -83,11 +83,11 @@ impl QueryCrossPartition {
 }
 
 impl Header for QueryCrossPartition {
-    fn name(&self) -> azure_core::headers::HeaderName {
+    fn name(&self) -> HeaderName {
         headers::HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION.into()
     }
 
-    fn value(&self) -> azure_core::headers::HeaderValue {
+    fn value(&self) -> HeaderValue {
         self.as_bool_str().to_owned().into()
     }
 }
@@ -110,11 +110,11 @@ impl ParallelizeCrossPartition {
 }
 
 impl Header for ParallelizeCrossPartition {
-    fn name(&self) -> azure_core::headers::HeaderName {
+    fn name(&self) -> HeaderName {
         headers::HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY.into()
     }
 
-    fn value(&self) -> azure_core::headers::HeaderValue {
+    fn value(&self) -> HeaderValue {
         self.as_bool_str().to_owned().into()
     }
 }
@@ -137,11 +137,11 @@ impl IsUpsert {
 }
 
 impl Header for IsUpsert {
-    fn name(&self) -> azure_core::headers::HeaderName {
+    fn name(&self) -> HeaderName {
         headers::HEADER_DOCUMENTDB_IS_UPSERT.into()
     }
 
-    fn value(&self) -> azure_core::headers::HeaderValue {
+    fn value(&self) -> HeaderValue {
         self.as_bool_str().to_owned().into()
     }
 }
@@ -154,36 +154,15 @@ pub enum ChangeFeed {
     None,
 }
 
-impl Header for ChangeFeed {
-    fn add_to_builder(&self, builder: Builder) -> Builder {
-        match self {
-            Self::Incremental => builder.header(headers::HEADER_A_IM, "Incremental feed"),
-            Self::None => builder,
-        }
-    }
-
-    fn add_to_request(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
+impl AsHeaders for ChangeFeed {
+    type Iter = std::option::IntoIter<(HeaderName, HeaderValue)>;
+    fn as_headers(&self) -> Self::Iter {
         match self {
             Self::Incremental => {
-                request.headers_mut().insert(
-                    headers::HEADER_A_IM,
-                    http::header::HeaderValue::from_str("Incremental feed")?,
-                );
+                Some((headers::HEADER_A_IM.into(), "Incremental feed".into())).into_iter()
             }
-            Self::None => {}
+            Self::None => None.into_iter(),
         }
-        Ok(())
-    }
-
-    fn name(&self) -> azure_core::headers::HeaderName {
-        todo!()
-    }
-
-    fn value(&self) -> azure_core::headers::HeaderValue {
-        todo!()
     }
 }
 
@@ -205,11 +184,11 @@ impl TentativeWritesAllowance {
 }
 
 impl Header for TentativeWritesAllowance {
-    fn name(&self) -> azure_core::headers::HeaderName {
+    fn name(&self) -> HeaderName {
         headers::HEADER_ALLOW_MULTIPLE_WRITES.into()
     }
 
-    fn value(&self) -> azure_core::headers::HeaderValue {
+    fn value(&self) -> HeaderValue {
         self.as_bool_str().to_owned().into()
     }
 }
@@ -226,11 +205,11 @@ impl PartitionRangeId {
 }
 
 impl Header for PartitionRangeId {
-    fn name(&self) -> azure_core::headers::HeaderName {
+    fn name(&self) -> HeaderName {
         headers::HEADER_DOCUMENTDB_PARTITIONRANGEID.into()
     }
 
-    fn value(&self) -> azure_core::headers::HeaderValue {
+    fn value(&self) -> HeaderValue {
         self.0.clone().into()
     }
 }

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -155,14 +155,14 @@ pub enum ChangeFeed {
 }
 
 impl Header for ChangeFeed {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         match self {
             Self::Incremental => builder.header(headers::HEADER_A_IM, "Incremental feed"),
             Self::None => builder,
         }
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut azure_core::Request,
     ) -> Result<(), azure_core::HttpHeaderError> {

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -83,12 +83,12 @@ impl QueryCrossPartition {
 }
 
 impl Header for QueryCrossPartition {
-    fn name(&self) -> &'static str {
-        headers::HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::HEADER_DOCUMENTDB_QUERY_ENABLECROSSPARTITION.into()
     }
 
-    fn value(&self) -> String {
-        self.as_bool_str().to_owned()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.as_bool_str().to_owned().into()
     }
 }
 
@@ -110,12 +110,12 @@ impl ParallelizeCrossPartition {
 }
 
 impl Header for ParallelizeCrossPartition {
-    fn name(&self) -> &'static str {
-        headers::HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::HEADER_DOCUMENTDB_QUERY_PARALLELIZECROSSPARTITIONQUERY.into()
     }
 
-    fn value(&self) -> String {
-        self.as_bool_str().to_owned()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.as_bool_str().to_owned().into()
     }
 }
 
@@ -137,12 +137,12 @@ impl IsUpsert {
 }
 
 impl Header for IsUpsert {
-    fn name(&self) -> &'static str {
-        headers::HEADER_DOCUMENTDB_IS_UPSERT
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::HEADER_DOCUMENTDB_IS_UPSERT.into()
     }
 
-    fn value(&self) -> String {
-        self.as_bool_str().to_owned()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.as_bool_str().to_owned().into()
     }
 }
 
@@ -178,11 +178,11 @@ impl Header for ChangeFeed {
         Ok(())
     }
 
-    fn name(&self) -> &'static str {
+    fn name(&self) -> azure_core::headers::HeaderName {
         todo!()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> azure_core::headers::HeaderValue {
         todo!()
     }
 }
@@ -205,12 +205,12 @@ impl TentativeWritesAllowance {
 }
 
 impl Header for TentativeWritesAllowance {
-    fn name(&self) -> &'static str {
-        headers::HEADER_ALLOW_MULTIPLE_WRITES
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::HEADER_ALLOW_MULTIPLE_WRITES.into()
     }
 
-    fn value(&self) -> String {
-        self.as_bool_str().to_owned()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.as_bool_str().to_owned().into()
     }
 }
 
@@ -226,11 +226,11 @@ impl PartitionRangeId {
 }
 
 impl Header for PartitionRangeId {
-    fn name(&self) -> &'static str {
-        headers::HEADER_DOCUMENTDB_PARTITIONRANGEID
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::HEADER_DOCUMENTDB_PARTITIONRANGEID.into()
     }
 
-    fn value(&self) -> String {
-        self.0.clone()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.0.clone().into()
     }
 }

--- a/sdk/data_cosmos/src/resources/permission/mod.rs
+++ b/sdk/data_cosmos/src/resources/permission/mod.rs
@@ -14,8 +14,7 @@ pub use permission_token::PermissionToken;
 pub use permission_token::PermissionTokenParseError;
 
 use crate::headers;
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 /// The amount of time before authorization expires
 #[derive(Debug, Clone, Copy)]
@@ -28,19 +27,12 @@ impl ExpirySeconds {
     }
 }
 
-impl AddAsHeader for ExpirySeconds {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::HEADER_DOCUMENTDB_EXPIRY_SECONDS, self.0)
+impl Header for ExpirySeconds {
+    fn name(&self) -> &'static str {
+        headers::HEADER_DOCUMENTDB_EXPIRY_SECONDS
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            headers::HEADER_DOCUMENTDB_EXPIRY_SECONDS,
-            http::header::HeaderValue::from(self.0),
-        );
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_string()
     }
 }

--- a/sdk/data_cosmos/src/resources/permission/mod.rs
+++ b/sdk/data_cosmos/src/resources/permission/mod.rs
@@ -28,11 +28,11 @@ impl ExpirySeconds {
 }
 
 impl Header for ExpirySeconds {
-    fn name(&self) -> &'static str {
-        headers::HEADER_DOCUMENTDB_EXPIRY_SECONDS
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::HEADER_DOCUMENTDB_EXPIRY_SECONDS.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_string()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.0.to_string().into()
     }
 }

--- a/sdk/data_tables/src/if_match_condition.rs
+++ b/sdk/data_tables/src/if_match_condition.rs
@@ -1,7 +1,6 @@
 use azure_core::headers::{self, Header};
 use azure_core::Etag;
 use http::header::IF_MATCH;
-use http::request::Builder;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum IfMatchCondition {
@@ -16,30 +15,6 @@ impl From<Etag> for IfMatchCondition {
 }
 
 impl Header for IfMatchCondition {
-    fn add_to_builder(&self, builder: Builder) -> Builder {
-        match self {
-            IfMatchCondition::Etag(etag) => builder.header(IF_MATCH, etag.as_ref()),
-            IfMatchCondition::Any => builder.header(IF_MATCH, "*"),
-        }
-    }
-
-    fn add_to_request(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            IfMatchCondition::Etag(etag) => (IF_MATCH, etag.as_ref()),
-            IfMatchCondition::Any => (IF_MATCH, "*"),
-        };
-
-        request.headers_mut().insert(
-            header_name,
-            http::header::HeaderValue::from_str(header_value)?,
-        );
-
-        Ok(())
-    }
-
     fn name(&self) -> headers::HeaderName {
         IF_MATCH.into()
     }

--- a/sdk/data_tables/src/if_match_condition.rs
+++ b/sdk/data_tables/src/if_match_condition.rs
@@ -1,4 +1,4 @@
-use azure_core::{AddAsHeader, Etag};
+use azure_core::{Etag, Header};
 use http::header::IF_MATCH;
 use http::request::Builder;
 
@@ -14,7 +14,7 @@ impl From<Etag> for IfMatchCondition {
     }
 }
 
-impl AddAsHeader for IfMatchCondition {
+impl Header for IfMatchCondition {
     fn add_as_header(&self, builder: Builder) -> Builder {
         match self {
             IfMatchCondition::Etag(etag) => builder.header(IF_MATCH, etag.as_ref()),
@@ -37,5 +37,16 @@ impl AddAsHeader for IfMatchCondition {
         );
 
         Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        IF_MATCH.as_str()
+    }
+
+    fn value(&self) -> String {
+        match self {
+            IfMatchCondition::Etag(etag) => etag.to_string(),
+            IfMatchCondition::Any => "*".to_owned(),
+        }
     }
 }

--- a/sdk/data_tables/src/if_match_condition.rs
+++ b/sdk/data_tables/src/if_match_condition.rs
@@ -15,14 +15,14 @@ impl From<Etag> for IfMatchCondition {
 }
 
 impl Header for IfMatchCondition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         match self {
             IfMatchCondition::Etag(etag) => builder.header(IF_MATCH, etag.as_ref()),
             IfMatchCondition::Any => builder.header(IF_MATCH, "*"),
         }
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut azure_core::Request,
     ) -> Result<(), azure_core::HttpHeaderError> {

--- a/sdk/data_tables/src/if_match_condition.rs
+++ b/sdk/data_tables/src/if_match_condition.rs
@@ -32,7 +32,7 @@ impl Header for IfMatchCondition {
             IfMatchCondition::Any => (IF_MATCH, "*"),
         };
 
-        request.headers_mut().append(
+        request.headers_mut().insert(
             header_name,
             http::header::HeaderValue::from_str(header_value)?,
         );

--- a/sdk/data_tables/src/if_match_condition.rs
+++ b/sdk/data_tables/src/if_match_condition.rs
@@ -1,4 +1,5 @@
-use azure_core::{Etag, Header};
+use azure_core::headers::{self, Header};
+use azure_core::Etag;
 use http::header::IF_MATCH;
 use http::request::Builder;
 
@@ -39,14 +40,15 @@ impl Header for IfMatchCondition {
         Ok(())
     }
 
-    fn name(&self) -> &'static str {
-        IF_MATCH.as_str()
+    fn name(&self) -> headers::HeaderName {
+        IF_MATCH.into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self {
             IfMatchCondition::Etag(etag) => etag.to_string(),
             IfMatchCondition::Any => "*".to_owned(),
         }
+        .into()
     }
 }

--- a/sdk/data_tables/src/return_entity.rs
+++ b/sdk/data_tables/src/return_entity.rs
@@ -1,5 +1,4 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 use http::StatusCode;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -18,30 +17,17 @@ impl ReturnEntity {
     }
 }
 
-impl AddAsHeader for ReturnEntity {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(
-            "Prefer",
-            match self.0 {
-                true => "return-content",
-                false => "return-no-content",
-            },
-        )
+impl Header for ReturnEntity {
+    fn name(&self) -> &'static str {
+        "Prefer"
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            "Prefer",
-            http::header::HeaderValue::from_str(match self.0 {
-                true => "return-content",
-                false => "return-no-content",
-            })?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        match self.0 {
+            true => "return-content",
+            false => "return-no-content",
+        }
+        .to_owned()
     }
 }
 

--- a/sdk/data_tables/src/return_entity.rs
+++ b/sdk/data_tables/src/return_entity.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 use http::StatusCode;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -18,16 +18,16 @@ impl ReturnEntity {
 }
 
 impl Header for ReturnEntity {
-    fn name(&self) -> &'static str {
-        "Prefer"
+    fn name(&self) -> headers::HeaderName {
+        "Prefer".into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self.0 {
             true => "return-content",
             false => "return-no-content",
         }
-        .to_owned()
+        .into()
     }
 }
 

--- a/sdk/storage_blobs/src/access_tier.rs
+++ b/sdk/storage_blobs/src/access_tier.rs
@@ -1,5 +1,4 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 create_enum!(
     AccessTier,
@@ -8,20 +7,12 @@ create_enum!(
     (Archive, "Archive")
 );
 
-impl AddAsHeader for AccessTier {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(azure_core::headers::BLOB_ACCESS_TIER, self.as_ref())
+impl Header for AccessTier {
+    fn name(&self) -> &'static str {
+        azure_core::headers::BLOB_ACCESS_TIER
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            azure_core::headers::BLOB_ACCESS_TIER,
-            http::header::HeaderValue::from_str(self.as_ref())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.as_ref().to_owned()
     }
 }

--- a/sdk/storage_blobs/src/access_tier.rs
+++ b/sdk/storage_blobs/src/access_tier.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 
 create_enum!(
     AccessTier,
@@ -8,11 +8,11 @@ create_enum!(
 );
 
 impl Header for AccessTier {
-    fn name(&self) -> &'static str {
-        azure_core::headers::BLOB_ACCESS_TIER
+    fn name(&self) -> headers::HeaderName {
+        azure_core::headers::BLOB_ACCESS_TIER.into()
     }
 
-    fn value(&self) -> String {
-        self.as_ref().to_owned()
+    fn value(&self) -> headers::HeaderValue {
+        self.as_ref().to_owned().into()
     }
 }

--- a/sdk/storage_blobs/src/ba512_range.rs
+++ b/sdk/storage_blobs/src/ba512_range.rs
@@ -1,4 +1,5 @@
-use crate::{Header, Not512ByteAlignedError, Parse512AlignedError};
+use crate::{Not512ByteAlignedError, Parse512AlignedError};
+use azure_core::headers::{self, Header};
 use azure_core::prelude::Range;
 use std::convert::TryFrom;
 use std::fmt;
@@ -61,12 +62,12 @@ impl TryFrom<(u64, u64)> for BA512Range {
 }
 
 impl Header for BA512Range {
-    fn name(&self) -> &'static str {
-        http::header::RANGE.as_str()
+    fn name(&self) -> headers::HeaderName {
+        http::header::RANGE.into()
     }
 
-    fn value(&self) -> String {
-        self.to_string()
+    fn value(&self) -> headers::HeaderValue {
+        self.to_string().into()
     }
 }
 

--- a/sdk/storage_blobs/src/ba512_range.rs
+++ b/sdk/storage_blobs/src/ba512_range.rs
@@ -1,7 +1,5 @@
-use crate::{AddAsHeader, Not512ByteAlignedError, Parse512AlignedError};
+use crate::{Header, Not512ByteAlignedError, Parse512AlignedError};
 use azure_core::prelude::Range;
-use azure_core::{HttpHeaderError, Request};
-use http::request::Builder;
 use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
@@ -62,18 +60,13 @@ impl TryFrom<(u64, u64)> for BA512Range {
     }
 }
 
-impl AddAsHeader for BA512Range {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(http::header::RANGE, &format!("{}", self))
+impl Header for BA512Range {
+    fn name(&self) -> &'static str {
+        http::header::RANGE.as_str()
     }
 
-    fn add_as_header2(&self, request: &mut Request) -> Result<(), HttpHeaderError> {
-        request.headers_mut().append(
-            http::header::RANGE,
-            http::HeaderValue::from_str(&self.to_string())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.to_string()
     }
 }
 

--- a/sdk/storage_blobs/src/blob/requests/copy_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/copy_blob_builder.rs
@@ -74,7 +74,11 @@ impl<'a> CopyBlobBuilder<'a> {
             &http::Method::PUT,
             &|mut request| {
                 request = request.header(COPY_SOURCE, self.source_url.as_str());
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request = add_optional_header(&self.sequence_number_condition, request);
                 request = add_optional_header(&self.if_modified_since_condition, request);
                 request = add_optional_header(&self.if_match_condition, request);

--- a/sdk/storage_blobs/src/blob/requests/copy_blob_from_url_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/copy_blob_from_url_builder.rs
@@ -2,7 +2,7 @@ use super::SourceContentMD5;
 use crate::blob::responses::CopyBlobFromUrlResponse;
 use crate::prelude::*;
 use azure_core::headers::{
-    add_optional_header, add_optional_header_ref, COPY_SOURCE, REQUIRES_SYNC, add_mandatory_header,
+    add_mandatory_header, add_optional_header, add_optional_header_ref, COPY_SOURCE, REQUIRES_SYNC,
 };
 use azure_core::prelude::*;
 use std::convert::TryInto;

--- a/sdk/storage_blobs/src/blob/requests/copy_blob_from_url_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/copy_blob_from_url_builder.rs
@@ -2,7 +2,7 @@ use super::SourceContentMD5;
 use crate::blob::responses::CopyBlobFromUrlResponse;
 use crate::prelude::*;
 use azure_core::headers::{
-    add_optional_header, add_optional_header_ref, COPY_SOURCE, REQUIRES_SYNC,
+    add_optional_header, add_optional_header_ref, COPY_SOURCE, REQUIRES_SYNC, add_mandatory_header,
 };
 use azure_core::prelude::*;
 use std::convert::TryInto;
@@ -68,7 +68,11 @@ impl<'a> CopyBlobFromUrlBuilder<'a> {
             &|mut request| {
                 request = request.header(COPY_SOURCE, self.source_url);
                 request = request.header(REQUIRES_SYNC, format!("{}", self.is_synchronous));
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request = add_optional_header(&self.if_modified_since_condition, request);
                 request = add_optional_header(&self.if_match_condition, request);
                 request = add_optional_header_ref(&self.lease_id, request);

--- a/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
@@ -1,6 +1,7 @@
 use crate::blob::responses::GetBlobResponse;
 use crate::prelude::*;
 use crate::Header;
+use azure_core::headers::add_optional_headers;
 use azure_core::headers::{add_optional_header, add_optional_header_ref, CLIENT_REQUEST_ID};
 use azure_core::prelude::*;
 use futures::stream::Stream;
@@ -77,7 +78,7 @@ impl<'a> GetBlobBuilder<'a> {
             url.as_str(),
             &http::Method::GET,
             &|mut request| {
-                request = add_optional_header(&self.range, request);
+                request = add_optional_headers(&self.range, request);
                 request = add_optional_header(&self.client_request_id, request);
                 request = add_optional_header_ref(&self.lease_id, request);
                 request

--- a/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
@@ -1,10 +1,9 @@
 use crate::blob::responses::GetBlobResponse;
 use crate::prelude::*;
-use crate::AddAsHeader;
+use crate::Header;
 use azure_core::headers::{add_optional_header, add_optional_header_ref, CLIENT_REQUEST_ID};
 use azure_core::prelude::*;
 use futures::stream::Stream;
-use http::request::Builder;
 use std::convert::TryInto;
 
 // TODO Copy trait is required for current stream approach, once migrated to new approach with
@@ -24,20 +23,13 @@ impl<'a> From<&'a str> for ClientRequestId<'a> {
     }
 }
 
-impl<'a> AddAsHeader for ClientRequestId<'a> {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(CLIENT_REQUEST_ID, self.0)
+impl<'a> Header for ClientRequestId<'a> {
+    fn name(&self) -> &'static str {
+        CLIENT_REQUEST_ID
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request
-            .headers_mut()
-            .append(CLIENT_REQUEST_ID, http::HeaderValue::from_str(self.0)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_owned()
     }
 }
 

--- a/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
@@ -24,12 +24,12 @@ impl<'a> From<&'a str> for ClientRequestId<'a> {
 }
 
 impl<'a> Header for ClientRequestId<'a> {
-    fn name(&self) -> &'static str {
-        CLIENT_REQUEST_ID
+    fn name(&self) -> azure_core::headers::HeaderName {
+        CLIENT_REQUEST_ID.into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_owned()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.0.to_owned().into()
     }
 }
 

--- a/sdk/storage_blobs/src/blob/requests/put_append_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_append_blob_builder.rs
@@ -1,6 +1,8 @@
 use crate::blob::responses::PutBlobResponse;
 use crate::prelude::*;
-use azure_core::headers::{add_optional_header, add_optional_header_ref, BLOB_TYPE, add_mandatory_header};
+use azure_core::headers::{
+    add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_TYPE,
+};
 use azure_core::prelude::*;
 
 #[derive(Debug, Clone)]

--- a/sdk/storage_blobs/src/blob/requests/put_append_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_append_blob_builder.rs
@@ -1,6 +1,6 @@
 use crate::blob::responses::PutBlobResponse;
 use crate::prelude::*;
-use azure_core::headers::{add_optional_header, add_optional_header_ref, BLOB_TYPE};
+use azure_core::headers::{add_optional_header, add_optional_header_ref, BLOB_TYPE, add_mandatory_header};
 use azure_core::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -61,7 +61,11 @@ impl<'a> PutAppendBlobBuilder<'a> {
                 request = add_optional_header(&self.content_encoding, request);
                 request = add_optional_header(&self.content_language, request);
                 request = add_optional_header(&self.content_disposition, request);
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request = add_optional_header_ref(&self.lease_id, request);
                 request = add_optional_header(&self.client_request_id, request);
                 request

--- a/sdk/storage_blobs/src/blob/requests/put_block_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_block_blob_builder.rs
@@ -1,6 +1,6 @@
 use crate::blob::responses::PutBlockBlobResponse;
 use crate::prelude::*;
-use azure_core::headers::BLOB_TYPE;
+use azure_core::headers::{add_mandatory_header, BLOB_TYPE};
 use azure_core::headers::{add_optional_header, add_optional_header_ref};
 use azure_core::prelude::*;
 use bytes::Bytes;
@@ -72,7 +72,11 @@ impl<'a> PutBlockBlobBuilder<'a> {
                 request = add_optional_header(&self.content_encoding, request);
                 request = add_optional_header(&self.content_language, request);
                 request = add_optional_header(&self.content_disposition, request);
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request = add_optional_header(&self.access_tier, request);
                 request = add_optional_header_ref(&self.lease_id, request);
                 request = add_optional_header(&self.client_request_id, request);

--- a/sdk/storage_blobs/src/blob/requests/put_block_list_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_block_list_builder.rs
@@ -1,6 +1,6 @@
 use crate::blob::responses::PutBlockListResponse;
 use crate::prelude::*;
-use azure_core::headers::{add_optional_header, add_optional_header_ref, add_mandatory_header};
+use azure_core::headers::{add_mandatory_header, add_optional_header, add_optional_header_ref};
 use azure_core::prelude::*;
 use bytes::Bytes;
 

--- a/sdk/storage_blobs/src/blob/requests/put_block_list_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_block_list_builder.rs
@@ -1,6 +1,6 @@
 use crate::blob::responses::PutBlockListResponse;
 use crate::prelude::*;
-use azure_core::headers::{add_optional_header, add_optional_header_ref};
+use azure_core::headers::{add_optional_header, add_optional_header_ref, add_mandatory_header};
 use azure_core::prelude::*;
 use bytes::Bytes;
 
@@ -83,7 +83,11 @@ impl<'a> PutBlockListBuilder<'a> {
                 request = add_optional_header(&self.content_language, request);
                 request = add_optional_header(&self.content_disposition, request);
                 request = add_optional_header(&self.content_md5, request);
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request = add_optional_header(&self.access_tier, request);
                 request = add_optional_header_ref(&self.lease_id, request);
                 request = add_optional_header(&self.client_request_id, request);

--- a/sdk/storage_blobs/src/blob/requests/put_page_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_page_blob_builder.rs
@@ -1,7 +1,8 @@
 use crate::blob::responses::PutBlobResponse;
 use crate::prelude::*;
 use azure_core::headers::{
-    add_optional_header, add_optional_header_ref, BLOB_CONTENT_LENGTH, BLOB_TYPE, add_mandatory_header,
+    add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_CONTENT_LENGTH,
+    BLOB_TYPE,
 };
 use azure_core::prelude::*;
 

--- a/sdk/storage_blobs/src/blob/requests/put_page_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_page_blob_builder.rs
@@ -1,7 +1,7 @@
 use crate::blob::responses::PutBlobResponse;
 use crate::prelude::*;
 use azure_core::headers::{
-    add_optional_header, add_optional_header_ref, BLOB_CONTENT_LENGTH, BLOB_TYPE,
+    add_optional_header, add_optional_header_ref, BLOB_CONTENT_LENGTH, BLOB_TYPE, add_mandatory_header,
 };
 use azure_core::prelude::*;
 
@@ -69,7 +69,11 @@ impl<'a> PutPageBlobBuilder<'a> {
                 request = add_optional_header(&self.content_encoding, request);
                 request = add_optional_header(&self.content_language, request);
                 request = add_optional_header(&self.content_disposition, request);
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request = add_optional_header_ref(&self.lease_id, request);
                 request = add_optional_header(&self.sequence_number, request);
                 request = add_optional_header(&self.client_request_id, request);

--- a/sdk/storage_blobs/src/blob/requests/set_blob_metadata_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/set_blob_metadata_builder.rs
@@ -1,6 +1,6 @@
 use crate::blob::responses::SetBlobMetadataResponse;
 use crate::prelude::*;
-use azure_core::headers::{add_optional_header, add_optional_header_ref};
+use azure_core::headers::{add_optional_header, add_optional_header_ref, add_mandatory_header};
 use azure_core::prelude::*;
 use std::convert::TryInto;
 
@@ -47,7 +47,11 @@ impl<'a> SetBlobMetadataBuilder<'a> {
             &|mut request| {
                 request = add_optional_header(&self.client_request_id, request);
                 request = add_optional_header_ref(&self.lease_id, request);
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request
             },
             None,

--- a/sdk/storage_blobs/src/blob/requests/set_blob_metadata_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/set_blob_metadata_builder.rs
@@ -1,6 +1,6 @@
 use crate::blob::responses::SetBlobMetadataResponse;
 use crate::prelude::*;
-use azure_core::headers::{add_optional_header, add_optional_header_ref, add_mandatory_header};
+use azure_core::headers::{add_mandatory_header, add_optional_header, add_optional_header_ref};
 use azure_core::prelude::*;
 use std::convert::TryInto;
 

--- a/sdk/storage_blobs/src/blob/requests/source_content_md5.rs
+++ b/sdk/storage_blobs/src/blob/requests/source_content_md5.rs
@@ -1,5 +1,4 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct SourceContentMD5([u8; 16]);
@@ -10,20 +9,12 @@ impl From<md5::Digest> for SourceContentMD5 {
     }
 }
 
-impl AddAsHeader for SourceContentMD5 {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header("x-ms-source-content-md5", base64::encode(self.0))
+impl Header for SourceContentMD5 {
+    fn name(&self) -> &'static str {
+        "x-ms-source-content-md5"
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            "x-ms-source-content-md5",
-            http::header::HeaderValue::from_str(&base64::encode(self.0))?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        base64::encode(self.0)
     }
 }

--- a/sdk/storage_blobs/src/blob/requests/source_content_md5.rs
+++ b/sdk/storage_blobs/src/blob/requests/source_content_md5.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct SourceContentMD5([u8; 16]);
@@ -10,11 +10,11 @@ impl From<md5::Digest> for SourceContentMD5 {
 }
 
 impl Header for SourceContentMD5 {
-    fn name(&self) -> &'static str {
-        "x-ms-source-content-md5"
+    fn name(&self) -> headers::HeaderName {
+        "x-ms-source-content-md5".into()
     }
 
-    fn value(&self) -> String {
-        base64::encode(self.0)
+    fn value(&self) -> headers::HeaderValue {
+        base64::encode(self.0).into()
     }
 }

--- a/sdk/storage_blobs/src/blob_content_md5.rs
+++ b/sdk/storage_blobs/src/blob_content_md5.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct BlobContentMD5([u8; 16]);
@@ -10,11 +10,11 @@ impl From<md5::Digest> for BlobContentMD5 {
 }
 
 impl Header for BlobContentMD5 {
-    fn name(&self) -> &'static str {
-        "x-ms-blob-content-md5"
+    fn name(&self) -> headers::HeaderName {
+        "x-ms-blob-content-md5".into()
     }
 
-    fn value(&self) -> String {
-        base64::encode(self.0)
+    fn value(&self) -> headers::HeaderValue {
+        base64::encode(self.0).into()
     }
 }

--- a/sdk/storage_blobs/src/blob_content_md5.rs
+++ b/sdk/storage_blobs/src/blob_content_md5.rs
@@ -1,5 +1,4 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
 pub struct BlobContentMD5([u8; 16]);
@@ -10,20 +9,12 @@ impl From<md5::Digest> for BlobContentMD5 {
     }
 }
 
-impl AddAsHeader for BlobContentMD5 {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header("x-ms-blob-content-md5", base64::encode(self.0))
+impl Header for BlobContentMD5 {
+    fn name(&self) -> &'static str {
+        "x-ms-blob-content-md5"
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            "x-ms-blob-content-md5",
-            http::header::HeaderValue::from_str(&base64::encode(self.0))?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        base64::encode(self.0)
     }
 }

--- a/sdk/storage_blobs/src/condition_append_position.rs
+++ b/sdk/storage_blobs/src/condition_append_position.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConditionAppendPosition(u64);
@@ -16,11 +16,11 @@ impl From<u64> for ConditionAppendPosition {
 }
 
 impl Header for ConditionAppendPosition {
-    fn name(&self) -> &'static str {
-        "x-ms-blob-condition-appendpos"
+    fn name(&self) -> headers::HeaderName {
+        "x-ms-blob-condition-appendpos".into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_string()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_string().into()
     }
 }

--- a/sdk/storage_blobs/src/condition_append_position.rs
+++ b/sdk/storage_blobs/src/condition_append_position.rs
@@ -1,5 +1,4 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConditionAppendPosition(u64);
@@ -16,20 +15,12 @@ impl From<u64> for ConditionAppendPosition {
     }
 }
 
-impl AddAsHeader for ConditionAppendPosition {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header("x-ms-blob-condition-appendpos", &format!("{}", self.0))
+impl Header for ConditionAppendPosition {
+    fn name(&self) -> &'static str {
+        "x-ms-blob-condition-appendpos"
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            "x-ms-blob-condition-appendpos",
-            http::header::HeaderValue::from_str(&self.0.to_string())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_string()
     }
 }

--- a/sdk/storage_blobs/src/condition_max_size.rs
+++ b/sdk/storage_blobs/src/condition_max_size.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConditionMaxSize(u64);
@@ -16,11 +16,11 @@ impl From<u64> for ConditionMaxSize {
 }
 
 impl Header for ConditionMaxSize {
-    fn name(&self) -> &'static str {
-        "x-ms-blob-condition-maxsize"
+    fn name(&self) -> headers::HeaderName {
+        "x-ms-blob-condition-maxsize".into()
     }
 
-    fn value(&self) -> String {
-        self.0.to_string()
+    fn value(&self) -> headers::HeaderValue {
+        self.0.to_string().into()
     }
 }

--- a/sdk/storage_blobs/src/condition_max_size.rs
+++ b/sdk/storage_blobs/src/condition_max_size.rs
@@ -1,5 +1,4 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ConditionMaxSize(u64);
@@ -16,20 +15,12 @@ impl From<u64> for ConditionMaxSize {
     }
 }
 
-impl AddAsHeader for ConditionMaxSize {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header("x-ms-blob-condition-maxsize", &format!("{}", self.0))
+impl Header for ConditionMaxSize {
+    fn name(&self) -> &'static str {
+        "x-ms-blob-condition-maxsize"
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            "x-ms-blob-condition-maxsize",
-            http::header::HeaderValue::from(self.0),
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.0.to_string()
     }
 }

--- a/sdk/storage_blobs/src/container/mod.rs
+++ b/sdk/storage_blobs/src/container/mod.rs
@@ -42,7 +42,7 @@ impl Header for PublicAccess {
             PublicAccess::None => return Ok(()),
         };
 
-        request.headers_mut().append(
+        request.headers_mut().insert(
             header_name,
             http::header::HeaderValue::from_str(header_value)?,
         );

--- a/sdk/storage_blobs/src/container/mod.rs
+++ b/sdk/storage_blobs/src/container/mod.rs
@@ -1,4 +1,4 @@
-use azure_core::AddAsHeader;
+use azure_core::Header;
 pub mod requests;
 pub mod responses;
 
@@ -23,7 +23,7 @@ create_enum!(
     (Blob, "blob")
 );
 
-impl AddAsHeader for PublicAccess {
+impl Header for PublicAccess {
     fn add_as_header(&self, builder: Builder) -> Builder {
         match self {
             PublicAccess::Blob => builder.header(BLOB_PUBLIC_ACCESS, "blob"),
@@ -48,6 +48,14 @@ impl AddAsHeader for PublicAccess {
         );
 
         Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        todo!()
+    }
+
+    fn value(&self) -> String {
+        todo!()
     }
 }
 

--- a/sdk/storage_blobs/src/container/mod.rs
+++ b/sdk/storage_blobs/src/container/mod.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 pub mod requests;
 pub mod responses;
 
@@ -50,11 +50,11 @@ impl Header for PublicAccess {
         Ok(())
     }
 
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         todo!()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         todo!()
     }
 }

--- a/sdk/storage_blobs/src/container/mod.rs
+++ b/sdk/storage_blobs/src/container/mod.rs
@@ -24,7 +24,7 @@ create_enum!(
 );
 
 impl Header for PublicAccess {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+    fn add_to_builder(&self, builder: Builder) -> Builder {
         match self {
             PublicAccess::Blob => builder.header(BLOB_PUBLIC_ACCESS, "blob"),
             PublicAccess::Container => builder.header(BLOB_PUBLIC_ACCESS, "container"),
@@ -32,7 +32,7 @@ impl Header for PublicAccess {
         }
     }
 
-    fn add_as_header2(
+    fn add_to_request(
         &self,
         request: &mut azure_core::Request,
     ) -> Result<(), azure_core::HttpHeaderError> {

--- a/sdk/storage_blobs/src/container/requests/create_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/create_builder.rs
@@ -1,6 +1,6 @@
 use crate::{container::PublicAccess, prelude::*};
 use azure_core::{
-    headers::{add_mandatory_header, add_optional_header},
+    headers::{add_mandatory_header, add_optional_header, AsHeaders},
     prelude::*,
 };
 use http::{method::Method, status::StatusCode};
@@ -43,7 +43,9 @@ impl<'a> CreateBuilder<'a> {
             url.as_str(),
             &Method::PUT,
             &|mut request| {
-                request = add_mandatory_header(&self.public_access, request);
+                for (name, value) in self.public_access.as_headers() {
+                    request = request.header(name.as_str(), value.as_str())
+                }
                 if let Some(metadata) = &self.metadata {
                     for m in metadata.iter() {
                         request = add_mandatory_header(&m, request);

--- a/sdk/storage_blobs/src/container/requests/create_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/create_builder.rs
@@ -44,7 +44,11 @@ impl<'a> CreateBuilder<'a> {
             &Method::PUT,
             &|mut request| {
                 request = add_mandatory_header(&self.public_access, request);
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request = add_optional_header(&self.client_request_id, request);
                 request
             },

--- a/sdk/storage_blobs/src/container/requests/set_acl_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/set_acl_builder.rs
@@ -1,6 +1,6 @@
 use crate::container::public_access_from_header;
 use crate::prelude::*;
-use azure_core::headers::{add_mandatory_header, add_optional_header, add_optional_header_ref};
+use azure_core::headers::{add_optional_header, add_optional_header_ref, AsHeaders};
 use azure_core::prelude::*;
 use azure_storage::core::StoredAccessPolicyList;
 use bytes::Bytes;
@@ -50,7 +50,9 @@ impl<'a> SetACLBuilder<'a> {
             url.as_str(),
             &Method::PUT,
             &|mut request| {
-                request = add_mandatory_header(&self.public_access, request);
+                for (name, value) in self.public_access.as_headers() {
+                    request = request.header(name.as_str(), value.as_str())
+                }
                 request = add_optional_header(&self.client_request_id, request);
                 request = add_optional_header_ref(&self.lease_id, request);
                 request

--- a/sdk/storage_blobs/src/delete_snapshot_method.rs
+++ b/sdk/storage_blobs/src/delete_snapshot_method.rs
@@ -1,22 +1,13 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 create_enum!(DeleteSnapshotsMethod, (Include, "include"), (Only, "only"));
 
-impl AddAsHeader for DeleteSnapshotsMethod {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(azure_core::headers::DELETE_SNAPSHOTS, format!("{}", self))
+impl Header for DeleteSnapshotsMethod {
+    fn name(&self) -> &'static str {
+        azure_core::headers::DELETE_SNAPSHOTS
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            azure_core::headers::DELETE_SNAPSHOTS,
-            http::header::HeaderValue::from_str(self.as_ref())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.to_string()
     }
 }

--- a/sdk/storage_blobs/src/delete_snapshot_method.rs
+++ b/sdk/storage_blobs/src/delete_snapshot_method.rs
@@ -1,13 +1,13 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 
 create_enum!(DeleteSnapshotsMethod, (Include, "include"), (Only, "only"));
 
 impl Header for DeleteSnapshotsMethod {
-    fn name(&self) -> &'static str {
-        azure_core::headers::DELETE_SNAPSHOTS
+    fn name(&self) -> headers::HeaderName {
+        azure_core::headers::DELETE_SNAPSHOTS.into()
     }
 
-    fn value(&self) -> String {
-        self.to_string()
+    fn value(&self) -> headers::HeaderValue {
+        self.to_string().into()
     }
 }

--- a/sdk/storage_blobs/src/hash.rs
+++ b/sdk/storage_blobs/src/hash.rs
@@ -1,5 +1,4 @@
-use azure_core::AddAsHeader;
-use http::request::Builder;
+use azure_core::Header;
 
 use azure_storage::core::headers::{CONTENT_CRC64, CONTENT_MD5};
 
@@ -9,29 +8,19 @@ pub enum Hash {
     CRC64(u64),
 }
 
-impl AddAsHeader for Hash {
-    fn add_as_header(&self, builder: Builder) -> Builder {
+impl Header for Hash {
+    fn name(&self) -> &'static str {
         match self {
-            Hash::MD5(md5) => builder.header(CONTENT_MD5, base64::encode(md5)),
-            Hash::CRC64(crc64) => builder.header(CONTENT_CRC64, &format!("{}", crc64)),
+            Hash::MD5(_) => CONTENT_MD5,
+            Hash::CRC64(_) => CONTENT_CRC64,
         }
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        let (header_name, header_value) = match self {
-            Hash::MD5(md5) => (CONTENT_MD5, base64::encode(md5)),
-            Hash::CRC64(crc64) => (CONTENT_CRC64, crc64.to_string()),
-        };
-
-        request.headers_mut().append(
-            header_name,
-            http::header::HeaderValue::from_str(&header_value)?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        match self {
+            Hash::MD5(md5) => base64::encode(md5),
+            Hash::CRC64(crc64) => format!("{}", crc64),
+        }
     }
 }
 

--- a/sdk/storage_blobs/src/hash.rs
+++ b/sdk/storage_blobs/src/hash.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 
 use azure_storage::core::headers::{CONTENT_CRC64, CONTENT_MD5};
 
@@ -9,18 +9,20 @@ pub enum Hash {
 }
 
 impl Header for Hash {
-    fn name(&self) -> &'static str {
+    fn name(&self) -> headers::HeaderName {
         match self {
             Hash::MD5(_) => CONTENT_MD5,
             Hash::CRC64(_) => CONTENT_CRC64,
         }
+        .into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         match self {
             Hash::MD5(md5) => base64::encode(md5),
             Hash::CRC64(crc64) => format!("{}", crc64),
         }
+        .into()
     }
 }
 

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -71,11 +71,11 @@ impl AppendToUrlQuery for &BlobVersioning {
 create_enum!(RehydratePriority, (High, "High"), (Standard, "Standard"));
 
 impl Header for RehydratePriority {
-    fn name(&self) -> &'static str {
-        headers::REHYDRATE_PRIORITY
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::REHYDRATE_PRIORITY.into()
     }
 
-    fn value(&self) -> String {
-        self.to_string()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.to_string().into()
     }
 }

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -27,7 +27,7 @@ mod snapshot;
 mod version_id;
 
 pub use access_tier::AccessTier;
-use azure_core::{AddAsHeader, AppendToUrlQuery};
+use azure_core::{AppendToUrlQuery, Header};
 pub use ba512_range::BA512Range;
 pub use blob_content_md5::BlobContentMD5;
 pub use block_id::BlockId;
@@ -36,7 +36,6 @@ pub use condition_max_size::ConditionMaxSize;
 pub use delete_snapshot_method::DeleteSnapshotsMethod;
 pub use errors::*;
 pub use hash::Hash;
-use http::request::Builder;
 pub use snapshot::Snapshot;
 pub use version_id::VersionId;
 
@@ -71,20 +70,12 @@ impl AppendToUrlQuery for &BlobVersioning {
 
 create_enum!(RehydratePriority, (High, "High"), (Standard, "Standard"));
 
-impl AddAsHeader for RehydratePriority {
-    fn add_as_header(&self, builder: Builder) -> Builder {
-        builder.header(headers::REHYDRATE_PRIORITY, &format!("{}", self))
+impl Header for RehydratePriority {
+    fn name(&self) -> &'static str {
+        headers::REHYDRATE_PRIORITY
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> std::result::Result<(), azure_core::HttpHeaderError> {
-        request.headers_mut().append(
-            headers::REHYDRATE_PRIORITY,
-            http::header::HeaderValue::from_str(self.as_ref())?,
-        );
-
-        Ok(())
+    fn value(&self) -> String {
+        self.to_string()
     }
 }

--- a/sdk/storage_datalake/src/authorization_policies/bearer_token.rs
+++ b/sdk/storage_datalake/src/authorization_policies/bearer_token.rs
@@ -32,7 +32,7 @@ impl Policy for BearerTokenAuthorizationPolicy {
 
         request
             .headers_mut()
-            .append(AUTHORIZATION, HeaderValue::from_str(&auth_header_value)?);
+            .insert(AUTHORIZATION, HeaderValue::from_str(&auth_header_value)?);
 
         // now next[0] is safe (will not panic) because we checked
         // at the beginning of the function.

--- a/sdk/storage_datalake/src/authorization_policies/shared_key.rs
+++ b/sdk/storage_datalake/src/authorization_policies/shared_key.rs
@@ -29,13 +29,13 @@ impl Policy for SharedKeyAuthorizationPolicy {
         );
 
         let headers_mut = request.headers_mut();
-        headers_mut.append(
+        headers_mut.insert(
             azure_core::headers::MS_DATE,
             HeaderValue::from_str(
                 format!("{}", chrono::Utc::now().format("%a, %d %h %Y %T GMT")).as_str(),
             )?,
         );
-        headers_mut.append(
+        headers_mut.insert(
             azure_core::headers::VERSION,
             HeaderValue::from_str("2019-12-12")?,
         ); // TODO: Remove duplication with storage_account_client.rs
@@ -51,7 +51,7 @@ impl Policy for SharedKeyAuthorizationPolicy {
 
         request
             .headers_mut()
-            .append(http::header::AUTHORIZATION, HeaderValue::from_str(&auth)?);
+            .insert(http::header::AUTHORIZATION, HeaderValue::from_str(&auth)?);
 
         // now next[0] is safe (will not panic) because we checked
         // at the beginning of the function.

--- a/sdk/storage_datalake/src/authorization_policies/token_credential.rs
+++ b/sdk/storage_datalake/src/authorization_policies/token_credential.rs
@@ -48,7 +48,7 @@ impl Policy for TokenCredentialAuthorizationPolicy {
 
         request
             .headers_mut()
-            .append(AUTHORIZATION, HeaderValue::from_str(&auth_header_value)?);
+            .insert(AUTHORIZATION, HeaderValue::from_str(&auth_header_value)?);
 
         next[0].send(ctx, request, &next[1..]).await
     }

--- a/sdk/storage_datalake/src/operations/path_get.rs
+++ b/sdk/storage_datalake/src/operations/path_get.rs
@@ -2,9 +2,8 @@ use crate::clients::{FileClient, PathClient};
 use azure_core::headers::{etag_from_headers, last_modified_from_headers};
 use azure_core::prelude::*;
 use azure_core::{
-    collect_pinned_stream,
-    headers::{add_mandatory_header2, add_optional_header2},
-    AppendToUrlQuery, Response as HttpResponse,
+    collect_pinned_stream, headers::add_optional_header2, AppendToUrlQuery,
+    Response as HttpResponse,
 };
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -62,7 +61,7 @@ impl GetFileBuilder {
             let mut request = this.client.prepare_request(url.as_str(), http::Method::GET);
 
             let requested_range = self.range.unwrap_or_else(|| Range::new(0, u64::MAX));
-            add_mandatory_header2(&requested_range, &mut request)?;
+            request.insert_headers(&requested_range);
 
             add_optional_header2(&this.client_request_id, &mut request)?;
             add_optional_header2(&this.if_match_condition, &mut request)?;

--- a/sdk/storage_datalake/src/properties.rs
+++ b/sdk/storage_datalake/src/properties.rs
@@ -1,4 +1,4 @@
-use azure_core::Header;
+use azure_core::headers::{self, Header};
 use http::HeaderMap;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -34,11 +34,11 @@ impl Properties {
 }
 
 impl Header for Properties {
-    fn name(&self) -> &'static str {
-        HEADER
+    fn name(&self) -> headers::HeaderName {
+        HEADER.into()
     }
 
-    fn value(&self) -> String {
+    fn value(&self) -> headers::HeaderValue {
         // the header is a comma separated list of key=base64(value) see
         // [https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/filesystem/create#request-headers](https://docs.microsoft.com/rest/api/storageservices/datalakestoragegen2/filesystem/create#request-headers)
         self.0
@@ -46,6 +46,7 @@ impl Header for Properties {
             .map(|(k, v)| format!("{}={}", k.as_ref(), base64::encode(v.as_ref())))
             .collect::<Vec<_>>()
             .join(",")
+            .into()
     }
 }
 

--- a/sdk/storage_datalake/src/request_options.rs
+++ b/sdk/storage_datalake/src/request_options.rs
@@ -1,8 +1,7 @@
 //! Request properties used in datalake rest api operations
-use azure_core::AddAsHeader;
 use azure_core::AppendToUrlQuery;
-use azure_storage::core::headers::RENAME_SOURCE;
-use http::request::Builder;
+use azure_core::Header;
+use azure_storage::core::headers;
 
 #[derive(Debug, Clone)]
 pub enum ResourceType {
@@ -189,21 +188,13 @@ where
     }
 }
 
-impl AddAsHeader for RenameSource {
-    fn add_as_header(&self, _builder: Builder) -> Builder {
-        unimplemented!("Datalake crate only supports pipeline architecture")
+impl Header for RenameSource {
+    fn name(&self) -> &'static str {
+        headers::RENAME_SOURCE
     }
 
-    fn add_as_header2(
-        &self,
-        request: &mut azure_core::Request,
-    ) -> Result<(), azure_core::HttpHeaderError> {
-        let encoded: String = url::form_urlencoded::byte_serialize(self.0.as_bytes()).collect();
-        request
-            .headers_mut()
-            .append(RENAME_SOURCE, http::HeaderValue::from_str(&encoded)?);
-
-        Ok(())
+    fn value(&self) -> String {
+        url::form_urlencoded::byte_serialize(self.0.as_bytes()).collect()
     }
 }
 

--- a/sdk/storage_datalake/src/request_options.rs
+++ b/sdk/storage_datalake/src/request_options.rs
@@ -189,12 +189,14 @@ where
 }
 
 impl Header for RenameSource {
-    fn name(&self) -> &'static str {
-        headers::RENAME_SOURCE
+    fn name(&self) -> azure_core::headers::HeaderName {
+        headers::RENAME_SOURCE.into()
     }
 
-    fn value(&self) -> String {
-        url::form_urlencoded::byte_serialize(self.0.as_bytes()).collect()
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        url::form_urlencoded::byte_serialize(self.0.as_bytes())
+            .collect::<String>()
+            .into()
     }
 }
 

--- a/sdk/storage_queues/src/requests/create_queue_builder.rs
+++ b/sdk/storage_queues/src/requests/create_queue_builder.rs
@@ -1,6 +1,6 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::headers::add_optional_header;
+use azure_core::headers::{add_optional_header, add_mandatory_header};
 use azure_core::prelude::*;
 use std::convert::TryInto;
 
@@ -40,7 +40,11 @@ impl<'a> CreateQueueBuilder<'a> {
             &http::method::Method::PUT,
             &|mut request| {
                 request = add_optional_header(&self.client_request_id, request);
-                request = add_optional_header(&self.metadata, request);
+                if let Some(metadata) = &self.metadata {
+                    for m in metadata.iter() {
+                        request = add_mandatory_header(&m, request);
+                    }
+                }
                 request
             },
             None,

--- a/sdk/storage_queues/src/requests/create_queue_builder.rs
+++ b/sdk/storage_queues/src/requests/create_queue_builder.rs
@@ -1,6 +1,6 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::headers::{add_optional_header, add_mandatory_header};
+use azure_core::headers::{add_mandatory_header, add_optional_header};
 use azure_core::prelude::*;
 use std::convert::TryInto;
 

--- a/sdk/storage_queues/src/requests/set_queue_metadata_builder.rs
+++ b/sdk/storage_queues/src/requests/set_queue_metadata_builder.rs
@@ -46,7 +46,9 @@ impl<'a> SetQueueMetadataBuilder<'a> {
             url.as_str(),
             &http::method::Method::PUT,
             &|mut request| {
-                request = add_mandatory_header(&metadata, request);
+                for m in metadata.iter() {
+                    request = add_mandatory_header(&m, request);
+                }
                 request = add_optional_header(&self.client_request_id, request);
                 request
             },


### PR DESCRIPTION
*worked on with @yoshuawuyts! 🎉*

This PR introduces a few mechanisms which make it easier to handle headers.

In general, we provide rich high-level types that can be mapped to some set of headers. This is accomplished through the `AsHeaders` trait which allows a type to define an iterator over some set of `(HeaderName, HeaderValue)`. 

As a convenience there is the `Header` trait which allows a type to specify itself as mapping of a type 1 to 1 to a header. This is provided since a 1 to 1 mapping is the most common case and so makes definitions a bit more straight forward. 

This change is largely internal facing (i.e., users won't really notice a difference). However, internally, the definition of how to turn a type into headers is much shorter and adding those headers to a request is a bit more succinct. 