### PR TITLE
remove defunct enable_hyper feature

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -20,7 +20,6 @@ chrono = "0.4"
 dyn-clone = "1.0"
 futures = "0.3"
 http = "0.2"
-hyper = { version = "0.14", optional = true }
 hyper-rustls = { version = "0.23", optional = true }
 log = "0.4"
 oauth2 = { version = "4.0", default-features = false }
@@ -52,7 +51,6 @@ default = ["enable_reqwest"]
 enable_reqwest = ["reqwest/default-tls", "oauth2/native-tls"]
 enable_reqwest_gzip = ["reqwest/gzip"]
 enable_reqwest_rustls = ["reqwest/rustls-tls", "oauth2/rustls-tls"]
-enable_hyper = ["hyper", "hyper-rustls"]
 test_e2e = []
 azurite_workaround = []
 mock_transport_framework = []

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -8,11 +8,6 @@ use http::header::{DATE, ETAG, LAST_MODIFIED, SERVER};
 use http::HeaderMap;
 use std::str::FromStr;
 
-#[cfg(feature = "enable_hyper")]
-use http::status::StatusCode;
-#[cfg(feature = "enable_hyper")]
-use hyper::{Body, Client, Request};
-
 pub fn get_option_str_from_headers<'a>(
     headers: &'a HeaderMap,
     key: &str,

--- a/sdk/core/src/http_client.rs
+++ b/sdk/core/src/http_client.rs
@@ -68,41 +68,6 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
     }
 }
 
-// TODO: To reimplement once the Request and Response are validated.
-//#[cfg(feature = "enable_hyper")]
-//#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-//#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-//impl HttpClient for hyper::Client<HttpsConnector<hyper::client::HttpConnector>> {
-//    async fn execute_request(
-//        &self,
-//        request: Request<Bytes>,
-//    ) -> Result<Response<Bytes>, Box<dyn std::error::Error + Sync + Send>> {
-//        let mut hyper_request = hyper::Request::builder()
-//            .uri(request.uri())
-//            .method(request.method());
-//
-//        for header in request.headers() {
-//            hyper_request = hyper_request.header(header.0, header.1);
-//        }
-//
-//        let hyper_request = hyper_request.body(hyper::Body::from(request.into_body()))?;
-//
-//        let hyper_response = self.request(hyper_request).await?;
-//
-//        let mut response = Response::builder()
-//            .status(hyper_response.status())
-//            .version(hyper_response.version());
-//
-//        for (key, value) in hyper_response.headers() {
-//            response = response.header(key, value);
-//        }
-//
-//        let response = response.body(hyper::body::to_bytes(hyper_response.into_body()).await?)?;
-//
-//        Ok(response)
-//    }
-//}
-
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -44,7 +44,9 @@ pub use context::Context;
 pub use errors::*;
 #[doc(inline)]
 pub use headers::Header;
-pub use http_client::{new_http_client, to_json, HttpClient};
+#[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
+pub use http_client::new_http_client;
+pub use http_client::{to_json, HttpClient};
 pub use models::*;
 pub use options::*;
 pub use pageable::*;


### PR DESCRIPTION
This is a subset of #755. It hasn't been supported for months. A user could implement the `HttpClient` trait to pass in their own version. Fix #688.