### PR TITLE
prep release for idiomatic crates

### DIFF
--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_data_cosmos"
-version = "0.1.0"
+version = "0.2.0"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Cosmos DB"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.2", default-features=false}
-azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"]}
+azure_storage = { path = "../storage", version = "0.2", default-features=false, features=["account"]}
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_data_tables"
-version = "0.1.0"
+version = "0.2.0"
 description = "Azure Table storage crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/device_update/Cargo.toml
+++ b/sdk/device_update/Cargo.toml
@@ -25,11 +25,10 @@ getset = "0.1"
 azure_core = { path = "../core", version = "0.2" }
 tokio = { version = "1.0", features = ["full"] }
 log = "0.4"
-azure_identity = { path = "../identity", version = "0.1" }
+azure_identity = { path = "../identity", version = "0.2" }
 
 [dev-dependencies]
 oauth2 = "4.0.0"
-azure_identity = { path = "../identity", version = "0.1" }
 mockito = "0.31"
 async-trait = "0.1"
 

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_identity"
-version = "0.1.1"
+version = "0.2.0"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure identity helper crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -34,7 +34,7 @@ uuid = { version = "1.0",  features = ["v4"] }
 tokio = { version = "1.0", features = ["macros"] }
 env_logger = "0.9"
 serde_test = "1"
-azure_security_keyvault = { path = "../security_keyvault", version = "0.1"}
+azure_security_keyvault = { path = "../security_keyvault", version = "0.2"}
 
 [features]
 default = ["development", "enable_reqwest"]

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_iot_hub"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Microsoft Corp."]
 edition = "2021"
 description = "Azure IoT Hub"

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_messaging_eventgrid"
-version = "0.1.0"
+version = "0.2.0"
 description = "Rust wrappers around Microsoft Azure Event Grid REST APIs"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_messaging_servicebus"
-version = "0.1.0"
+version = "0.2.0"
 description = "Rust wrappers around Microsoft Azure REST APIs - Service Bus crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Microsoft Corp."]
 description = "Rust wrapper around Microsoft Azure REST APIs for Azure Key Vault"
 repository = "https://github.com/azure/azure-sdk-for-rust"
@@ -26,7 +26,7 @@ azure_core = { path = "../core", version = "0.2" }
 
 [dev-dependencies]
 oauth2 = "4.0.0"
-azure_identity = { path = "../identity", version = "0.1" }
+azure_identity = { path = "../identity", version = "0.2" }
 mockito = "0.31"
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["full"] }

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage"
-version = "0.1.0"
+version = "0.2.0"
 description = "Azure Storage crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]
@@ -36,7 +36,7 @@ sha2 = "0.10"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }
 env_logger = "0.9"
-azure_identity = { path = "../identity", version = "0.1" }
+azure_identity = { path = "../identity", version = "0.2" }
 reqwest = "0.11"
 
 [features]

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.2", default-features=false }
-azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"] }
+azure_storage = { path = "../storage", version = "0.2", default-features=false, features=["account"] }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_blobs"
-version = "0.1.0"
+version = "0.2.0"
 description = "Azure Blob Storage crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]
@@ -34,7 +34,7 @@ thiserror = "1.0"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.9"
-azure_identity = { path = "../identity", version = "0.1" }
+azure_identity = { path = "../identity", version = "0.2" }
 reqwest = "0.11"
 oauth2 = { version = "4.0.0", default-features = false }
 

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_datalake"
-version = "0.1.1"
+version = "0.2.0"
 description = "Azure Data Lake Storage Gen2 crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]
@@ -31,7 +31,7 @@ url = "2.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
-azure_identity = { path = "../identity", version = "0.1" }
+azure_identity = { path = "../identity", version = "0.2" }
 
 [features]
 default = ["enable_reqwest"]

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.2" }
-azure_storage = { path = "../storage", version = "0.1" }
+azure_storage = { path = "../storage", version = "0.2" }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_queues"
-version = "0.1.0"
+version = "0.2.0"
 description = "Azure Queue Storage crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.2", default-features=false }
-azure_storage = { path = "../storage", version = "0.1", default-features=false, features=["account"] }
+azure_storage = { path = "../storage", version = "0.2", default-features=false, features=["account"] }
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"


### PR DESCRIPTION
All of the idiomatic crates had their dependencies (primarily `azure_core`) bumped in source but not released.

In the future, it would be good if tags were added for each release such that generating changelogs between releases was straight forward.