### PR TITLE
set azure_core to 0.2.1

### DIFF
--- a/sdk/core/CHANGELOG.md
+++ b/sdk/core/CHANGELOG.md
@@ -1,0 +1,9 @@
+# 0.2.1 (2022-04)
+
+- [#625](https://github.com/Azure/azure-sdk-for-rust/pull/625) Improved Error Handling
+- [#690](https://github.com/Azure/azure-sdk-for-rust/pull/690) Better header insertion handling
+- [#691](https://github.com/Azure/azure-sdk-for-rust/pull/691) Better header handling
+
+# 0.1.1 (2022-01)
+
+- initial publish to [crates.io](https://crates.io/crates/azure_core)

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core"
-version = "0.1.1"
+version = "0.2.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -1,3 +1,12 @@
-# azure_core crate
+# Azure SDK for Rust - Core crate
 
-The azure_core crate is an [Azure SDK for Rust](https://github.com/Azure/azure-sdk-for-rust) crate. It is a library that provides cross-cutting services to other client libraries. Please see the [general guidelines](https://azure.github.io/azure-sdk/general_azurecore.html). For changes in this version, see the [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/core/CHANGELOG.md). For open issues, filter with the [core label](https://github.com/Azure/azure-sdk-for-rust/issues?q=is%3Aopen+is%3Aissue+label%3Acore).
+Core crate for the unofficial Microsoft Azure SDK for Rust. This crate is part of a collection of crates: for more information please refer to [https://github.com/azure/azure-sdk-for-rust](https://github.com/azure/azure-sdk-for-rust).
+
+## Usage
+
+To set this crate as a dependency, add this to your Cargo.toml
+
+```toml
+[dependencies]
+azure_core = "0.1"
+```

--- a/sdk/core/README.md
+++ b/sdk/core/README.md
@@ -1,12 +1,3 @@
-# Azure SDK for Rust - Core crate
+# azure_core crate
 
-Core crate for the unofficial Microsoft Azure SDK for Rust. This crate is part of a collection of crates: for more information please refer to [https://github.com/azure/azure-sdk-for-rust](https://github.com/azure/azure-sdk-for-rust).
-
-## Usage
-
-To set this crate as a dependency, add this to your Cargo.toml
-
-```toml
-[dependencies]
-azure_core = "0.1"
-```
+The azure_core crate is an [Azure SDK for Rust](https://github.com/Azure/azure-sdk-for-rust) crate. It is a library that provides cross-cutting services to other client libraries. Please see the [general guidelines](https://azure.github.io/azure-sdk/general_azurecore.html). For changes in this version, see the [CHANGELOG.md](https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/core/CHANGELOG.md). For open issues, filter with the [core label](https://github.com/Azure/azure-sdk-for-rust/issues?q=is%3Aopen+is%3Aissue+label%3Acore).

--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.1" }
+azure_core = { path = "../core", version = "0.2" }
 base64 = "0.13"
 chrono = "0.4"
 http = "0.2"

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1", default-features=false}
+azure_core = { path = "../core", version = "0.2", default-features=false}
 azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"]}
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 reqwest = { version = "0.11", features = ["json"], default-features = false }
-azure_core = { path = "../core", version = "0.1", default-features = false }
+azure_core = { path = "../core", version = "0.2", default-features = false }
 async-lock = "2.5"
 oauth2 = { version = "4.0.0", default-features = false }
 url = "2.2"

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -7,7 +7,7 @@ description = "Azure IoT Hub"
 license = "MIT"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1" }
+azure_core = { path = "../core", version = "0.2" }
 base64 = "0.13"
 bytes = "1.0"
 chrono = "0.4"

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1" }
+azure_core = { path = "../core", version = "0.2" }
 chrono = { version = "0.4", features = ["serde"] }
 http = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1" }
+azure_core = { path = "../core", version = "0.2" }
 base64 = "0.13"
 chrono = "0.4"
 log = "0.4"

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-azure_core = { path = "../core", version = "0.1" }
+azure_core = { path = "../core", version = "0.2" }
 
 [dev-dependencies]
 oauth2 = "4.0.0"

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.1", default-features=false }
+azure_core = { path = "../core", version = "0.2", default-features=false }
 base64 = "0.13"
 chrono = "0.4"
 http = "0.2"

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1", default-features=false }
+azure_core = { path = "../core", version = "0.2", default-features=false }
 azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"] }
 base64 = "0.13"
 bytes = "1.0"

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.1" }
+azure_core = { path = "../core", version = "0.2" }
 azure_storage = { path = "../storage", version = "0.1" }
 base64 = "0.13"
 bytes = "1.0"

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.1", default-features=false }
+azure_core = { path = "../core", version = "0.2", default-features=false }
 azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"] }
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/services/autorust/codegen/src/cargo_toml.rs
+++ b/services/autorust/codegen/src/cargo_toml.rs
@@ -41,7 +41,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/{}"
 
 [dependencies]
-azure_core = {{ path = "../../../sdk/core", version = "0.1", default-features = false }}
+azure_core = {{ path = "../../../sdk/core", version = "0.2", default-features = false }}
 serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/activedirectory/Cargo.toml
+++ b/services/mgmt/activedirectory/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_activedirectory"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/addons/Cargo.toml
+++ b/services/mgmt/addons/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_addons"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/adhybridhealthservice/Cargo.toml
+++ b/services/mgmt/adhybridhealthservice/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_adhybridhealthservice"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/adp/Cargo.toml
+++ b/services/mgmt/adp/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_adp"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/advisor/Cargo.toml
+++ b/services/mgmt/advisor/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_advisor"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/agrifood/Cargo.toml
+++ b/services/mgmt/agrifood/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_agrifood"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/alertsmanagement/Cargo.toml
+++ b/services/mgmt/alertsmanagement/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_alertsmanagement"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/analysisservices/Cargo.toml
+++ b/services/mgmt/analysisservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_analysisservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/apimanagement/Cargo.toml
+++ b/services/mgmt/apimanagement/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_apimanagement"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/app/Cargo.toml
+++ b/services/mgmt/app/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_app"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/appconfiguration/Cargo.toml
+++ b/services/mgmt/appconfiguration/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_appconfiguration"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/applicationinsights/Cargo.toml
+++ b/services/mgmt/applicationinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_applicationinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/appplatform/Cargo.toml
+++ b/services/mgmt/appplatform/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_appplatform"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/arcdata/Cargo.toml
+++ b/services/mgmt/arcdata/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_arcdata"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/attestation/Cargo.toml
+++ b/services/mgmt/attestation/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_attestation"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/authorization/Cargo.toml
+++ b/services/mgmt/authorization/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_authorization"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/automanage/Cargo.toml
+++ b/services/mgmt/automanage/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_automanage"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/automation/Cargo.toml
+++ b/services/mgmt/automation/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_automation"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/baremetalinfrastructure/Cargo.toml
+++ b/services/mgmt/baremetalinfrastructure/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_baremetalinfrastructure"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/batch/Cargo.toml
+++ b/services/mgmt/batch/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_batch"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/billing/Cargo.toml
+++ b/services/mgmt/billing/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_billing"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/blockchain/Cargo.toml
+++ b/services/mgmt/blockchain/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_blockchain"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/blueprint/Cargo.toml
+++ b/services/mgmt/blueprint/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_blueprint"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/botservice/Cargo.toml
+++ b/services/mgmt/botservice/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_botservice"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cdn/Cargo.toml
+++ b/services/mgmt/cdn/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_cdn"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/changeanalysis/Cargo.toml
+++ b/services/mgmt/changeanalysis/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_changeanalysis"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/chaos/Cargo.toml
+++ b/services/mgmt/chaos/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_chaos"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cloudshell/Cargo.toml
+++ b/services/mgmt/cloudshell/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_cloudshell"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cognitiveservices/Cargo.toml
+++ b/services/mgmt/cognitiveservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_cognitiveservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/commerce/Cargo.toml
+++ b/services/mgmt/commerce/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_commerce"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/communication/Cargo.toml
+++ b/services/mgmt/communication/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_communication"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/compute/Cargo.toml
+++ b/services/mgmt/compute/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_compute"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/confidentialledger/Cargo.toml
+++ b/services/mgmt/confidentialledger/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_confidentialledger"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/confluent/Cargo.toml
+++ b/services/mgmt/confluent/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_confluent"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/connectedvmware/Cargo.toml
+++ b/services/mgmt/connectedvmware/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_connectedvmware"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/consumption/Cargo.toml
+++ b/services/mgmt/consumption/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_consumption"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/containerinstance/Cargo.toml
+++ b/services/mgmt/containerinstance/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_containerinstance"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/containerregistry/Cargo.toml
+++ b/services/mgmt/containerregistry/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_containerregistry"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/containerservice/Cargo.toml
+++ b/services/mgmt/containerservice/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_containerservice"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cosmosdb/Cargo.toml
+++ b/services/mgmt/cosmosdb/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_cosmosdb"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/costmanagement/Cargo.toml
+++ b/services/mgmt/costmanagement/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_costmanagement"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/cpim/Cargo.toml
+++ b/services/mgmt/cpim/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_cpim"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/customerinsights/Cargo.toml
+++ b/services/mgmt/customerinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_customerinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/customerlockbox/Cargo.toml
+++ b/services/mgmt/customerlockbox/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_customerlockbox"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/customproviders/Cargo.toml
+++ b/services/mgmt/customproviders/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_customproviders"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dashboard/Cargo.toml
+++ b/services/mgmt/dashboard/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_dashboard"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/data/Cargo.toml
+++ b/services/mgmt/data/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_data"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/databox/Cargo.toml
+++ b/services/mgmt/databox/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_databox"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/databoxedge/Cargo.toml
+++ b/services/mgmt/databoxedge/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_databoxedge"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/databricks/Cargo.toml
+++ b/services/mgmt/databricks/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_databricks"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datacatalog/Cargo.toml
+++ b/services/mgmt/datacatalog/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_datacatalog"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datadog/Cargo.toml
+++ b/services/mgmt/datadog/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_datadog"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datafactory/Cargo.toml
+++ b/services/mgmt/datafactory/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_datafactory"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datalakeanalytics/Cargo.toml
+++ b/services/mgmt/datalakeanalytics/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_datalakeanalytics"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datalakestore/Cargo.toml
+++ b/services/mgmt/datalakestore/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_datalakestore"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dataprotection/Cargo.toml
+++ b/services/mgmt/dataprotection/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_dataprotection"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/datashare/Cargo.toml
+++ b/services/mgmt/datashare/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_datashare"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/deploymentmanager/Cargo.toml
+++ b/services/mgmt/deploymentmanager/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_deploymentmanager"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/desktopvirtualization/Cargo.toml
+++ b/services/mgmt/desktopvirtualization/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_desktopvirtualization"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/deviceupdate/Cargo.toml
+++ b/services/mgmt/deviceupdate/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_deviceupdate"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/devops/Cargo.toml
+++ b/services/mgmt/devops/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_devops"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/devspaces/Cargo.toml
+++ b/services/mgmt/devspaces/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_devspaces"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/devtestlabs/Cargo.toml
+++ b/services/mgmt/devtestlabs/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_devtestlabs"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dfp/Cargo.toml
+++ b/services/mgmt/dfp/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_dfp"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/digitaltwins/Cargo.toml
+++ b/services/mgmt/digitaltwins/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_digitaltwins"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dns/Cargo.toml
+++ b/services/mgmt/dns/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_dns"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/dnsresolver/Cargo.toml
+++ b/services/mgmt/dnsresolver/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_dnsresolver"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/domainservices/Cargo.toml
+++ b/services/mgmt/domainservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_domainservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/edgeorder/Cargo.toml
+++ b/services/mgmt/edgeorder/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_edgeorder"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/edgeorderpartner/Cargo.toml
+++ b/services/mgmt/edgeorderpartner/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_edgeorderpartner"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/elastic/Cargo.toml
+++ b/services/mgmt/elastic/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_elastic"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/engagementfabric/Cargo.toml
+++ b/services/mgmt/engagementfabric/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_engagementfabric"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/enterpriseknowledgegraph/Cargo.toml
+++ b/services/mgmt/enterpriseknowledgegraph/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_enterpriseknowledgegraph"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/eventgrid/Cargo.toml
+++ b/services/mgmt/eventgrid/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_eventgrid"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/eventhub/Cargo.toml
+++ b/services/mgmt/eventhub/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_eventhub"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/extendedlocation/Cargo.toml
+++ b/services/mgmt/extendedlocation/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_extendedlocation"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/fluidrelay/Cargo.toml
+++ b/services/mgmt/fluidrelay/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_fluidrelay"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/frontdoor/Cargo.toml
+++ b/services/mgmt/frontdoor/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_frontdoor"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/guestconfiguration/Cargo.toml
+++ b/services/mgmt/guestconfiguration/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_guestconfiguration"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hanaon/Cargo.toml
+++ b/services/mgmt/hanaon/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hanaon"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hardwaresecuritymodules/Cargo.toml
+++ b/services/mgmt/hardwaresecuritymodules/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hardwaresecuritymodules"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hdinsight/Cargo.toml
+++ b/services/mgmt/hdinsight/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hdinsight"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/healthbot/Cargo.toml
+++ b/services/mgmt/healthbot/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_healthbot"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/healthcareapis/Cargo.toml
+++ b/services/mgmt/healthcareapis/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_healthcareapis"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridcompute/Cargo.toml
+++ b/services/mgmt/hybridcompute/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hybridcompute"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridconnectivity/Cargo.toml
+++ b/services/mgmt/hybridconnectivity/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hybridconnectivity"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybriddatamanager/Cargo.toml
+++ b/services/mgmt/hybriddatamanager/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hybriddatamanager"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridkubernetes/Cargo.toml
+++ b/services/mgmt/hybridkubernetes/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hybridkubernetes"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/hybridnetwork/Cargo.toml
+++ b/services/mgmt/hybridnetwork/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_hybridnetwork"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/imagebuilder/Cargo.toml
+++ b/services/mgmt/imagebuilder/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_imagebuilder"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/intune/Cargo.toml
+++ b/services/mgmt/intune/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_intune"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/iotcentral/Cargo.toml
+++ b/services/mgmt/iotcentral/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_iotcentral"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/iothub/Cargo.toml
+++ b/services/mgmt/iothub/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_iothub"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/keyvault/Cargo.toml
+++ b/services/mgmt/keyvault/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_keyvault"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/kubernetesconfiguration/Cargo.toml
+++ b/services/mgmt/kubernetesconfiguration/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_kubernetesconfiguration"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/kusto/Cargo.toml
+++ b/services/mgmt/kusto/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_kusto"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/labservices/Cargo.toml
+++ b/services/mgmt/labservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_labservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/loadtestservice/Cargo.toml
+++ b/services/mgmt/loadtestservice/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_loadtestservice"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/logic/Cargo.toml
+++ b/services/mgmt/logic/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_logic"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/logz/Cargo.toml
+++ b/services/mgmt/logz/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_logz"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearning/Cargo.toml
+++ b/services/mgmt/machinelearning/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_machinelearning"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearningcompute/Cargo.toml
+++ b/services/mgmt/machinelearningcompute/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_machinelearningcompute"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearningexperimentation/Cargo.toml
+++ b/services/mgmt/machinelearningexperimentation/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_machinelearningexperimentation"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/machinelearningservices/Cargo.toml
+++ b/services/mgmt/machinelearningservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_machinelearningservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/maintenance/Cargo.toml
+++ b/services/mgmt/maintenance/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_maintenance"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managednetwork/Cargo.toml
+++ b/services/mgmt/managednetwork/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_managednetwork"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managedservices/Cargo.toml
+++ b/services/mgmt/managedservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_managedservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managementgroups/Cargo.toml
+++ b/services/mgmt/managementgroups/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_managementgroups"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/managementpartner/Cargo.toml
+++ b/services/mgmt/managementpartner/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_managementpartner"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/maps/Cargo.toml
+++ b/services/mgmt/maps/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_maps"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/mariadb/Cargo.toml
+++ b/services/mgmt/mariadb/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_mariadb"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/marketplacenotifications/Cargo.toml
+++ b/services/mgmt/marketplacenotifications/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_marketplacenotifications"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/marketplaceordering/Cargo.toml
+++ b/services/mgmt/marketplaceordering/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_marketplaceordering"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/mediaservices/Cargo.toml
+++ b/services/mgmt/mediaservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_mediaservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/migrate/Cargo.toml
+++ b/services/mgmt/migrate/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_migrate"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/migrateprojects/Cargo.toml
+++ b/services/mgmt/migrateprojects/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_migrateprojects"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/mobilenetwork/Cargo.toml
+++ b/services/mgmt/mobilenetwork/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_mobilenetwork"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/monitor/Cargo.toml
+++ b/services/mgmt/monitor/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_monitor"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/msi/Cargo.toml
+++ b/services/mgmt/msi/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_msi"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/mysql/Cargo.toml
+++ b/services/mgmt/mysql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_mysql"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/netapp/Cargo.toml
+++ b/services/mgmt/netapp/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_netapp"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/network/Cargo.toml
+++ b/services/mgmt/network/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_network"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/notificationhubs/Cargo.toml
+++ b/services/mgmt/notificationhubs/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_notificationhubs"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/oep/Cargo.toml
+++ b/services/mgmt/oep/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_oep"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/operationalinsights/Cargo.toml
+++ b/services/mgmt/operationalinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_operationalinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/operationsmanagement/Cargo.toml
+++ b/services/mgmt/operationsmanagement/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_operationsmanagement"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/orbital/Cargo.toml
+++ b/services/mgmt/orbital/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_orbital"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/peering/Cargo.toml
+++ b/services/mgmt/peering/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_peering"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/policyinsights/Cargo.toml
+++ b/services/mgmt/policyinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_policyinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/portal/Cargo.toml
+++ b/services/mgmt/portal/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_portal"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/postgresql/Cargo.toml
+++ b/services/mgmt/postgresql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_postgresql"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/postgresqlhsc/Cargo.toml
+++ b/services/mgmt/postgresqlhsc/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_postgresqlhsc"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerbidedicated/Cargo.toml
+++ b/services/mgmt/powerbidedicated/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_powerbidedicated"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerbiembedded/Cargo.toml
+++ b/services/mgmt/powerbiembedded/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_powerbiembedded"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerbiprivatelinks/Cargo.toml
+++ b/services/mgmt/powerbiprivatelinks/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_powerbiprivatelinks"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/powerplatform/Cargo.toml
+++ b/services/mgmt/powerplatform/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_powerplatform"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/privatedns/Cargo.toml
+++ b/services/mgmt/privatedns/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_privatedns"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/providerhub/Cargo.toml
+++ b/services/mgmt/providerhub/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_providerhub"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/purview/Cargo.toml
+++ b/services/mgmt/purview/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_purview"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/quantum/Cargo.toml
+++ b/services/mgmt/quantum/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_quantum"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/quota/Cargo.toml
+++ b/services/mgmt/quota/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_quota"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/recoveryservices/Cargo.toml
+++ b/services/mgmt/recoveryservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_recoveryservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/recoveryservicesbackup/Cargo.toml
+++ b/services/mgmt/recoveryservicesbackup/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_recoveryservicesbackup"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/recoveryservicessiterecovery/Cargo.toml
+++ b/services/mgmt/recoveryservicessiterecovery/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_recoveryservicessiterecovery"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/redhatopenshift/Cargo.toml
+++ b/services/mgmt/redhatopenshift/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_redhatopenshift"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/redis/Cargo.toml
+++ b/services/mgmt/redis/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_redis"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/redisenterprise/Cargo.toml
+++ b/services/mgmt/redisenterprise/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_redisenterprise"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/relay/Cargo.toml
+++ b/services/mgmt/relay/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_relay"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/reservations/Cargo.toml
+++ b/services/mgmt/reservations/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_reservations"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourceconnector/Cargo.toml
+++ b/services/mgmt/resourceconnector/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_resourceconnector"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourcegraph/Cargo.toml
+++ b/services/mgmt/resourcegraph/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_resourcegraph"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourcehealth/Cargo.toml
+++ b/services/mgmt/resourcehealth/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_resourcehealth"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resourcemover/Cargo.toml
+++ b/services/mgmt/resourcemover/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_resourcemover"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/resources/Cargo.toml
+++ b/services/mgmt/resources/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_resources"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/saas/Cargo.toml
+++ b/services/mgmt/saas/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_saas"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/scheduler/Cargo.toml
+++ b/services/mgmt/scheduler/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_scheduler"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/search/Cargo.toml
+++ b/services/mgmt/search/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_search"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/security/Cargo.toml
+++ b/services/mgmt/security/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_security"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/securityandcompliance/Cargo.toml
+++ b/services/mgmt/securityandcompliance/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_securityandcompliance"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/securityinsights/Cargo.toml
+++ b/services/mgmt/securityinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_securityinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/serialconsole/Cargo.toml
+++ b/services/mgmt/serialconsole/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_serialconsole"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/servicebus/Cargo.toml
+++ b/services/mgmt/servicebus/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_servicebus"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/servicefabricmesh/Cargo.toml
+++ b/services/mgmt/servicefabricmesh/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_servicefabricmesh"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/servicelinker/Cargo.toml
+++ b/services/mgmt/servicelinker/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_servicelinker"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/signalr/Cargo.toml
+++ b/services/mgmt/signalr/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_signalr"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/softwareplan/Cargo.toml
+++ b/services/mgmt/softwareplan/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_softwareplan"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/solutions/Cargo.toml
+++ b/services/mgmt/solutions/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_solutions"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/sql/Cargo.toml
+++ b/services/mgmt/sql/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_sql"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/sqlvirtualmachine/Cargo.toml
+++ b/services/mgmt/sqlvirtualmachine/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_sqlvirtualmachine"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/stack/Cargo.toml
+++ b/services/mgmt/stack/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_stack"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storage/Cargo.toml
+++ b/services/mgmt/storage/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_storage"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storagecache/Cargo.toml
+++ b/services/mgmt/storagecache/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_storagecache"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storageimportexport/Cargo.toml
+++ b/services/mgmt/storageimportexport/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_storageimportexport"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storagepool/Cargo.toml
+++ b/services/mgmt/storagepool/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_storagepool"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storagesync/Cargo.toml
+++ b/services/mgmt/storagesync/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_storagesync"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storsimple1200series/Cargo.toml
+++ b/services/mgmt/storsimple1200series/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_storsimple1200series"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/storsimple8000series/Cargo.toml
+++ b/services/mgmt/storsimple8000series/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_storsimple8000series"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/streamanalytics/Cargo.toml
+++ b/services/mgmt/streamanalytics/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_streamanalytics"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/subscription/Cargo.toml
+++ b/services/mgmt/subscription/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_subscription"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/support/Cargo.toml
+++ b/services/mgmt/support/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_support"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/synapse/Cargo.toml
+++ b/services/mgmt/synapse/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_synapse"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/testbase/Cargo.toml
+++ b/services/mgmt/testbase/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_testbase"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/timeseriesinsights/Cargo.toml
+++ b/services/mgmt/timeseriesinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_timeseriesinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/trafficmanager/Cargo.toml
+++ b/services/mgmt/trafficmanager/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_trafficmanager"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/vi/Cargo.toml
+++ b/services/mgmt/vi/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_vi"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/videoanalyzer/Cargo.toml
+++ b/services/mgmt/videoanalyzer/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_videoanalyzer"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/visualstudio/Cargo.toml
+++ b/services/mgmt/visualstudio/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_visualstudio"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/vmware/Cargo.toml
+++ b/services/mgmt/vmware/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_vmware"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/vmwarecloudsimple/Cargo.toml
+++ b/services/mgmt/vmwarecloudsimple/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_vmwarecloudsimple"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/web/Cargo.toml
+++ b/services/mgmt/web/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_web"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/webpubsub/Cargo.toml
+++ b/services/mgmt/webpubsub/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_webpubsub"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/windowsesu/Cargo.toml
+++ b/services/mgmt/windowsesu/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_windowsesu"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/windowsiot/Cargo.toml
+++ b/services/mgmt/windowsiot/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_windowsiot"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/mgmt/workloadmonitor/Cargo.toml
+++ b/services/mgmt/workloadmonitor/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_mgmt_workloadmonitor"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/appconfiguration/Cargo.toml
+++ b/services/svc/appconfiguration/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_appconfiguration"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/applicationinsights/Cargo.toml
+++ b/services/svc/applicationinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_applicationinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/attestation/Cargo.toml
+++ b/services/svc/attestation/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_attestation"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/batch/Cargo.toml
+++ b/services/svc/batch/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_batch"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/blobstorage/Cargo.toml
+++ b/services/svc/blobstorage/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_blobstorage"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/confidentialledger/Cargo.toml
+++ b/services/svc/confidentialledger/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_confidentialledger"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/containerregistry/Cargo.toml
+++ b/services/svc/containerregistry/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_containerregistry"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/cosmosdb/Cargo.toml
+++ b/services/svc/cosmosdb/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_cosmosdb"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/datalakeanalytics/Cargo.toml
+++ b/services/svc/datalakeanalytics/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_datalakeanalytics"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/deviceprovisioningservices/Cargo.toml
+++ b/services/svc/deviceprovisioningservices/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_deviceprovisioningservices"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/deviceupdate/Cargo.toml
+++ b/services/svc/deviceupdate/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_deviceupdate"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/digitaltwins/Cargo.toml
+++ b/services/svc/digitaltwins/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_digitaltwins"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/eventgrid/Cargo.toml
+++ b/services/svc/eventgrid/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_eventgrid"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/filestorage/Cargo.toml
+++ b/services/svc/filestorage/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_filestorage"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/graphrbac/Cargo.toml
+++ b/services/svc/graphrbac/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_graphrbac"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/imds/Cargo.toml
+++ b/services/svc/imds/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_imds"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/iotcentral/Cargo.toml
+++ b/services/svc/iotcentral/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_iotcentral"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/keyvault/Cargo.toml
+++ b/services/svc/keyvault/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_keyvault"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/loadtestservice/Cargo.toml
+++ b/services/svc/loadtestservice/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_loadtestservice"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/marketplacecatalog/Cargo.toml
+++ b/services/svc/marketplacecatalog/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_marketplacecatalog"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/mixedreality/Cargo.toml
+++ b/services/svc/mixedreality/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_mixedreality"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/monitor/Cargo.toml
+++ b/services/svc/monitor/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_monitor"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/operationalinsights/Cargo.toml
+++ b/services/svc/operationalinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_operationalinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/purview/Cargo.toml
+++ b/services/svc/purview/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_purview"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/quantum/Cargo.toml
+++ b/services/svc/quantum/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_quantum"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/queuestorage/Cargo.toml
+++ b/services/svc/queuestorage/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_queuestorage"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/schemaregistry/Cargo.toml
+++ b/services/svc/schemaregistry/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_schemaregistry"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/servicefabric/Cargo.toml
+++ b/services/svc/servicefabric/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_servicefabric"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/storagedatalake/Cargo.toml
+++ b/services/svc/storagedatalake/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_storagedatalake"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/synapse/Cargo.toml
+++ b/services/svc/synapse/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_synapse"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/timeseriesinsights/Cargo.toml
+++ b/services/svc/timeseriesinsights/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_timeseriesinsights"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"

--- a/services/svc/webpubsub/Cargo.toml
+++ b/services/svc/webpubsub/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_svc_webpubsub"
 
 [dependencies]
-azure_core = { path = "../../../sdk/core", version = "0.1", default-features = false }
+azure_core = { path = "../../../sdk/core", version = "0.2", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bytes = "1.0"


### PR DESCRIPTION
It is set to 0.2.1 because 0.2.0 is [yanked](https://crates.io/crates/azure_core/versions). This updates the README and adds a CHANGELOG.