### PR TITLE
adding option to specify client_id for MSI

### DIFF
--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -142,7 +142,9 @@ impl Default for DefaultAzureCredential {
         DefaultAzureCredential {
             sources: vec![
                 DefaultAzureCredentialEnum::Environment(EnvironmentCredential::default()),
-                DefaultAzureCredentialEnum::ManagedIdentity(ImdsManagedIdentityCredential::default()),
+                DefaultAzureCredentialEnum::ManagedIdentity(
+                    ImdsManagedIdentityCredential::default(),
+                ),
                 DefaultAzureCredentialEnum::AzureCli(AzureCliCredential {}),
             ],
         }

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -58,7 +58,7 @@ impl DefaultAzureCredentialBuilder {
         }
         if self.include_managed_identity_credential {
             sources.push(DefaultAzureCredentialEnum::ManagedIdentity(
-                ImdsManagedIdentityCredential {},
+                ImdsManagedIdentityCredential::default(),
             ))
         }
         if self.include_cli_credential {
@@ -142,7 +142,7 @@ impl Default for DefaultAzureCredential {
         DefaultAzureCredential {
             sources: vec![
                 DefaultAzureCredentialEnum::Environment(EnvironmentCredential::default()),
-                DefaultAzureCredentialEnum::ManagedIdentity(ImdsManagedIdentityCredential {}),
+                DefaultAzureCredentialEnum::ManagedIdentity(ImdsManagedIdentityCredential::default()),
                 DefaultAzureCredentialEnum::AzureCli(AzureCliCredential {}),
             ],
         }

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -22,20 +22,20 @@ const MSI_API_VERSION: &str = "2019-08-01";
 pub struct ImdsManagedIdentityCredential {
     object_id: Option<String>,
     client_id: Option<String>,
-    mi_res_id: Option<String>,
+    msi_res_id: Option<String>,
 }
 
 impl ImdsManagedIdentityCredential {
-    /// Create a new ImdsManagedIdentityCredential with the given optional parameters. Only one of object_id, client_id and mi_res_id may be set.
+    /// Create a new ImdsManagedIdentityCredential with the given optional parameters. Only one of object_id, client_id and msi_res_id may be set.
     pub fn new(
         object_id: Option<String>,
         client_id: Option<String>,
-        mi_res_id: Option<String>,
+        msi_res_id: Option<String>,
     ) -> Self {
         Self {
             object_id,
             client_id,
-            mi_res_id,
+            msi_res_id,
         }
     }
 }
@@ -59,7 +59,7 @@ pub enum ManagedIdentityCredentialError {
     IdentityUnavailableError,
     #[error("The request failed due to a gateway error.")]
     GatewayError,
-    #[error("Only one of object_id, client_id, and mi_res_id may be specified on a request to get a token.")]
+    #[error("Only one of object_id, client_id, and msi_res_id may be specified on a request to get a token.")]
     MoreThanOneIdParameterSpecified,
 }
 
@@ -76,11 +76,11 @@ impl TokenCredential for ImdsManagedIdentityCredential {
         match (
             self.object_id.as_ref(),
             self.client_id.as_ref(),
-            self.mi_res_id.as_ref(),
+            self.msi_res_id.as_ref(),
         ) {
             (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
             (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
-            (None, None, Some(mi_res_id)) => query_items.push(("mi_res_id", mi_res_id)),
+            (None, None, Some(msi_res_id)) => query_items.push(("msi_res_id", msi_res_id)),
             _ => {
                 return Err(ManagedIdentityCredentialError::MoreThanOneIdParameterSpecified);
             }

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -26,7 +26,7 @@ pub struct ImdsManagedIdentityCredential {
 }
 
 impl ImdsManagedIdentityCredential {
-    /// Create a new ImdsManagedIdentityCredential with the given client_id
+    /// Create a new ImdsManagedIdentityCredential with the given optional parameters. Only one of client_id, principal_id and mi_res_id may be set.
     pub fn new(
         client_id: Option<String>,
         principal_id: Option<String>,

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -20,21 +20,21 @@ const MSI_API_VERSION: &str = "2019-08-01";
 /// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
 #[derive(Default)]
 pub struct ImdsManagedIdentityCredential {
+    object_id: Option<String>,
     client_id: Option<String>,
-    principal_id: Option<String>,
     mi_res_id: Option<String>,
 }
 
 impl ImdsManagedIdentityCredential {
-    /// Create a new ImdsManagedIdentityCredential with the given optional parameters. Only one of client_id, principal_id and mi_res_id may be set.
+    /// Create a new ImdsManagedIdentityCredential with the given optional parameters. Only one of object_id, client_id and mi_res_id may be set.
     pub fn new(
+        object_id: Option<String>,
         client_id: Option<String>,
-        principal_id: Option<String>,
         mi_res_id: Option<String>,
     ) -> Self {
         Self {
+            object_id,
             client_id,
-            principal_id,
             mi_res_id,
         }
     }
@@ -59,8 +59,8 @@ pub enum ManagedIdentityCredentialError {
     IdentityUnavailableError,
     #[error("The request failed due to a gateway error.")]
     GatewayError,
-    #[error("Only one of client_id, principal_id, and mi_res_id may be specified on a request to get a token.")]
-    MoreThanOneIdParameterSpecifiedError,
+    #[error("Only one of object_id, client_id, and mi_res_id may be specified on a request to get a token.")]
+    MoreThanOneIdParameterSpecified,
 }
 
 #[async_trait::async_trait]
@@ -73,46 +73,17 @@ impl TokenCredential for ImdsManagedIdentityCredential {
 
         let mut query_items = vec![("api-version", MSI_API_VERSION), ("resource", resource)];
 
-        match self.client_id {
-            Some(ref client_id) => {
-                if self.principal_id.is_some() || self.mi_res_id.is_some() {
-                    return Err(
-                        ManagedIdentityCredentialError::MoreThanOneIdParameterSpecifiedError,
-                    );
-                }
-                if !client_id.trim().is_empty() {
-                    query_items.push(("client_id", client_id))
-                }
+        match (
+            self.object_id.as_ref(),
+            self.client_id.as_ref(),
+            self.mi_res_id.as_ref(),
+        ) {
+            (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
+            (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
+            (None, None, Some(mi_res_id)) => query_items.push(("mi_res_id", mi_res_id)),
+            _ => {
+                return Err(ManagedIdentityCredentialError::MoreThanOneIdParameterSpecified);
             }
-            None => (),
-        }
-
-        match self.principal_id {
-            Some(ref principal_id) => {
-                if self.client_id.is_some() || self.mi_res_id.is_some() {
-                    return Err(
-                        ManagedIdentityCredentialError::MoreThanOneIdParameterSpecifiedError,
-                    );
-                }
-                if !principal_id.trim().is_empty() {
-                    query_items.push(("principal_id", principal_id))
-                }
-            }
-            None => (),
-        }
-
-        match self.mi_res_id {
-            Some(ref mi_res_id) => {
-                if self.client_id.is_some() || self.principal_id.is_some() {
-                    return Err(
-                        ManagedIdentityCredentialError::MoreThanOneIdParameterSpecifiedError,
-                    );
-                }
-                if !mi_res_id.trim().is_empty() {
-                    query_items.push(("mi_res_id", mi_res_id))
-                }
-            }
-            None => (),
         }
 
         let msi_endpoint_url = Url::parse_with_params(&msi_endpoint, &query_items)

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -29,8 +29,11 @@ impl ImdsManagedIdentityCredential {
     /// Specifies the object id associated with a user assigned managed service identity resource that should be used to retrieve the access token.
     ///
     /// The values of client_id and msi_res_id are discarded, as only one id parameter may be set when getting a token.
-    pub fn with_object_id(mut self, object_id: String) -> Self {
-        self.object_id = Some(object_id);
+    pub fn with_object_id<A>(mut self, object_id: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.object_id = Some(object_id.into());
         self.client_id = None;
         self.msi_res_id = None;
         self
@@ -39,8 +42,11 @@ impl ImdsManagedIdentityCredential {
     /// Specifies the application id (client id) associated with a user assigned managed service identity resource that should be used to retrieve the access token.
     ///
     /// The values of object_id and msi_res_id are discarded, as only one id parameter may be set when getting a token.
-    pub fn with_client_id(mut self, client_id: String) -> Self {
-        self.client_id = Some(client_id);
+    pub fn with_client_id<A>(mut self, client_id: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.client_id = Some(client_id.into());
         self.object_id = None;
         self.msi_res_id = None;
         self
@@ -49,8 +55,11 @@ impl ImdsManagedIdentityCredential {
     /// Specifies the ARM resource id of the user assigned managed service identity resource that should be used to retrieve the access token.
     ///
     /// The values of object_id and client_id are discarded, as only one id parameter may be set when getting a token.
-    pub fn with_identity(mut self, msi_res_id: String) -> Self {
-        self.msi_res_id = Some(msi_res_id);
+    pub fn with_identity<A>(mut self, msi_res_id: A) -> Self
+    where
+        A: Into<String>,
+    {
+        self.msi_res_id = Some(msi_res_id.into());
         self.object_id = None;
         self.client_id = None;
         self

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -78,6 +78,7 @@ impl TokenCredential for ImdsManagedIdentityCredential {
             self.client_id.as_ref(),
             self.msi_res_id.as_ref(),
         ) {
+            (None, None, None) => (),
             (Some(object_id), None, None) => query_items.push(("object_id", object_id)),
             (None, Some(client_id), None) => query_items.push(("client_id", client_id)),
             (None, None, Some(msi_res_id)) => query_items.push(("msi_res_id", msi_res_id)),


### PR DESCRIPTION
My team recently ran into an error when using an MSI to get a token from an AKS cluster. The agent pool for this particular cluster had two MSIs, the one we created and another one that came from AzSecPack. Other clusters with our same application were fine, but only had the single MSI we were expecting to be there.

We spun up an ubuntu container and ran some curl commands

`curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource={ourResource}' -H Metadata:true`

resulted in

`{
  "error":"invalid_request",
  "error_description":"Multiple user assigned identities exist, please specify the clientId / resourceId of the identity in the token request"
}`

and 

`curl 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource={ourResource}&client_id={ourClientId}' -H Metadata:true`

resulted in a good response.

Looking at https://docs.microsoft.com/en-us/azure/app-service/overview-managed-identity?tabs=portal%2Cdotnet#rest-protocol-examples I saw that one can specify the `client_id` as a query parameter on the URL to fetch the token, so that is what I am trying to do in this pull request.
