### PR TITLE
move to using `Arc<dyn HttpClient>` in azure_identity

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -28,6 +28,8 @@ openssl = { version = "0.10",  optional=true }
 base64 = "0.13.0"
 uuid = { version = "1.0",  features = ["v4"] }
 http = "0.2"
+# work around https://github.com/rust-lang/rust/issues/63033
+fix-hidden-lifetime-bug = "0.2"
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json"], default-features = false }

--- a/sdk/identity/examples/client_credentials_flow.rs
+++ b/sdk/identity/examples/client_credentials_flow.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let http_client = azure_core::new_http_client();
     // This will give you the final token to use in authorization.
     let token = client_credentials_flow::perform(
-        http_client.as_ref(),
+        http_client.clone(),
         &client_id,
         &client_secret,
         &["https://management.azure.com/"],

--- a/sdk/identity/examples/client_credentials_flow_blob.rs
+++ b/sdk/identity/examples/client_credentials_flow_blob.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let http_client = azure_core::new_http_client();
 
     let token = client_credentials_flow::perform(
-        http_client.as_ref(),
+        http_client.clone(),
         &client_id,
         &client_secret,
         &[&format!(

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -24,7 +24,7 @@
 //!     let http_client = azure_core::new_http_client();
 //!     // This will give you the final token to use in authorization.
 //!     let token = client_credentials_flow::perform(
-//!         http_client.as_ref(),
+//!         http_client.clone(),
 //!         &client_id,
 //!         &client_secret,
 //!         &["https://management.azure.com/"],
@@ -46,11 +46,12 @@ use azure_core::{
 };
 use http::Method;
 use login_response::LoginResponse;
+use std::sync::Arc;
 use url::form_urlencoded;
 
 /// Perform the client credentials flow
 pub async fn perform(
-    http_client: &dyn HttpClient,
+    http_client: Arc<dyn HttpClient>,
     client_id: &oauth2::ClientId,
     client_secret: &oauth2::ClientSecret,
     scopes: &[&str],

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 use url::form_urlencoded;
 
 /// Perform the client credentials flow
+#[fix_hidden_lifetime_bug::fix_hidden_lifetime_bug]
 pub async fn perform(
     http_client: Arc<dyn HttpClient>,
     client_id: &oauth2::ClientId,

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 use url::form_urlencoded;
 
 /// Perform the client credentials flow
+#[allow(clippy::manual_async_fn)]
 #[fix_hidden_lifetime_bug::fix_hidden_lifetime_bug]
 pub async fn perform(
     http_client: Arc<dyn HttpClient>,

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use url::form_urlencoded;
 
 /// Exchange a refresh token for a new access token and refresh token
+#[allow(clippy::manual_async_fn)]
 #[fix_hidden_lifetime_bug::fix_hidden_lifetime_bug]
 pub async fn exchange(
     http_client: Arc<dyn HttpClient>,

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -9,11 +9,12 @@ use http::Method;
 use oauth2::{AccessToken, ClientId, ClientSecret};
 use serde::Deserialize;
 use std::fmt;
+use std::sync::Arc;
 use url::form_urlencoded;
 
 /// Exchange a refresh token for a new access token and refresh token
 pub async fn exchange(
-    http_client: &dyn HttpClient,
+    http_client: Arc<dyn HttpClient>,
     tenant_id: &str,
     client_id: &ClientId,
     client_secret: Option<&ClientSecret>,

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use url::form_urlencoded;
 
 /// Exchange a refresh token for a new access token and refresh token
+#[fix_hidden_lifetime_bug::fix_hidden_lifetime_bug]
 pub async fn exchange(
     http_client: Arc<dyn HttpClient>,
     tenant_id: &str,

--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(1)
         .expect("please specify the storage account name as first command line parameter");
 
-    let client = reqwest::Client::new();
+    let http_client = azure_core::new_http_client();
 
     // the process requires two steps. The first is to ask for
     // the code to show to the user. This is done with the following
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // receive the refresh token as well.
     // We are requesting access to the storage account passed as parameter.
     let device_code_flow = device_code_flow::start(
-        &client,
+        http_client.clone(),
         &tenant_id,
         &client_id,
         &[
@@ -73,7 +73,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // this example we are creating an Azure Storage client
     // using the access token.
 
-    let http_client = azure_core::new_http_client();
     let storage_account_client = StorageAccountClient::new_bearer_token(
         http_client.clone(),
         &storage_account_name,
@@ -89,7 +88,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     // now let's refresh the token, if available
     if let Some(refresh_token) = authorization.refresh_token() {
         let refreshed_token =
-            refresh_token::exchange(&client, &tenant_id, &client_id, None, refresh_token).await?;
+            refresh_token::exchange(http_client, &tenant_id, &client_id, None, refresh_token)
+                .await?;
         println!("refreshed token == {:#?}", refreshed_token);
     }
 


### PR DESCRIPTION
From discussions in a previous PR, the more common method in the SDK is to clone the `Arc<dyn HttpClient>`, rather than pass a reference.

https://github.com/Azure/azure-sdk-for-rust/pull/785#discussion_r895938450

Note, this uses the crate [fix-hidden-lifetime-bug](https://crates.io/crates/fix-hidden-lifetime-bug) to work around an issue with async fn trait issues (ref: https://github.com/rust-lang/rust/issues/63033).

Without this workaround, we see the error:
```
error[E0700]: hidden type for `impl Trait` captures lifetime that does not appear in bounds
  --> sdk/identity/src/client_credentials_flow/mod.rs:59:28
   |
59 |   ) -> Result<LoginResponse> {
   |  ____________________________^
60 | |     let encoded: String = form_urlencoded::Serializer::new(String::new())
61 | |         .append_pair("client_id", client_id.as_str())
62 | |         .append_pair("scope", &scopes.join(" "))
...  |
89 | |     serde_json::from_slice(&rsp_body).map_kind(ErrorKind::DataConversion)
90 | | }
   | |_^
   |
   = note: hidden type `impl futures::Future<Output = std::result::Result<client_credentials_flow::login_response::LoginResponse, azure_core::error::Error>>` captures lifetime '_#42r
```