### PR TITLE
make reqwest optional for azure_core

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,11 +59,11 @@ jobs:
           cargo fmt --manifest-path services/Cargo.toml --all -- --check
         if: matrix.rust == 'stable'
 
+      - name: check core with --no-default-features
+        run: cargo check -p azure_core --no-default-features
+
       - name: check core for wasm
         run: cargo check -p azure_core --target=wasm32-unknown-unknown
-
-      # - name: check core for hyper
-      #   run: cargo check -p azure_core --no-default-features --features enable_hyper
 
       - name: sdk tests
         run: cargo test --all --features mock_transport_framework

--- a/sdk/core/src/errors.rs
+++ b/sdk/core/src/errors.rs
@@ -51,10 +51,7 @@ impl From<super::error::Error> for Error {
     }
 }
 
-#[cfg(feature = "enable_hyper")]
-type HttpClientError = hyper::Error;
-#[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
-type HttpClientError = reqwest::Error;
+type HttpClientError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// An error caused by a failure to parse data.
 #[non_exhaustive]

--- a/sdk/core/src/options.rs
+++ b/sdk/core/src/options.rs
@@ -16,6 +16,10 @@ use std::time::Duration;
 ///     .telemetry(TelemetryOptions::default().application_id("my-application"));
 /// ```
 #[derive(Clone, Debug)]
+#[cfg_attr(
+    any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"),
+    derive(Default)
+)]
 pub struct ClientOptions {
     /// Policies called per call.
     pub(crate) per_call_policies: Vec<Arc<dyn Policy>>,
@@ -27,14 +31,6 @@ pub struct ClientOptions {
     pub(crate) telemetry: TelemetryOptions,
     /// Transport options.
     pub(crate) transport: TransportOptions,
-}
-
-#[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
-impl Default for ClientOptions {
-    /// Creates an instance of the `ClientOptions` using the default `TransportOptions`.
-    fn default() -> Self {
-        Self::new(TransportOptions::default())
-    }
 }
 
 impl ClientOptions {

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -1,19 +1,19 @@
 use bytes::Bytes;
 use futures::Stream;
 use futures::StreamExt;
-use http::{header::HeaderName, HeaderMap, HeaderValue, StatusCode};
+use http::{HeaderMap, StatusCode};
 use std::pin::Pin;
 
 type PinnedStream = Pin<Box<dyn Stream<Item = crate::error::Result<Bytes>> + Send + Sync>>;
 
-#[allow(dead_code)]
+#[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 pub(crate) struct ResponseBuilder {
     status: StatusCode,
     headers: HeaderMap,
 }
 
+#[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 impl ResponseBuilder {
-    #[allow(dead_code)]
     pub fn new(status: StatusCode) -> Self {
         Self {
             status,
@@ -21,13 +21,16 @@ impl ResponseBuilder {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn with_header(&mut self, key: &HeaderName, value: HeaderValue) -> &mut Self {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn with_header(
+        &mut self,
+        key: &http::header::HeaderName,
+        value: http::HeaderValue,
+    ) -> &mut Self {
         self.headers.append(key, value);
         self
     }
 
-    #[allow(dead_code)]
     pub fn with_pinned_stream(self, response: PinnedStream) -> Response {
         Response::new(self.status, self.headers, response)
     }
@@ -41,6 +44,7 @@ pub struct Response {
 }
 
 impl Response {
+    #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
     pub(crate) fn new(status: StatusCode, headers: HeaderMap, body: PinnedStream) -> Self {
         Self {
             status,

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -13,6 +13,7 @@ pub(crate) struct ResponseBuilder {
 }
 
 impl ResponseBuilder {
+    #[allow(dead_code)]
     pub fn new(status: StatusCode) -> Self {
         Self {
             status,
@@ -26,6 +27,7 @@ impl ResponseBuilder {
         self
     }
 
+    #[allow(dead_code)]
     pub fn with_pinned_stream(self, response: PinnedStream) -> Response {
         Response::new(self.status, self.headers, response)
     }

--- a/sdk/device_update/src/client.rs
+++ b/sdk/device_update/src/client.rs
@@ -74,12 +74,12 @@ impl DeviceUpdateClient {
             .bearer_auth(self.get_token().await?.token.secret())
             .send()
             .await
-            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e))))?;
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e.into()))))?;
 
         let body = resp
             .bytes()
             .await
-            .map_err(|e| Error::Core(CoreError::Http(HttpError::ReadBytes(e))))?;
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ReadBytes(e.into()))))?;
         serde_json::from_slice(&body).map_err(|e| Error::Core(CoreError::Json(e)))
     }
 
@@ -97,7 +97,7 @@ impl DeviceUpdateClient {
         let resp = req
             .send()
             .await
-            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e))))?;
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e.into()))))?;
 
         if resp.status() == 202u16 {
             let headers = resp.headers();
@@ -120,11 +120,11 @@ impl DeviceUpdateClient {
             .header("Content-Type", "application/json")
             .send()
             .await
-            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e))))?;
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ExecuteRequest(e.into()))))?;
         let body = resp
             .text()
             .await
-            .map_err(|e| Error::Core(CoreError::Http(HttpError::ReadBytes(e))))?;
+            .map_err(|e| Error::Core(CoreError::Http(HttpError::ReadBytes(e.into()))))?;
         Ok(body)
     }
 }


### PR DESCRIPTION
For #735, it adds a check for `cargo check -p azure_core --no-default-features` which does not include `enable_reqwest`. Note, that these legacy errors can't be removed until  #771.