### PR TITLE
expose internal sleep implementation

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_core"
-version = "0.2.1"
+version = "0.2.2"
 description = "Rust wrappers around Microsoft Azure REST APIs - Core crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -26,8 +26,8 @@ mod request;
 mod request_options;
 mod response;
 mod seekable_stream;
-mod sleep;
 
+pub mod sleep;
 pub mod auth;
 pub mod headers;
 #[cfg(feature = "mock_transport_framework")]
@@ -53,6 +53,7 @@ pub use policies::*;
 pub use request::*;
 pub use response::*;
 pub use seekable_stream::*;
+pub use sleep::sleep;
 
 /// A unique identifier for a request.
 // NOTE: only used for Storage?

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -27,13 +27,13 @@ mod request_options;
 mod response;
 mod seekable_stream;
 
-pub mod sleep;
 pub mod auth;
 pub mod headers;
 #[cfg(feature = "mock_transport_framework")]
 pub mod mock;
 pub mod parsing;
 pub mod prelude;
+pub mod sleep;
 pub mod util;
 
 use uuid::Uuid;

--- a/sdk/core/src/sleep.rs
+++ b/sdk/core/src/sleep.rs
@@ -4,14 +4,15 @@ use std::task::{Context, Poll};
 use std::thread;
 use std::time::Duration;
 
-pub(crate) fn sleep(duration: Duration) -> Sleep {
+pub fn sleep(duration: Duration) -> Sleep {
     Sleep {
         thread: None,
         duration,
     }
 }
 
-pub(crate) struct Sleep {
+#[derive(Debug)]
+pub struct Sleep {
     thread: Option<thread::JoinHandle<()>>,
     duration: Duration,
 }

--- a/sdk/device_update/Cargo.toml
+++ b/sdk/device_update/Cargo.toml
@@ -23,11 +23,11 @@ url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
 azure_core = { path = "../core", version = "0.2" }
-tokio = { version = "1.0", features = ["full"] }
 log = "0.4"
 azure_identity = { path = "../identity", version = "0.1" }
 
 [dev-dependencies]
+tokio = { version = "1.0", features = ["full"] }
 oauth2 = "4.0.0"
 azure_identity = { path = "../identity", version = "0.1" }
 mockito = "0.31"

--- a/sdk/device_update/src/device_update.rs
+++ b/sdk/device_update/src/device_update.rs
@@ -1,5 +1,5 @@
 use crate::{client::API_VERSION_PARAM, DeviceUpdateClient, Error, Result};
-use azure_core::{Error as CoreError, HttpError, sleep};
+use azure_core::{sleep, Error as CoreError, HttpError};
 use chrono::{DateTime, Utc};
 use getset::Getters;
 use log::debug;

--- a/sdk/device_update/src/device_update.rs
+++ b/sdk/device_update/src/device_update.rs
@@ -1,5 +1,5 @@
 use crate::{client::API_VERSION_PARAM, DeviceUpdateClient, Error, Result};
-use azure_core::{Error as CoreError, HttpError};
+use azure_core::{Error as CoreError, HttpError, sleep};
 use chrono::{DateTime, Utc};
 use getset::Getters;
 use log::debug;
@@ -176,7 +176,7 @@ impl DeviceUpdateClient {
         debug!("Import response: {}", &resp_body);
 
         loop {
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            sleep(std::time::Duration::from_secs(5)).await;
             let mut uri = self.device_update_url.clone();
             uri.set_path(&resp_body);
             debug!("Requesting operational status: {}", &uri);


### PR DESCRIPTION
For now, use expose the internal sleep implementation as to not require
tokio during runtime of device_update.