### PR TITLE
convert error responses from bytes

### DIFF
--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -1,4 +1,5 @@
 use crate::Response;
+use bytes::Bytes;
 use std::collections::HashMap;
 
 /// An unsuccessful HTTP response
@@ -7,13 +8,13 @@ pub struct HttpError {
     status: u16,
     error_code: Option<String>,
     headers: std::collections::HashMap<String, String>,
-    body: String,
+    body: Bytes,
 }
 
 impl HttpError {
     /// Create an error from an http response.
     ///
-    /// This does not check whether the response was a success and should only be used with unsuccessul responses.
+    /// This does not check whether the response was a success and should only be used with unsuccessful responses.
     pub async fn new(response: Response) -> Self {
         let status = response.status();
         let mut error_code = get_error_code_from_header(&response);
@@ -24,7 +25,7 @@ impl HttpError {
             headers.insert(name.to_string(), value);
         }
 
-        let body = response.into_body_string().await;
+        let body = response.into_body().await;
         error_code = error_code.or_else(|| get_error_code_from_body(&body));
         HttpError {
             status: status.as_u16(),
@@ -55,7 +56,7 @@ impl std::fmt::Display for HttpError {
             self.error_code.as_deref().unwrap_or("unknown")
         )?;
         // TODO: sanitize body
-        writeln!(f, "\tBody: \"{}\"", self.body)?;
+        writeln!(f, "\tBody: \"{:?}\"", self.body)?;
         writeln!(f, "\tHeaders:")?;
         // TODO: sanitize headers
         for (k, v) in &self.headers {
@@ -85,9 +86,9 @@ fn get_error_code_from_header(response: &Response) -> Option<String> {
 /// Gets the error code if it's present in the body
 ///
 /// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
-pub(crate) fn get_error_code_from_body(body: &str) -> Option<String> {
+pub(crate) fn get_error_code_from_body(body: &Bytes) -> Option<String> {
     Some(
-        serde_json::from_str::<serde_json::Value>(body)
+        serde_json::from_slice::<serde_json::Value>(body)
             .ok()?
             .get("error")?
             .get("code")?

--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -86,7 +86,7 @@ fn get_error_code_from_header(response: &Response) -> Option<String> {
 /// Gets the error code if it's present in the body
 ///
 /// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
-pub(crate) fn get_error_code_from_body(body: &Bytes) -> Option<String> {
+pub(crate) fn get_error_code_from_body<'a>(body: &'a [u8]) -> Option<String> {
     Some(
         serde_json::from_slice::<serde_json::Value>(body)
             .ok()?

--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -86,7 +86,7 @@ fn get_error_code_from_header(response: &Response) -> Option<String> {
 /// Gets the error code if it's present in the body
 ///
 /// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
-pub(crate) fn get_error_code_from_body<'a>(body: &'a [u8]) -> Option<String> {
+pub(crate) fn get_error_code_from_body(body: &[u8]) -> Option<String> {
     Some(
         serde_json::from_slice::<serde_json::Value>(body)
             .ok()?

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -1,14 +1,13 @@
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};
-
 mod azure_core_errors;
 mod http_error;
 mod hyperium_http;
 mod macros;
-
+use bytes::Bytes;
 pub use http_error::HttpError;
 
-/// A convience alias for `Result` where the error type is hard coded to `Error`
+/// A convenience alias for `Result` where the error type is hard coded to `Error`
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// The kind of error
@@ -39,7 +38,7 @@ impl ErrorKind {
         Self::HttpResponse { status, error_code }
     }
 
-    pub fn http_response_from_body(status: u16, body: &str) -> Self {
+    pub fn http_response_from_body(status: u16, body: &Bytes) -> Self {
         let error_code = http_error::get_error_code_from_body(body);
         Self::HttpResponse { status, error_code }
     }
@@ -232,7 +231,7 @@ impl Display for Error {
     }
 }
 
-/// An extention to the `Result` type that easy allows creating `Error` values from exsiting errors
+/// An extension to the `Result` type that easy allows creating `Error` values from existing errors
 ///
 /// This trait cannot be implemented on custom types and is meant for usage with `Result`
 pub trait ResultExt<T>: private::Sealed {
@@ -381,7 +380,7 @@ mod tests {
 
     #[test]
     fn matching_against_http_error() {
-        let kind = ErrorKind::http_response_from_body(418, "{}");
+        let kind = ErrorKind::http_response_from_body(418, &Bytes::from_static(b"{}"));
 
         assert!(matches!(
             kind,
@@ -391,7 +390,10 @@ mod tests {
             }
         ));
 
-        let kind = ErrorKind::http_response_from_body(418, r#"{"error": {"code":"teepot"}}"#);
+        let kind = ErrorKind::http_response_from_body(
+            418,
+            &Bytes::from_static(br#"{"error": {"code":"teepot"}}"#),
+        );
 
         assert!(matches!(
             kind,

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -4,7 +4,6 @@ mod azure_core_errors;
 mod http_error;
 mod hyperium_http;
 mod macros;
-use bytes::Bytes;
 pub use http_error::HttpError;
 
 /// A convenience alias for `Result` where the error type is hard coded to `Error`
@@ -38,7 +37,7 @@ impl ErrorKind {
         Self::HttpResponse { status, error_code }
     }
 
-    pub fn http_response_from_body(status: u16, body: &Bytes) -> Self {
+    pub fn http_response_from_body<'a>(status: u16, body: &'a [u8]) -> Self {
         let error_code = http_error::get_error_code_from_body(body);
         Self::HttpResponse { status, error_code }
     }

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -301,9 +301,8 @@ struct Custom {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
-
     use super::*;
+    use bytes::Bytes;
     use std::io;
 
     #[allow(dead_code, unconditional_recursion)]

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -302,7 +302,6 @@ struct Custom {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
     use std::io;
 
     #[allow(dead_code, unconditional_recursion)]
@@ -380,7 +379,7 @@ mod tests {
 
     #[test]
     fn matching_against_http_error() {
-        let kind = ErrorKind::http_response_from_body(418, &Bytes::from_static(b"{}"));
+        let kind = ErrorKind::http_response_from_body(418, b"{}");
 
         assert!(matches!(
             kind,
@@ -390,10 +389,7 @@ mod tests {
             }
         ));
 
-        let kind = ErrorKind::http_response_from_body(
-            418,
-            &Bytes::from_static(br#"{"error": {"code":"teepot"}}"#),
-        );
+        let kind = ErrorKind::http_response_from_body(418, br#"{"error": {"code":"teepot"}}"#);
 
         assert!(matches!(
             kind,

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -37,7 +37,7 @@ impl ErrorKind {
         Self::HttpResponse { status, error_code }
     }
 
-    pub fn http_response_from_body<'a>(status: u16, body: &'a [u8]) -> Self {
+    pub fn http_response_from_body(status: u16, body: &[u8]) -> Self {
         let error_code = http_error::get_error_code_from_body(body);
         Self::HttpResponse { status, error_code }
     }

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -301,6 +301,8 @@ struct Custom {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+
     use super::*;
     use std::io;
 

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -1,3 +1,4 @@
+use bytes::Bytes;
 use http::StatusCode;
 use std::cmp::PartialEq;
 use std::fmt::Debug;
@@ -118,7 +119,7 @@ pub enum StreamError {
 #[derive(Debug, thiserror::Error)]
 pub enum HttpError {
     #[error("HTTP error status (status: {:?}, body: {:?})", status, body)]
-    StatusCode { status: StatusCode, body: String },
+    StatusCode { status: StatusCode, body: Bytes },
     #[error("UTF8 conversion error: {0}")]
     Utf8(#[from] std::str::Utf8Error),
     #[error("failed to build request")]

--- a/sdk/core/src/http_client.rs
+++ b/sdk/core/src/http_client.rs
@@ -62,7 +62,7 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
         if (200..400).contains(&status.as_u16()) {
             Ok(response)
         } else {
-            let body = std::str::from_utf8(response.body())?.to_owned();
+            let body = response.into_body();
             Err(crate::HttpError::StatusCode { status, body })
         }
     }

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -62,15 +62,18 @@ impl Response {
         (self.status, self.headers, self.body)
     }
 
+    /// Consume the HTTP response and return the HTTP body bytes.
+    pub async fn into_body(self) -> Bytes {
+        collect_pinned_stream(self.body)
+            .await
+            .unwrap_or_else(|_| Bytes::from_static(b"<INVALID BODY>"))
+    }
+
     /// Consume the HTTP response and read the HTTP body into a string.
     pub async fn into_body_string(self) -> String {
-        let body = collect_pinned_stream(self.body)
-            .await
-            .unwrap_or_else(|_| Bytes::from_static("<INVALID BODY>".as_bytes()));
-        let body = std::str::from_utf8(&body)
+        std::str::from_utf8(&self.into_body().await)
             .unwrap_or("<NON-UTF8 BODY>")
-            .to_owned();
-        body
+            .to_owned()
     }
 }
 


### PR DESCRIPTION
The conversion to a String first is not needed. After this change, `http_response_from_body` can be used from services. I skipped using it [here](https://github.com/Azure/azure-sdk-for-rust/pull/765#discussion_r881203828).