### PR TITLE
2022 June Release update

### DIFF
--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_data_cosmos"
-version = "0.3.0"
+version = "0.4.0"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Cosmos DB"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_data_tables"
-version = "0.3.0"
+version = "0.4.0"
 description = "Azure Table storage crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.3", default-features=false}
-azure_storage = { path = "../storage", version = "0.3", default-features=false, features=["account"]}
+azure_storage = { path = "../storage", version = "0.4", default-features=false, features=["account"]}
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage"
-version = "0.3.0"
+version = "0.4.0"
 description = "Azure Storage crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.3", default-features = false }
-azure_storage = { path = "../storage", version = "0.3", default-features = false, features = [
+azure_storage = { path = "../storage", version = "0.4", default-features = false, features = [
   "account",
 ] }
 base64 = "0.13"

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.3" }
-azure_storage = { path = "../storage", version = "0.3" }
+azure_storage = { path = "../storage", version = "0.4" }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_storage_queues"
-version = "0.3.0"
+version = "0.4.0"
 description = "Azure Queue Storage crate from the Azure SDK for Rust"
 readme = "README.md"
 authors = ["Microsoft Corp."]
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.3", default-features=false }
-azure_storage = { path = "../storage", version = "0.3", default-features=false, features=["account"] }
+azure_storage = { path = "../storage", version = "0.4", default-features=false, features=["account"] }
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"


### PR DESCRIPTION
After publishing #813 yesterday, going to republish a few crates with these changes:

- #798
- #814
- #815 
- #816
- #817
- #818
- #819

Publishing these crates:

- azure_data_cosmos 0.4.0
- azure_data_tables 0.4.0
- azure_storage 0.4.0
- azure_storage_blobs 0.4.0
- azure_storage_datalake 0.4.0
- azure_storage_queues 0.4.0