### PR TITLE
address some concerns in initial device_update PR

### DIFF
--- a/sdk/device_update/Cargo.toml
+++ b/sdk/device_update/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2018"
 [dependencies]
 base64 = "0.13"
 thiserror = "1.0"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", features = ["json"], default_features=false }
 chrono = { version = "0.4", features = ["serde"] }
-const_format = "0.2.13"
+const_format = "0.2"
 serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
@@ -25,9 +25,15 @@ getset = "0.1"
 azure_core = { path = "../core", version = "0.2" }
 tokio = { version = "1.0", features = ["full"] }
 log = "0.4"
+azure_identity = { path = "../identity", version = "0.1" }
 
 [dev-dependencies]
 oauth2 = "4.0.0"
 azure_identity = { path = "../identity", version = "0.1" }
-mockito = "0.30"
+mockito = "0.31"
 async-trait = "0.1"
+
+[features]
+default = ["enable_reqwest"]
+enable_reqwest = ["reqwest/default-tls"]
+enable_reqwest_rustls = ["reqwest/rustls-tls"]

--- a/sdk/device_update/examples/delete_update.rs
+++ b/sdk/device_update/examples/delete_update.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,13 +19,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let version = env::var("DEVICE_UPDATE_VERSION")
         .expect("Missing DEVICE_UPDATE_VERSION environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let delete_response = client
         .delete_update(&instance_id, &provider, &name, &version)

--- a/sdk/device_update/examples/get_file.rs
+++ b/sdk/device_update/examples/get_file.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -21,13 +21,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_id = env::var("DEVICE_UPDATE_FILE_ID")
         .expect("Missing DEVICE_UPDATE_FILE_ID environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let get_file_response = client
         .get_file(&instance_id, &provider, &name, &version, &file_id)

--- a/sdk/device_update/examples/get_operation.rs
+++ b/sdk/device_update/examples/get_operation.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -15,13 +15,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let operation_id = env::var("DEVICE_UPDATE_OPERATION_ID")
         .expect("Missing DEVICE_UPDATE_OPERATION_ID environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let get_operation_response = client.get_operation(&instance_id, &operation_id).await?;
     dbg!(&get_operation_response);

--- a/sdk/device_update/examples/get_update.rs
+++ b/sdk/device_update/examples/get_update.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,13 +19,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let version = env::var("DEVICE_UPDATE_VERSION")
         .expect("Missing DEVICE_UPDATE_VERSION environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let get_update_response = client
         .get_update(&instance_id, &provider, &name, &version)

--- a/sdk/device_update/examples/import_update.rs
+++ b/sdk/device_update/examples/import_update.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -14,13 +14,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .expect("Missing DEVICE_UPDATE_INSTANCE_ID environment variable.");
     let import_json = env::var("IMPORT_VALUE").expect("Missing IMPORT_VALUE environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let import_update_response = client.import_update(&instance_id, import_json).await?;
     dbg!(&import_update_response);

--- a/sdk/device_update/examples/list_files.rs
+++ b/sdk/device_update/examples/list_files.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -19,13 +19,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let version = env::var("DEVICE_UPDATE_VERSION")
         .expect("Missing DEVICE_UPDATE_VERSION environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let list_files_response = client
         .list_files(&instance_id, &provider, &name, &version)

--- a/sdk/device_update/examples/list_names.rs
+++ b/sdk/device_update/examples/list_names.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -15,13 +15,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let provider = env::var("DEVICE_UPDATE_PROVIDER")
         .expect("Missing DEVICE_UPDATE_PROVIDER environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let list_names_response = client.list_names(&instance_id, &provider).await?;
     dbg!(&list_names_response);

--- a/sdk/device_update/examples/list_operations.rs
+++ b/sdk/device_update/examples/list_operations.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let instance_id = env::var("DEVICE_UPDATE_INSTANCE_ID")
         .expect("Missing DEVICE_UPDATE_INSTANCE_ID environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let s_filter = env::var("DEVICE_UPDATE_FILTER").unwrap_or_default();
 

--- a/sdk/device_update/examples/list_providers.rs
+++ b/sdk/device_update/examples/list_providers.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let instance_id = env::var("DEVICE_UPDATE_INSTANCE_ID")
         .expect("Missing DEVICE_UPDATE_INSTANCE_ID environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let list_names_response = client.list_providers(&instance_id).await?;
     dbg!(&list_names_response);

--- a/sdk/device_update/examples/list_updates.rs
+++ b/sdk/device_update/examples/list_updates.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let instance_id = env::var("DEVICE_UPDATE_INSTANCE_ID")
         .expect("Missing DEVICE_UPDATE_INSTANCE_ID environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let s_filter = env::var("DEVICE_UPDATE_FILTER").unwrap_or_default();
     let mut filter: Option<&str> = None;

--- a/sdk/device_update/examples/list_versions.rs
+++ b/sdk/device_update/examples/list_versions.rs
@@ -1,6 +1,6 @@
 use azure_device_update::DeviceUpdateClient;
 use azure_identity::token_credentials::{ClientSecretCredential, TokenCredentialOptions};
-use std::env;
+use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,13 +17,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let provider = env::var("DEVICE_UPDATE_PROVIDER")
         .expect("Missing DEVICE_UPDATE_PROVIDER environment variable.");
 
-    let creds = ClientSecretCredential::new(
+    let creds = Arc::new(ClientSecretCredential::new(
         tenant_id,
         client_id,
         client_secret,
         TokenCredentialOptions::default(),
-    );
-    let mut client = DeviceUpdateClient::new(&device_update_url, &creds)?;
+    ));
+    let client = DeviceUpdateClient::new(&device_update_url, creds)?;
 
     let s_filter = env::var("DEVICE_UPDATE_FILTER").unwrap_or_default();
 

--- a/sdk/device_update/src/client.rs
+++ b/sdk/device_update/src/client.rs
@@ -1,6 +1,12 @@
-use crate::Error;
-use azure_core::auth::{TokenCredential, TokenResponse};
+use crate::{Error, Result};
+use azure_core::{
+    auth::{TokenCredential, TokenResponse},
+    Error as CoreError, HttpError,
+};
+use azure_identity::token_credentials::AutoRefreshingTokenCredential;
 use const_format::formatcp;
+use serde::de::DeserializeOwned;
+use std::sync::Arc;
 use url::Url;
 
 pub(crate) const API_VERSION: &str = "2021-06-01-preview";
@@ -13,18 +19,18 @@ pub(crate) const API_VERSION_PARAM: &str = formatcp!("api-version={}", API_VERSI
 /// ```no_run
 /// use azure_device_update::DeviceUpdateClient;
 /// use azure_identity::token_credentials::DefaultAzureCredential;
-/// let creds = DefaultAzureCredential::default();
-/// let client = DeviceUpdateClient::new("contoso.api.adu.microsoft.com", &creds).unwrap();
+/// let creds = std::sync::Arc::new(DefaultAzureCredential::default());
+/// let client = DeviceUpdateClient::new("contoso.api.adu.microsoft.com", creds).unwrap();
 /// ```
-#[derive(Debug)]
-pub struct DeviceUpdateClient<'a, T> {
+
+#[derive(Clone)]
+pub struct DeviceUpdateClient {
     pub(crate) device_update_url: Url,
     pub(crate) endpoint: String,
-    pub(crate) token_credential: &'a T,
-    pub(crate) token: Option<TokenResponse>,
+    pub(crate) token_credential: AutoRefreshingTokenCredential,
 }
 
-impl<'a, T: TokenCredential> DeviceUpdateClient<'a, T> {
+impl DeviceUpdateClient {
     /// Creates a new `DeviceUpdateClient`.
     ///
     /// # Example
@@ -32,79 +38,55 @@ impl<'a, T: TokenCredential> DeviceUpdateClient<'a, T> {
     /// ```no_run
     /// use azure_device_update::DeviceUpdateClient;
     /// use azure_identity::token_credentials::DefaultAzureCredential;
-    /// let creds = DefaultAzureCredential::default();
-    /// let client = DeviceUpdateClient::new("contoso.api.adu.microsoft.com", &creds).unwrap();
+    /// let creds = std::sync::Arc::new(DefaultAzureCredential::default());
+    /// let client = DeviceUpdateClient::new("contoso.api.adu.microsoft.com", creds).unwrap();
     /// ```
-    pub fn new(device_update_url: &str, token_credential: &'a T) -> Result<Self, Error> {
-        let device_update_url = Url::parse(device_update_url)?;
+    pub fn new(
+        device_update_url: &str,
+        token_credential: Arc<dyn TokenCredential>,
+    ) -> Result<Self> {
+        let device_update_url =
+            Url::parse(device_update_url).map_err(|e| CoreError::Http(HttpError::Url(e)))?;
         let endpoint = extract_endpoint(&device_update_url)?;
+        let token_credential = AutoRefreshingTokenCredential::new(token_credential);
+
         let client = DeviceUpdateClient {
             device_update_url,
             endpoint,
             token_credential,
-            token: None,
         };
         Ok(client)
     }
 
-    pub(crate) async fn refresh_token(&mut self) -> Result<(), Error> {
-        if matches!(&self.token, Some(token) if token.expires_on > chrono::Utc::now()) {
-            // Token is valid, return it.
-            return Ok(());
-        }
-
-        let token = self
-            .token_credential
+    async fn get_token(&self) -> Result<TokenResponse> {
+        self.token_credential
             .get_token(&self.endpoint)
             .await
-            .map_err(|_| Error::Authorization)?;
-        self.token = Some(token);
-        Ok(())
+            .map_err(Error::Core)
     }
 
-    pub(crate) async fn get_authed(&mut self, uri: String) -> Result<String, Error> {
-        self.refresh_token().await?;
-
+    pub(crate) async fn get<R>(&self, uri: String) -> Result<R>
+    where
+        R: DeserializeOwned,
+    {
         let resp = reqwest::Client::new()
             .get(&uri)
-            .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .send()
-            .await;
-        let resp = match resp {
-            Ok(r) => r,
-            Err(_e) => {
-                return Err(Error::InvalidOperationPath());
-            }
-        };
-        let body = resp.text().await.unwrap();
-        Ok(body)
-    }
-
-    pub(crate) async fn _put_authed(&mut self, uri: String, body: String) -> Result<String, Error> {
-        self.refresh_token().await?;
-
-        let resp = reqwest::Client::new()
-            .put(&uri)
-            .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
-            .body(body)
+            .bearer_auth(self.get_token().await?.token.secret())
             .send()
             .await
-            .unwrap();
-        let body = resp.text().await?;
-        Ok(body)
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e))))?;
+
+        let body = resp
+            .bytes()
+            .await
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ReadBytes(e))))?;
+        serde_json::from_slice(&body).map_err(|e| Error::Core(CoreError::Json(e)))
     }
 
-    pub(crate) async fn post_authed(
-        &mut self,
-        uri: String,
-        json_body: Option<String>,
-    ) -> Result<String, Error> {
-        self.refresh_token().await?;
-
+    pub(crate) async fn post(&self, uri: String, json_body: Option<String>) -> Result<String> {
         let mut req = reqwest::Client::new()
             .post(&uri)
-            .bearer_auth(self.token.as_ref().unwrap().token.secret());
+            .bearer_auth(self.get_token().await?.token.secret());
 
         if let Some(body) = json_body {
             req = req.header("Content-Type", "application/json").body(body);
@@ -112,68 +94,44 @@ impl<'a, T: TokenCredential> DeviceUpdateClient<'a, T> {
             req = req.header("Content-Length", 0);
         }
 
-        let resp = req.send().await?;
+        let resp = req
+            .send()
+            .await
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e))))?;
+
         if resp.status() == 202u16 {
             let headers = resp.headers();
-            if headers.contains_key("operation-location") {
-                return match headers.get("operation-location").unwrap().to_str() {
-                    Ok(p) => Ok(p.to_owned()),
-                    Err(_e) => Err(Error::InvalidOperationPath()),
-                };
-            } else {
-                return Err(Error::NoOperationLocation);
-            }
+            return match headers.get("operation-location") {
+                Some(location) => location
+                    .to_str()
+                    .map(|x| x.to_string())
+                    .map_err(|_| Error::InvalidOperationPath),
+                None => Err(Error::NoOperationLocation),
+            };
         }
 
         Err(Error::ImportError(resp.status()))
     }
 
-    pub(crate) async fn _patch_authed(
-        &mut self,
-        uri: String,
-        body: String,
-    ) -> Result<String, Error> {
-        self.refresh_token().await?;
-
-        let resp = reqwest::Client::new()
-            .patch(&uri)
-            .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .await
-            .unwrap();
-
-        let body = resp.text().await.unwrap();
-
-        let body_serialized = serde_json::from_str::<serde_json::Value>(&body).unwrap();
-
-        if let Some(err) = body_serialized.get("error") {
-            let msg = err.get("message").ok_or(Error::UnparsableError)?;
-            Err(Error::General(msg.to_string()))
-        } else {
-            Ok(body)
-        }
-    }
-
-    pub(crate) async fn delete_authed(&mut self, uri: String) -> Result<String, Error> {
-        self.refresh_token().await?;
-
+    pub(crate) async fn delete(&self, uri: String) -> Result<String> {
         let resp = reqwest::Client::new()
             .delete(&uri)
-            .bearer_auth(self.token.as_ref().unwrap().token.secret())
+            .bearer_auth(self.get_token().await?.token.secret())
             .header("Content-Type", "application/json")
             .send()
             .await
-            .unwrap();
-        let body = resp.text().await.unwrap();
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e))))?;
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ReadBytes(e))))?;
         Ok(body)
     }
 }
 
 /// Helper to get vault endpoint with a scheme and a trailing slash
 /// ex. `https://vault.azure.net/` where the full client url is `https://myvault.vault.azure.net`
-fn extract_endpoint(url: &Url) -> Result<String, Error> {
+fn extract_endpoint(url: &Url) -> Result<String> {
     let endpoint = url
         .host_str()
         .ok_or(Error::DomainParse)?
@@ -188,22 +146,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn can_extract_endpoint() {
-        let suffix =
-            extract_endpoint(&Url::parse("https://myadu.api.adu.microsoft.com").unwrap()).unwrap();
+    fn can_extract_endpoint() -> Result<()> {
+        let suffix = extract_endpoint(
+            &Url::parse("https://myadu.api.adu.microsoft.com")
+                .map_err(|e| CoreError::Http(HttpError::Url(e)))?,
+        )?;
         assert_eq!(suffix, "https://api.adu.microsoft.com");
 
-        let suffix =
-            extract_endpoint(&Url::parse("https://myadu.mycustom.api.adu.server.net").unwrap())
-                .unwrap();
+        let suffix = extract_endpoint(
+            &Url::parse("https://myadu.mycustom.api.adu.server.net")
+                .map_err(|e| CoreError::Http(HttpError::Url(e)))?,
+        )?;
         assert_eq!(suffix, "https://mycustom.api.adu.server.net");
 
-        let suffix = extract_endpoint(&Url::parse("https://myadu.internal").unwrap()).unwrap();
+        let suffix = extract_endpoint(
+            &Url::parse("https://myadu.internal")
+                .map_err(|e| CoreError::Http(HttpError::Url(e)))?,
+        )?;
         assert_eq!(suffix, "https://internal");
 
-        let suffix =
-            extract_endpoint(&Url::parse("some-scheme://myadu.api.adu.microsoft.com").unwrap())
-                .unwrap();
+        let suffix = extract_endpoint(
+            &Url::parse("some-scheme://myadu.api.adu.microsoft.com")
+                .map_err(|e| CoreError::Http(HttpError::Url(e)))?,
+        )?;
         assert_eq!(suffix, "some-scheme://api.adu.microsoft.com");
+        Ok(())
     }
 }

--- a/sdk/device_update/src/lib.rs
+++ b/sdk/device_update/src/lib.rs
@@ -1,33 +1,17 @@
 mod client;
 pub mod device_update;
 
+use crate::device_update::UpdateOperation;
 pub use client::DeviceUpdateClient;
 
 #[non_exhaustive]
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
-    #[error("Azure Active Directory authorization error")]
-    Authorization,
-
-    #[error(
-        "Received an error accessing the Device Update, which could not be parsed as expected."
-    )]
-    UnparsableError,
-
     #[error(transparent)]
-    Reqwest(#[from] reqwest::Error),
-
-    #[error("Device Update Error: {0}")]
-    General(String),
+    Core(#[from] azure_core::Error),
 
     #[error("Base64 Decode Error: {0}")]
     Base64(#[from] base64::DecodeError),
-
-    #[error("Failed to parse response from Device Update: {0}")]
-    SerdeParse(#[from] serde_json::Error),
-
-    #[error("URL parse error: {0}")]
-    UrlParseError(#[from] url::ParseError),
 
     #[error("Could not get device update domain")]
     DomainParse,
@@ -36,34 +20,34 @@ pub enum Error {
     NoOperationLocation,
 
     #[error("Invalid characters in operation-location path")]
-    InvalidOperationPath(),
+    InvalidOperationPath,
 
     #[error("Import unsuccessful, status: {0}")]
     ImportError(reqwest::StatusCode),
 
-    #[error("Import unsuccessful with status Failed, error: {0}")]
-    ImportFailed(String),
+    #[error("Import unsuccessful with status Failed, error: {0:?}")]
+    ImportFailed(UpdateOperation),
 
-    #[error("Import unsuccessful with status Undefined, error: {0}")]
-    ImportUndefined(String),
+    #[error("Import unsuccessful with status Undefined, error: {0:?}")]
+    ImportUndefined(UpdateOperation),
 }
+
+pub type Result<T> = std::result::Result<T, Error>;
 
 #[cfg(test)]
 mod tests {
     use azure_core::auth::{TokenCredential, TokenResponse};
+    use azure_identity::token_credentials::AutoRefreshingTokenCredential;
     use chrono::{Duration, Utc};
     use oauth2::AccessToken;
+    use std::sync::Arc;
 
-    #[macro_export]
-    macro_rules! mock_key_client {
-        ($device_update_name:expr, $creds:expr, ) => {{
-            crate::client::DeviceUpdateClient {
-                device_update_url: url::Url::parse(&mockito::server_url()).unwrap(),
-                endpoint: "".to_string(),
-                token_credential: $creds,
-                token: None,
-            }
-        }};
+    pub(crate) fn mock_client() -> crate::client::DeviceUpdateClient {
+        crate::client::DeviceUpdateClient {
+            device_update_url: url::Url::parse(&mockito::server_url()).unwrap(),
+            endpoint: "".to_string(),
+            token_credential: AutoRefreshingTokenCredential::new(Arc::new(MockCredential)),
+        }
     }
 
     pub(crate) struct MockCredential;


### PR DESCRIPTION
This PR adds the following changes:
* moves to enabling the client to support light-weight clones rather than managing lifetimes for the client.
* removes the need for the client to be mutable
* moves to using `azure_identity`'s `AutoRefreshingTokenCredential` rather than by-hand token refresh.
* replaces runtime panics with returning errors
* moves helper functions to return the `DeserializeOwned` trait, rather than strings which get immediately deserialized
* moves many of the errors to use the `azure_core` error types (in prep for moving to the pipeline archtecture)
* moves to using `query_pairs_mut` to add URL params, rather than building query strings by hand
* simplfies creating the mock client used for testing

Things still to do (in follow-up PRs):
* Move to using `azure_svc_deviceupdate` under the hood
* Rather than iteratively fetching all the results at once before returning to the client, move to using a streaming api, akin to [azure_data_tables::requests::QueryEntityBuilder.stream](https://docs.rs/azure_data_tables/latest/azure_data_tables/requests/struct.QueryEntityBuilder.html#method.stream)