### PR TITLE
iot_hub: Add support for configurations

### DIFF
--- a/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
+++ b/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
@@ -1,0 +1,71 @@
+use azure_iot_hub::service::ServiceClient;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let iot_hub_connection_string = std::env::var("IOTHUB_CONNECTION_STRING")
+        .expect("Set env variable IOTHUB_CONNECTION_STRING first!");
+
+    let device_id = std::env::args()
+        .nth(1)
+        .expect("Please pass the device id as the first parameter");
+
+    println!("Applying configuration on device: {}", device_id);
+
+    let modules_content = serde_json::json!({
+        "$edgeAgent": {
+            "properties.desired": {
+                "modules": {},
+                "runtime": {
+                    "settings": {
+                        "minDockerVersion": "v1.25"
+                    },
+                    "type": "docker"
+                },
+                "schemaVersion": "1.1",
+                "systemModules": {
+                    "edgeAgent": {
+                        "settings": {
+                            "image": "mcr.microsoft.com/azureiotedge-agent:1.1",
+                            "createOptions": ""
+                        },
+                        "type": "docker"
+                    },
+                    "edgeHub": {
+                        "settings": {
+                            "image": "mcr.microsoft.com/azureiotedge-hub:1.1",
+                            "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}],\"8883/tcp\":[{\"HostPort\":\"8883\"}]}}}"
+                        },
+                        "type": "docker",
+                        "status": "running",
+                        "restartPolicy": "always"
+                    }
+                }
+            }
+        },
+        "$edgeHub": {
+            "properties.desired": {
+                "routes": {
+                    "route": "FROM /messages/* INTO $upstream"
+                },
+                "schemaVersion": "1.1",
+                "storeAndForwardConfiguration": {
+                    "timeToLiveSecs": 7200
+                }
+            }
+        }
+    });
+
+    let http_client = azure_core::new_http_client();
+    let service_client =
+        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    service_client
+        .apply_on_edge_device(device_id)
+        .modules_content(modules_content)
+        .execute()
+        .await?;
+
+    println!("Successfully applied the configuration");
+
+    Ok(())
+}

--- a/sdk/iot_hub/examples/configuration.rs
+++ b/sdk/iot_hub/examples/configuration.rs
@@ -10,11 +10,34 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(1)
         .expect("Please pass the configuration id as the first parameter");
 
-    println!("Getting configuration: {}", configuration_id);
-
     let http_client = azure_core::new_http_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+
+    println!("Creating a new configuration with id: {}", configuration_id);
+
+    let configuration = service_client
+        .create_configuration(&configuration_id, 10, "tags.environment='test'")
+        .device_content(serde_json::json!({
+            "properties.desired.settings": {
+                "test": "test",
+                "otherKey": "otherValue"
+            }
+        }))
+        .label("some", "label")
+        .metric(
+            "metric1",
+            "SELECT deviceId FROM devices WHERE properties.reported.lastDesiredStatus.code = 200",
+        )
+        .execute()
+        .await?;
+
+    println!(
+        "Successfully created a new configuration with id: {}",
+        configuration.id,
+    );
+
+    println!("Getting configuration: {}", configuration_id);
     let configuration = service_client.get_configuration(configuration_id).await?;
 
     println!(
@@ -22,11 +45,53 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         configuration
     );
 
+    println!(
+        "Updating the newly created configuration with id: {}",
+        configuration.id
+    );
+
+    let configuration = service_client
+        .update_configuration(
+            &configuration.id,
+            20,
+            "tags.environment='debug'",
+            &configuration.etag,
+        )
+        .device_content(serde_json::json!({
+            "properties.desired.settings": {
+                "test": "test2",
+                "otherKey": "otherValue3"
+            }
+        }))
+        .labels(configuration.labels)
+        .metrics(configuration.metrics.queries)
+        .execute()
+        .await?;
+
     let multiple_configurations = service_client.get_configurations().await?;
     println!(
         "Successfully retrieved all configurations '{:?}'",
         multiple_configurations
     );
 
+    println!(
+        "Succesfully updated the newly created configuration with id: {}",
+        configuration.id
+    );
+
+    println!(
+        "Deleting newly created configuration with id: {}",
+        configuration.id
+    );
+
+    service_client
+        .delete_configuration(&configuration.id, configuration.etag)
+        .execute()
+        .await?;
+
+    println!(
+        "Successfully deleted configuration with id: {}",
+        configuration.id,
+    );
     Ok(())
 }

--- a/sdk/iot_hub/examples/configuration.rs
+++ b/sdk/iot_hub/examples/configuration.rs
@@ -22,5 +22,11 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         configuration
     );
 
+    let multiple_configurations = service_client.get_configurations().await?;
+    println!(
+        "Successfully retrieved all configurations '{:?}'",
+        multiple_configurations
+    );
+
     Ok(())
 }

