### PR TITLE
Make `Pageable` implement `Send`

### DIFF
--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -306,6 +306,11 @@ mod tests {
     use super::*;
     use std::io;
 
+    #[allow(dead_code, unconditional_recursion)]
+    fn ensure_send<T: Send>() {
+        ensure_send::<Error>();
+    }
+
     #[derive(thiserror::Error, Debug)]
     enum IntermediateError {
         #[error("second error")]

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -198,6 +198,11 @@ impl<T> Continuable for ListDocumentsResponse<T> {
 mod tests {
     use super::*;
 
+    #[allow(dead_code, unconditional_recursion)]
+    fn ensure_send<T: Send>() {
+        ensure_send::<ListDocuments<()>>();
+    }
+
     const BODY: &str = "
 {
     \"_rid\": \"3iNTAJKxVCk=\",


### PR DESCRIPTION
As reported in #752, `Pageable` did not enforce that it implemented `Send` and so it was not possible to use a `Pageable` stream in a context that required `Send` like spawning a `tokio` task. This fixes that issue. 