### PR TITLE
Migrate storage_queues to new azure_core::error scheme

### DIFF
--- a/sdk/storage_queues/src/clients/pop_receipt_client.rs
+++ b/sdk/storage_queues/src/clients/pop_receipt_client.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::requests::*;
+use azure_core::error::Result;
 use azure_core::HttpClient;
 use azure_storage::core::clients::StorageClient;
 use std::sync::Arc;
@@ -51,7 +52,7 @@ impl PopReceiptClient {
             .http_client()
     }
 
-    pub(crate) fn pop_receipt_url(&self) -> Result<url::Url, url::ParseError> {
+    pub(crate) fn pop_receipt_url(&self) -> Result<url::Url> {
         let mut url = self.queue_client.url_with_segments(
             ["messages", self.pop_receipt.message_id()]
                 .iter()

--- a/sdk/storage_queues/src/clients/queue_client.rs
+++ b/sdk/storage_queues/src/clients/queue_client.rs
@@ -1,4 +1,5 @@
 use crate::requests::*;
+use azure_core::error::{ErrorKind, Result, ResultExt};
 use azure_storage::core::clients::{AsStorageClient, StorageAccountClient, StorageClient};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -37,15 +38,13 @@ impl QueueClient {
         self.storage_client.as_ref()
     }
 
-    pub(crate) fn url_with_segments<'a, I>(
-        &'a self,
-        segments: I,
-    ) -> Result<url::Url, url::ParseError>
+    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
         self.storage_client
             .queue_url_with_segments(Some(self.queue_name.as_str()).into_iter().chain(segments))
+            .map_kind(ErrorKind::DataConversion)
     }
 
     pub fn queue_name(&self) -> &str {

--- a/sdk/storage_queues/src/lib.rs
+++ b/sdk/storage_queues/src/lib.rs
@@ -5,7 +5,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate azure_core;
 
-pub use azure_storage::{Error, Result};
+//pub use azure_core::{Error, Result};
 
 mod clients;
 mod message_ttl;

--- a/sdk/storage_queues/src/lib.rs
+++ b/sdk/storage_queues/src/lib.rs
@@ -5,8 +5,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate azure_core;
 
-//pub use azure_core::{Error, Result};
-
 mod clients;
 mod message_ttl;
 mod number_of_messages;

--- a/sdk/storage_queues/src/responses/clear_messages_response.rs
+++ b/sdk/storage_queues/src/responses/clear_messages_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -9,9 +10,9 @@ pub struct ClearMessagesResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for ClearMessagesResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(ClearMessagesResponse {

--- a/sdk/storage_queues/src/responses/create_queue_response.rs
+++ b/sdk/storage_queues/src/responses/create_queue_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -9,9 +10,9 @@ pub struct CreateQueueResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for CreateQueueResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(CreateQueueResponse {

--- a/sdk/storage_queues/src/responses/delete_message_response.rs
+++ b/sdk/storage_queues/src/responses/delete_message_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -9,9 +10,9 @@ pub struct DeleteMessageResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for DeleteMessageResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(DeleteMessageResponse {

--- a/sdk/storage_queues/src/responses/delete_queue_response.rs
+++ b/sdk/storage_queues/src/responses/delete_queue_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -9,9 +10,9 @@ pub struct DeleteQueueResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for DeleteQueueResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(DeleteQueueResponse {

--- a/sdk/storage_queues/src/responses/get_messages_response.rs
+++ b/sdk/storage_queues/src/responses/get_messages_response.rs
@@ -1,4 +1,5 @@
 use crate::PopReceipt;
+use azure_core::error::{Error, ErrorKind, Result, ResultExt};
 use azure_core::headers::utc_date_from_rfc2822;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::core::xml::read_xml;
@@ -54,15 +55,15 @@ struct MessagesInternal {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetMessagesResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         let headers = response.headers();
         let body = response.body();
 
         debug!("headers == {:?}", headers);
         debug!("body == {:#?}", body);
-        let response: MessagesInternal = read_xml(body)?;
+        let response: MessagesInternal = read_xml(body).map_kind(ErrorKind::DataConversion)?;
         debug!("response == {:?}", response);
 
         let mut messages = Vec::new();

--- a/sdk/storage_queues/src/responses/get_queue_metadata_response.rs
+++ b/sdk/storage_queues/src/responses/get_queue_metadata_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_core::prelude::*;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -11,9 +12,9 @@ pub struct GetQueueMetadataResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueMetadataResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         let headers = response.headers();
 
         debug!("headers == {:?}", headers);

--- a/sdk/storage_queues/src/responses/get_queue_service_properties_response.rs
+++ b/sdk/storage_queues/src/responses/get_queue_service_properties_response.rs
@@ -1,4 +1,5 @@
 use crate::QueueServiceProperties;
+use azure_core::error::{Error, ErrorKind, Result, ResultExt};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::core::xml::read_xml;
 use bytes::Bytes;
@@ -12,15 +13,16 @@ pub struct GetQueueServicePropertiesResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueServicePropertiesResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         let headers = response.headers();
         let body = response.body();
 
         debug!("headers == {:?}", headers);
         debug!("body == {:#?}", body);
-        let queue_service_properties: QueueServiceProperties = read_xml(body)?;
+        let queue_service_properties: QueueServiceProperties =
+            read_xml(body).map_kind(ErrorKind::DataConversion)?;
         debug!("deserde == {:#?}", response);
 
         Ok(GetQueueServicePropertiesResponse {

--- a/sdk/storage_queues/src/responses/list_queues_response.rs
+++ b/sdk/storage_queues/src/responses/list_queues_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, ErrorKind, Result, ResultExt};
 use azure_core::prelude::*;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::xml::read_xml;
@@ -56,14 +57,15 @@ pub struct Queue {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for ListQueuesResponse {
-    type Error = crate::Error;
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    type Error = Error;
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         let headers = response.headers();
         let body = response.body();
 
         debug!("headers == {:?}", headers);
         debug!("body == {:#?}", body);
-        let mut response: ListQueuesResponseInternal = read_xml(body)?;
+        let mut response: ListQueuesResponseInternal =
+            read_xml(body).map_kind(ErrorKind::DataConversion)?;
 
         // get rid of the ugly Some("") empty string
         // we use None instead

--- a/sdk/storage_queues/src/responses/peek_messages_response.rs
+++ b/sdk/storage_queues/src/responses/peek_messages_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, ErrorKind, Result, ResultExt};
 use azure_core::headers::utc_date_from_rfc2822;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::core::xml::read_xml;
@@ -42,15 +43,15 @@ struct PeekMessagesInternal {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for PeekMessagesResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         let headers = response.headers();
         let body = response.body();
 
         debug!("headers == {:?}", headers);
         debug!("body == {:#?}", body);
-        let response: PeekMessagesInternal = read_xml(body)?;
+        let response: PeekMessagesInternal = read_xml(body).map_kind(ErrorKind::DataConversion)?;
         debug!("response == {:?}", response);
 
         let mut messages = Vec::new();

--- a/sdk/storage_queues/src/responses/put_message_response.rs
+++ b/sdk/storage_queues/src/responses/put_message_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, ErrorKind, Result, ResultExt};
 use azure_core::headers::utc_date_from_rfc2822;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::xml::read_xml;
@@ -42,14 +43,15 @@ struct QueueMessageInternal {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for PutMessageResponse {
-    type Error = crate::Error;
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    type Error = Error;
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         let headers = response.headers();
         let body = response.body();
 
         debug!("headers == {:?}", headers);
         debug!("body == {:#?}", body);
-        let response: PutMessageResponseInternal = read_xml(body)?;
+        let response: PutMessageResponseInternal =
+            read_xml(body).map_kind(ErrorKind::DataConversion)?;
         let queue_message = response.queue_message;
 
         let queue_message = QueueMessage {

--- a/sdk/storage_queues/src/responses/set_queue_acl_response.rs
+++ b/sdk/storage_queues/src/responses/set_queue_acl_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -9,9 +10,9 @@ pub struct SetQueueACLResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueACLResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(SetQueueACLResponse {

--- a/sdk/storage_queues/src/responses/set_queue_metadata_response.rs
+++ b/sdk/storage_queues/src/responses/set_queue_metadata_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -9,9 +10,9 @@ pub struct SetQueueMetadataResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueMetadataResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(SetQueueMetadataResponse {

--- a/sdk/storage_queues/src/responses/set_queue_service_properties_response.rs
+++ b/sdk/storage_queues/src/responses/set_queue_service_properties_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -9,9 +10,9 @@ pub struct SetQueueServicePropertiesResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueServicePropertiesResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(SetQueueServicePropertiesResponse {

--- a/sdk/storage_queues/src/responses/update_message_response.rs
+++ b/sdk/storage_queues/src/responses/update_message_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_core::headers::{get_str_from_headers, rfc2822_from_headers_mandatory};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -13,9 +14,9 @@ pub struct UpdateMessageResponse {
 }
 
 impl std::convert::TryFrom<&Response<Bytes>> for UpdateMessageResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(UpdateMessageResponse {


### PR DESCRIPTION
Part of the mission to migrate crates to the new error scheme:
https://github.com/Azure/azure-sdk-for-rust/issues/771