### PR TITLE
add AutoRefreshingTokenCredential support to StorageAccountClient

### DIFF
--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -33,12 +33,11 @@ const HEADER_VERSION: &str = "x-ms-version";
 
 const AZURE_VERSION: &str = "2019-12-12";
 
-#[derive(Clone)]
 pub enum StorageCredentials {
     Key(String, String),
     SASToken(Vec<(String, String)>),
     BearerToken(String),
-    TokenCredential(Arc<dyn TokenCredential>),
+    TokenCredential(Box<dyn TokenCredential>),
 }
 
 impl std::fmt::Debug for StorageCredentials {
@@ -53,20 +52,6 @@ impl std::fmt::Debug for StorageCredentials {
     }
 }
 
-impl PartialEq for StorageCredentials {
-    fn eq(&self, other: &Self) -> bool {
-        match &self {
-            StorageCredentials::TokenCredential(_) => {
-                // can't compare tokens because calling get_token is probably not a good idea
-                false
-            }
-            _ => self.eq(other),
-        }
-    }
-}
-
-impl Eq for StorageCredentials {}
-
 #[derive(Debug, Clone, Copy)]
 pub enum ServiceType {
     Blob,
@@ -75,7 +60,7 @@ pub enum ServiceType {
     Table,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct StorageAccountClient {
     storage_credentials: StorageCredentials,
     http_client: Arc<dyn HttpClient>,
@@ -269,7 +254,7 @@ impl StorageAccountClient {
     pub fn new_token_credential<A>(
         http_client: Arc<dyn HttpClient>,
         account: A,
-        token_credential: Arc<dyn TokenCredential>,
+        token_credential: Box<dyn TokenCredential>,
     ) -> Arc<Self>
     where
         A: Into<String>,

--- a/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
+++ b/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .expect("please specify the blob name as third command line parameter");
 
     let creds = std::sync::Arc::new(DefaultAzureCredential::default());
-    let auto_creds = std::sync::Arc::new(AutoRefreshingTokenCredential::new(creds));
+    let auto_creds = Box::new(AutoRefreshingTokenCredential::new(creds));
 
     let http_client = azure_core::new_http_client();
     let blob_client =

--- a/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
+++ b/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
@@ -1,0 +1,43 @@
+#[macro_use]
+extern crate log;
+
+use azure_identity::token_credentials::AutoRefreshingTokenCredential;
+use azure_identity::token_credentials::DefaultAzureCredential;
+use azure_storage::core::prelude::*;
+use azure_storage_blobs::prelude::*;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    env_logger::init();
+    // First we retrieve the account name, container and blob name from command line args
+
+    let account = std::env::args()
+        .nth(1)
+        .expect("please specify the account name as first command line parameter");
+    let container = std::env::args()
+        .nth(2)
+        .expect("please specify the container name as second command line parameter");
+    let blob = std::env::args()
+        .nth(3)
+        .expect("please specify the blob name as third command line parameter");
+
+    let creds = std::sync::Arc::new(DefaultAzureCredential::default());
+    let auto_creds = std::sync::Arc::new(AutoRefreshingTokenCredential::new(creds));
+
+    let http_client = azure_core::new_http_client();
+    let blob_client =
+        StorageAccountClient::new_token_credential(http_client.clone(), &account, auto_creds)
+            .as_container_client(&container)
+            .as_blob_client(&blob);
+
+    trace!("Requesting blob");
+
+    let response = blob_client.get().execute().await?;
+
+    let s_content = String::from_utf8(response.data.to_vec())?;
+    println!("blob == {:?}", blob);
+    println!("s_content == {}", s_content);
+
+    Ok(())
+}


### PR DESCRIPTION
For https://github.com/vectordotdev/vector/issues/8667 a way to refresh the managed identity token is needed. Vector is a log agent that can forward logs to azure blob storage. See also https://github.com/Azure/azure-sdk-for-rust/issues/739.

I add a way to pass TokenCredential to the StorageAccountClient so AutoRefreshingTokenCredential can be passed to it and the client can refresh the token automatically. I tested it locally using the added example.

I don't what's preferred here and can easily drop the second commit:
* In the first commit I used arc for TokenCredential and implemented Debug, PartialEq and Eq manually.
* In the second commit I just used box for TokenCredential and removed currently unused traits Clone, PartialEq and Eq.