--- a/sdk/iot_hub/examples/configuration.rs
+++ b/sdk/iot_hub/examples/configuration.rs
@@ -1,0 +1,26 @@
+use azure_iot_hub::service::ServiceClient;
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+    let iot_hub_connection_string = std::env::var("IOTHUB_CONNECTION_STRING")
+        .expect("Set env variable IOTHUB_CONNECTION_STRING first!");
+
+    let configuration_id = std::env::args()
+        .nth(1)
+        .expect("Please pass the configuration id as the first parameter");
+
+    println!("Getting configuration: {}", configuration_id);
+
+    let http_client = azure_core::new_http_client();
+    let service_client =
+        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let configuration = service_client.get_configuration(configuration_id).await?;
+
+    println!(
+        "Successfully retrieved the new configuration '{:?}'",
+        configuration
+    );
+
+    Ok(())
+}

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -15,13 +15,14 @@ pub mod resources;
 pub mod responses;
 
 use crate::service::requests::{
-    get_identity, get_twin, CreateOrUpdateDeviceIdentityBuilder,
-    CreateOrUpdateModuleIdentityBuilder, DeleteIdentityBuilder, InvokeMethodBuilder, QueryBuilder,
-    UpdateOrReplaceTwinBuilder,
+    get_configuration, get_identity, get_twin, ApplyOnEdgeDeviceBuilder,
+    CreateOrUpdateDeviceIdentityBuilder, CreateOrUpdateModuleIdentityBuilder,
+    DeleteIdentityBuilder, InvokeMethodBuilder, QueryBuilder, UpdateOrReplaceTwinBuilder,
 };
 use crate::service::resources::identity::IdentityOperation;
 use crate::service::responses::{
-    DeviceIdentityResponse, DeviceTwinResponse, ModuleIdentityResponse, ModuleTwinResponse,
+    ConfigurationResponse, DeviceIdentityResponse, DeviceTwinResponse, ModuleIdentityResponse,
+    ModuleTwinResponse,
 };
 
 /// The API version to use for any requests
