### PR TITLE
Remove the use of `#[macro_use]` which isn't the most idiomatic these days

### DIFF
--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -9,9 +9,6 @@
 // #![warn(missing_docs, future_incompatible, unreachable_pub)]
 
 #[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
 mod macros;
 
 mod bytes_stream;

--- a/sdk/core/src/models/etag.rs
+++ b/sdk/core/src/models/etag.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/sdk/core/src/request_options/next_marker.rs
+++ b/sdk/core/src/request_options/next_marker.rs
@@ -1,6 +1,7 @@
+use super::Continuation;
 use crate::{AppendToUrlQuery, Error, HttpHeaderError};
 
-use super::Continuation;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NextMarker(String);


### PR DESCRIPTION
`#[macro_use]`  is not yet deprecated but on a path towards being so at some point. This puts us a bit ahead of the curve. 