### PR TITLE
Migrate data_tables to new azure_core::error scheme

### DIFF
--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -1,5 +1,6 @@
 use crate::prelude::*;
 use crate::requests::*;
+use azure_core::error::Result;
 use azure_storage::core::clients::StorageAccountClient;
 use bytes::Bytes;
 use http::method::Method;
@@ -59,7 +60,7 @@ impl PartitionKeyClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> crate::Result<(Request<Bytes>, url::Url)> {
+    ) -> Result<(Request<Bytes>, url::Url)> {
         self.table_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -1,5 +1,6 @@
 use crate::clients::TableServiceClient;
 use crate::requests::*;
+use azure_core::error::Result;
 use azure_storage::core::clients::StorageAccountClient;
 use bytes::Bytes;
 use http::method::Method;
@@ -71,7 +72,7 @@ impl TableClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> crate::Result<(Request<Bytes>, url::Url)> {
+    ) -> Result<(Request<Bytes>, url::Url)> {
         self.table_service_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -1,4 +1,5 @@
 use crate::requests::ListTablesBuilder;
+use azure_core::error::{ErrorKind, Result, ResultExt};
 use azure_storage::core::clients::{StorageAccountClient, StorageClient};
 use bytes::Bytes;
 use http::method::Method;
@@ -7,11 +8,11 @@ use std::sync::Arc;
 use url::Url;
 
 pub trait AsTableServiceClient {
-    fn as_table_service_client(&self) -> Result<Arc<TableServiceClient>, url::ParseError>;
+    fn as_table_service_client(&self) -> Result<Arc<TableServiceClient>>;
 }
 
 impl AsTableServiceClient for Arc<StorageClient> {
-    fn as_table_service_client(&self) -> Result<Arc<TableServiceClient>, url::ParseError> {
+    fn as_table_service_client(&self) -> Result<Arc<TableServiceClient>> {
         TableServiceClient::new(self.clone())
     }
 }
@@ -23,7 +24,7 @@ pub struct TableServiceClient {
 }
 
 impl TableServiceClient {
-    pub(crate) fn new(storage_client: Arc<StorageClient>) -> Result<Arc<Self>, url::ParseError> {
+    pub(crate) fn new(storage_client: Arc<StorageClient>) -> Result<Arc<Self>> {
         let mut url = storage_client
             .storage_account_client()
             .table_storage_url()
@@ -60,7 +61,7 @@ impl TableServiceClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> crate::Result<(Request<Bytes>, url::Url)> {
+    ) -> Result<(Request<Bytes>, url::Url)> {
         self.storage_client
             .storage_account_client()
             .prepare_request(
@@ -70,6 +71,7 @@ impl TableServiceClient {
                 azure_storage::core::clients::ServiceType::Table,
                 request_body,
             )
+            .context(ErrorKind::Other, "failed to prepare request")
     }
 }
 

--- a/sdk/data_tables/src/continuation_next_partition_and_row_key.rs
+++ b/sdk/data_tables/src/continuation_next_partition_and_row_key.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{ErrorKind, Result, ResultExt};
 use azure_core::AppendToUrlQuery;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -15,16 +16,24 @@ impl ContinuationNextPartitionAndRowKey {
         &self.0
     }
 
-    pub fn from_header_optional(headers: &http::HeaderMap) -> crate::Result<Option<Self>> {
+    pub fn from_header_optional(headers: &http::HeaderMap) -> Result<Option<Self>> {
         let partition_header_as_str = headers
             .get("x-ms-continuation-NextPartitionKey")
             .map(|item| item.to_str())
-            .transpose()?;
+            .transpose()
+            .context(
+                ErrorKind::DataConversion,
+                "failed to convert x-ms-continuation-NextPartitionKey header value to string",
+            )?;
 
         let row_header_as_str = headers
             .get("x-ms-continuation-NextRowKey")
             .map(|item| item.to_str())
-            .transpose()?;
+            .transpose()
+            .context(
+                ErrorKind::DataConversion,
+                "failed to convert x-ms-continuation-NextRowKey header value to string",
+            )?;
 
         Ok(partition_header_as_str.filter(|h| !h.is_empty()).map(|h| {
             ContinuationNextPartitionAndRowKey::new(

--- a/sdk/data_tables/src/continuation_next_table_name.rs
+++ b/sdk/data_tables/src/continuation_next_table_name.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{ErrorKind, Result, ResultExt};
 use azure_core::AppendToUrlQuery;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -12,11 +13,15 @@ impl ContinuationNextTableName {
         &self.0
     }
 
-    pub fn from_header_optional(headers: &http::HeaderMap) -> crate::Result<Option<Self>> {
+    pub fn from_header_optional(headers: &http::HeaderMap) -> Result<Option<Self>> {
         let header_as_str = headers
             .get("x-ms-continuation-NextTableName")
             .map(|item| item.to_str())
-            .transpose()?;
+            .transpose()
+            .context(
+                ErrorKind::DataConversion,
+                "failed to convert x-ms-continuation-NextTableName header value to string",
+            )?;
 
         Ok(header_as_str
             .filter(|h| !h.is_empty())

--- a/sdk/data_tables/src/lib.rs
+++ b/sdk/data_tables/src/lib.rs
@@ -5,8 +5,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate azure_core;
 
-pub use azure_storage::{Error, Result};
-
 pub mod clients;
 mod continuation_next_partition_and_row_key;
 mod continuation_next_table_name;

--- a/sdk/data_tables/src/responses/create_table_response.rs
+++ b/sdk/data_tables/src/responses/create_table_response.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -11,9 +12,9 @@ pub struct CreateTableResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for CreateTableResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/delete_entity_response.rs
+++ b/sdk/data_tables/src/responses/delete_entity_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -9,9 +10,9 @@ pub struct DeleteEntityResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for DeleteEntityResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/delete_table_response.rs
+++ b/sdk/data_tables/src/responses/delete_table_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -9,9 +10,9 @@ pub struct DeleteTableResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for DeleteTableResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/get_entity_response.rs
+++ b/sdk/data_tables/src/responses/get_entity_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_core::{headers::etag_from_headers, Etag};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -28,9 +29,9 @@ impl<E> TryFrom<&Response<Bytes>> for GetEntityResponse<E>
 where
     E: DeserializeOwned,
 {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/insert_entity_response.rs
+++ b/sdk/data_tables/src/responses/insert_entity_response.rs
@@ -1,4 +1,5 @@
 use crate::EntityWithMetadata;
+use azure_core::error::{Error, ErrorKind, Result};
 use azure_core::{
     headers::{etag_from_headers, get_str_from_headers},
     Etag,
@@ -26,9 +27,9 @@ impl<E> TryFrom<&Response<Bytes>> for InsertEntityResponse<E>
 where
     E: DeserializeOwned,
 {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 
@@ -37,8 +38,9 @@ where
                 "return-no-content" => None,
                 "return-content" => Some(response.try_into()?),
                 _ => {
-                    return Err(crate::Error::GenericErrorWithText(
-                        "Unexpected value for preference-applied header".to_owned(),
+                    return Err(Error::message(
+                        ErrorKind::Other,
+                        "Unexpected value for preference-applied header",
                     ))
                 }
             };

--- a/sdk/data_tables/src/responses/list_tables_response.rs
+++ b/sdk/data_tables/src/responses/list_tables_response.rs
@@ -1,4 +1,5 @@
 use crate::{prelude::*, ContinuationNextTableName};
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -21,9 +22,9 @@ struct ListTablesResponseInternal {
 }
 
 impl TryFrom<&Response<Bytes>> for ListTablesResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/operation_on_entity_response.rs
+++ b/sdk/data_tables/src/responses/operation_on_entity_response.rs
@@ -1,3 +1,4 @@
+use azure_core::error::{Error, Result};
 use azure_core::{headers::etag_from_headers, Etag};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -11,9 +12,9 @@ pub struct OperationOnEntityResponse {
 }
 
 impl TryFrom<&Response<Bytes>> for OperationOnEntityResponse {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/query_entity_response.rs
+++ b/sdk/data_tables/src/responses/query_entity_response.rs
@@ -1,4 +1,5 @@
 use crate::ContinuationNextPartitionAndRowKey;
+use azure_core::error::{Error, Result};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -25,9 +26,9 @@ struct QueryEntityResponseInternal<E> {
 }
 
 impl<E: DeserializeOwned> TryFrom<&Response<Bytes>> for QueryEntityResponse<E> {
-    type Error = crate::Error;
+    type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self, Self::Error> {
+    fn try_from(response: &Response<Bytes>) -> Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 


### PR DESCRIPTION
Part of the mission to migrate crates to the new error scheme:
https://github.com/Azure/azure-sdk-for-rust/issues/771