### PR TITLE
data tables queries use `eq` not `=` for string equality

### DIFF
--- a/sdk/data_tables/examples/table_00.rs
+++ b/sdk/data_tables/examples/table_00.rs
@@ -118,7 +118,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let mut stream = Box::pin(
         table_client
             .query()
-            .filter("Name = 'Carl'")
+            .filter("Name eq 'Carl'")
             .top(2)
             .stream::<MyEntity>(),
     );


### PR DESCRIPTION
The example for the data tables service shows using `eq` for string
checking:

https://myaccount.table.core.windows.net/Customers()?$filter=LastName%20ge%20'A'%20and%20LastName%20lt%20'B'

Ref: https://docs.microsoft.com/en-us/rest/api/storageservices/querying-tables-and-entities