### PR TITLE
fix: `azure_core` fails to build with `azurite_workaround` feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: check core for wasm
         run: cargo check -p azure_core --target=wasm32-unknown-unknown
 
+      - name: check for azurite_workaround
+        run: cargo check --all --feature azurite_workaround
+
       - name: sdk tests
         run: cargo test --all --features mock_transport_framework
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
         run: cargo check -p azure_core --target=wasm32-unknown-unknown
 
       - name: check for azurite_workaround
-        run: cargo check --all --feature azurite_workaround
+        run: cargo check --all --features azurite_workaround
 
       - name: sdk tests
         run: cargo test --all --features mock_transport_framework

--- a/sdk/core/src/parsing.rs
+++ b/sdk/core/src/parsing.rs
@@ -95,7 +95,7 @@ pub mod rfc2822_time_format_optional {
 
 #[inline]
 #[cfg(feature = "azurite_workaround")]
-pub fn from_azure_time(s: &str) -> Result<chrono::DateTime<chrono::Utc>, chrono::ParseError> {
+pub fn from_azure_time(s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
     if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(s) {
         let dt_utc: chrono::DateTime<chrono::Utc> = dt.with_timezone(&chrono::Utc);
         Ok(dt_utc)

--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -35,11 +35,12 @@ use http::header;
 use std::{collections::HashMap, convert::TryInto, str::FromStr};
 
 #[cfg(feature = "azurite_workaround")]
-fn get_creation_time(h: &header::HeaderMap) -> crate::Result<Option<DateTime<Utc>>> {
+fn get_creation_time(h: &header::HeaderMap) -> azure_core::error::Result<Option<DateTime<Utc>>> {
     if let Some(creation_time) = h.get(CREATION_TIME) {
         // Check that the creation time is valid
-        let creation_time = creation_time.to_str()?;
-        let creation_time = DateTime::parse_from_rfc2822(creation_time)?;
+        let creation_time = creation_time.to_str().map_kind(ErrorKind::DataConversion)?;
+        let creation_time =
+            DateTime::parse_from_rfc2822(creation_time).map_kind(ErrorKind::DataConversion)?;
         let creation_time = DateTime::from_utc(creation_time.naive_utc(), Utc);
         Ok(Some(creation_time))
     } else {


### PR DESCRIPTION
This PR fixes a conflicting error definition left behind the `azurite_workaround` feature gate.

closes #823 