@@ -252,7 +253,6 @@ impl ServiceClient {
     /// Create a new device method
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -285,7 +285,6 @@ impl ServiceClient {
     /// Create a new module method
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -320,7 +319,6 @@ impl ServiceClient {
     /// Get the module twin of a given device and module
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -349,7 +347,6 @@ impl ServiceClient {
     /// Get the device twin of a given device
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -368,7 +365,6 @@ impl ServiceClient {
     /// Update the module twin of a given device or module
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -400,7 +396,6 @@ impl ServiceClient {
     /// Replace the module twin of a given device and module
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -427,7 +422,6 @@ impl ServiceClient {
     /// Update the device twin of a given device
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -452,7 +446,6 @@ impl ServiceClient {
     /// Replace the device twin of a given device
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -477,7 +470,6 @@ impl ServiceClient {
     /// Get the identity of a given device
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -499,7 +491,6 @@ impl ServiceClient {
     /// Create a new device identity
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
@@ -517,7 +508,6 @@ impl ServiceClient {
     /// Update an existing device identity
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
@@ -541,7 +531,6 @@ impl ServiceClient {
     /// an unconditional delete will be performed.
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -565,7 +554,6 @@ impl ServiceClient {
     /// Get the identity of a given module
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -589,7 +577,6 @@ impl ServiceClient {
     /// Create a new module identity
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
@@ -607,7 +594,6 @@ impl ServiceClient {
     /// Update an existing module identity
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
@@ -631,7 +617,6 @@ impl ServiceClient {
     /// an unconditional delete will be performed.
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -662,7 +647,6 @@ impl ServiceClient {
     /// Invoke a query
     ///
     /// ```
-    /// use std::sync::Arc;
     /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
@@ -673,6 +657,45 @@ impl ServiceClient {
     /// ```
     pub fn query(&self) -> QueryBuilder<'_> {
         QueryBuilder::new(self)
+    }
+
+    /// Apply configuration on an Edge device
+    ///
+    /// ```
+    /// use azure_core::HttpClient;
+    /// use azure_iot_hub::service::ServiceClient;
+    ///
+    /// # let http_client = azure_core::new_http_client();
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device");
+    /// ```
+    pub fn apply_on_edge_device<S>(&self, device_id: S) -> ApplyOnEdgeDeviceBuilder
+    where
+        S: Into<String>,
+    {
+        ApplyOnEdgeDeviceBuilder::new(self, device_id.into())
+    }
+
+    /// Get the identity of a given module
+    ///
+    /// ```
+    /// use azure_core::HttpClient;
+    /// use azure_iot_hub::service::ServiceClient;
+    ///
+    /// # let http_client = azure_core::new_http_client();
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let device = iot_hub.get_configuration("some-configuration");
+    /// ```
+    pub async fn get_configuration<S>(
+        &self,
+        configuration_id: S,
+    ) -> crate::Result<ConfigurationResponse>
+    where
+        S: Into<String>,
+    {
+        get_configuration(self, configuration_id.into()).await
     }
 
     /// Prepares a request that can be used by any request builders.

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -22,7 +22,7 @@ use crate::service::requests::{
 use crate::service::resources::identity::IdentityOperation;
 use crate::service::responses::{
     ConfigurationResponse, DeviceIdentityResponse, DeviceTwinResponse, ModuleIdentityResponse,
-    ModuleTwinResponse,
+    ModuleTwinResponse, MultipleConfigurationResponse,
 };
 
 /// The API version to use for any requests
@@ -677,7 +677,7 @@ impl ServiceClient {
         ApplyOnEdgeDeviceBuilder::new(self, device_id.into())
     }
 
-    /// Get the identity of a given module
+    /// Get a configuration
     ///
     /// ```
     /// use azure_core::HttpClient;
@@ -695,7 +695,22 @@ impl ServiceClient {
     where
         S: Into<String>,
     {
-        get_configuration(self, configuration_id.into()).await
+        get_configuration(self, Some(configuration_id.into())).await
+    }
+
+    /// Get all configurations
+    ///
+    /// ```
+    /// use azure_core::HttpClient;
+    /// use azure_iot_hub::service::ServiceClient;
+    ///
+    /// # let http_client = azure_core::new_http_client();
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let device = iot_hub.get_configurations();
+    /// ```
+    pub async fn get_configurations(&self) -> crate::Result<MultipleConfigurationResponse> {
+        get_configuration(self, None).await
     }
 
     /// Prepares a request that can be used by any request builders.

--- a/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
+++ b/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
@@ -1,6 +1,5 @@
 use http::{Method, StatusCode};
 use serde::Serialize;
-use std::convert::TryInto;
 
 use crate::service::{ServiceClient, API_VERSION};
 
@@ -11,58 +10,98 @@ pub struct ApplyOnEdgeDeviceBuilder<'a> {
     device_id: String,
     device_content: serde_json::Value,
     module_content: serde_json::Value,
-    modules_content: serde_json::Value
+    modules_content: serde_json::Value,
 }
 
 impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
-    pub(crate) fn new(
-        service_client: &'a ServiceClient,
-        device_id: String
-    ) -> Self {
+    pub(crate) fn new(service_client: &'a ServiceClient, device_id: String) -> Self {
         Self {
             service_client,
             device_id,
             device_content: serde_json::json!({}),
             module_content: serde_json::json!({}),
-            modules_content: serde_json::json!({})
+            modules_content: serde_json::json!({}),
         }
     }
 
     /// Sets the device content
+    ///
+    ///
+    /// ```
+    /// use azure_iot_hub::service::ServiceClient;
+    /// use serde_json;
+    ///
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// # let http_client = azure_core::new_http_client();
+    ///
+    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device").device_content(serde_json::json!({}));
+    /// ```
     pub fn device_content(mut self, device_content: serde_json::Value) -> Self {
         self.device_content = device_content;
         self
     }
 
     /// Sets the module content
+    ///
+    ///
+    /// ```
+    /// use azure_iot_hub::service::ServiceClient;
+    /// use serde_json;
+    ///
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// # let http_client = azure_core::new_http_client();
+    ///
+    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device").module_content(serde_json::json!({}));
+    /// ```
     pub fn module_content(mut self, module_content: serde_json::Value) -> Self {
         self.module_content = module_content;
         self
     }
 
     /// Sets the modules content
+    ///
+    ///
+    /// ```
+    /// use azure_iot_hub::service::ServiceClient;
+    /// use serde_json;
+    ///
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// # let http_client = azure_core::new_http_client();
+    ///
+    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device").modules_content(serde_json::json!({}));
+    /// ```
     pub fn modules_content(mut self, modules_content: serde_json::Value) -> Self {
         self.modules_content = modules_content;
         self
     }
 
     /// Performs the apply on edge device request
-    pub async fn execute(
-        self,
-    ) -> crate::Result<()>
-    {
+    ///
+    ///
+    /// ```
+    /// use azure_iot_hub::service::ServiceClient;
+    /// use serde_json;
+    ///
+    /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
+    /// # let http_client = azure_core::new_http_client();
+    ///
+    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// iot_hub.apply_on_edge_device("some-device").execute();
+    /// ```
+    pub async fn execute(self) -> crate::Result<()> {
         let uri = format!(
             "https://{}.azure-devices.net/devices/{}/applyConfigurationContent?api-version={}",
-            self.service_client.iot_hub_name,
-            self.device_id,
-            API_VERSION
+            self.service_client.iot_hub_name, self.device_id, API_VERSION
         );
 
-        let mut request = self.service_client.prepare_request(&uri, Method::POST);
+        let request = self.service_client.prepare_request(&uri, Method::POST);
         let body = ApplyOnEdgeDeviceBody {
             device_content: self.device_content,
             module_content: self.module_content,
-            modules_content: self.modules_content
+            modules_content: self.modules_content,
         };
 
         let body = azure_core::to_json(&body)?;
@@ -71,14 +110,14 @@ impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
         self.service_client
             .http_client()
             .execute_request_check_status(request, StatusCode::NO_CONTENT)
-            .await?
-            .try_into()
+            .await?;
+        Ok(())
     }
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ApplyOnEdgeDeviceBody<'a> {
+struct ApplyOnEdgeDeviceBody {
     device_content: serde_json::Value,
     module_content: serde_json::Value,
     modules_content: serde_json::Value,

--- a/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
+++ b/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
@@ -1,0 +1,85 @@
+use http::{Method, StatusCode};
+use serde::Serialize;
+use std::convert::TryInto;
+
+use crate::service::{ServiceClient, API_VERSION};
+
+/// The ApplyOnEdgeDeviceBuilder is used to construct a new device identity
+/// or the update an existing one.
+pub struct ApplyOnEdgeDeviceBuilder<'a> {
+    service_client: &'a ServiceClient,
+    device_id: String,
+    device_content: serde_json::Value,
+    module_content: serde_json::Value,
+    modules_content: serde_json::Value
+}
+
+impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
+    pub(crate) fn new(
+        service_client: &'a ServiceClient,
+        device_id: String
+    ) -> Self {
+        Self {
+            service_client,
+            device_id,
+            device_content: serde_json::json!({}),
+            module_content: serde_json::json!({}),
+            modules_content: serde_json::json!({})
+        }
+    }
+
+    /// Sets the device content
+    pub fn device_content(mut self, device_content: serde_json::Value) -> Self {
+        self.device_content = device_content;
+        self
+    }
+
+    /// Sets the module content
+    pub fn module_content(mut self, module_content: serde_json::Value) -> Self {
+        self.module_content = module_content;
+        self
+    }
+
+    /// Sets the modules content
+    pub fn modules_content(mut self, modules_content: serde_json::Value) -> Self {
+        self.modules_content = modules_content;
+        self
+    }
+
+    /// Performs the apply on edge device request
+    pub async fn execute(
+        self,
+    ) -> crate::Result<()>
+    {
+        let uri = format!(
+            "https://{}.azure-devices.net/devices/{}/applyConfigurationContent?api-version={}",
+            self.service_client.iot_hub_name,
+            self.device_id,
+            API_VERSION
+        );
+
+        let mut request = self.service_client.prepare_request(&uri, Method::POST);
+        let body = ApplyOnEdgeDeviceBody {
+            device_content: self.device_content,
+            module_content: self.module_content,
+            modules_content: self.modules_content
+        };
+
+        let body = azure_core::to_json(&body)?;
+        let request = request.body(body)?;
+
+        self.service_client
+            .http_client()
+            .execute_request_check_status(request, StatusCode::NO_CONTENT)
+            .await?
+            .try_into()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ApplyOnEdgeDeviceBody<'a> {
+    device_content: serde_json::Value,
+    module_content: serde_json::Value,
+    modules_content: serde_json::Value,
+}

--- a/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
@@ -1,0 +1,151 @@
+use http::Method;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+use crate::service::resources::{ConfigurationContent, ConfigurationMetrics};
+use crate::service::responses::ConfigurationResponse;
+use crate::service::{ServiceClient, API_VERSION};
+
+/// The CreateOrUpdateConfigurationBuilder is used to construct a new configuration
+/// or update an existing one.
+pub struct CreateOrUpdateConfigurationBuilder<'a> {
+    service_client: &'a ServiceClient,
+    configuration_id: String,
+    priority: u64,
+    target_condition: String,
+    etag: Option<String>,
+    content: ConfigurationContent,
+    metrics: HashMap<String, String>,
+    labels: HashMap<String, String>,
+}
+
+impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
+    pub(crate) fn new(
+        service_client: &'a ServiceClient,
+        configuration_id: String,
+        priority: u64,
+        target_condition: String,
+        etag: Option<String>,
+    ) -> Self {
+        Self {
+            service_client,
+            configuration_id,
+            priority,
+            target_condition,
+            etag,
+            content: ConfigurationContent {
+                device_content: None,
+                module_content: None,
+                modules_content: None,
+            },
+            metrics: HashMap::new(),
+            labels: HashMap::new(),
+        }
+    }
+
+    /// Sets the device content for the configuration
+    /// The content cannot be updated once it has been created.
+    pub fn device_content(mut self, device_content: serde_json::Value) -> Self {
+        self.content.device_content = Some(device_content);
+        self
+    }
+
+    /// Sets the module content for the configuration.
+    /// The content cannot be updated once it has been created.
+    pub fn module_content(mut self, module_content: serde_json::Value) -> Self {
+        self.content.module_content = Some(module_content);
+        self
+    }
+
+    /// Sets the module content for the configuration
+    /// The content cannot be updated once it has been created.
+    pub fn modules_content(mut self, modules_content: serde_json::Value) -> Self {
+        self.content.modules_content = Some(modules_content);
+        self
+    }
+
+    /// Add a metric to the configuration
+    pub fn metric<S, T>(mut self, key: S, value: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.metrics.insert(key.into(), value.into());
+        self
+    }
+
+    /// Add multiple metrics to the configuration.
+    pub fn metrics(mut self, metrics: HashMap<String, String>) -> Self {
+        self.metrics = metrics;
+        self
+    }
+
+    /// Add a label to the configuration.
+    pub fn label<S, T>(mut self, key: S, value: T) -> Self
+    where
+        S: Into<String>,
+        T: Into<String>,
+    {
+        self.labels.insert(key.into(), value.into());
+        self
+    }
+
+    /// Add multiple labels to the configuration.
+    pub fn labels(mut self, labels: HashMap<String, String>) -> Self {
+        self.labels = labels;
+        self
+    }
+
+    /// Performs the create or update request on the device identity
+    pub async fn execute(self) -> crate::Result<ConfigurationResponse> {
+        let uri = format!(
+            "https://{}.azure-devices.net/configurations/{}?api-version={}",
+            self.service_client.iot_hub_name, &self.configuration_id, API_VERSION
+        );
+
+        let mut request = self.service_client.prepare_request(&uri, Method::PUT);
+
+        match &self.etag {
+            Some(etag) => {
+                request = request.header(http::header::IF_MATCH, format!("\"{}\"", etag));
+            }
+            None => (),
+        }
+
+        let body = CreateOrUpdateConfigurationBody {
+            content: self.content,
+            etag: self.etag,
+            id: &self.configuration_id,
+            labels: self.labels,
+            metrics: ConfigurationMetrics {
+                queries: self.metrics,
+                results: HashMap::new(),
+            },
+            priority: self.priority,
+            target_condition: &self.target_condition,
+        };
+
+        let body = azure_core::to_json(&body)?;
+        let request = request.body(body)?;
+
+        self.service_client
+            .http_client()
+            .execute_request_check_status(request, http::StatusCode::OK)
+            .await?
+            .try_into()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateOrUpdateConfigurationBody<'a, 'b> {
+    content: ConfigurationContent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    etag: Option<String>,
+    id: &'a str,
+    labels: HashMap<String, String>,
+    metrics: ConfigurationMetrics,
+    priority: u64,
+    target_condition: &'b str,
+}

--- a/sdk/iot_hub/src/service/requests/delete_configuration_builder.rs
+++ b/sdk/iot_hub/src/service/requests/delete_configuration_builder.rs
@@ -1,0 +1,45 @@
+use http::{Method, StatusCode};
+
+use crate::service::{ServiceClient, API_VERSION};
+
+/// The DeleteConfigurationBuilder is used to construct a request to delete a configuration.
+pub struct DeleteConfigurationBuilder<'a> {
+    service_client: &'a ServiceClient,
+    if_match: String,
+    configuration_id: String,
+}
+
+impl<'a> DeleteConfigurationBuilder<'a> {
+    pub(crate) fn new(
+        service_client: &'a ServiceClient,
+        if_match: String,
+        configuration_id: String,
+    ) -> Self {
+        Self {
+            service_client,
+            if_match,
+            configuration_id,
+        }
+    }
+
+    /// Execute the request to delete the configuration.
+    pub async fn execute(&self) -> crate::Result<()> {
+        let uri = format!(
+            "https://{}.azure-devices.net/configurations/{}?api-version={}",
+            self.service_client.iot_hub_name, self.configuration_id, API_VERSION
+        );
+
+        let request = self
+            .service_client
+            .prepare_request(&uri, Method::DELETE)
+            .header(http::header::IF_MATCH, format!("\"{}\"", &self.if_match));
+
+        let request = request.body(azure_core::EMPTY_BODY)?;
+
+        self.service_client
+            .http_client()
+            .execute_request_check_status(request, StatusCode::NO_CONTENT)
+            .await?;
+        Ok(())
+    }
+}

--- a/sdk/iot_hub/src/service/requests/get_configuration.rs
+++ b/sdk/iot_hub/src/service/requests/get_configuration.rs
@@ -8,15 +8,21 @@ use crate::service::{ServiceClient, API_VERSION};
 /// Execute the request to get the configuration of a given identifier.
 pub(crate) async fn get_configuration<T>(
     service_client: &ServiceClient,
-    configuration_id: String,
+    configuration_id: Option<String>,
 ) -> crate::Result<T>
 where
     T: TryFrom<Response<Bytes>, Error = crate::Error>,
 {
-    let uri = format!(
-        "https://{}.azure-devices.net/configurations/{}?api-version={}",
-        service_client.iot_hub_name, configuration_id, API_VERSION
-    );
+    let uri = match configuration_id {
+        Some(val) => format!(
+            "https://{}.azure-devices.net/configurations/{}?api-version={}",
+            service_client.iot_hub_name, val, API_VERSION
+        ),
+        None => format!(
+            "https://{}.azure-devices.net/configurations?api-version={}",
+            service_client.iot_hub_name, API_VERSION
+        ),
+    };
 
     let request = service_client.prepare_request(&uri, Method::GET);
     let request = request.body(azure_core::EMPTY_BODY)?;

--- a/sdk/iot_hub/src/service/requests/get_identity.rs
+++ b/sdk/iot_hub/src/service/requests/get_identity.rs
@@ -5,7 +5,7 @@ use http::{Method, Response, StatusCode};
 
 use crate::service::{ServiceClient, API_VERSION};
 
-/// Execute the request to create or update the module or device identity.
+/// Execute the request to get the identity of a device or module.
 pub(crate) async fn get_identity<T>(
     service_client: &ServiceClient,
     device_id: String,

--- a/sdk/iot_hub/src/service/requests/mod.rs
+++ b/sdk/iot_hub/src/service/requests/mod.rs
@@ -15,3 +15,4 @@ pub(crate) use get_twin::get_twin;
 pub use invoke_method_builder::InvokeMethodBuilder;
 pub use query_builder::QueryBuilder;
 pub use update_or_replace_twin_builder::UpdateOrReplaceTwinBuilder;
+pub use apply_on_edge_device_builder::ApplyOnEdgeDeviceBuilder;

--- a/sdk/iot_hub/src/service/requests/mod.rs
+++ b/sdk/iot_hub/src/service/requests/mod.rs
@@ -1,18 +1,21 @@
+mod apply_on_edge_device_builder;
 mod create_or_update_device_identity_builder;
 mod create_or_update_module_identity_builder;
 mod delete_identity_builder;
+mod get_configuration;
 mod get_identity;
 mod get_twin;
 mod invoke_method_builder;
 mod query_builder;
 mod update_or_replace_twin_builder;
 
+pub use apply_on_edge_device_builder::ApplyOnEdgeDeviceBuilder;
 pub use create_or_update_device_identity_builder::CreateOrUpdateDeviceIdentityBuilder;
 pub use create_or_update_module_identity_builder::CreateOrUpdateModuleIdentityBuilder;
 pub use delete_identity_builder::DeleteIdentityBuilder;
+pub(crate) use get_configuration::get_configuration;
 pub(crate) use get_identity::get_identity;
 pub(crate) use get_twin::get_twin;
 pub use invoke_method_builder::InvokeMethodBuilder;
 pub use query_builder::QueryBuilder;
 pub use update_or_replace_twin_builder::UpdateOrReplaceTwinBuilder;
-pub use apply_on_edge_device_builder::ApplyOnEdgeDeviceBuilder;

--- a/sdk/iot_hub/src/service/requests/mod.rs
+++ b/sdk/iot_hub/src/service/requests/mod.rs
@@ -1,6 +1,8 @@
 mod apply_on_edge_device_builder;
+mod create_or_update_configuration_builder;
 mod create_or_update_device_identity_builder;
 mod create_or_update_module_identity_builder;
+mod delete_configuration_builder;
 mod delete_identity_builder;
 mod get_configuration;
 mod get_identity;
@@ -10,8 +12,10 @@ mod query_builder;
 mod update_or_replace_twin_builder;
 
 pub use apply_on_edge_device_builder::ApplyOnEdgeDeviceBuilder;
+pub use create_or_update_configuration_builder::CreateOrUpdateConfigurationBuilder;
 pub use create_or_update_device_identity_builder::CreateOrUpdateDeviceIdentityBuilder;
 pub use create_or_update_module_identity_builder::CreateOrUpdateModuleIdentityBuilder;
+pub use delete_configuration_builder::DeleteConfigurationBuilder;
 pub use delete_identity_builder::DeleteIdentityBuilder;
 pub(crate) use get_configuration::get_configuration;
 pub(crate) use get_identity::get_identity;

--- a/sdk/iot_hub/src/service/resources/configuration.rs
+++ b/sdk/iot_hub/src/service/resources/configuration.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+/// The configuration content for devices or modules on edge devices.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationContent {
+    /// The device configuration content.
+    device_content: Option<serde_json::Value>,
+    /// The module configuration content.
+    module_content: Option<serde_json::Value>,
+    /// The modules configuration content.
+    modules_content: Option<serde_json::Value>,
+}
+
+/// The configuration metrics for Iot hub devices and modules.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationMetrics {
+    /// The key-value pairs with queries and their identifier.
+    queries: serde_json::Value,
+    /// The results of the metrics collection queries.
+    results: serde_json::Value,
+}

--- a/sdk/iot_hub/src/service/resources/configuration.rs
+++ b/sdk/iot_hub/src/service/resources/configuration.rs
@@ -1,23 +1,55 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// The configuration content for devices or modules on edge devices.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationContent {
     /// The device configuration content.
-    device_content: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub device_content: Option<serde_json::Value>,
     /// The module configuration content.
-    module_content: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module_content: Option<serde_json::Value>,
     /// The modules configuration content.
-    modules_content: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modules_content: Option<serde_json::Value>,
 }
 
 /// The configuration metrics for Iot hub devices and modules.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigurationMetrics {
     /// The key-value pairs with queries and their identifier.
-    queries: serde_json::Value,
+    pub queries: HashMap<String, String>,
     /// The results of the metrics collection queries.
-    results: serde_json::Value,
+    pub results: HashMap<String, serde_json::Value>,
+}
+
+/// The configuration metrics for Iot hub devices and modules.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Configuration {
+    /// The content of the configuration.
+    pub content: ConfigurationContent,
+    /// The creation date and time of the configuration.
+    pub created_time_utc: String,
+    /// The ETag of the configuration.
+    pub etag: String,
+    /// The unique identifier of the configuration.
+    pub id: String,
+    /// The key-value pairs used to describe the configuration
+    pub labels: HashMap<String, String>,
+    /// The update date and time of the configuration
+    pub last_updated_time_utc: String,
+    /// The custom metrics specified by the developer as queries against twin reported properties
+    pub metrics: ConfigurationMetrics,
+    /// The priority number assigned to the configuration
+    pub priority: u64,
+    /// The schema version of the configuration
+    pub schema_version: Option<String>,
+    /// The system metrics computed by the IoT Hub that cannot be customized
+    pub system_metrics: ConfigurationMetrics,
+    /// The query used to define the targeted devices or modules.
+    pub target_condition: String,
 }

--- a/sdk/iot_hub/src/service/resources/mod.rs
+++ b/sdk/iot_hub/src/service/resources/mod.rs
@@ -1,6 +1,8 @@
+mod configuration;
 pub(crate) mod identity;
 mod twin_properties;
 
+pub use configuration::{ConfigurationContent, ConfigurationMetrics};
 pub use identity::{
     AuthenticationMechanism, AuthenticationType, ConnectionState, DesiredCapability,
     DeviceCapabilities, Status, SymmetricKey, X509ThumbPrint,

--- a/sdk/iot_hub/src/service/resources/mod.rs
+++ b/sdk/iot_hub/src/service/resources/mod.rs
@@ -2,7 +2,7 @@ mod configuration;
 pub(crate) mod identity;
 mod twin_properties;
 
-pub use configuration::{ConfigurationContent, ConfigurationMetrics};
+pub use configuration::{Configuration, ConfigurationContent, ConfigurationMetrics};
 pub use identity::{
     AuthenticationMechanism, AuthenticationType, ConnectionState, DesiredCapability,
     DeviceCapabilities, Status, SymmetricKey, X509ThumbPrint,

--- a/sdk/iot_hub/src/service/responses/configuration_response.rs
+++ b/sdk/iot_hub/src/service/responses/configuration_response.rs
@@ -1,0 +1,44 @@
+use http::Response;
+use serde::{Deserialize, Serialize};
+
+use crate::service::resources::{ConfigurationContent, ConfigurationMetrics};
+
+/// The representation of a configuration.
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationResponse {
+    /// The content of the configuration.
+    content: ConfigurationContent,
+    /// The creation date and time of the configuration.
+    created_time_utc: String,
+    /// The ETag of the configuration.
+    etag: String,
+    /// The unique identifier of the configuration.
+    id: String,
+    /// The key-value pairs used to describe the configuration
+    labels: serde_json::Value,
+    /// The update date and time of the configuration
+    last_updated_time_utc: String,
+    /// The custom metrics specified by the developer as queries against twin reported properties
+    metrics: ConfigurationMetrics,
+    /// The priority number assigned to the configuration
+    priority: u64,
+    /// The schema version of the configuration
+    schema_version: Option<String>,
+    /// The system metrics computed by the IoT Hub that cannot be customized
+    system_metrics: ConfigurationMetrics,
+    /// The query used to define the targeted devices or modules.
+    target_condition: String,
+}
+
+impl std::convert::TryFrom<Response<bytes::Bytes>> for ConfigurationResponse {
+    type Error = crate::Error;
+
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
+        let body = response.body();
+
+        let configuration_response: ConfigurationResponse = serde_json::from_slice(body)?;
+
+        Ok(configuration_response)
+    }
+}

--- a/sdk/iot_hub/src/service/responses/configuration_response.rs
+++ b/sdk/iot_hub/src/service/responses/configuration_response.rs
@@ -1,37 +1,12 @@
 use http::Response;
 use serde::{Deserialize, Serialize};
 
-use crate::service::resources::{ConfigurationContent, ConfigurationMetrics};
+use crate::service::resources::Configuration;
 
-/// The representation of a configuration.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct ConfigurationResponse {
-    /// The content of the configuration.
-    content: ConfigurationContent,
-    /// The creation date and time of the configuration.
-    created_time_utc: String,
-    /// The ETag of the configuration.
-    etag: String,
-    /// The unique identifier of the configuration.
-    id: String,
-    /// The key-value pairs used to describe the configuration
-    labels: serde_json::Value,
-    /// The update date and time of the configuration
-    last_updated_time_utc: String,
-    /// The custom metrics specified by the developer as queries against twin reported properties
-    metrics: ConfigurationMetrics,
-    /// The priority number assigned to the configuration
-    priority: u64,
-    /// The schema version of the configuration
-    schema_version: Option<String>,
-    /// The system metrics computed by the IoT Hub that cannot be customized
-    system_metrics: ConfigurationMetrics,
-    /// The query used to define the targeted devices or modules.
-    target_condition: String,
-}
+/// The configuration response
+pub type ConfigurationResponse = Configuration;
 
-/// Representation of multiple configurations
+/// Representation of a multiple configurations response
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct MultipleConfigurationResponse(Vec<ConfigurationResponse>);
 

--- a/sdk/iot_hub/src/service/responses/configuration_response.rs
+++ b/sdk/iot_hub/src/service/responses/configuration_response.rs
@@ -31,6 +31,10 @@ pub struct ConfigurationResponse {
     target_condition: String,
 }
 
+/// Representation of multiple configurations
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct MultipleConfigurationResponse(Vec<ConfigurationResponse>);
+
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ConfigurationResponse {
     type Error = crate::Error;
 
@@ -38,6 +42,18 @@ impl std::convert::TryFrom<Response<bytes::Bytes>> for ConfigurationResponse {
         let body = response.body();
 
         let configuration_response: ConfigurationResponse = serde_json::from_slice(body)?;
+
+        Ok(configuration_response)
+    }
+}
+
+impl std::convert::TryFrom<Response<bytes::Bytes>> for MultipleConfigurationResponse {
+    type Error = crate::Error;
+
+    fn try_from(response: Response<bytes::Bytes>) -> Result<Self, Self::Error> {
+        let body = response.body();
+
+        let configuration_response: MultipleConfigurationResponse = serde_json::from_slice(body)?;
 
         Ok(configuration_response)
     }

--- a/sdk/iot_hub/src/service/responses/mod.rs
+++ b/sdk/iot_hub/src/service/responses/mod.rs
@@ -6,7 +6,7 @@ mod module_identity_response;
 mod module_twin_response;
 mod query_response;
 
-pub use configuration_response::ConfigurationResponse;
+pub use configuration_response::{ConfigurationResponse, MultipleConfigurationResponse};
 pub use device_identity_response::DeviceIdentityResponse;
 pub use device_twin_response::DeviceTwinResponse;
 pub use invoke_method_response::InvokeMethodResponse;

--- a/sdk/iot_hub/src/service/responses/mod.rs
+++ b/sdk/iot_hub/src/service/responses/mod.rs
@@ -1,3 +1,4 @@
+mod configuration_response;
 mod device_identity_response;
 mod device_twin_response;
 mod invoke_method_response;
@@ -5,6 +6,7 @@ mod module_identity_response;
 mod module_twin_response;
 mod query_response;
 
+pub use configuration_response::ConfigurationResponse;
 pub use device_identity_response::DeviceIdentityResponse;
 pub use device_twin_response::DeviceTwinResponse;
 pub use invoke_method_response::InvokeMethodResponse;


### PR DESCRIPTION
This PR contains the following changes:
1. Add support for applying a configuration on an edge device.
2. Add support for: Get, create, update, or delete a configuration.
3. Some minor fixes to documentation and typos. 

The deployment manifest that is required for applying a configuration on an edge device is quite complex. I considered creating a builder for this but this would lead to a lot of code that might need changes again once this deployment manifest gets updated (and it does every once in a while). Therefore just went with supplying the raw JSON as other Microsoft SDK's follow a similar approach.
