### PR TITLE
Move Result to top of core crate

### DIFF
--- a/sdk/core/src/auth.rs
+++ b/sdk/core/src/auth.rs
@@ -1,6 +1,5 @@
 //! Azure authentication and authorization.
 
-use crate::error::Error;
 use chrono::{DateTime, Utc};
 use oauth2::AccessToken;
 use std::fmt::Debug;
@@ -25,5 +24,5 @@ impl TokenResponse {
 #[async_trait::async_trait]
 pub trait TokenCredential: Send + Sync {
     /// Gets a `TokenResponse` for the specified resource
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse, Error>;
+    async fn get_token(&self, resource: &str) -> crate::Result<TokenResponse>;
 }

--- a/sdk/core/src/bytes_stream.rs
+++ b/sdk/core/src/bytes_stream.rs
@@ -37,7 +37,7 @@ impl From<Bytes> for BytesStream {
 }
 
 impl Stream for BytesStream {
-    type Item = crate::error::Result<Bytes>;
+    type Item = crate::Result<Bytes>;
 
     fn poll_next(
         self: Pin<&mut Self>,
@@ -58,7 +58,7 @@ impl Stream for BytesStream {
 
 #[async_trait::async_trait]
 impl SeekableStream for BytesStream {
-    async fn reset(&mut self) -> crate::error::Result<()> {
+    async fn reset(&mut self) -> crate::Result<()> {
         self.bytes_read = 0;
         Ok(())
     }

--- a/sdk/core/src/error/macros.rs
+++ b/sdk/core/src/error/macros.rs
@@ -83,17 +83,17 @@ mod tests {
 
     #[test]
     fn ensure_works() {
-        fn test_ensure(predicate: bool) -> Result<()> {
+        fn test_ensure(predicate: bool) -> crate::Result<()> {
             ensure!(predicate, ErrorKind::Other, "predicate failed");
             Ok(())
         }
 
-        fn test_ensure_eq(item1: &str, item2: &str) -> Result<()> {
+        fn test_ensure_eq(item1: &str, item2: &str) -> crate::Result<()> {
             ensure_eq!(item1, item2, ErrorKind::Other, "predicate failed");
             Ok(())
         }
 
-        fn test_ensure_ne(item1: &str, item2: &str) -> Result<()> {
+        fn test_ensure_ne(item1: &str, item2: &str) -> crate::Result<()> {
             ensure_ne!(item1, item2, ErrorKind::Other, "predicate failed");
             Ok(())
         }

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::error::{Error, ErrorKind, Result};
+use crate::error::{Error, ErrorKind};
 use crate::request_options::LeaseId;
 use crate::{RequestId, SessionToken};
 
@@ -11,7 +11,7 @@ use std::str::FromStr;
 pub fn get_option_str_from_headers<'a>(
     headers: &'a HeaderMap,
     key: &str,
-) -> Result<Option<&'a str>> {
+) -> crate::Result<Option<&'a str>> {
     let h = match headers.get(key) {
         Some(h) => h,
         None => return Ok(None),
@@ -25,7 +25,7 @@ pub fn get_option_str_from_headers<'a>(
     })?))
 }
 
-pub fn get_str_from_headers<'a>(headers: &'a HeaderMap, key: &str) -> Result<&'a str> {
+pub fn get_str_from_headers<'a>(headers: &'a HeaderMap, key: &str) -> crate::Result<&'a str> {
     get_option_str_from_headers(headers, key)?.ok_or_else(|| {
         Error::with_message(ErrorKind::DataConversion, || {
             format!("could not find '{key}' in headers")
@@ -33,7 +33,7 @@ pub fn get_str_from_headers<'a>(headers: &'a HeaderMap, key: &str) -> Result<&'a
     })
 }
 
-pub fn get_option_from_headers<T>(headers: &HeaderMap, key: &str) -> Result<Option<T>>
+pub fn get_option_from_headers<T>(headers: &HeaderMap, key: &str) -> crate::Result<Option<T>>
 where
     T: std::str::FromStr + 'static,
     T::Err: std::error::Error + Send + Sync,
@@ -56,7 +56,7 @@ where
     })?))
 }
 
-pub fn get_from_headers<T>(headers: &HeaderMap, key: &str) -> Result<T>
+pub fn get_from_headers<T>(headers: &HeaderMap, key: &str) -> crate::Result<T>
 where
     T: std::str::FromStr + 'static,
     T::Err: std::error::Error + Send + Sync,
@@ -74,7 +74,7 @@ where
     })
 }
 
-pub fn parse_date_from_str(date: &str, fmt: &str) -> Result<DateTime<FixedOffset>> {
+pub fn parse_date_from_str(date: &str, fmt: &str) -> crate::Result<DateTime<FixedOffset>> {
     DateTime::parse_from_str(date, fmt).map_err(|e| {
         Error::full(
             ErrorKind::DataConversion,
@@ -87,7 +87,7 @@ pub fn parse_date_from_str(date: &str, fmt: &str) -> Result<DateTime<FixedOffset
     })
 }
 
-pub fn parse_date_from_rfc2822(date: &str) -> Result<DateTime<FixedOffset>> {
+pub fn parse_date_from_rfc2822(date: &str) -> crate::Result<DateTime<FixedOffset>> {
     DateTime::parse_from_rfc2822(date).map_err(|e| {
         Error::full(
             ErrorKind::DataConversion,
@@ -97,7 +97,7 @@ pub fn parse_date_from_rfc2822(date: &str) -> Result<DateTime<FixedOffset>> {
     })
 }
 
-pub fn parse_int<F>(s: &str) -> Result<F>
+pub fn parse_int<F>(s: &str) -> crate::Result<F>
 where
     F: FromStr<Err = std::num::ParseIntError>,
 {
@@ -110,11 +110,11 @@ where
     })
 }
 
-pub fn lease_id_from_headers(headers: &HeaderMap) -> Result<LeaseId> {
+pub fn lease_id_from_headers(headers: &HeaderMap) -> crate::Result<LeaseId> {
     get_from_headers(headers, LEASE_ID)
 }
 
-pub fn request_id_from_headers(headers: &HeaderMap) -> Result<RequestId> {
+pub fn request_id_from_headers(headers: &HeaderMap) -> crate::Result<RequestId> {
     get_from_headers(headers, REQUEST_ID)
 }
 
@@ -124,89 +124,93 @@ pub fn client_request_id_from_headers_optional(headers: &HeaderMap) -> Option<St
         .flatten()
 }
 
-pub fn last_modified_from_headers_optional(headers: &HeaderMap) -> Result<Option<DateTime<Utc>>> {
+pub fn last_modified_from_headers_optional(
+    headers: &HeaderMap,
+) -> crate::Result<Option<DateTime<Utc>>> {
     get_option_from_headers(headers, LAST_MODIFIED.as_str())
 }
 
-pub fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>> {
+pub fn date_from_headers(headers: &HeaderMap) -> crate::Result<DateTime<Utc>> {
     rfc2822_from_headers_mandatory(headers, DATE.as_str())
 }
 
-pub fn last_modified_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>> {
+pub fn last_modified_from_headers(headers: &HeaderMap) -> crate::Result<DateTime<Utc>> {
     rfc2822_from_headers_mandatory(headers, LAST_MODIFIED.as_str())
 }
 
 pub fn rfc2822_from_headers_mandatory(
     headers: &HeaderMap,
     header_name: &str,
-) -> Result<DateTime<Utc>> {
+) -> crate::Result<DateTime<Utc>> {
     let date = get_str_from_headers(headers, header_name)?;
     utc_date_from_rfc2822(date)
 }
 
-pub fn utc_date_from_rfc2822(date: &str) -> Result<DateTime<Utc>> {
+pub fn utc_date_from_rfc2822(date: &str) -> crate::Result<DateTime<Utc>> {
     let date = parse_date_from_rfc2822(date)?;
     Ok(DateTime::from_utc(date.naive_utc(), Utc))
 }
 
-pub fn continuation_token_from_headers_optional(headers: &HeaderMap) -> Result<Option<String>> {
+pub fn continuation_token_from_headers_optional(
+    headers: &HeaderMap,
+) -> crate::Result<Option<String>> {
     Ok(get_option_str_from_headers(headers, CONTINUATION)?.map(String::from))
 }
 
-pub fn sku_name_from_headers(headers: &HeaderMap) -> Result<String> {
+pub fn sku_name_from_headers(headers: &HeaderMap) -> crate::Result<String> {
     Ok(get_str_from_headers(headers, SKU_NAME)?.to_owned())
 }
 
-pub fn account_kind_from_headers(headers: &HeaderMap) -> Result<String> {
+pub fn account_kind_from_headers(headers: &HeaderMap) -> crate::Result<String> {
     Ok(get_str_from_headers(headers, ACCOUNT_KIND)?.to_owned())
 }
 
-pub fn etag_from_headers_optional(headers: &HeaderMap) -> Result<Option<String>> {
+pub fn etag_from_headers_optional(headers: &HeaderMap) -> crate::Result<Option<String>> {
     Ok(get_option_str_from_headers(headers, ETAG.as_str())?.map(String::from))
 }
 
-pub fn etag_from_headers(headers: &HeaderMap) -> Result<String> {
+pub fn etag_from_headers(headers: &HeaderMap) -> crate::Result<String> {
     Ok(get_str_from_headers(headers, ETAG.as_str())?.to_owned())
 }
 
-pub fn lease_time_from_headers(headers: &HeaderMap) -> Result<u8> {
+pub fn lease_time_from_headers(headers: &HeaderMap) -> crate::Result<u8> {
     get_from_headers(headers, LEASE_TIME)
 }
 
 #[cfg(not(feature = "azurite_workaround"))]
-pub fn delete_type_permanent_from_headers(headers: &HeaderMap) -> Result<bool> {
+pub fn delete_type_permanent_from_headers(headers: &HeaderMap) -> crate::Result<bool> {
     get_from_headers(headers, DELETE_TYPE_PERMANENT)
 }
 
 #[cfg(feature = "azurite_workaround")]
-pub fn delete_type_permanent_from_headers(headers: &HeaderMap) -> Result<Option<bool>> {
+pub fn delete_type_permanent_from_headers(headers: &HeaderMap) -> crate::Result<Option<bool>> {
     get_option_from_headers(headers, DELETE_TYPE_PERMANENT)
 }
 
-pub fn sequence_number_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub fn sequence_number_from_headers(headers: &HeaderMap) -> crate::Result<u64> {
     get_from_headers(headers, BLOB_SEQUENCE_NUMBER)
 }
 
-pub fn session_token_from_headers(headers: &HeaderMap) -> Result<SessionToken> {
+pub fn session_token_from_headers(headers: &HeaderMap) -> crate::Result<SessionToken> {
     get_str_from_headers(headers, SESSION_TOKEN).map(ToOwned::to_owned)
 }
 
-pub fn server_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub fn server_from_headers(headers: &HeaderMap) -> crate::Result<&str> {
     get_str_from_headers(headers, SERVER.as_str())
 }
 
-pub fn version_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub fn version_from_headers(headers: &HeaderMap) -> crate::Result<&str> {
     get_str_from_headers(headers, VERSION)
 }
 
-pub fn request_server_encrypted_from_headers(headers: &HeaderMap) -> Result<bool> {
+pub fn request_server_encrypted_from_headers(headers: &HeaderMap) -> crate::Result<bool> {
     get_from_headers(headers, REQUEST_SERVER_ENCRYPTED)
 }
 
-pub fn content_type_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub fn content_type_from_headers(headers: &HeaderMap) -> crate::Result<&str> {
     get_str_from_headers(headers, http::header::CONTENT_TYPE.as_str())
 }
 
-pub fn item_count_from_headers(headers: &HeaderMap) -> Result<u32> {
+pub fn item_count_from_headers(headers: &HeaderMap) -> crate::Result<u32> {
     get_from_headers(headers, ITEM_COUNT)
 }

--- a/sdk/core/src/http_client.rs
+++ b/sdk/core/src/http_client.rs
@@ -1,4 +1,3 @@
-use crate::error::Result;
 #[allow(unused_imports)]
 use crate::error::{Error, ErrorKind, ResultExt};
 #[allow(unused_imports)]
@@ -24,7 +23,7 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
     /// Send out a request using `hyperium/http`'s types.
     ///
     /// This method is considered deprecated and should not be used in new code.
-    async fn execute_request(&self, request: Request<Bytes>) -> Result<Response<Bytes>>;
+    async fn execute_request(&self, request: Request<Bytes>) -> crate::Result<Response<Bytes>>;
 
     /// Send out a request using `azure_core`'s types.
     ///
@@ -34,7 +33,7 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
     /// responsibility of another policy (not the transport one). It does not consume the request.
     /// Implementors are expected to clone the necessary parts of the request and pass them to the
     /// underlying transport.
-    async fn execute_request2(&self, request: &crate::Request) -> Result<crate::Response>;
+    async fn execute_request2(&self, request: &crate::Request) -> crate::Result<crate::Response>;
 
     /// Send out a request and validate it was in the `2xx` range, using
     /// `hyperium/http`'s types.
@@ -46,7 +45,7 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
         &self,
         request: Request<Bytes>,
         _expected_status: StatusCode,
-    ) -> Result<Response<Bytes>> {
+    ) -> crate::Result<Response<Bytes>> {
         let response = self.execute_request(request).await?;
         let status = response.status();
         if (200..400).contains(&status.as_u16()) {
@@ -62,7 +61,7 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
 #[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
 impl HttpClient for reqwest::Client {
-    async fn execute_request(&self, request: Request<Bytes>) -> Result<Response<Bytes>> {
+    async fn execute_request(&self, request: Request<Bytes>) -> crate::Result<Response<Bytes>> {
         let url = url::Url::parse(&request.uri().to_string())?;
         let mut reqwest_request = self.request(request.method().clone(), url);
         for (header, value) in request.headers() {
@@ -97,7 +96,7 @@ impl HttpClient for reqwest::Client {
         Ok(response)
     }
 
-    async fn execute_request2(&self, request: &crate::Request) -> Result<crate::Response> {
+    async fn execute_request2(&self, request: &crate::Request) -> crate::Result<crate::Response> {
         let url = request.url().clone();
         let mut reqwest_request = self.request(request.method(), url);
         for (name, value) in request.headers().iter() {
@@ -146,7 +145,7 @@ impl HttpClient for reqwest::Client {
 }
 
 /// Serialize a type to json.
-pub fn to_json<T>(value: &T) -> Result<Bytes>
+pub fn to_json<T>(value: &T) -> crate::Result<Bytes>
 where
     T: ?Sized + Serialize,
 {

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -40,6 +40,7 @@ use uuid::Uuid;
 pub use bytes_stream::*;
 pub use constants::*;
 pub use context::Context;
+pub use error::Result;
 #[doc(inline)]
 pub use headers::Header;
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]

--- a/sdk/core/src/mock/mock_transaction.rs
+++ b/sdk/core/src/mock/mock_transaction.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorKind, Result, ResultExt};
+use crate::error::{Error, ErrorKind, ResultExt};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -29,7 +29,7 @@ impl MockTransaction {
         self.number.fetch_add(1, Ordering::SeqCst)
     }
 
-    pub(crate) fn file_path(&self, create_when_not_exist: bool) -> Result<PathBuf> {
+    pub(crate) fn file_path(&self, create_when_not_exist: bool) -> crate::Result<PathBuf> {
         let mut path = PathBuf::from(workspace_root().context(
             ErrorKind::MockFramework,
             "could not read the workspace_root from the cargo metadata",
@@ -67,7 +67,7 @@ impl MockTransaction {
 }
 
 /// Run cargo to get the root of the workspace
-fn workspace_root() -> Result<String> {
+fn workspace_root() -> crate::Result<String> {
     let output = std::process::Command::new("cargo")
         .arg("metadata")
         .output()?;

--- a/sdk/core/src/parsing.rs
+++ b/sdk/core/src/parsing.rs
@@ -1,25 +1,25 @@
 //! Parser helper utilities.
 
-use crate::error::{Error, ErrorKind, Result, ResultExt};
+use crate::error::{Error, ErrorKind, ResultExt};
 
 pub trait FromStringOptional<T> {
-    fn from_str_optional(s: &str) -> Result<T>;
+    fn from_str_optional(s: &str) -> crate::Result<T>;
 }
 
 impl FromStringOptional<u64> for u64 {
-    fn from_str_optional(s: &str) -> Result<u64> {
+    fn from_str_optional(s: &str) -> crate::Result<u64> {
         s.parse::<u64>().map_kind(ErrorKind::DataConversion)
     }
 }
 
 impl FromStringOptional<String> for String {
-    fn from_str_optional(s: &str) -> Result<String> {
+    fn from_str_optional(s: &str) -> crate::Result<String> {
         Ok(s.to_owned())
     }
 }
 
 impl FromStringOptional<bool> for bool {
-    fn from_str_optional(s: &str) -> Result<bool> {
+    fn from_str_optional(s: &str) -> crate::Result<bool> {
         match s {
             "true" => Ok(true),
             "false" => Ok(false),
@@ -31,7 +31,7 @@ impl FromStringOptional<bool> for bool {
 }
 
 impl FromStringOptional<chrono::DateTime<chrono::Utc>> for chrono::DateTime<chrono::Utc> {
-    fn from_str_optional(s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+    fn from_str_optional(s: &str) -> crate::Result<chrono::DateTime<chrono::Utc>> {
         from_azure_time(s).with_context(ErrorKind::DataConversion, || {
             format!("error parsing date time '{s}'")
         })
@@ -40,7 +40,7 @@ impl FromStringOptional<chrono::DateTime<chrono::Utc>> for chrono::DateTime<chro
 
 #[inline]
 #[cfg(not(feature = "azurite_workaround"))]
-pub fn from_azure_time(s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+pub fn from_azure_time(s: &str) -> crate::Result<chrono::DateTime<chrono::Utc>> {
     let dt = chrono::DateTime::parse_from_rfc2822(s).map_kind(ErrorKind::DataConversion)?;
     let dt_utc: chrono::DateTime<chrono::Utc> = dt.with_timezone(&chrono::Utc);
     Ok(dt_utc)
@@ -95,7 +95,7 @@ pub mod rfc2822_time_format_optional {
 
 #[inline]
 #[cfg(feature = "azurite_workaround")]
-pub fn from_azure_time(s: &str) -> Result<chrono::DateTime<chrono::Utc>> {
+pub fn from_azure_time(s: &str) -> crate::Result<chrono::DateTime<chrono::Utc>> {
     if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(s) {
         let dt_utc: chrono::DateTime<chrono::Utc> = dt.with_timezone(&chrono::Utc);
         Ok(dt_utc)

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -106,11 +106,7 @@ impl Pipeline {
         &self.pipeline
     }
 
-    pub async fn send(
-        &self,
-        ctx: &mut Context,
-        request: &mut Request,
-    ) -> crate::error::Result<Response> {
+    pub async fn send(&self, ctx: &mut Context, request: &mut Request) -> crate::Result<Response> {
         let res = self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
             .await?;

--- a/sdk/core/src/request_options/content_range.rs
+++ b/sdk/core/src/request_options/content_range.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorKind, Result, ResultExt};
+use crate::error::{Error, ErrorKind, ResultExt};
 use std::fmt;
 use std::str::FromStr;
 
@@ -39,7 +39,7 @@ impl ContentRange {
 
 impl FromStr for ContentRange {
     type Err = Error;
-    fn from_str(s: &str) -> Result<ContentRange> {
+    fn from_str(s: &str) -> crate::Result<ContentRange> {
         let remaining = s.strip_prefix(PREFIX).ok_or_else(|| {
             Error::with_message(ErrorKind::Other, || {
                 format!(

--- a/sdk/core/src/request_options/next_marker.rs
+++ b/sdk/core/src/request_options/next_marker.rs
@@ -1,5 +1,5 @@
 use super::Continuation;
-use crate::error::{ErrorKind, Result, ResultExt};
+use crate::error::{ErrorKind, ResultExt};
 use crate::AppendToUrlQuery;
 use serde::{Deserialize, Serialize};
 
@@ -31,7 +31,7 @@ impl NextMarker {
         url.query_pairs_mut().append_pair("continuation", &self.0);
     }
 
-    pub fn from_header_optional(headers: &http::HeaderMap) -> Result<Option<Self>> {
+    pub fn from_header_optional(headers: &http::HeaderMap) -> crate::Result<Option<Self>> {
         let header_as_str = headers
             .get("x-ms-continuation")
             .map(|item| item.to_str())

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorKind, Result, ResultExt};
+use crate::error::{Error, ErrorKind, ResultExt};
 use crate::headers::{AsHeaders, HeaderName, HeaderValue};
 use std::convert::From;
 use std::fmt;
@@ -65,7 +65,7 @@ impl From<std::ops::Range<usize>> for Range {
 
 impl FromStr for Range {
     type Err = Error;
-    fn from_str(s: &str) -> Result<Range> {
+    fn from_str(s: &str) -> crate::Result<Range> {
         let v = s.split('/').collect::<Vec<&str>>();
         if v.len() != 2 {
             return Err(Error::with_message(ErrorKind::Other, || {

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 use http::{HeaderMap, StatusCode};
 use std::pin::Pin;
 
-type PinnedStream = Pin<Box<dyn Stream<Item = crate::error::Result<Bytes>> + Send + Sync>>;
+type PinnedStream = Pin<Box<dyn Stream<Item = crate::Result<Bytes>> + Send + Sync>>;
 
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 #[cfg(not(target_arch = "wasm32"))]

--- a/sdk/data_cosmos/README.md
+++ b/sdk/data_cosmos/README.md
@@ -12,7 +12,6 @@ should also be possible with this crate.
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos DB.
 use azure_data_cosmos::prelude::*;
 use azure_core::Context;
-use azure_core::error::Result;
 use serde::{Deserialize, Serialize};
 
 // This is the stuct we want to use in our sample.
@@ -37,7 +36,7 @@ impl<'a> azure_data_cosmos::CosmosEntity<'a> for MySampleStruct {
 // This code will perform these tasks:
 // 1. Create 10 documents in the collection.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // Let's get Cosmos account and master key from env variables.
     let master_key =
         std::env::var("COSMOS_MASTER_KEY").expect("Set env variable COSMOS_MASTER_KEY first!");

--- a/sdk/data_cosmos/examples/attachments_00.rs
+++ b/sdk/data_cosmos/examples/attachments_00.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -23,7 +22,7 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // This example expects you to have created a collection
 // with partitionKey on "id".
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database_name = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -4,7 +4,7 @@ use stop_token::StopSource;
 use tokio::time::{Duration, Instant};
 
 #[tokio::main]
-async fn main() -> azure_core::error::Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
     // First we retrieve the account name and master key from environment variables, and
     // create an authorization token.

--- a/sdk/data_cosmos/examples/collection.rs
+++ b/sdk/data_cosmos/examples/collection.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/examples/create_delete_database.rs
+++ b/sdk/data_cosmos/examples/create_delete_database.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/examples/database_00.rs
+++ b/sdk/data_cosmos/examples/database_00.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use serde_json::Value;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/examples/database_01.rs
+++ b/sdk/data_cosmos/examples/database_01.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/examples/document_00.rs
+++ b/sdk/data_cosmos/examples/document_00.rs
@@ -2,8 +2,8 @@ use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos
 // DB.
-use azure_core::error::Result;
 use azure_core::prelude::*;
+
 use azure_data_cosmos::prelude::*;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
@@ -32,7 +32,7 @@ const COLLECTION: &str = "azuresdktc";
 // 3. Store an entry in collection *COLLECTION* of database *DATABASE*.
 // 4. Delete everything.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // Let's get Cosmos account and master key from env variables.
     // This helps automated testing.
     let master_key =

--- a/sdk/data_cosmos/examples/document_entries_00.rs
+++ b/sdk/data_cosmos/examples/document_entries_00.rs
@@ -1,5 +1,5 @@
-use azure_core::error::Result;
 use azure_core::prelude::*;
+
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -24,7 +24,7 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // This example expects you to have created a collection
 // with partitionKey on "id".
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database_name = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/document_entries_01.rs
+++ b/sdk/data_cosmos/examples/document_entries_01.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -22,7 +21,7 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // This example expects you to have created a collection
 // with partitionKey on "id".
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database_name = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -1,11 +1,11 @@
-use azure_core::error::Result;
 use azure_core::headers::{HeaderName, HeaderValue, Headers};
 use azure_core::prelude::*;
 use azure_core::CustomHeaders;
+
 use azure_data_cosmos::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/examples/key_ranges_00.rs
+++ b/sdk/data_cosmos/examples/key_ranges_00.rs
@@ -1,8 +1,7 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/permission_00.rs
+++ b/sdk/data_cosmos/examples/permission_00.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/examples/query_document_00.rs
+++ b/sdk/data_cosmos/examples/query_document_00.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -20,7 +19,7 @@ struct MySecondSampleStructOwned {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database_name = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/readme.rs
+++ b/sdk/data_cosmos/examples/readme.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos.
-use azure_core::error::Result;
+
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 
@@ -31,7 +31,7 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // 4. Delete the documents returned by task 4.
 // 5. Check the remaining documents.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // Let's get Cosmos account and master key from env variables.
     // This helps automated testing.
     let master_key =

--- a/sdk/data_cosmos/examples/remove_all_documents.rs
+++ b/sdk/data_cosmos/examples/remove_all_documents.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 use serde_json::Value;
@@ -6,7 +5,7 @@ use serde_json::Value;
 // This example expects you to have created a collection
 // with partitionKey on "id".
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database_name = std::env::args()
         .nth(1)
         .expect("please specify the database name as first command line parameter");

--- a/sdk/data_cosmos/examples/stored_proc_00.rs
+++ b/sdk/data_cosmos/examples/stored_proc_00.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 /// This sample showcases execution of stored procedure
 /// Create stored procedure called test_proc, like so:
 /// function f(personToGreet) {
@@ -9,7 +8,7 @@ use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/stored_proc_01.rs
+++ b/sdk/data_cosmos/examples/stored_proc_01.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 /// This sample showcases execution of stored procedure
 /// Create stored procedure called test_proc, like so:
 /// function f(personToGreet) {
@@ -10,7 +9,7 @@ use azure_data_cosmos::prelude::*;
 use futures::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let function_body: &str = r#"
         function f(personToGreet) {
             var context = getContext();

--- a/sdk/data_cosmos/examples/trigger_00.rs
+++ b/sdk/data_cosmos/examples/trigger_00.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use azure_data_cosmos::resources::trigger::{TriggerOperation, TriggerType};
 use futures::stream::StreamExt;
@@ -34,7 +33,7 @@ function updateMetadata() {
 }"#;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/user_00.rs
+++ b/sdk/data_cosmos/examples/user_00.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/examples/user_defined_function_00.rs
+++ b/sdk/data_cosmos/examples/user_defined_function_00.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
 
@@ -15,7 +14,7 @@ function tax(income) {
 }"#;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let database = std::env::args()
         .nth(1)
         .expect("please specify database name as first command line parameter");

--- a/sdk/data_cosmos/examples/user_permission_token.rs
+++ b/sdk/data_cosmos/examples/user_permission_token.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_data_cosmos::prelude::*;
 use futures::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     // We expect master keys (ie, not resource constrained)
     let master_key =

--- a/sdk/data_cosmos/src/clients/collection.rs
+++ b/sdk/data_cosmos/src/clients/collection.rs
@@ -41,7 +41,7 @@ impl CollectionClient {
         &self,
         document_name: S,
         partition_key: &PK,
-    ) -> azure_core::error::Result<DocumentClient> {
+    ) -> azure_core::Result<DocumentClient> {
         DocumentClient::new(self.clone(), document_name, partition_key)
     }
 

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -135,7 +135,7 @@ impl CosmosClient {
         mut request: Request,
         mut context: Context,
         resource_type: ResourceType,
-    ) -> azure_core::error::Result<Response> {
+    ) -> azure_core::Result<Response> {
         self.pipeline
             .send(context.insert(resource_type), &mut request)
             .await

--- a/sdk/data_cosmos/src/clients/document.rs
+++ b/sdk/data_cosmos/src/clients/document.rs
@@ -20,7 +20,7 @@ impl DocumentClient {
         collection: CollectionClient,
         document_name: S,
         partition_key: &PK,
-    ) -> azure_core::error::Result<Self> {
+    ) -> azure_core::Result<Self> {
         Ok(Self {
             collection,
             document_name: document_name.into(),

--- a/sdk/data_cosmos/src/cosmos_entity.rs
+++ b/sdk/data_cosmos/src/cosmos_entity.rs
@@ -19,7 +19,7 @@ impl CosmosEntity for serde_json::Value {
 }
 
 /// Serialize the partition key in the format CosmosDB expects.
-pub(crate) fn serialize_partition_key<PK: Serialize>(pk: &PK) -> azure_core::error::Result<String> {
+pub(crate) fn serialize_partition_key<PK: Serialize>(pk: &PK) -> azure_core::Result<String> {
     use azure_core::error::ResultExt;
     // this must be serialized as an array even tough CosmosDB supports only a sigle partition key.
     serde_json::to_string(&[pk]).context(

--- a/sdk/data_cosmos/src/headers/from_headers.rs
+++ b/sdk/data_cosmos/src/headers/from_headers.rs
@@ -3,100 +3,112 @@ use crate::resource_quota::resource_quotas_from_str;
 use crate::resources::document::IndexingDirective;
 use crate::ResourceQuota;
 
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use azure_core::headers::{self, parse_int};
 use chrono::{DateTime, Utc};
 use http::HeaderMap;
 
-pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> Result<f64> {
+pub(crate) fn request_charge_from_headers(headers: &HeaderMap) -> azure_core::Result<f64> {
     headers::get_from_headers(headers, HEADER_REQUEST_CHARGE)
 }
 
-pub(crate) fn role_from_headers(headers: &HeaderMap) -> Result<u32> {
+pub(crate) fn role_from_headers(headers: &HeaderMap) -> azure_core::Result<u32> {
     headers::get_from_headers(headers, HEADER_ROLE)
 }
 
-pub(crate) fn number_of_read_regions_from_headers(headers: &HeaderMap) -> Result<u32> {
+pub(crate) fn number_of_read_regions_from_headers(headers: &HeaderMap) -> azure_core::Result<u32> {
     headers::get_from_headers(headers, HEADER_NUMBER_OF_READ_REGIONS)
 }
 
-pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> Result<uuid::Uuid> {
+pub(crate) fn activity_id_from_headers(headers: &HeaderMap) -> azure_core::Result<uuid::Uuid> {
     headers::get_from_headers(headers, HEADER_ACTIVITY_ID)
 }
 
-pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub(crate) fn content_path_from_headers(headers: &HeaderMap) -> azure_core::Result<&str> {
     headers::get_str_from_headers(headers, HEADER_CONTENT_PATH)
 }
 
-pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub(crate) fn alt_content_path_from_headers(headers: &HeaderMap) -> azure_core::Result<&str> {
     headers::get_str_from_headers(headers, HEADER_ALT_CONTENT_PATH)
 }
 
-pub(crate) fn resource_quota_from_headers(headers: &HeaderMap) -> Result<Vec<ResourceQuota>> {
+pub(crate) fn resource_quota_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<Vec<ResourceQuota>> {
     let s = headers::get_str_from_headers(headers, HEADER_RESOURCE_QUOTA)?;
     resource_quotas_from_str(s)
 }
 
-pub(crate) fn resource_usage_from_headers(headers: &HeaderMap) -> Result<Vec<ResourceQuota>> {
+pub(crate) fn resource_usage_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<Vec<ResourceQuota>> {
     let s = headers::get_str_from_headers(headers, HEADER_RESOURCE_USAGE)?;
     resource_quotas_from_str(s)
 }
 
-pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn quorum_acked_lsn_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_QUORUM_ACKED_LSN)
 }
 
-pub(crate) fn quorum_acked_lsn_from_headers_optional(headers: &HeaderMap) -> Result<Option<u64>> {
+pub(crate) fn quorum_acked_lsn_from_headers_optional(
+    headers: &HeaderMap,
+) -> azure_core::Result<Option<u64>> {
     headers::get_option_from_headers(headers, HEADER_QUORUM_ACKED_LSN)
 }
 
-pub(crate) fn cosmos_quorum_acked_llsn_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn cosmos_quorum_acked_llsn_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_COSMOS_QUORUM_ACKED_LLSN)
 }
 
 pub(crate) fn cosmos_quorum_acked_llsn_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>> {
+) -> azure_core::Result<Option<u64>> {
     headers::get_option_from_headers(headers, HEADER_COSMOS_QUORUM_ACKED_LLSN)
 }
 
-pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn current_write_quorum_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_CURRENT_WRITE_QUORUM)
 }
 
 pub(crate) fn current_write_quorum_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>> {
+) -> azure_core::Result<Option<u64>> {
     headers::get_option_from_headers(headers, HEADER_CURRENT_WRITE_QUORUM)
 }
 
-pub(crate) fn collection_partition_index_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn collection_partition_index_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_COLLECTION_PARTITION_INDEX)
 }
 
 pub(crate) fn indexing_directive_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<IndexingDirective>> {
+) -> azure_core::Result<Option<IndexingDirective>> {
     headers::get_option_from_headers(headers, HEADER_INDEXING_DIRECTIVE)
 }
 
-pub(crate) fn collection_service_index_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn collection_service_index_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_COLLECTION_SERVICE_INDEX)
 }
 
-pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn lsn_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_LSN)
 }
 
-pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn item_lsn_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_ITEM_LSN)
 }
 
-pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn transport_request_id_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_TRANSPORT_REQUEST_ID)
 }
 
-pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     let s = headers::get_str_from_headers(headers, HEADER_GLOBAL_COMMITTED_LSN)?;
     Ok(if s == "-1" {
         0
@@ -114,53 +126,57 @@ pub(crate) fn global_committed_lsn_from_headers(headers: &HeaderMap) -> Result<u
     })
 }
 
-pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn cosmos_llsn_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_COSMOS_LLSN)
 }
 
-pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn cosmos_item_llsn_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_COSMOS_ITEM_LLSN)
 }
 
-pub(crate) fn current_replica_set_size_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn current_replica_set_size_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_CURRENT_REPLICA_SET_SIZE)
 }
 
 pub(crate) fn current_replica_set_size_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<u64>> {
+) -> azure_core::Result<Option<u64>> {
     headers::get_option_from_headers(headers, HEADER_CURRENT_REPLICA_SET_SIZE)
 }
 
-pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub(crate) fn schema_version_from_headers(headers: &HeaderMap) -> azure_core::Result<&str> {
     headers::get_str_from_headers(headers, HEADER_SCHEMA_VERSION)
 }
 
-pub(crate) fn server_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub(crate) fn server_from_headers(headers: &HeaderMap) -> azure_core::Result<&str> {
     headers::get_str_from_headers(headers, &http::header::SERVER.to_string())
 }
 
-pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub(crate) fn service_version_from_headers(headers: &HeaderMap) -> azure_core::Result<&str> {
     headers::get_str_from_headers(headers, HEADER_SERVICE_VERSION)
 }
 
-pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub(crate) fn content_location_from_headers(headers: &HeaderMap) -> azure_core::Result<&str> {
     headers::get_str_from_headers(headers, &http::header::CONTENT_LOCATION.to_string())
 }
 
-pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> Result<&str> {
+pub(crate) fn gateway_version_from_headers(headers: &HeaderMap) -> azure_core::Result<&str> {
     headers::get_str_from_headers(headers, HEADER_GATEWAY_VERSION)
 }
 
-pub(crate) fn max_media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn max_media_storage_usage_mb_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_MAX_MEDIA_STORAGE_USAGE_MB)
 }
 
-pub(crate) fn media_storage_usage_mb_from_headers(headers: &HeaderMap) -> Result<u64> {
+pub(crate) fn media_storage_usage_mb_from_headers(headers: &HeaderMap) -> azure_core::Result<u64> {
     headers::get_from_headers(headers, HEADER_MEDIA_STORAGE_USAGE_MB)
 }
 
-fn _date_from_headers(headers: &HeaderMap, header_name: &str) -> Result<DateTime<Utc>> {
+fn _date_from_headers(headers: &HeaderMap, header_name: &str) -> azure_core::Result<DateTime<Utc>> {
     let date = headers::get_str_from_headers(headers, header_name)?;
     // since Azure returns "GMT" instead of +0000 as timezone we replace it ourselves.
     // For example: Wed, 15 Jan 2020 23:39:44.369 GMT
@@ -169,11 +185,13 @@ fn _date_from_headers(headers: &HeaderMap, header_name: &str) -> Result<DateTime
     Ok(DateTime::from_utc(date.naive_utc(), Utc))
 }
 
-pub(crate) fn last_state_change_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>> {
+pub(crate) fn last_state_change_from_headers(
+    headers: &HeaderMap,
+) -> azure_core::Result<DateTime<Utc>> {
     _date_from_headers(headers, HEADER_LAST_STATE_CHANGE_UTC)
 }
 
-pub(crate) fn date_from_headers(headers: &HeaderMap) -> Result<DateTime<Utc>> {
+pub(crate) fn date_from_headers(headers: &HeaderMap) -> azure_core::Result<DateTime<Utc>> {
     let header = http::header::DATE;
     _date_from_headers(headers, header.as_str())
 }

--- a/sdk/data_cosmos/src/lib.rs
+++ b/sdk/data_cosmos/src/lib.rs
@@ -17,7 +17,6 @@ should also be possible with this crate.
 use azure_data_cosmos::prelude::*;
 use azure_core::Context;
 use serde::{Deserialize, Serialize};
-use azure_core::error::Result;
 
 // This is the stuct we want to use in our sample.
 // Make sure to have a collection with partition key "a_number" for this example to
@@ -41,7 +40,7 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // This code will perform these tasks:
 // 1. Create 10 documents in the collection.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // Let's get Cosmos account and master key from env variables.
     let master_key =
         std::env::var("COSMOS_MASTER_KEY").expect("Set env variable COSMOS_MASTER_KEY first!");

--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -78,7 +78,7 @@ impl std::future::IntoFuture for CreateCollectionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type CreateCollection =
-    futures::future::BoxFuture<'static, azure_core::error::Result<CreateCollectionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<CreateCollectionResponse>>;
 
 /// Body for the create collection request
 #[derive(Serialize, Debug)]
@@ -108,7 +108,7 @@ pub struct CreateCollectionResponse {
 }
 
 impl CreateCollectionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -69,7 +69,7 @@ impl std::future::IntoFuture for CreateDatabaseBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type CreateDatabase =
-    futures::future::BoxFuture<'static, azure_core::error::Result<CreateDatabaseResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<CreateDatabaseResponse>>;
 
 #[derive(Serialize)]
 struct CreateDatabaseBody<'a> {
@@ -95,7 +95,7 @@ pub struct CreateDatabaseResponse {
 }
 
 impl CreateDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -52,10 +52,7 @@ impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {
         context: Context => context,
     }
 
-    pub fn partition_key<PK: Serialize>(
-        mut self,
-        partition_key: &PK,
-    ) -> azure_core::error::Result<Self> {
+    pub fn partition_key<PK: Serialize>(mut self, partition_key: &PK) -> azure_core::Result<Self> {
         self.partition_key = Some(serialize_partition_key(partition_key)?);
         Ok(self)
     }
@@ -97,7 +94,7 @@ impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {
 
 /// The future returned by calling `into_future` on the builder.
 pub type CreateDocument =
-    futures::future::BoxFuture<'static, azure_core::error::Result<CreateDocumentResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<CreateDocumentResponse>>;
 
 #[cfg(feature = "into_future")]
 impl<D: Serialize + CosmosEntity + Send + 'static> std::future::IntoFuture
@@ -140,7 +137,7 @@ pub struct CreateDocumentResponse {
 }
 
 impl CreateDocumentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -87,10 +87,8 @@ impl CreateOrReplaceAttachmentBuilder {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type CreateOrReplaceAttachment = futures::future::BoxFuture<
-    'static,
-    azure_core::error::Result<CreateOrReplaceAttachmentResponse>,
->;
+pub type CreateOrReplaceAttachment =
+    futures::future::BoxFuture<'static, azure_core::Result<CreateOrReplaceAttachmentResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateOrReplaceAttachmentBuilder {
@@ -130,7 +128,7 @@ pub struct CreateOrReplaceAttachmentResponse {
 }
 
 impl CreateOrReplaceAttachmentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -93,10 +93,8 @@ impl CreateOrReplaceSlugAttachmentBuilder {
     }
 }
 /// The future returned by calling `into_future` on the builder.
-pub type CreateOrReplaceSlugAttachment = futures::future::BoxFuture<
-    'static,
-    azure_core::error::Result<CreateOrReplaceSlugAttachmentResponse>,
->;
+pub type CreateOrReplaceSlugAttachment =
+    futures::future::BoxFuture<'static, azure_core::Result<CreateOrReplaceSlugAttachmentResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateOrReplaceSlugAttachmentBuilder {
@@ -135,7 +133,7 @@ pub struct CreateOrReplaceSlugAttachmentResponse {
 }
 
 impl CreateOrReplaceSlugAttachmentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -90,7 +90,7 @@ impl CreateOrReplaceTriggerBuilder {
 }
 /// The future returned by calling `into_future` on the builder.
 pub type CreateOrReplaceTrigger =
-    futures::future::BoxFuture<'static, azure_core::error::Result<CreateOrReplaceTriggerResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<CreateOrReplaceTriggerResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateOrReplaceTriggerBuilder {
@@ -131,7 +131,7 @@ pub struct CreateOrReplaceTriggerResponse {
 }
 
 impl CreateOrReplaceTriggerResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -73,7 +73,7 @@ impl CreateOrReplaceUserDefinedFunctionBuilder {
 /// The future returned by calling `into_future` on the builder.
 pub type CreateOrReplaceUserDefinedFunction = futures::future::BoxFuture<
     'static,
-    azure_core::error::Result<CreateOrReplaceUserDefinedFunctionResponse>,
+    azure_core::Result<CreateOrReplaceUserDefinedFunctionResponse>,
 >;
 
 #[cfg(feature = "into_future")]
@@ -115,7 +115,7 @@ pub struct CreateOrReplaceUserDefinedFunctionResponse {
 }
 
 impl CreateOrReplaceUserDefinedFunctionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -76,7 +76,7 @@ impl CreatePermissionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type CreatePermission =
-    futures::future::BoxFuture<'static, azure_core::error::Result<PermissionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<PermissionResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreatePermissionBuilder {

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -73,7 +73,7 @@ impl std::future::IntoFuture for CreateStoredProcedureBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type CreateStoredProcedure =
-    futures::future::BoxFuture<'static, azure_core::error::Result<CreateStoredProcedureResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<CreateStoredProcedureResponse>>;
 
 /// A stored procedure response
 #[derive(Debug, Clone, PartialEq)]
@@ -92,7 +92,7 @@ pub struct CreateStoredProcedureResponse {
 }
 
 impl CreateStoredProcedureResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -54,7 +54,7 @@ impl CreateUserBuilder {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type CreateUser = futures::future::BoxFuture<'static, azure_core::error::Result<UserResponse>>;
+pub type CreateUser = futures::future::BoxFuture<'static, azure_core::Result<UserResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for CreateUserBuilder {

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -64,7 +64,7 @@ impl DeleteAttachmentBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type DeleteAttachment =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeleteAttachmentResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteAttachmentResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteAttachmentBuilder {
@@ -102,7 +102,7 @@ pub struct DeleteAttachmentResponse {
 }
 
 impl DeleteAttachmentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -51,7 +51,7 @@ impl DeleteCollectionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type DeleteCollection =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeleteCollectionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteCollectionResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteCollectionBuilder {
@@ -91,7 +91,7 @@ pub struct DeleteCollectionResponse {
 }
 
 impl DeleteCollectionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -45,7 +45,7 @@ impl DeleteDatabaseBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type DeleteDatabase =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeleteDatabaseResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteDatabaseResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteDatabaseBuilder {
@@ -66,7 +66,7 @@ pub struct DeleteDatabaseResponse {
 }
 
 impl DeleteDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         let charge = request_charge_from_headers(headers)?;

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -71,7 +71,7 @@ impl DeleteDocumentBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type DeleteDocument =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeleteDocumentResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteDocumentResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteDocumentBuilder {
@@ -90,7 +90,7 @@ pub struct DeleteDocumentResponse {
 }
 
 impl DeleteDocumentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         let charge = request_charge_from_headers(&headers)?;

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -52,7 +52,7 @@ impl DeletePermissionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type DeletePermission =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeletePermissionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<DeletePermissionResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeletePermissionBuilder {
@@ -73,7 +73,7 @@ pub struct DeletePermissionResponse {
 }
 
 impl DeletePermissionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -52,7 +52,7 @@ impl DeleteStoredProcedureBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type DeleteStoredProcedure =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeleteStoredProcedureResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteStoredProcedureResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteStoredProcedureBuilder {
@@ -74,7 +74,7 @@ pub struct DeleteStoredProcedureResponse {
 }
 
 impl DeleteStoredProcedureResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -54,7 +54,7 @@ impl DeleteTriggerBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type DeleteTrigger =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeleteTriggerResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteTriggerResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteTriggerBuilder {
@@ -93,7 +93,7 @@ pub struct DeleteTriggerResponse {
     pub date: DateTime<Utc>,
 }
 impl DeleteTriggerResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -47,8 +47,7 @@ impl DeleteUserBuilder {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type DeleteUser =
-    futures::future::BoxFuture<'static, azure_core::error::Result<DeleteUserResponse>>;
+pub type DeleteUser = futures::future::BoxFuture<'static, azure_core::Result<DeleteUserResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for DeleteUserBuilder {
@@ -67,7 +66,7 @@ pub struct DeleteUserResponse {
 }
 
 impl DeleteUserResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -64,10 +64,8 @@ impl std::future::IntoFuture for DeleteUserDefinedFunctionBuilder {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type DeleteUserDefinedFunction = futures::future::BoxFuture<
-    'static,
-    azure_core::error::Result<DeleteUserDefinedFunctionResponse>,
->;
+pub type DeleteUserDefinedFunction =
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteUserDefinedFunctionResponse>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteUserDefinedFunctionResponse {
@@ -98,7 +96,7 @@ pub struct DeleteUserDefinedFunctionResponse {
 }
 
 impl DeleteUserDefinedFunctionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -40,7 +40,7 @@ impl ExecuteStoredProcedureBuilder {
         context: Context,
     }
 
-    pub fn partition_key<PK: serde::Serialize>(self, pk: &PK) -> azure_core::error::Result<Self> {
+    pub fn partition_key<PK: serde::Serialize>(self, pk: &PK) -> azure_core::Result<Self> {
         Ok(Self {
             partition_key: Some(crate::cosmos_entity::serialize_partition_key(pk)?),
             ..self
@@ -89,10 +89,8 @@ impl ExecuteStoredProcedureBuilder {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type ExecuteStoredProcedure<T> = futures::future::BoxFuture<
-    'static,
-    azure_core::error::Result<ExecuteStoredProcedureResponse<T>>,
->;
+pub type ExecuteStoredProcedure<T> =
+    futures::future::BoxFuture<'static, azure_core::Result<ExecuteStoredProcedureResponse<T>>>;
 
 #[derive(Debug, Clone)]
 pub struct ExecuteStoredProcedureResponse<T>
@@ -126,7 +124,7 @@ impl<T> ExecuteStoredProcedureResponse<T>
 where
     T: DeserializeOwned,
 {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -74,7 +74,7 @@ impl std::future::IntoFuture for GetAttachmentBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type GetAttachment =
-    futures::future::BoxFuture<'static, azure_core::error::Result<GetAttachmentResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<GetAttachmentResponse>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetAttachmentResponse {
@@ -105,7 +105,7 @@ pub struct GetAttachmentResponse {
 }
 
 impl GetAttachmentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -54,7 +54,7 @@ impl GetCollectionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type GetCollection =
-    futures::future::BoxFuture<'static, azure_core::error::Result<GetCollectionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<GetCollectionResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetCollectionBuilder {
@@ -95,7 +95,7 @@ pub struct GetCollectionResponse {
 }
 
 impl GetCollectionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -46,8 +46,7 @@ impl GetDatabaseBuilder {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type GetDatabase =
-    futures::future::BoxFuture<'static, azure_core::error::Result<GetDatabaseResponse>>;
+pub type GetDatabase = futures::future::BoxFuture<'static, azure_core::Result<GetDatabaseResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetDatabaseBuilder {
@@ -74,7 +73,7 @@ pub struct GetDatabaseResponse {
 }
 
 impl GetDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -76,7 +76,7 @@ impl GetDocumentBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type GetDocument<T> =
-    futures::future::BoxFuture<'static, azure_core::error::Result<GetDocumentResponse<T>>>;
+    futures::future::BoxFuture<'static, azure_core::Result<GetDocumentResponse<T>>>;
 
 #[derive(Debug, Clone)]
 // note(rylev): clippy seems to be falsely detecting that
@@ -92,7 +92,7 @@ impl<T> GetDocumentResponse<T>
 where
     T: DeserializeOwned,
 {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (status_code, headers, pinned_stream) = response.deconstruct();
 
         let has_been_found =
@@ -143,7 +143,7 @@ impl<T> FoundDocumentResponse<T>
 where
     T: DeserializeOwned,
 {
-    async fn try_from(headers: &HeaderMap, body: bytes::Bytes) -> azure_core::error::Result<Self> {
+    async fn try_from(headers: &HeaderMap, body: bytes::Bytes) -> azure_core::Result<Self> {
         Ok(Self {
             document: serde_json::from_slice(&body)?,
 
@@ -196,7 +196,7 @@ pub struct NotFoundDocumentResponse {
 }
 
 impl NotFoundDocumentResponse {
-    async fn try_from(headers: &HeaderMap) -> azure_core::error::Result<Self> {
+    async fn try_from(headers: &HeaderMap) -> azure_core::Result<Self> {
         Ok(Self {
             content_location: content_location_from_headers(headers)?.to_owned(),
             last_state_change: last_state_change_from_headers(headers)?,

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -67,7 +67,7 @@ impl GetPartitionKeyRangesBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type GetPartitionKeyRanges =
-    futures::future::BoxFuture<'static, azure_core::error::Result<GetPartitionKeyRangesResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<GetPartitionKeyRangesResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetPartitionKeyRangesBuilder {
@@ -103,7 +103,7 @@ pub struct GetPartitionKeyRangesResponse {
 }
 
 impl GetPartitionKeyRangesResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -49,7 +49,7 @@ impl GetPermissionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type GetPermission =
-    futures::future::BoxFuture<'static, azure_core::error::Result<PermissionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<PermissionResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetPermissionBuilder {

--- a/sdk/data_cosmos/src/operations/get_user.rs
+++ b/sdk/data_cosmos/src/operations/get_user.rs
@@ -47,7 +47,7 @@ impl GetUserBuilder {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type GetUser = futures::future::BoxFuture<'static, azure_core::error::Result<UserResponse>>;
+pub type GetUser = futures::future::BoxFuture<'static, azure_core::Result<UserResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetUserBuilder {

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -124,7 +124,7 @@ pub struct ListAttachmentsResponse {
 }
 
 impl ListAttachmentsResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -80,7 +80,7 @@ pub struct ListCollectionsResponse {
 }
 
 impl ListCollectionsResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -79,7 +79,7 @@ pub struct ListDatabasesResponse {
 }
 
 impl ListDatabasesResponse {
-    pub(crate) async fn try_from(response: Response) -> azure_core::error::Result<Self> {
+    pub(crate) async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -136,7 +136,7 @@ impl<T> ListDocumentsResponse<T>
 where
     T: DeserializeOwned,
 {
-    pub(crate) async fn try_from(response: Response) -> azure_core::error::Result<Self> {
+    pub(crate) async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body: bytes::Bytes = collect_pinned_stream(pinned_stream).await?;
         let headers = &headers;

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -79,7 +79,7 @@ pub struct ListPermissionsResponse {
 }
 
 impl ListPermissionsResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -86,7 +86,7 @@ pub struct ListStoredProceduresResponse {
 }
 
 impl ListStoredProceduresResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -103,7 +103,7 @@ pub struct ListTriggersResponse {
 }
 
 impl ListTriggersResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -107,7 +107,7 @@ pub struct ListUserDefinedFunctionsResponse {
 }
 
 impl ListUserDefinedFunctionsResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -80,7 +80,7 @@ pub struct ListUsersResponse {
 }
 
 impl ListUsersResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -60,7 +60,7 @@ impl QueryDocumentsBuilder {
         context: Context => context,
     }
 
-    pub fn partition_key<PK: serde::Serialize>(self, pk: &PK) -> azure_core::error::Result<Self> {
+    pub fn partition_key<PK: serde::Serialize>(self, pk: &PK) -> azure_core::Result<Self> {
         Ok(Self {
             partition_key_serialized: Some(crate::cosmos_entity::serialize_partition_key(pk)?),
             ..self
@@ -206,7 +206,7 @@ impl<T> QueryDocumentsResponse<T> {
         self.into()
     }
 
-    pub fn into_documents(self) -> azure_core::error::Result<QueryDocumentsResponseDocuments<T>> {
+    pub fn into_documents(self) -> azure_core::Result<QueryDocumentsResponseDocuments<T>> {
         self.try_into()
     }
 }
@@ -215,7 +215,7 @@ impl<T> QueryDocumentsResponse<T>
 where
     T: DeserializeOwned,
 {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -67,7 +67,7 @@ impl ReplaceCollectionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type ReplaceCollection =
-    futures::future::BoxFuture<'static, azure_core::error::Result<ReplaceCollectionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<ReplaceCollectionResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for ReplaceCollectionBuilder {
@@ -118,7 +118,7 @@ pub struct ReplaceCollectionResponse {
 }
 
 impl ReplaceCollectionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -48,10 +48,7 @@ impl<D: Serialize + Send + 'static> ReplaceDocumentBuilder<D> {
         context: Context => context,
     }
 
-    pub fn partition_key<T: Serialize>(
-        &mut self,
-        partition_key: &T,
-    ) -> azure_core::error::Result<()> {
+    pub fn partition_key<T: Serialize>(&mut self, partition_key: &T) -> azure_core::Result<()> {
         self.partition_key = Some(serialize_partition_key(partition_key)?);
         Ok(())
     }
@@ -96,7 +93,7 @@ impl<D: Serialize + Send + 'static> ReplaceDocumentBuilder<D> {
 
 /// The future returned by calling `into_future` on the builder.
 pub type ReplaceDocument =
-    futures::future::BoxFuture<'static, azure_core::error::Result<ReplaceDocumentResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<ReplaceDocumentResponse>>;
 
 #[cfg(feature = "into_future")]
 impl<D: Serialize + Send + 'static> std::future::IntoFuture for ReplaceDocumentBuilder<D> {
@@ -136,7 +133,7 @@ pub struct ReplaceDocumentResponse {
 }
 
 impl ReplaceDocumentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
         let document_attributes = serde_json::from_slice(&*body)?;

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -71,7 +71,7 @@ impl ReplacePermissionBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type ReplacePermission =
-    futures::future::BoxFuture<'static, azure_core::error::Result<PermissionResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<PermissionResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for ReplacePermissionBuilder {

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -72,6 +72,6 @@ impl std::future::IntoFuture for ReplaceStoredProcedureBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type ReplaceStoredProcedure =
-    futures::future::BoxFuture<'static, azure_core::error::Result<ReplaceStoredProcedureResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<ReplaceStoredProcedureResponse>>;
 
 pub type ReplaceStoredProcedureResponse = CreateStoredProcedureResponse;

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -57,7 +57,7 @@ struct ReplaceUserBody<'a> {
 }
 
 /// The future returned by calling `into_future` on the builder.
-pub type ReplaceUser = futures::future::BoxFuture<'static, azure_core::error::Result<UserResponse>>;
+pub type ReplaceUser = futures::future::BoxFuture<'static, azure_core::Result<UserResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for ReplaceUserBuilder {

--- a/sdk/data_cosmos/src/resource_quota.rs
+++ b/sdk/data_cosmos/src/resource_quota.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 
 /// A resource quota for the given resource kind
 ///
@@ -39,7 +39,9 @@ const INTEROP_USERS: &str = "interopUsers=";
 const AUTH_POLICY_ELEMENTS: &str = "authPolicyElements=";
 
 /// Parse a collection of [`ResourceQuota`] from a string
-pub(crate) fn resource_quotas_from_str(full_string: &str) -> Result<Vec<ResourceQuota>> {
+pub(crate) fn resource_quotas_from_str(
+    full_string: &str,
+) -> azure_core::Result<Vec<ResourceQuota>> {
     debug!("resource_quotas_from_str(\"{}\") called", full_string);
     let tokens: Vec<&str> = full_string.split(';').collect();
     let mut v = Vec::with_capacity(tokens.len());

--- a/sdk/data_cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/authorization_token.rs
@@ -16,9 +16,7 @@ impl AuthorizationToken {
     /// Create a primary `AuthorizationToken` from base64 encoded data
     ///
     /// The token is *not* verified to be valid.
-    pub fn primary_from_base64(
-        base64_encoded: &str,
-    ) -> azure_core::error::Result<AuthorizationToken> {
+    pub fn primary_from_base64(base64_encoded: &str) -> azure_core::Result<AuthorizationToken> {
         let key = base64::decode(base64_encoded).map_err(|e| {
             azure_core::error::Error::full(azure_core::error::ErrorKind::Credential, e,
             "failed to base64 decode the primary credential - ensure that the credential is properly base64 encoded")

--- a/sdk/data_cosmos/src/resources/permission/permission_response.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission_response.rs
@@ -17,7 +17,7 @@ pub struct PermissionResponse {
 }
 
 impl PermissionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<PermissionResponse> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<PermissionResponse> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/src/resources/user.rs
+++ b/sdk/data_cosmos/src/resources/user.rs
@@ -66,7 +66,7 @@ pub struct UserResponse {
 
 impl UserResponse {
     /// Creates a UserResponse from an HttpResponse
-    pub async fn try_from(response: HttpResponse) -> azure_core::error::Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
 

--- a/sdk/data_cosmos/tests/attachment_operations.rs
+++ b/sdk/data_cosmos/tests/attachment_operations.rs
@@ -28,7 +28,7 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 }
 
 #[tokio::test]
-async fn attachment_operations() -> azure_core::error::Result<()> {
+async fn attachment_operations() -> azure_core::Result<()> {
     const DATABASE_NAME: &str = "test-cosmos-db-attachment";
     const COLLECTION_NAME: &str = "test-collection-attachment";
 

--- a/sdk/data_cosmos/tests/collection_operations.rs
+++ b/sdk/data_cosmos/tests/collection_operations.rs
@@ -1,13 +1,12 @@
 #![cfg(feature = "mock_transport_framework")]
 
-use azure_core::error::Result;
 use azure_data_cosmos::resources::collection::*;
 use futures::StreamExt;
 
 mod setup;
 
 #[tokio::test]
-async fn collection_operations() -> Result<()> {
+async fn collection_operations() -> azure_core::Result<()> {
     env_logger::init();
 
     let client = setup::initialize("collection_operations")?;

--- a/sdk/data_cosmos/tests/database_operations.rs
+++ b/sdk/data_cosmos/tests/database_operations.rs
@@ -2,11 +2,10 @@
 
 mod setup;
 
-use azure_core::error::Result;
 use futures::StreamExt;
 
 #[tokio::test]
-async fn database_operations() -> Result<()> {
+async fn database_operations() -> azure_core::Result<()> {
     const DATABASE_NAME: &str = "cosmos-test-db-create-and-delete-database";
 
     let client = setup::initialize("database_operations")?;

--- a/sdk/data_cosmos/tests/setup.rs
+++ b/sdk/data_cosmos/tests/setup.rs
@@ -1,7 +1,7 @@
 use azure_data_cosmos::prelude::*;
 
 #[cfg(not(feature = "mock_transport_framework"))]
-pub fn initialize() -> azure_core::error::Result<CosmosClient> {
+pub fn initialize() -> azure_core::Result<CosmosClient> {
     let account = get_account();
     let authorization_token = get_authorization_token()?;
 
@@ -14,7 +14,7 @@ fn get_account() -> String {
     std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!")
 }
 
-fn get_authorization_token() -> azure_core::error::Result<AuthorizationToken> {
+fn get_authorization_token() -> azure_core::Result<AuthorizationToken> {
     let key =
         std::env::var("COSMOS_MASTER_KEY").expect("Set env variable COSMOS_MASTER_KEY first!");
 
@@ -22,7 +22,7 @@ fn get_authorization_token() -> azure_core::error::Result<AuthorizationToken> {
 }
 
 #[cfg(feature = "mock_transport_framework")]
-pub fn initialize(transaction_name: impl Into<String>) -> azure_core::error::Result<CosmosClient> {
+pub fn initialize(transaction_name: impl Into<String>) -> azure_core::Result<CosmosClient> {
     let account_name = (std::env::var(azure_core::mock::TESTING_MODE_KEY).as_deref()
         == Ok(azure_core::mock::TESTING_MODE_RECORD))
     .then(get_account)

--- a/sdk/data_cosmos/tests/trigger_operations.rs
+++ b/sdk/data_cosmos/tests/trigger_operations.rs
@@ -35,7 +35,7 @@ function updateMetadata() {
 }"#;
 
 #[tokio::test]
-async fn trigger_operations() -> azure_core::error::Result<()> {
+async fn trigger_operations() -> azure_core::Result<()> {
     const DATABASE_NAME: &str = "test-cosmos-db-trigger";
     const COLLECTION_NAME: &str = "test-udf";
     const TRIGGER_NAME: &str = "test";

--- a/sdk/data_cosmos/tests/user_defined_function_operations.rs
+++ b/sdk/data_cosmos/tests/user_defined_function_operations.rs
@@ -17,7 +17,7 @@ function tax(income) {
 }"#;
 
 #[tokio::test]
-async fn user_defined_function_operations() -> azure_core::error::Result<()> {
+async fn user_defined_function_operations() -> azure_core::Result<()> {
     const DATABASE_NAME: &str = "test-cosmos-db-udf";
     const COLLECTION_NAME: &str = "test-udf";
     const USER_DEFINED_FUNCTION_NAME: &str = "test";

--- a/sdk/data_tables/examples/table_00.rs
+++ b/sdk/data_tables/examples/table_00.rs
@@ -2,7 +2,6 @@ use azure_data_tables::prelude::*;
 use azure_storage::core::prelude::*;
 use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
-use std::error::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct MyEntity {
@@ -14,7 +13,7 @@ struct MyEntity {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, requests::*};
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use bytes::Bytes;
 use http::{
     method::Method,
@@ -9,11 +9,11 @@ use std::sync::Arc;
 use url::Url;
 
 pub trait AsEntityClient<RK: Into<String>> {
-    fn as_entity_client(&self, row_key: RK) -> Result<Arc<EntityClient>>;
+    fn as_entity_client(&self, row_key: RK) -> azure_core::Result<Arc<EntityClient>>;
 }
 
 impl<RK: Into<String>> AsEntityClient<RK> for Arc<PartitionKeyClient> {
-    fn as_entity_client(&self, row_key: RK) -> Result<Arc<EntityClient>> {
+    fn as_entity_client(&self, row_key: RK) -> azure_core::Result<Arc<EntityClient>> {
         EntityClient::new(self.clone(), row_key)
     }
 }
@@ -29,7 +29,7 @@ impl EntityClient {
     pub(crate) fn new<RK: Into<String>>(
         partition_key_client: Arc<PartitionKeyClient>,
         row_key: RK,
-    ) -> Result<Arc<Self>> {
+    ) -> azure_core::Result<Arc<Self>> {
         let row_key = row_key.into();
         let mut url = partition_key_client
             .storage_account_client()
@@ -104,7 +104,7 @@ impl EntityClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.partition_key_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, requests::*};
-use azure_core::error::Result;
+
 use azure_storage::core::clients::StorageAccountClient;
 use bytes::Bytes;
 use http::{
@@ -61,7 +61,7 @@ impl PartitionKeyClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.table_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -1,5 +1,5 @@
 use crate::{clients::TableServiceClient, requests::*};
-use azure_core::error::Result;
+
 use azure_storage::core::clients::StorageAccountClient;
 use bytes::Bytes;
 use http::{
@@ -73,7 +73,7 @@ impl TableClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.table_service_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -1,5 +1,5 @@
 use crate::requests::ListTablesBuilder;
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use azure_storage::core::clients::{StorageAccountClient, StorageClient};
 use bytes::Bytes;
 use http::{
@@ -10,11 +10,11 @@ use std::sync::Arc;
 use url::Url;
 
 pub trait AsTableServiceClient {
-    fn as_table_service_client(&self) -> Result<Arc<TableServiceClient>>;
+    fn as_table_service_client(&self) -> azure_core::Result<Arc<TableServiceClient>>;
 }
 
 impl AsTableServiceClient for Arc<StorageClient> {
-    fn as_table_service_client(&self) -> Result<Arc<TableServiceClient>> {
+    fn as_table_service_client(&self) -> azure_core::Result<Arc<TableServiceClient>> {
         TableServiceClient::new(self.clone())
     }
 }
@@ -26,7 +26,7 @@ pub struct TableServiceClient {
 }
 
 impl TableServiceClient {
-    pub(crate) fn new(storage_client: Arc<StorageClient>) -> Result<Arc<Self>> {
+    pub(crate) fn new(storage_client: Arc<StorageClient>) -> azure_core::Result<Arc<Self>> {
         let mut url = storage_client
             .storage_account_client()
             .table_storage_url()
@@ -63,7 +63,7 @@ impl TableServiceClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.storage_client
             .storage_account_client()
             .prepare_request(

--- a/sdk/data_tables/src/continuation_next_partition_and_row_key.rs
+++ b/sdk/data_tables/src/continuation_next_partition_and_row_key.rs
@@ -1,5 +1,5 @@
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     AppendToUrlQuery,
 };
 
@@ -18,7 +18,7 @@ impl ContinuationNextPartitionAndRowKey {
         &self.0
     }
 
-    pub fn from_header_optional(headers: &http::HeaderMap) -> Result<Option<Self>> {
+    pub fn from_header_optional(headers: &http::HeaderMap) -> azure_core::Result<Option<Self>> {
         let partition_header_as_str = headers
             .get("x-ms-continuation-NextPartitionKey")
             .map(|item| item.to_str())

--- a/sdk/data_tables/src/continuation_next_table_name.rs
+++ b/sdk/data_tables/src/continuation_next_table_name.rs
@@ -1,5 +1,5 @@
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     AppendToUrlQuery,
 };
 
@@ -15,7 +15,7 @@ impl ContinuationNextTableName {
         &self.0
     }
 
-    pub fn from_header_optional(headers: &http::HeaderMap) -> Result<Option<Self>> {
+    pub fn from_header_optional(headers: &http::HeaderMap) -> azure_core::Result<Option<Self>> {
         let header_as_str = headers
             .get("x-ms-continuation-NextTableName")
             .map(|item| item.to_str())

--- a/sdk/data_tables/src/requests/create_table_builder.rs
+++ b/sdk/data_tables/src/requests/create_table_builder.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, responses::*};
-use azure_core::{error::Result, headers::add_optional_header, prelude::*};
+use azure_core::{headers::add_optional_header, prelude::*};
 use http::{method::Method, status::StatusCode};
 use std::convert::TryInto;
 
@@ -21,7 +21,7 @@ impl<'a> CreateTableBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<CreateTableResponse> {
+    pub async fn execute(&self) -> azure_core::Result<CreateTableResponse> {
         let url = self.table_client.url();
         debug!("url = {}", url);
 

--- a/sdk/data_tables/src/requests/delete_entity_builder.rs
+++ b/sdk/data_tables/src/requests/delete_entity_builder.rs
@@ -4,7 +4,6 @@ use crate::{
     TransactionOperation,
 };
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header},
     prelude::*,
 };
@@ -35,7 +34,7 @@ impl<'a> DeleteEntityBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<DeleteEntityResponse> {
+    pub async fn execute(&self) -> azure_core::Result<DeleteEntityResponse> {
         let mut url = self.entity_client.url().clone();
 
         self.timeout.append_to_url_query(&mut url);
@@ -63,7 +62,7 @@ impl<'a> DeleteEntityBuilder<'a> {
         (&response).try_into()
     }
 
-    pub fn to_transaction_operation(&self) -> Result<TransactionOperation> {
+    pub fn to_transaction_operation(&self) -> azure_core::Result<TransactionOperation> {
         let url = self.entity_client.url();
 
         let request = http::Request::builder()

--- a/sdk/data_tables/src/requests/delete_table_builder.rs
+++ b/sdk/data_tables/src/requests/delete_table_builder.rs
@@ -1,6 +1,6 @@
 use crate::{prelude::*, responses::*};
 use azure_core::{
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     headers::add_optional_header,
     prelude::*,
 };
@@ -28,7 +28,7 @@ impl<'a> DeleteTableBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<DeleteTableResponse> {
+    pub async fn execute(&self) -> azure_core::Result<DeleteTableResponse> {
         let mut url = self.table_client.url().to_owned();
         url.path_segments_mut()
             .map_err(|()| Error::message(ErrorKind::Other, "invalid table URL"))?

--- a/sdk/data_tables/src/requests/insert_entity_builder.rs
+++ b/sdk/data_tables/src/requests/insert_entity_builder.rs
@@ -1,6 +1,6 @@
 use crate::{prelude::*, responses::*, TransactionOperation};
 use azure_core::{
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     headers::{add_mandatory_header, add_optional_header},
     prelude::*,
 };
@@ -32,7 +32,7 @@ impl<'a> InsertEntityBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute<E>(&self, entity: &E) -> Result<InsertEntityResponse<E>>
+    pub async fn execute<E>(&self, entity: &E) -> azure_core::Result<InsertEntityResponse<E>>
     where
         E: Serialize + DeserializeOwned,
     {
@@ -72,7 +72,10 @@ impl<'a> InsertEntityBuilder<'a> {
         (&response).try_into()
     }
 
-    pub fn to_transaction_operation<E>(&self, entity: &E) -> Result<TransactionOperation>
+    pub fn to_transaction_operation<E>(
+        &self,
+        entity: &E,
+    ) -> azure_core::Result<TransactionOperation>
     where
         E: Serialize,
     {

--- a/sdk/data_tables/src/requests/insert_or_replace_or_merge_entity_builder.rs
+++ b/sdk/data_tables/src/requests/insert_or_replace_or_merge_entity_builder.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, responses::*, TransactionOperation};
-use azure_core::{error::Result, headers::add_optional_header, prelude::*};
+use azure_core::{headers::add_optional_header, prelude::*};
 use http::{method::Method, StatusCode};
 use serde::Serialize;
 use std::convert::TryInto;
@@ -33,7 +33,7 @@ impl<'a> InsertOrReplaceOrMergeEntityBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute<E>(&self, entity: &E) -> Result<OperationOnEntityResponse>
+    pub async fn execute<E>(&self, entity: &E) -> azure_core::Result<OperationOnEntityResponse>
     where
         E: Serialize,
     {
@@ -70,7 +70,10 @@ impl<'a> InsertOrReplaceOrMergeEntityBuilder<'a> {
         (&response).try_into()
     }
 
-    pub fn to_transaction_operation<E>(&self, entity: &E) -> Result<TransactionOperation>
+    pub fn to_transaction_operation<E>(
+        &self,
+        entity: &E,
+    ) -> azure_core::Result<TransactionOperation>
     where
         E: Serialize,
     {

--- a/sdk/data_tables/src/requests/list_tables_builder.rs
+++ b/sdk/data_tables/src/requests/list_tables_builder.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, responses::*, ContinuationNextTableName};
-use azure_core::{error::Result, headers::add_optional_header, prelude::*, AppendToUrlQuery};
+use azure_core::{headers::add_optional_header, prelude::*, AppendToUrlQuery};
 use futures::stream::{unfold, Stream};
 use http::{method::Method, status::StatusCode};
 use std::convert::TryInto;
@@ -37,7 +37,7 @@ impl<'a> ListTablesBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<ListTablesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ListTablesResponse> {
         let mut url = self.table_service_client.url().to_owned();
 
         self.filter.append_to_url_query(&mut url);
@@ -70,7 +70,7 @@ impl<'a> ListTablesBuilder<'a> {
         (&response).try_into()
     }
 
-    pub fn stream(self) -> impl Stream<Item = Result<ListTablesResponse>> + 'a {
+    pub fn stream(self) -> impl Stream<Item = azure_core::Result<ListTablesResponse>> + 'a {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/data_tables/src/requests/query_entity_builder.rs
+++ b/sdk/data_tables/src/requests/query_entity_builder.rs
@@ -1,6 +1,6 @@
 use crate::{prelude::*, responses::*, ContinuationNextPartitionAndRowKey};
 use azure_core::{
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     headers::add_optional_header,
     prelude::*,
     AppendToUrlQuery,
@@ -40,7 +40,7 @@ impl<'a> QueryEntityBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute<E>(&self) -> Result<QueryEntityResponse<E>>
+    pub async fn execute<E>(&self) -> azure_core::Result<QueryEntityResponse<E>>
     where
         E: DeserializeOwned,
     {
@@ -80,7 +80,7 @@ impl<'a> QueryEntityBuilder<'a> {
         (&response).try_into()
     }
 
-    pub fn stream<E>(self) -> impl Stream<Item = Result<QueryEntityResponse<E>>> + 'a
+    pub fn stream<E>(self) -> impl Stream<Item = azure_core::Result<QueryEntityResponse<E>>> + 'a
     where
         E: DeserializeOwned,
     {

--- a/sdk/data_tables/src/requests/submit_transaction_builder.rs
+++ b/sdk/data_tables/src/requests/submit_transaction_builder.rs
@@ -1,6 +1,6 @@
 use crate::{prelude::*, responses::*};
 use azure_core::{
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     headers::add_optional_header,
     prelude::*,
 };
@@ -28,7 +28,10 @@ impl<'a> SubmitTransactionBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self, batch: &Transaction) -> Result<SubmitTransactionResponse> {
+    pub async fn execute(
+        &self,
+        batch: &Transaction,
+    ) -> azure_core::Result<SubmitTransactionResponse> {
         let mut url = self.partition_key_client.table_client().url().to_owned();
         url.path_segments_mut()
             .map_err(|()| Error::message(ErrorKind::Other, "invalid table URL"))?

--- a/sdk/data_tables/src/requests/update_or_merge_entity_builder.rs
+++ b/sdk/data_tables/src/requests/update_or_merge_entity_builder.rs
@@ -1,6 +1,5 @@
 use crate::{prelude::*, responses::*, IfMatchCondition, TransactionOperation};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header},
     prelude::*,
 };
@@ -42,7 +41,7 @@ impl<'a> UpdateOrMergeEntityBuilder<'a> {
         &self,
         entity: &E,
         if_match_condition: &IfMatchCondition,
-    ) -> Result<OperationOnEntityResponse>
+    ) -> azure_core::Result<OperationOnEntityResponse>
     where
         E: Serialize,
     {
@@ -82,7 +81,7 @@ impl<'a> UpdateOrMergeEntityBuilder<'a> {
         &self,
         entity: &E,
         if_match_condition: &IfMatchCondition,
-    ) -> Result<TransactionOperation>
+    ) -> azure_core::Result<TransactionOperation>
     where
         E: Serialize,
     {

--- a/sdk/data_tables/src/responses/create_table_response.rs
+++ b/sdk/data_tables/src/responses/create_table_response.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -14,7 +14,7 @@ pub struct CreateTableResponse {
 impl TryFrom<&Response<Bytes>> for CreateTableResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/delete_entity_response.rs
+++ b/sdk/data_tables/src/responses/delete_entity_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -12,7 +12,7 @@ pub struct DeleteEntityResponse {
 impl TryFrom<&Response<Bytes>> for DeleteEntityResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/delete_table_response.rs
+++ b/sdk/data_tables/src/responses/delete_table_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -12,7 +12,7 @@ pub struct DeleteTableResponse {
 impl TryFrom<&Response<Bytes>> for DeleteTableResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/get_entity_response.rs
+++ b/sdk/data_tables/src/responses/get_entity_response.rs
@@ -1,8 +1,4 @@
-use azure_core::{
-    error::{Error, Result},
-    headers::etag_from_headers,
-    Etag,
-};
+use azure_core::{error::Error, headers::etag_from_headers, Etag};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -34,7 +30,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/insert_entity_response.rs
+++ b/sdk/data_tables/src/responses/insert_entity_response.rs
@@ -1,6 +1,6 @@
 use crate::EntityWithMetadata;
 use azure_core::{
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     headers::{etag_from_headers, get_str_from_headers},
     Etag,
 };
@@ -28,7 +28,7 @@ where
 {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/list_tables_response.rs
+++ b/sdk/data_tables/src/responses/list_tables_response.rs
@@ -1,5 +1,5 @@
 use crate::{prelude::*, ContinuationNextTableName};
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -24,7 +24,7 @@ struct ListTablesResponseInternal {
 impl TryFrom<&Response<Bytes>> for ListTablesResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/operation_on_entity_response.rs
+++ b/sdk/data_tables/src/responses/operation_on_entity_response.rs
@@ -1,8 +1,4 @@
-use azure_core::{
-    error::{Error, Result},
-    headers::etag_from_headers,
-    Etag,
-};
+use azure_core::{error::Error, headers::etag_from_headers, Etag};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -17,7 +13,7 @@ pub struct OperationOnEntityResponse {
 impl TryFrom<&Response<Bytes>> for OperationOnEntityResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/query_entity_response.rs
+++ b/sdk/data_tables/src/responses/query_entity_response.rs
@@ -1,5 +1,5 @@
 use crate::ContinuationNextPartitionAndRowKey;
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::Response;
@@ -28,7 +28,7 @@ struct QueryEntityResponseInternal<E> {
 impl<E: DeserializeOwned> TryFrom<&Response<Bytes>> for QueryEntityResponse<E> {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("{}", std::str::from_utf8(response.body())?);
         debug!("headers == {:#?}", response.headers());
 

--- a/sdk/data_tables/src/responses/submit_transaction_response.rs
+++ b/sdk/data_tables/src/responses/submit_transaction_response.rs
@@ -1,5 +1,5 @@
 use azure_core::{
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     Etag,
 };
 use azure_storage::core::headers::CommonStorageResponseHeaders;
@@ -25,7 +25,7 @@ pub struct SubmitTransactionResponse {
 impl TryFrom<&Response<Bytes>> for SubmitTransactionResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let body = std::str::from_utf8(response.body())?;
         debug!("{}", body);
         debug!("headers == {:#?}", response.headers());

--- a/sdk/device_update/src/device_update.rs
+++ b/sdk/device_update/src/device_update.rs
@@ -1,6 +1,6 @@
 use crate::{client::API_VERSION_PARAM, DeviceUpdateClient};
 use azure_core::{
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     sleep,
 };
 use chrono::{DateTime, Utc};
@@ -167,7 +167,7 @@ impl DeviceUpdateClient {
         &self,
         instance_id: &str,
         import_json: String,
-    ) -> Result<UpdateOperation> {
+    ) -> azure_core::Result<UpdateOperation> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates");
         uri.set_path(&path);
@@ -219,7 +219,7 @@ impl DeviceUpdateClient {
         provider: &str,
         name: &str,
         version: &str,
-    ) -> Result<String> {
+    ) -> azure_core::Result<String> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/providers/{provider}/names/{name}/versions/{version}");
         uri.set_path(&path);
@@ -237,7 +237,7 @@ impl DeviceUpdateClient {
         name: &str,
         version: &str,
         file_id: &str,
-    ) -> Result<UpdateFile> {
+    ) -> azure_core::Result<UpdateFile> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/providers/{provider}/names/{name}/versions/{version}/files/{file_id}");
         uri.set_path(&path);
@@ -252,7 +252,7 @@ impl DeviceUpdateClient {
         &self,
         instance_id: &str,
         operation_id: &str,
-    ) -> Result<UpdateOperation> {
+    ) -> azure_core::Result<UpdateOperation> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/operations/{operation_id}");
         uri.set_path(&path);
@@ -269,7 +269,7 @@ impl DeviceUpdateClient {
         provider: &str,
         name: &str,
         version: &str,
-    ) -> Result<Update> {
+    ) -> azure_core::Result<Update> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/providers/{provider}/names/{name}/versions/{version}");
         uri.set_path(&path);
@@ -286,7 +286,7 @@ impl DeviceUpdateClient {
         provider: &str,
         name: &str,
         version: &str,
-    ) -> Result<Vec<String>> {
+    ) -> azure_core::Result<Vec<String>> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/providers/{provider}/names/{name}/versions/{version}/files");
         uri.set_path(&path);
@@ -315,7 +315,11 @@ impl DeviceUpdateClient {
 
     /// Get a list of all update names that match the specified provider.
     /// GET https://{endpoint}/deviceupdate/{instanceId}/updates/providers/{provider}/names?api-version=2021-06-01-preview
-    pub async fn list_names(&self, instance_id: &str, provider: &str) -> Result<Vec<String>> {
+    pub async fn list_names(
+        &self,
+        instance_id: &str,
+        provider: &str,
+    ) -> azure_core::Result<Vec<String>> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/providers/{provider}/names");
         uri.set_path(&path);
@@ -350,7 +354,7 @@ impl DeviceUpdateClient {
         instance_id: &str,
         filter: Option<&str>,
         top: Option<&str>,
-    ) -> Result<Vec<UpdateOperation>> {
+    ) -> azure_core::Result<Vec<UpdateOperation>> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/operations");
 
@@ -386,7 +390,7 @@ impl DeviceUpdateClient {
 
     /// Get a list of all update providers that have been imported to Device Update for IoT Hub.
     /// GET https://{endpoint}/deviceupdate/{instanceId}/updates/providers?api-version=2021-06-01-preview
-    pub async fn list_providers(&self, instance_id: &str) -> Result<Vec<String>> {
+    pub async fn list_providers(&self, instance_id: &str) -> azure_core::Result<Vec<String>> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates/providers");
         uri.set_path(&path);
@@ -420,7 +424,7 @@ impl DeviceUpdateClient {
         instance_id: &str,
         filter: Option<&str>,
         search: Option<&str>,
-    ) -> Result<Vec<Update>> {
+    ) -> azure_core::Result<Vec<Update>> {
         let mut uri = self.device_update_url.clone();
         let path = format!("deviceupdate/{instance_id}/updates");
         uri.set_path(&path);
@@ -463,7 +467,7 @@ impl DeviceUpdateClient {
         provider: &str,
         name: &str,
         filter: Option<&str>,
-    ) -> Result<Vec<String>> {
+    ) -> azure_core::Result<Vec<String>> {
         let mut uri = self.device_update_url.clone();
         let path = format!(
             "deviceupdate/{instance_id}/updates/providers/{provider}/names/{name}/versions"
@@ -504,10 +508,9 @@ mod tests {
     use serde_json::json;
 
     use crate::{client::API_VERSION, tests::mock_client};
-    use azure_core::error::Result;
 
     #[tokio::test]
-    async fn can_import_update() -> Result<()> {
+    async fn can_import_update() -> azure_core::Result<()> {
         let _m = mock("POST", "/deviceupdate/test-instance/updates")
             .match_query(Matcher::UrlEncoded(
                 "api-version".into(),

--- a/sdk/identity/src/authorization_code_flow.rs
+++ b/sdk/identity/src/authorization_code_flow.rs
@@ -2,7 +2,7 @@
 //!
 //! You can learn more about the OAuth2 authorization code flow [here](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow).
 
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use oauth2::basic::BasicClient;
 use oauth2::reqwest::async_http_client;
 use oauth2::{ClientId, ClientSecret};
@@ -78,7 +78,7 @@ impl AuthorizationCodeFlow {
     pub async fn exchange(
         self,
         code: oauth2::AuthorizationCode,
-    ) -> Result<
+    ) -> azure_core::Result<
         oauth2::StandardTokenResponse<oauth2::EmptyExtraTokenFields, oauth2::basic::BasicTokenType>,
     > {
         self.client

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -41,7 +41,7 @@ mod login_response;
 
 use azure_core::{
     content_type,
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     headers, HttpClient, Request,
 };
 use http::Method;
@@ -58,7 +58,7 @@ pub async fn perform(
     client_secret: &oauth2::ClientSecret,
     scopes: &[&str],
     tenant_id: &str,
-) -> Result<LoginResponse> {
+) -> azure_core::Result<LoginResponse> {
     let encoded: String = form_urlencoded::Serializer::new(String::new())
         .append_pair("client_id", client_id.as_str())
         .append_pair("scope", &scopes.join(" "))

--- a/sdk/identity/src/development.rs
+++ b/sdk/identity/src/development.rs
@@ -2,7 +2,7 @@
 //!
 //! These utilities should not be used in production
 use crate::authorization_code_flow::AuthorizationCodeFlow;
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use log::debug;
 use oauth2::{AuthorizationCode, CsrfToken};
 use std::io::{BufRead, BufReader, Write};
@@ -18,7 +18,7 @@ use url::Url;
 pub fn naive_redirect_server(
     auth_obj: &AuthorizationCodeFlow,
     port: u32,
-) -> Result<AuthorizationCode> {
+) -> azure_core::Result<AuthorizationCode> {
     let listener = TcpListener::bind(format!("127.0.0.1:{}", port)).unwrap();
 
     // The server will terminate itself after collecting the first code.

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -8,7 +8,7 @@ mod device_code_responses;
 use async_timer::timer::new_timer;
 use azure_core::{
     content_type,
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     headers, HttpClient, Request, Response,
 };
 pub use device_code_responses::*;
@@ -26,7 +26,7 @@ pub async fn start<'a, 'b, T>(
     tenant_id: T,
     client_id: &'a ClientId,
     scopes: &'b [&'b str],
-) -> Result<DeviceCodePhaseOneResponse<'a>>
+) -> azure_core::Result<DeviceCodePhaseOneResponse<'a>>
 where
     T: Into<Cow<'a, str>>,
 {
@@ -95,7 +95,9 @@ impl<'a> DeviceCodePhaseOneResponse<'a> {
 
     /// Polls the token endpoint while the user signs in.
     /// This will continue until either success or error is returned.
-    pub fn stream(&self) -> impl futures::Stream<Item = Result<DeviceCodeAuthorization>> + '_ {
+    pub fn stream(
+        &self,
+    ) -> impl futures::Stream<Item = azure_core::Result<DeviceCodeAuthorization>> + '_ {
         #[derive(Debug, Clone, PartialEq)]
         enum NextState {
             Continue,
@@ -170,7 +172,7 @@ async fn post_form(
     http_client: Arc<dyn HttpClient>,
     url: &str,
     form_body: String,
-) -> Result<Response> {
+) -> azure_core::Result<Response> {
     let url = Url::parse(url)?;
     let mut req = Request::new(url, Method::POST);
     req.headers_mut().insert(

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -2,7 +2,7 @@
 
 use azure_core::{
     content_type,
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     headers, HttpClient, Request,
 };
 use http::Method;
@@ -21,7 +21,7 @@ pub async fn exchange(
     client_id: &ClientId,
     client_secret: Option<&ClientSecret>,
     refresh_token: &AccessToken,
-) -> Result<RefreshTokenResponse> {
+) -> azure_core::Result<RefreshTokenResponse> {
     let mut encoded = form_urlencoded::Serializer::new(String::new());
     let encoded = encoded.append_pair("grant_type", "refresh_token");
     let encoded = encoded.append_pair("client_id", client_id.as_str());

--- a/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
+++ b/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
@@ -1,6 +1,6 @@
 use async_lock::RwLock;
 use azure_core::auth::{TokenCredential, TokenResponse};
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use chrono::{Duration, Utc};
 use std::sync::Arc;
 
@@ -12,7 +12,7 @@ fn is_expired(token: &TokenResponse) -> bool {
 /// Wraps a TokenCredential and handles token refresh on token expiry
 pub struct AutoRefreshingTokenCredential {
     credential: Arc<dyn TokenCredential>,
-    current_token: Arc<RwLock<Option<Result<TokenResponse>>>>,
+    current_token: Arc<RwLock<Option<azure_core::Result<TokenResponse>>>>,
 }
 
 impl std::fmt::Debug for AutoRefreshingTokenCredential {
@@ -35,7 +35,7 @@ impl AutoRefreshingTokenCredential {
 
 #[async_trait::async_trait]
 impl TokenCredential for AutoRefreshingTokenCredential {
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         if let Some(Ok(token)) = self.current_token.read().await.as_ref() {
             if !is_expired(token) {
                 return Ok(token.clone());

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -1,5 +1,5 @@
 use azure_core::auth::{TokenCredential, TokenResponse};
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use chrono::{DateTime, Utc};
 use oauth2::AccessToken;
 use serde::Deserialize;
@@ -42,7 +42,7 @@ pub struct AzureCliCredential;
 
 impl AzureCliCredential {
     /// Get an access token for an optional resource
-    fn get_access_token(resource: Option<&str>) -> Result<CliTokenResponse> {
+    fn get_access_token(resource: Option<&str>) -> azure_core::Result<CliTokenResponse> {
         // on window az is a cmd and it should be called like this
         // see https://doc.rust-lang.org/nightly/std/process/struct.Command.html
         let program = if cfg!(target_os = "windows") {
@@ -90,13 +90,13 @@ impl AzureCliCredential {
     }
 
     /// Returns the current subscription ID from the Azure CLI.
-    pub fn get_subscription() -> Result<String> {
+    pub fn get_subscription() -> azure_core::Result<String> {
         let tr = Self::get_access_token(None)?;
         Ok(tr.subscription)
     }
 
     /// Returns the current tenant ID from the Azure CLI.
-    pub fn get_tenant() -> Result<String> {
+    pub fn get_tenant() -> azure_core::Result<String> {
         let tr = Self::get_access_token(None)?;
         Ok(tr.tenant)
     }
@@ -104,7 +104,7 @@ impl AzureCliCredential {
 
 #[async_trait::async_trait]
 impl TokenCredential for AzureCliCredential {
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let tr = Self::get_access_token(Some(resource))?;
         Ok(TokenResponse::new(tr.access_token, tr.expires_on))
     }

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -1,6 +1,6 @@
 use super::{authority_hosts, TokenCredential};
 use azure_core::auth::TokenResponse;
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use base64::{CharacterSet, Config};
 use chrono::Utc;
 use oauth2::AccessToken;
@@ -142,7 +142,7 @@ fn get_encoded_cert(cert: &X509) -> Result<String, ClientCertificateCredentialEr
 
 #[async_trait::async_trait]
 impl TokenCredential for ClientCertificateCredential {
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let options = self.options();
         let url = &format!(
             "{}/{}/oauth2/v2.0/token",

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -1,5 +1,5 @@
 use azure_core::auth::{TokenCredential, TokenResponse};
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use chrono::Utc;
 use oauth2::{
     basic::BasicClient, reqwest::async_http_client, AccessToken, AuthType, AuthUrl, Scope, TokenUrl,
@@ -95,7 +95,7 @@ impl ClientSecretCredential {
 
 #[async_trait::async_trait]
 impl TokenCredential for ClientSecretCredential {
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let options = self.options();
         let authority_host = options.authority_host();
 

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -1,6 +1,6 @@
 use super::{AzureCliCredential, EnvironmentCredential, ImdsManagedIdentityCredential};
 use azure_core::auth::{TokenCredential, TokenResponse};
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 
 #[derive(Debug)]
 /// Provides a mechanism of selectively disabling credentials used for a `DefaultAzureCredential` instance
@@ -79,7 +79,7 @@ pub enum DefaultAzureCredentialEnum {
 
 #[async_trait::async_trait]
 impl TokenCredential for DefaultAzureCredentialEnum {
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         match self {
             DefaultAzureCredentialEnum::Environment(credential) => {
                 credential.get_token(resource).await.context(
@@ -140,7 +140,7 @@ impl Default for DefaultAzureCredential {
 #[async_trait::async_trait]
 impl TokenCredential for DefaultAzureCredential {
     /// Try to fetch a token using each of the credential sources until one succeeds
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let mut errors = Vec::new();
         for source in &self.sources {
             let token_res = source.get_token(resource).await;

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -1,6 +1,6 @@
 use super::{ClientSecretCredential, TokenCredentialOptions};
 use azure_core::auth::{TokenCredential, TokenResponse};
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 
 const AZURE_TENANT_ID_ENV_KEY: &str = "AZURE_TENANT_ID";
 const AZURE_CLIENT_ID_ENV_KEY: &str = "AZURE_CLIENT_ID";
@@ -36,7 +36,7 @@ impl EnvironmentCredential {
 
 #[async_trait::async_trait]
 impl TokenCredential for EnvironmentCredential {
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let tenant_id =
             std::env::var(AZURE_TENANT_ID_ENV_KEY).with_context(ErrorKind::Credential, || {
                 format!(

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -1,5 +1,5 @@
 use azure_core::auth::{TokenCredential, TokenResponse};
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::{HttpClient, Request};
 use chrono::{DateTime, TimeZone, Utc};
 use http::Method;
@@ -90,7 +90,7 @@ impl ImdsManagedIdentityCredential {
 
 #[async_trait::async_trait]
 impl TokenCredential for ImdsManagedIdentityCredential {
-    async fn get_token(&self, resource: &str) -> Result<TokenResponse> {
+    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let msi_endpoint = std::env::var(MSI_ENDPOINT_ENV_KEY)
             .unwrap_or_else(|_| "http://169.254.169.254/metadata/identity/oauth2/token".to_owned());
 

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::HttpClient;
 use base64::{decode, encode_config};
 use hmac::{Hmac, Mac};
@@ -81,7 +81,7 @@ impl ServiceClient {
         key_name: &str,
         private_key: &str,
         expires_in_seconds: i64,
-    ) -> Result<String> {
+    ) -> azure_core::Result<String> {
         type HmacSHA256 = Hmac<Sha256>;
         let expiry_date = chrono::Utc::now() + chrono::Duration::seconds(expires_in_seconds);
         let expiry_date_seconds = expiry_date.timestamp();
@@ -136,7 +136,7 @@ impl ServiceClient {
         key_name: T,
         private_key: U,
         expires_in_seconds: i64,
-    ) -> Result<Self>
+    ) -> azure_core::Result<Self>
     where
         S: Into<String>,
         T: AsRef<str>,
@@ -176,7 +176,7 @@ impl ServiceClient {
         http_client: Arc<dyn HttpClient>,
         connection_string: S,
         expires_in_seconds: i64,
-    ) -> Result<Self>
+    ) -> azure_core::Result<Self>
     where
         S: AsRef<str>,
     {
@@ -328,7 +328,7 @@ impl ServiceClient {
         &self,
         device_id: S,
         module_id: T,
-    ) -> Result<ModuleTwinResponse>
+    ) -> azure_core::Result<ModuleTwinResponse>
     where
         S: Into<String>,
         T: Into<String>,
@@ -352,7 +352,7 @@ impl ServiceClient {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.get_device_twin("some-device");
     /// ```
-    pub async fn get_device_twin<S>(&self, device_id: S) -> Result<DeviceTwinResponse>
+    pub async fn get_device_twin<S>(&self, device_id: S) -> azure_core::Result<DeviceTwinResponse>
     where
         S: Into<String>,
     {
@@ -475,7 +475,10 @@ impl ServiceClient {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.get_device_identity("some-device");
     /// ```
-    pub async fn get_device_identity<S>(&self, device_id: S) -> Result<DeviceIdentityResponse>
+    pub async fn get_device_identity<S>(
+        &self,
+        device_id: S,
+    ) -> azure_core::Result<DeviceIdentityResponse>
     where
         S: Into<String>,
     {
@@ -560,7 +563,7 @@ impl ServiceClient {
         &self,
         device_id: S,
         module_id: T,
-    ) -> Result<ModuleIdentityResponse>
+    ) -> azure_core::Result<ModuleIdentityResponse>
     where
         S: Into<String>,
         T: Into<String>,
@@ -682,7 +685,10 @@ impl ServiceClient {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.get_configuration("some-configuration");
     /// ```
-    pub async fn get_configuration<S>(&self, configuration_id: S) -> Result<ConfigurationResponse>
+    pub async fn get_configuration<S>(
+        &self,
+        configuration_id: S,
+    ) -> azure_core::Result<ConfigurationResponse>
     where
         S: Into<String>,
     {
@@ -700,7 +706,7 @@ impl ServiceClient {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.get_configurations();
     /// ```
-    pub async fn get_configurations(&self) -> Result<MultipleConfigurationResponse> {
+    pub async fn get_configurations(&self) -> azure_core::Result<MultipleConfigurationResponse> {
         get_configuration(self, None).await
     }
 

--- a/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
+++ b/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
@@ -1,5 +1,5 @@
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::Result;
+
 use http::{Method, StatusCode};
 use serde::Serialize;
 /// The ApplyOnEdgeDeviceBuilder is used to construct a new device identity
@@ -90,7 +90,7 @@ impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// iot_hub.apply_on_edge_device("some-device").execute();
     /// ```
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> azure_core::Result<()> {
         let uri = format!(
             "https://{}.azure-devices.net/devices/{}/applyConfigurationContent?api-version={}",
             self.service_client.iot_hub_name, self.device_id, API_VERSION

--- a/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use http::Method;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -99,7 +98,7 @@ impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
     }
 
     /// Performs the create or update request on the device identity
-    pub async fn execute(self) -> Result<ConfigurationResponse> {
+    pub async fn execute(self) -> azure_core::Result<ConfigurationResponse> {
         let uri = format!(
             "https://{}.azure-devices.net/configurations/{}?api-version={}",
             self.service_client.iot_hub_name, &self.configuration_id, API_VERSION

--- a/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
@@ -4,7 +4,7 @@ use crate::service::resources::{
 };
 use crate::service::responses::DeviceIdentityResponse;
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use http::Method;
 use serde::Serialize;
 use std::convert::TryInto;
@@ -46,7 +46,7 @@ impl<'a> CreateOrUpdateDeviceIdentityBuilder<'a> {
         device_id: S,
         status: Status,
         authentication: AuthenticationMechanism,
-    ) -> Result<DeviceIdentityResponse>
+    ) -> azure_core::Result<DeviceIdentityResponse>
     where
         S: AsRef<str>,
     {

--- a/sdk/iot_hub/src/service/requests/create_or_update_module_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_module_identity_builder.rs
@@ -1,7 +1,7 @@
 use crate::service::resources::{identity::IdentityOperation, AuthenticationMechanism};
 use crate::service::responses::ModuleIdentityResponse;
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use http::Method;
 use serde::Serialize;
 use std::convert::TryInto;
@@ -34,7 +34,7 @@ impl<'a> CreateOrUpdateModuleIdentityBuilder<'a> {
         module_id: T,
         managed_by: U,
         authentication: AuthenticationMechanism,
-    ) -> Result<ModuleIdentityResponse>
+    ) -> azure_core::Result<ModuleIdentityResponse>
     where
         S: AsRef<str>,
         T: AsRef<str>,

--- a/sdk/iot_hub/src/service/requests/delete_configuration_builder.rs
+++ b/sdk/iot_hub/src/service/requests/delete_configuration_builder.rs
@@ -1,5 +1,5 @@
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::Result;
+
 use http::{Method, StatusCode};
 
 /// The DeleteConfigurationBuilder is used to construct a request to delete a configuration.
@@ -23,7 +23,7 @@ impl<'a> DeleteConfigurationBuilder<'a> {
     }
 
     /// Execute the request to delete the configuration.
-    pub async fn execute(&self) -> Result<()> {
+    pub async fn execute(&self) -> azure_core::Result<()> {
         let uri = format!(
             "https://{}.azure-devices.net/configurations/{}?api-version={}",
             self.service_client.iot_hub_name, self.configuration_id, API_VERSION

--- a/sdk/iot_hub/src/service/requests/delete_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/delete_identity_builder.rs
@@ -1,5 +1,5 @@
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::Result;
+
 use http::{Method, StatusCode};
 
 /// The DeleteIdentityBuilder is used to construct a request to delete a module or device identity.
@@ -26,7 +26,7 @@ impl<'a> DeleteIdentityBuilder<'a> {
     }
 
     /// Execute the request to delete the module or device identity.
-    pub async fn execute(&self) -> Result<()> {
+    pub async fn execute(&self) -> azure_core::Result<()> {
         let uri = match &self.module_id {
             Some(module_id) => format!(
                 "https://{}.azure-devices.net/devices/{}/modules/{}?api-version={}",

--- a/sdk/iot_hub/src/service/requests/get_configuration.rs
+++ b/sdk/iot_hub/src/service/requests/get_configuration.rs
@@ -1,5 +1,5 @@
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use bytes::Bytes;
 use http::{Method, Response, StatusCode};
 use std::convert::{TryFrom, TryInto};
@@ -8,7 +8,7 @@ use std::convert::{TryFrom, TryInto};
 pub(crate) async fn get_configuration<T>(
     service_client: &ServiceClient,
     configuration_id: Option<String>,
-) -> Result<T>
+) -> azure_core::Result<T>
 where
     T: TryFrom<Response<Bytes>, Error = Error>,
 {

--- a/sdk/iot_hub/src/service/requests/get_identity.rs
+++ b/sdk/iot_hub/src/service/requests/get_identity.rs
@@ -1,5 +1,5 @@
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use bytes::Bytes;
 use http::{Method, Response, StatusCode};
 use std::convert::{TryFrom, TryInto};
@@ -9,7 +9,7 @@ pub(crate) async fn get_identity<T>(
     service_client: &ServiceClient,
     device_id: String,
     module_id: Option<String>,
-) -> Result<T>
+) -> azure_core::Result<T>
 where
     T: TryFrom<Response<Bytes>, Error = Error>,
 {

--- a/sdk/iot_hub/src/service/requests/get_twin.rs
+++ b/sdk/iot_hub/src/service/requests/get_twin.rs
@@ -1,5 +1,5 @@
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use bytes::Bytes;
 use http::{Method, Response, StatusCode};
 use std::convert::TryFrom;
@@ -10,7 +10,7 @@ pub(crate) async fn get_twin<T>(
     service_client: &ServiceClient,
     device_id: String,
     module_id: Option<String>,
-) -> Result<T>
+) -> azure_core::Result<T>
 where
     T: TryFrom<Response<Bytes>, Error = Error>,
 {

--- a/sdk/iot_hub/src/service/requests/invoke_method_builder.rs
+++ b/sdk/iot_hub/src/service/requests/invoke_method_builder.rs
@@ -1,6 +1,5 @@
 use crate::service::responses::InvokeMethodResponse;
 use crate::service::{ServiceClient, API_VERSION};
-use azure_core::error::Result;
 use http::{Method, StatusCode};
 use serde::Serialize;
 use std::convert::TryInto;
@@ -60,7 +59,10 @@ impl<'a> InvokeMethodBuilder<'a> {
     ///
     /// great_method.execute(serde_json::json!({"hello": "world"}));
     /// ```
-    pub async fn execute(&self, payload: serde_json::Value) -> Result<InvokeMethodResponse> {
+    pub async fn execute(
+        &self,
+        payload: serde_json::Value,
+    ) -> azure_core::Result<InvokeMethodResponse> {
         let uri = match &self.module_id {
             Some(module_id_value) => format!(
                 "https://{}.azure-devices.net/twins/{}/modules/{}/methods?api-version={}",

--- a/sdk/iot_hub/src/service/requests/query_builder.rs
+++ b/sdk/iot_hub/src/service/requests/query_builder.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs)]
 
 use crate::service::{responses::QueryResponse, ServiceClient, API_VERSION};
-use azure_core::error::Result;
 use azure_core::prelude::*;
 use azure_core::setters;
 use http::{Method, StatusCode};
@@ -48,7 +47,7 @@ impl<'a> QueryBuilder<'a> {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let query_builder = iot_hub.query().max_item_count(1).continuation("some_token").execute("SELECT * FROM devices");
     /// ```
-    pub async fn execute<S>(self, query: S) -> Result<QueryResponse>
+    pub async fn execute<S>(self, query: S) -> azure_core::Result<QueryResponse>
     where
         S: Into<String>,
     {

--- a/sdk/iot_hub/src/service/requests/update_or_replace_twin_builder.rs
+++ b/sdk/iot_hub/src/service/requests/update_or_replace_twin_builder.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use bytes::Bytes;
 use http::{Method, Response, StatusCode};
 use serde::Serialize;
@@ -126,7 +126,7 @@ where
     ///              .properties(serde_json::json!({"PropertyName": "PropertyValue"}))
     ///              .execute();
     /// ```
-    pub async fn execute(self) -> Result<R> {
+    pub async fn execute(self) -> azure_core::Result<R> {
         let body = DesiredTwinBody {
             tags: self.desired_tags,
             properties: DesiredTwinProperties {

--- a/sdk/iot_hub/src/service/responses/configuration_response.rs
+++ b/sdk/iot_hub/src/service/responses/configuration_response.rs
@@ -1,5 +1,5 @@
 use crate::service::resources::Configuration;
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use http::Response;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ pub struct MultipleConfigurationResponse(Vec<ConfigurationResponse>);
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ConfigurationResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         let configuration_response: ConfigurationResponse = serde_json::from_slice(body)?;
@@ -25,7 +25,7 @@ impl std::convert::TryFrom<Response<bytes::Bytes>> for ConfigurationResponse {
 impl std::convert::TryFrom<Response<bytes::Bytes>> for MultipleConfigurationResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         let configuration_response: MultipleConfigurationResponse = serde_json::from_slice(body)?;

--- a/sdk/iot_hub/src/service/responses/device_identity_response.rs
+++ b/sdk/iot_hub/src/service/responses/device_identity_response.rs
@@ -1,7 +1,7 @@
 use crate::service::resources::{
     AuthenticationMechanism, ConnectionState, DeviceCapabilities, Status,
 };
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use http::Response;
 use serde::{Deserialize, Serialize};
 
@@ -41,7 +41,7 @@ pub struct DeviceIdentityResponse {
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeviceIdentityResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         let device_identity_response: DeviceIdentityResponse = serde_json::from_slice(body)?;

--- a/sdk/iot_hub/src/service/responses/device_twin_response.rs
+++ b/sdk/iot_hub/src/service/responses/device_twin_response.rs
@@ -1,7 +1,7 @@
 use crate::service::resources::{
     AuthenticationType, ConnectionState, DeviceCapabilities, Status, TwinProperties, X509ThumbPrint,
 };
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use http::Response;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -49,7 +49,7 @@ pub struct DeviceTwinResponse {
 impl std::convert::TryFrom<Response<bytes::Bytes>> for DeviceTwinResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         let device_twin_response: DeviceTwinResponse = serde_json::from_slice(body)?;

--- a/sdk/iot_hub/src/service/responses/invoke_method_response.rs
+++ b/sdk/iot_hub/src/service/responses/invoke_method_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use http::response::Response;
 use serde::Deserialize;
 
@@ -15,7 +15,7 @@ pub struct InvokeMethodResponse {
 impl std::convert::TryFrom<Response<bytes::Bytes>> for InvokeMethodResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         let invoke_method_response: InvokeMethodResponse = serde_json::from_slice(body)?;

--- a/sdk/iot_hub/src/service/responses/module_identity_response.rs
+++ b/sdk/iot_hub/src/service/responses/module_identity_response.rs
@@ -1,5 +1,5 @@
 use crate::service::resources::{AuthenticationMechanism, ConnectionState};
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use http::Response;
 use serde::Deserialize;
 
@@ -33,7 +33,7 @@ pub struct ModuleIdentityResponse {
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ModuleIdentityResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         let module_identity_response: ModuleIdentityResponse = serde_json::from_slice(body)?;

--- a/sdk/iot_hub/src/service/responses/module_twin_response.rs
+++ b/sdk/iot_hub/src/service/responses/module_twin_response.rs
@@ -1,7 +1,7 @@
 use crate::service::resources::{
     AuthenticationType, ConnectionState, Status, TwinProperties, X509ThumbPrint,
 };
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use http::Response;
 use serde::Deserialize;
 
@@ -40,7 +40,7 @@ pub struct ModuleTwinResponse {
 impl std::convert::TryFrom<Response<bytes::Bytes>> for ModuleTwinResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         let module_twin_response: ModuleTwinResponse = serde_json::from_slice(body)?;

--- a/sdk/iot_hub/src/service/responses/query_response.rs
+++ b/sdk/iot_hub/src/service/responses/query_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_core::headers::{self, continuation_token_from_headers_optional, get_str_from_headers};
 use http::response::Response;
 use serde_json::Value;
@@ -16,7 +16,7 @@ pub struct QueryResponse {
 impl std::convert::TryFrom<Response<bytes::Bytes>> for QueryResponse {
     type Error = Error;
 
-    fn try_from(response: Response<bytes::Bytes>) -> Result<Self> {
+    fn try_from(response: Response<bytes::Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body: &[u8] = response.body();
 

--- a/sdk/messaging_servicebus/tests/service_bus.rs
+++ b/sdk/messaging_servicebus/tests/service_bus.rs
@@ -1,7 +1,6 @@
 #![cfg(all(test, feature = "test_e2e"))] // to run this, do: `cargo test --features test_e2e`
 extern crate log;
 
-use azure_core::error::Result;
 use azure_messaging_servicebus::service_bus::Client;
 use chrono::Duration;
 
@@ -83,7 +82,7 @@ async fn unlock_message() {
         .expect("Failed to unlock message's lock");
 }
 
-fn create_client() -> Result<Client> {
+fn create_client() -> azure_core::Result<Client> {
     let service_bus_namespace = std::env::var("AZURE_SERVICE_BUS_NAMESPACE")
         .expect("Please set AZURE_SERVICE_BUS_NAMESPACE env variable first!");
 

--- a/sdk/storage/examples/account00.rs
+++ b/sdk/storage/examples/account00.rs
@@ -1,8 +1,7 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage/src/account/operations/get_account_information.rs
+++ b/sdk/storage/src/account/operations/get_account_information.rs
@@ -1,5 +1,4 @@
 use crate::core::prelude::*;
-use azure_core::error::Result;
 use azure_core::headers::{
     account_kind_from_headers, date_from_headers, request_id_from_headers, sku_name_from_headers,
 };
@@ -51,7 +50,7 @@ impl GetAccountInformationBuilder {
 
 /// The future returned by calling `into_future` on the builder.
 pub type GetAccountInformation =
-    futures::future::BoxFuture<'static, azure_core::error::Result<GetAccountInformationResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<GetAccountInformationResponse>>;
 
 #[cfg(feature = "into_future")]
 impl std::future::IntoFuture for GetAccountInformationBuilder {
@@ -71,7 +70,9 @@ pub struct GetAccountInformationResponse {
 }
 
 impl GetAccountInformationResponse {
-    pub(crate) fn try_from(headers: &HeaderMap) -> Result<GetAccountInformationResponse> {
+    pub(crate) fn try_from(
+        headers: &HeaderMap,
+    ) -> azure_core::Result<GetAccountInformationResponse> {
         let request_id = request_id_from_headers(headers)?;
         let date = date_from_headers(headers)?;
         let sku_name = sku_name_from_headers(headers)?;

--- a/sdk/storage/src/account/requests/find_blobs_by_tags_builder.rs
+++ b/sdk/storage/src/account/requests/find_blobs_by_tags_builder.rs
@@ -1,6 +1,5 @@
 use crate::account::responses::ListBlobsByTagsResponse;
 use crate::core::prelude::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
 use std::convert::TryInto;
@@ -41,7 +40,7 @@ impl<'a> FindBlobsByTagsBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<ListBlobsByTagsResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ListBlobsByTagsResponse> {
         let mut url = self
             .client
             .storage_account_client()

--- a/sdk/storage/src/account/responses/list_blobs_by_tags_response.rs
+++ b/sdk/storage/src/account/responses/list_blobs_by_tags_response.rs
@@ -1,5 +1,5 @@
 use crate::xml::read_xml;
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_core::headers::{date_from_headers, request_id_from_headers};
 use azure_core::prelude::NextMarker;
 use azure_core::RequestId;
@@ -46,7 +46,7 @@ pub struct Blob {
 impl TryFrom<&http::Response<Bytes>> for ListBlobsByTagsResponse {
     type Error = Error;
 
-    fn try_from(response: &http::Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &http::Response<Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         trace!("body == {:?}", body);

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -9,7 +9,7 @@ use crate::{
     },
 };
 use azure_core::auth::TokenCredential;
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::Request as CoreRequest;
 use azure_core::{headers::*, Pipeline};
 use azure_core::{ClientOptions, HttpClient};
@@ -79,7 +79,7 @@ pub struct StorageAccountClient {
     pipeline: Pipeline,
 }
 
-fn get_sas_token_parms(sas_token: &str) -> Result<Vec<(String, String)>> {
+fn get_sas_token_parms(sas_token: &str) -> azure_core::Result<Vec<(String, String)>> {
     // Any base url will do: we just need to parse the SAS token
     // to get its query pairs.
     let base_url = Url::parse("https://blob.core.windows.net").unwrap();
@@ -211,7 +211,7 @@ impl StorageAccountClient {
         http_client: Arc<dyn HttpClient>,
         account: A,
         sas_token: S,
-    ) -> Result<Arc<Self>>
+    ) -> azure_core::Result<Arc<Self>>
     where
         A: Into<String>,
         S: AsRef<str>,
@@ -307,7 +307,7 @@ impl StorageAccountClient {
     pub fn new_connection_string(
         http_client: Arc<dyn HttpClient>,
         connection_string: &str,
-    ) -> Result<Arc<Self>> {
+    ) -> azure_core::Result<Arc<Self>> {
         match ConnectionString::new(connection_string)? {
             ConnectionString {
                 account_name: Some(account),
@@ -432,7 +432,7 @@ impl StorageAccountClient {
         http_header_adder: &dyn Fn(Builder) -> Builder,
         service_type: ServiceType,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         let dt = chrono::Utc::now();
         let time = format!("{}", dt.format("%a, %d %h %Y %T GMT"));
 
@@ -532,7 +532,7 @@ impl StorageAccountClient {
 impl ClientAccountSharedAccessSignature for StorageAccountClient {
     fn shared_access_signature(
         &self,
-    ) -> Result<AccountSharedAccessSignatureBuilder<No, No, No, No>> {
+    ) -> azure_core::Result<AccountSharedAccessSignatureBuilder<No, No, No, No>> {
         match self.storage_credentials {
             StorageCredentials::Key(ref account, ref key) => {
                 Ok(AccountSharedAccessSignatureBuilder::new(account, key))
@@ -717,7 +717,11 @@ fn lexy_sort<'a>(
     v_values
 }
 
-fn get_endpoint_uri(url: Option<&str>, account: &str, endpoint_type: &str) -> Result<url::Url> {
+fn get_endpoint_uri(
+    url: Option<&str>,
+    account: &str,
+    endpoint_type: &str,
+) -> azure_core::Result<url::Url> {
     Ok(match url {
         Some(value) => url::Url::parse(value)?,
         None => url::Url::parse(&format!(

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -1,6 +1,6 @@
 use crate::core::clients::{ServiceType, StorageAccountClient};
 use crate::operations::*;
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use bytes::Bytes;
 use http::method::Method;
 use http::request::{Builder, Request};
@@ -38,7 +38,7 @@ impl StorageClient {
         self.storage_account_client.http_client()
     }
 
-    fn url_with_segments<'a, I>(mut url: url::Url, segments: I) -> Result<url::Url>
+    fn url_with_segments<'a, I>(mut url: url::Url, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -56,7 +56,7 @@ impl StorageClient {
         Ok(url)
     }
 
-    pub fn blob_url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
+    pub fn blob_url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -66,7 +66,7 @@ impl StorageClient {
         )
     }
 
-    pub fn queue_url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
+    pub fn queue_url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -92,7 +92,7 @@ impl StorageClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.storage_account_client.prepare_request(
             url,
             method,

--- a/sdk/storage/src/core/connection_string.rs
+++ b/sdk/storage/src/core/connection_string.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 
 // Key names.
 pub const ACCOUNT_KEY_KEY_NAME: &str = "AccountKey";
@@ -72,7 +72,7 @@ pub struct ConnectionString<'a> {
 }
 
 impl<'a> ConnectionString<'a> {
-    pub fn new(connection_string: &'a str) -> Result<Self> {
+    pub fn new(connection_string: &'a str) -> azure_core::Result<Self> {
         let mut account_name = None;
         let mut account_key = None;
         let mut sas = None;

--- a/sdk/storage/src/core/copy_id.rs
+++ b/sdk/storage/src/core/copy_id.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 
 use http::HeaderMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -10,7 +10,7 @@ use super::headers::COPY_ID;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CopyId(uuid::Uuid);
 
-pub fn copy_id_from_headers(headers: &HeaderMap) -> Result<CopyId> {
+pub fn copy_id_from_headers(headers: &HeaderMap) -> azure_core::Result<CopyId> {
     let copy_id = headers
         .get(COPY_ID)
         .ok_or_else(|| Error::message(ErrorKind::Other, "failed to get copy id from headers"))?;
@@ -35,7 +35,7 @@ impl From<uuid::Uuid> for CopyId {
 impl TryFrom<&str> for CopyId {
     type Error = Error;
 
-    fn try_from(s: &str) -> Result<Self> {
+    fn try_from(s: &str) -> azure_core::Result<Self> {
         Ok(Self(
             s.parse().with_context(ErrorKind::DataConversion, || {
                 format!("failed to parse CopyId from {s}")

--- a/sdk/storage/src/core/copy_progress.rs
+++ b/sdk/storage/src/core/copy_progress.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, str::FromStr};
@@ -18,7 +18,7 @@ impl fmt::Display for CopyProgress {
 impl FromStr for CopyProgress {
     type Err = Error;
 
-    fn from_str(s: &str) -> Result<Self> {
+    fn from_str(s: &str) -> azure_core::Result<Self> {
         let tokens = s.split('/').collect::<Vec<&str>>();
         if tokens.len() < 2 {
             return Err(Error::with_message(ErrorKind::DataConversion, || {

--- a/sdk/storage/src/core/headers/mod.rs
+++ b/sdk/storage/src/core/headers/mod.rs
@@ -1,5 +1,5 @@
 use crate::{ConsistencyCRC64, ConsistencyMD5};
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::headers::*;
 use azure_core::RequestId;
 use chrono::{DateTime, Utc};
@@ -18,7 +18,7 @@ pub struct CommonStorageResponseHeaders {
 impl TryFrom<&HeaderMap> for CommonStorageResponseHeaders {
     type Error = Error;
 
-    fn try_from(headers: &HeaderMap) -> Result<Self> {
+    fn try_from(headers: &HeaderMap) -> azure_core::Result<Self> {
         Ok(Self {
             request_id: request_id_from_headers(headers)?,
             client_request_id: client_request_id_from_headers_optional(headers),
@@ -34,7 +34,7 @@ pub const CONTENT_MD5: &str = "Content-MD5";
 pub const COPY_ID: &str = "x-ms-copy-id";
 pub const RENAME_SOURCE: &str = "x-ms-rename-source";
 
-pub fn content_crc64_from_headers(headers: &HeaderMap) -> Result<ConsistencyCRC64> {
+pub fn content_crc64_from_headers(headers: &HeaderMap) -> azure_core::Result<ConsistencyCRC64> {
     let content_crc64 = headers
         .get(CONTENT_CRC64)
         .ok_or_else(|| {
@@ -58,7 +58,7 @@ pub fn content_crc64_from_headers(headers: &HeaderMap) -> Result<ConsistencyCRC6
 
 pub fn content_crc64_from_headers_optional(
     headers: &HeaderMap,
-) -> Result<Option<ConsistencyCRC64>> {
+) -> azure_core::Result<Option<ConsistencyCRC64>> {
     if headers.contains_key(CONTENT_CRC64) {
         Ok(Some(content_crc64_from_headers(headers)?))
     } else {
@@ -66,7 +66,7 @@ pub fn content_crc64_from_headers_optional(
     }
 }
 
-pub fn content_md5_from_headers(headers: &HeaderMap) -> Result<ConsistencyMD5> {
+pub fn content_md5_from_headers(headers: &HeaderMap) -> azure_core::Result<ConsistencyMD5> {
     let content_md5 = headers
         .get(CONTENT_MD5)
         .ok_or_else(|| {
@@ -85,7 +85,9 @@ pub fn content_md5_from_headers(headers: &HeaderMap) -> Result<ConsistencyMD5> {
     Ok(content_md5)
 }
 
-pub fn content_md5_from_headers_optional(headers: &HeaderMap) -> Result<Option<ConsistencyMD5>> {
+pub fn content_md5_from_headers_optional(
+    headers: &HeaderMap,
+) -> azure_core::Result<Option<ConsistencyMD5>> {
     if headers.contains_key(CONTENT_MD5) {
         Ok(Some(content_md5_from_headers(headers)?))
     } else {
@@ -95,7 +97,7 @@ pub fn content_md5_from_headers_optional(headers: &HeaderMap) -> Result<Option<C
 
 pub fn consistency_from_headers(
     headers: &HeaderMap,
-) -> Result<(Option<ConsistencyMD5>, Option<ConsistencyCRC64>)> {
+) -> azure_core::Result<(Option<ConsistencyMD5>, Option<ConsistencyCRC64>)> {
     let content_crc64 = content_crc64_from_headers_optional(headers)?;
     let content_md5 = content_md5_from_headers_optional(headers)?;
     Ok((content_md5, content_crc64))

--- a/sdk/storage/src/core/hmac.rs
+++ b/sdk/storage/src/core/hmac.rs
@@ -1,9 +1,9 @@
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use base64::encode;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
-pub fn sign(data: &str, key: &str) -> Result<String> {
+pub fn sign(data: &str, key: &str) -> azure_core::Result<String> {
     let mut hmac = Hmac::<Sha256>::new_from_slice(
         &base64::decode(key).with_context(ErrorKind::DataConversion, || {
             format!("failed to decode hmac. key: {key}")

--- a/sdk/storage/src/core/into_azure_path.rs
+++ b/sdk/storage/src/core/into_azure_path.rs
@@ -1,11 +1,11 @@
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use std::borrow::Borrow;
 
 pub trait IntoAzurePath {
-    fn container_name(&self) -> Result<&str>;
-    fn blob_name(&self) -> Result<&str>;
+    fn container_name(&self) -> azure_core::Result<&str>;
+    fn blob_name(&self) -> azure_core::Result<&str>;
 
-    fn components(&self) -> Result<(&str, &str)> {
+    fn components(&self) -> azure_core::Result<(&str, &str)> {
         Ok((self.container_name()?, self.blob_name()?))
     }
 }
@@ -14,25 +14,25 @@ impl<T> IntoAzurePath for (T, T)
 where
     T: Borrow<str> + Clone,
 {
-    fn container_name(&self) -> Result<&str> {
+    fn container_name(&self) -> azure_core::Result<&str> {
         Ok(self.0.borrow())
     }
-    fn blob_name(&self) -> Result<&str> {
+    fn blob_name(&self) -> azure_core::Result<&str> {
         Ok(self.1.borrow())
     }
 }
 
 impl<'a> IntoAzurePath for &'a str {
-    fn container_name(&self) -> Result<&str> {
+    fn container_name(&self) -> azure_core::Result<&str> {
         split(self.borrow()).map(|(container_name, _blob_name)| container_name)
     }
 
-    fn blob_name(&self) -> Result<&str> {
+    fn blob_name(&self) -> azure_core::Result<&str> {
         split(self.borrow()).map(|(_container_name, blob_name)| blob_name)
     }
 }
 
-fn split(b: &str) -> Result<(&str, &str)> {
+fn split(b: &str) -> azure_core::Result<(&str, &str)> {
     let slash_pos = b.find('/').ok_or_else(|| {
         Error::with_message(ErrorKind::Other, || {
             format!("failed to find path separator. path: {b}")

--- a/sdk/storage/src/core/mod.rs
+++ b/sdk/storage/src/core/mod.rs
@@ -18,7 +18,7 @@ pub use copy_progress::CopyProgress;
 pub mod parsing_xml;
 pub mod storage_shared_key_credential;
 mod stored_access_policy;
-pub use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+pub use azure_core::error::{Error, ErrorKind, ResultExt};
 pub mod util;
 pub mod xml;
 
@@ -48,7 +48,7 @@ pub use stored_access_policy::{StoredAccessPolicy, StoredAccessPolicyList};
 pub use consistency::{ConsistencyCRC64, ConsistencyMD5};
 
 mod consistency {
-    use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+    use azure_core::error::{Error, ErrorKind, ResultExt};
     use bytes::Bytes;
     use serde::{Deserialize, Deserializer};
     use std::convert::TryInto;
@@ -60,7 +60,7 @@ mod consistency {
 
     impl ConsistencyCRC64 {
         /// Decodes from base64 encoded input
-        pub fn decode(input: impl AsRef<[u8]>) -> Result<Self> {
+        pub fn decode(input: impl AsRef<[u8]>) -> azure_core::Result<Self> {
             let bytes = base64::decode(input).context(
                 ErrorKind::DataConversion,
                 "ConsistencyCRC64 failed base64 decode",
@@ -109,7 +109,7 @@ mod consistency {
 
     impl ConsistencyMD5 {
         /// Decodes from base64 encoded input
-        pub fn decode(input: impl AsRef<[u8]>) -> Result<Self> {
+        pub fn decode(input: impl AsRef<[u8]>) -> azure_core::Result<Self> {
             let bytes = base64::decode(input)
                 .context(ErrorKind::DataConversion, "ConsistencyMD5 failed decode")?;
             let bytes = Bytes::from(bytes);

--- a/sdk/storage/src/core/parsing_xml.rs
+++ b/sdk/storage/src/core/parsing_xml.rs
@@ -1,10 +1,13 @@
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use azure_core::parsing::FromStringOptional;
 use xml::Element;
 use xml::Xml::{CharacterNode, ElementNode};
 
 #[inline]
-pub fn traverse_single_must<'a>(node: &'a Element, path: &[&str]) -> Result<&'a Element> {
+pub fn traverse_single_must<'a>(
+    node: &'a Element,
+    path: &[&str],
+) -> azure_core::Result<&'a Element> {
     let vec = traverse(node, path, false)?;
     if vec.len() > 1 {
         return Err(Error::with_message(ErrorKind::Other, || {
@@ -18,7 +21,7 @@ pub fn traverse_single_must<'a>(node: &'a Element, path: &[&str]) -> Result<&'a 
 pub fn traverse_single_optional<'a>(
     node: &'a Element,
     path: &[&str],
-) -> Result<Option<&'a Element>> {
+) -> azure_core::Result<Option<&'a Element>> {
     let vec = traverse(node, path, true)?;
     if vec.len() > 1 {
         return Err(Error::with_message(ErrorKind::Other, || {
@@ -38,7 +41,7 @@ pub fn traverse<'a>(
     node: &'a Element,
     path: &[&str],
     ignore_empty_leaf: bool,
-) -> Result<Vec<&'a Element>> {
+) -> azure_core::Result<Vec<&'a Element>> {
     trace!(
         "traverse(node == {:?}, path == {:?}, ignore_empty_leaf == {})",
         node,
@@ -99,7 +102,7 @@ pub fn find_subnodes<'a>(node: &'a Element, subnode: &str) -> Vec<&'a Element> {
 }
 
 #[inline]
-pub fn inner_text(node: &Element) -> Result<&str> {
+pub fn inner_text(node: &Element) -> azure_core::Result<&str> {
     for child in &node.children {
         match *child {
             CharacterNode(ref txt) => return Ok(txt),
@@ -114,7 +117,7 @@ pub fn inner_text(node: &Element) -> Result<&str> {
 }
 
 #[inline]
-pub fn cast_optional<'a, T>(node: &'a Element, path: &[&str]) -> Result<Option<T>>
+pub fn cast_optional<'a, T>(node: &'a Element, path: &[&str]) -> azure_core::Result<Option<T>>
 where
     T: FromStringOptional<T>,
 {
@@ -128,7 +131,7 @@ where
 }
 
 #[inline]
-pub fn cast_must<'a, T>(node: &'a Element, path: &[&str]) -> Result<T>
+pub fn cast_must<'a, T>(node: &'a Element, path: &[&str]) -> azure_core::Result<T>
 where
     T: FromStringOptional<T>,
 {

--- a/sdk/storage/src/core/stored_access_policy.rs
+++ b/sdk/storage/src/core/stored_access_policy.rs
@@ -1,5 +1,5 @@
 use crate::xml::read_xml;
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use bytes::Bytes;
 use chrono::{DateTime, FixedOffset};
 
@@ -41,7 +41,7 @@ impl StoredAccessPolicyList {
         StoredAccessPolicyList::default()
     }
 
-    pub fn from_xml(xml: &Bytes) -> Result<StoredAccessPolicyList> {
+    pub fn from_xml(xml: &Bytes) -> azure_core::Result<StoredAccessPolicyList> {
         debug!("{:?}", xml);
 
         let mut sal = StoredAccessPolicyList::default();

--- a/sdk/storage_blobs/examples/blob_00.rs
+++ b/sdk/storage_blobs/examples/blob_00.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate log;
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     prelude::*,
 };
 use azure_storage::core::prelude::*;
@@ -9,7 +9,7 @@ use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/blob_01.rs
+++ b/sdk/storage_blobs/examples/blob_01.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
 
     // First we retrieve the account name and master key from environment variables.

--- a/sdk/storage_blobs/examples/blob_02_bearer_token.rs
+++ b/sdk/storage_blobs/examples/blob_02_bearer_token.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate log;
 
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
 
     let account = std::env::args()

--- a/sdk/storage_blobs/examples/blob_04.rs
+++ b/sdk/storage_blobs/examples/blob_04.rs
@@ -1,10 +1,10 @@
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use bytes::{BufMut, Bytes};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
 
     // First we retrieve the account name and master key from environment variables.

--- a/sdk/storage_blobs/examples/blob_05_default_credential.rs
+++ b/sdk/storage_blobs/examples/blob_05_default_credential.rs
@@ -3,14 +3,14 @@ extern crate log;
 
 use azure_core::{
     auth::TokenCredential,
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
 };
 use azure_identity::DefaultAzureCredential;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
     // First we retrieve the account name, container and blob name from command line args
 

--- a/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
+++ b/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
@@ -1,14 +1,14 @@
 #[macro_use]
 extern crate log;
 
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use azure_identity::{AutoRefreshingTokenCredential, DefaultAzureCredential};
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
     // First we retrieve the account name, container and blob name from command line args
 

--- a/sdk/storage_blobs/examples/blob_range.rs
+++ b/sdk/storage_blobs/examples/blob_range.rs
@@ -1,10 +1,10 @@
-use azure_core::{error::Result, prelude::*};
+use azure_core::prelude::*;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/connection_string.rs
+++ b/sdk/storage_blobs/examples/connection_string.rs
@@ -1,11 +1,10 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
 use std::{num::NonZeroU32, time::Duration};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account connection string from environment variables.
     let connection_string =
         std::env::var("CONNECTION_STRING").expect("Set env variable CONNECTION_STRING first!");

--- a/sdk/storage_blobs/examples/container_00.rs
+++ b/sdk/storage_blobs/examples/container_00.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use std::num::NonZeroU32;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/container_01.rs
+++ b/sdk/storage_blobs/examples/container_01.rs
@@ -1,11 +1,11 @@
-use azure_core::{error::Result, prelude::*};
+use azure_core::prelude::*;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use chrono::{FixedOffset, Utc};
 use std::{ops::Add, time::Duration};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/container_and_blob.rs
+++ b/sdk/storage_blobs/examples/container_and_blob.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use bytes::Bytes;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
     // First we retrieve the account name and master key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/copy_blob.rs
+++ b/sdk/storage_blobs/examples/copy_blob.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use chrono::{Duration, Utc};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let source_account = std::env::var("SOURCE_STORAGE_ACCOUNT")
         .expect("Set env variable SOURCE_STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/examples/copy_blob_from_url.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/count_blobs.rs
+++ b/sdk/storage_blobs/examples/count_blobs.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
     let master_key =

--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_identity::{device_code_flow, refresh_token};
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
@@ -7,7 +6,7 @@ use oauth2::ClientId;
 use std::env;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let client_id =
         ClientId::new(env::var("CLIENT_ID").expect("Missing CLIENT_ID environment variable."));
     let tenant_id = env::var("TENANT_ID").expect("Missing TENANT_ID environment variable.");

--- a/sdk/storage_blobs/examples/emulator_00.rs
+++ b/sdk/storage_blobs/examples/emulator_00.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
 
     // this is how you use the emulator.

--- a/sdk/storage_blobs/examples/list_blobs_00.rs
+++ b/sdk/storage_blobs/examples/list_blobs_00.rs
@@ -1,11 +1,10 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
 use std::{num::NonZeroU32, time::Duration};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/list_blobs_01.rs
+++ b/sdk/storage_blobs/examples/list_blobs_01.rs
@@ -1,11 +1,10 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
 use std::{num::NonZeroU32, time::Duration};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/list_blobs_02.rs
+++ b/sdk/storage_blobs/examples/list_blobs_02.rs
@@ -1,9 +1,8 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
@@ -30,7 +29,7 @@ async fn main() -> Result<()> {
 async fn create_container_and_list(
     storage_client: std::sync::Arc<StorageClient>,
     container_name: &str,
-) -> Result<()> {
+) -> azure_core::Result<()> {
     let container_client = storage_client.as_container_client(container_name);
 
     container_client.create().execute().await?;

--- a/sdk/storage_blobs/examples/list_containers2.rs
+++ b/sdk/storage_blobs/examples/list_containers2.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use serde::Serialize;
@@ -10,7 +9,7 @@ struct SampleEntity {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/put_append_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_append_blob_00.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate log;
 
-use azure_core::{error::Result, prelude::*};
+use azure_core::prelude::*;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
 
     // First we retrieve the account name and master key from environment variables.

--- a/sdk/storage_blobs/examples/put_block_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_block_blob_00.rs
@@ -1,14 +1,13 @@
 #[macro_use]
 extern crate log;
 
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use bytes::Bytes;
 use std::time::Duration;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
     debug!("log initialized");
     // First we retrieve the account name and master key from environment variables.

--- a/sdk/storage_blobs/examples/put_page_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_page_blob_00.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate log;
-use azure_core::{error::Result, prelude::*};
+use azure_core::prelude::*;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::{prelude::*, BA512Range};
 use bytes::Bytes;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     env_logger::init();
     trace!("example started");
 

--- a/sdk/storage_blobs/examples/shared_access_signature.rs
+++ b/sdk/storage_blobs/examples/shared_access_signature.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use chrono::{Duration, Utc};
@@ -8,7 +7,7 @@ fn main() {
     code().unwrap();
 }
 
-fn code() -> Result<()> {
+fn code() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/stream_blob_00.rs
+++ b/sdk/storage_blobs/examples/stream_blob_00.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
@@ -11,7 +11,7 @@ use std::{cell::RefCell, rc::Rc};
 // We do not use leases here but you definitely want to do so otherwise the returned stream
 // is not guaranteed to be consistent.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let file_name = "azure_sdk_for_rust_stream_test.txt";
 
     // First we retrieve the account name and master key from environment variables.

--- a/sdk/storage_blobs/examples/stream_blob_01.rs
+++ b/sdk/storage_blobs/examples/stream_blob_01.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_blobs::{blob::responses::GetBlobResponse, prelude::*};
 use futures::stream::StreamExt;
@@ -10,7 +9,7 @@ use futures::stream::StreamExt;
 // We do not use leases here but you definitely want to do so otherwise the returned stream
 // is not guaranteed to be consistent.
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let file_name = "azure_sdk_for_rust_stream_test.txt";
 
     // First we retrieve the account name and master key from environment variables.
@@ -41,7 +40,7 @@ async fn main() -> Result<()> {
 
 fn get_blob_stream(
     blob_client: &'_ BlobClient,
-) -> impl futures::Stream<Item = Result<GetBlobResponse>> + '_ {
+) -> impl futures::Stream<Item = azure_core::Result<GetBlobResponse>> + '_ {
     let stream = blob_client.get().stream(1024);
     stream
 }

--- a/sdk/storage_blobs/src/ba512_range.rs
+++ b/sdk/storage_blobs/src/ba512_range.rs
@@ -1,5 +1,5 @@
 use azure_core::{
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     headers::{self, Header},
     prelude::Range,
 };
@@ -19,7 +19,7 @@ impl BA512Range {
         self.end
     }
 
-    pub fn new(start: u64, end: u64) -> Result<Self> {
+    pub fn new(start: u64, end: u64) -> azure_core::Result<Self> {
         if start % 512 != 0 {
             return Err(Error::with_message(ErrorKind::Other, || {
                 format!("start range not 512-byte aligned: {}", start)
@@ -52,7 +52,7 @@ impl From<BA512Range> for Range {
 impl TryFrom<Range> for BA512Range {
     type Error = Error;
 
-    fn try_from(r: Range) -> Result<Self> {
+    fn try_from(r: Range) -> azure_core::Result<Self> {
         BA512Range::new(r.start, r.end)
     }
 }
@@ -60,7 +60,7 @@ impl TryFrom<Range> for BA512Range {
 impl TryFrom<(u64, u64)> for BA512Range {
     type Error = Error;
 
-    fn try_from((start, end): (u64, u64)) -> Result<Self> {
+    fn try_from((start, end): (u64, u64)) -> azure_core::Result<Self> {
         BA512Range::new(start, end)
     }
 }
@@ -77,7 +77,7 @@ impl Header for BA512Range {
 
 impl FromStr for BA512Range {
     type Err = Error;
-    fn from_str(s: &str) -> Result<BA512Range> {
+    fn from_str(s: &str) -> azure_core::Result<BA512Range> {
         let v = s.split('/').collect::<Vec<&str>>();
         if v.len() != 2 {
             return Err(Error::message(ErrorKind::Other, "split not found"));

--- a/sdk/storage_blobs/src/blob/block_with_size_list.rs
+++ b/sdk/storage_blobs/src/blob/block_with_size_list.rs
@@ -41,7 +41,7 @@ pub struct BlockWithSizeList {
 }
 
 impl BlockWithSizeList {
-    pub fn try_from_xml(xml: &str) -> crate::Result<Self> {
+    pub fn try_from_xml(xml: &str) -> azure_core::Result<Self> {
         let bl: BlockList =
             serde_xml_rs::de::from_reader(xml.as_bytes()).map_kind(ErrorKind::DataConversion)?;
         debug!("bl == {:?}", bl);

--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -35,7 +35,7 @@ use http::header;
 use std::{collections::HashMap, convert::TryInto, str::FromStr};
 
 #[cfg(feature = "azurite_workaround")]
-fn get_creation_time(h: &header::HeaderMap) -> azure_core::error::Result<Option<DateTime<Utc>>> {
+fn get_creation_time(h: &header::HeaderMap) -> azure_core::Result<Option<DateTime<Utc>>> {
     if let Some(creation_time) = h.get(CREATION_TIME) {
         // Check that the creation time is valid
         let creation_time = creation_time.to_str().map_kind(ErrorKind::DataConversion)?;
@@ -200,7 +200,7 @@ impl Blob {
     pub(crate) fn from_headers<BN: Into<String>>(
         blob_name: BN,
         h: &header::HeaderMap,
-    ) -> crate::Result<Blob> {
+    ) -> azure_core::Result<Blob> {
         trace!("\n{:?}", h);
 
         #[cfg(not(feature = "azurite_workaround"))]
@@ -419,7 +419,9 @@ impl Blob {
     }
 }
 
-pub(crate) fn copy_status_from_headers(headers: &http::HeaderMap) -> crate::Result<CopyStatus> {
+pub(crate) fn copy_status_from_headers(
+    headers: &http::HeaderMap,
+) -> azure_core::Result<CopyStatus> {
     let val = headers
         .get_as_str(azure_core::headers::COPY_STATUS)
         .ok_or_else(|| Error::message(ErrorKind::DataConversion, COPY_STATUS))?;

--- a/sdk/storage_blobs/src/blob/page_range_list.rs
+++ b/sdk/storage_blobs/src/blob/page_range_list.rs
@@ -35,7 +35,7 @@ pub struct PageRangeList {
 }
 
 impl PageRangeList {
-    pub fn try_from_xml(xml: &str) -> crate::Result<Self> {
+    pub fn try_from_xml(xml: &str) -> azure_core::Result<Self> {
         let pl: PageList =
             serde_xml_rs::de::from_reader(xml.as_bytes()).map_kind(ErrorKind::DataConversion)?;
         debug!("pl == {:?}", pl);

--- a/sdk/storage_blobs/src/blob/requests/acquire_lease_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/acquire_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::AcquireBlobLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref, LEASE_ACTION},
     prelude::*,
 };
@@ -34,7 +33,7 @@ impl<'a> AcquireLeaseBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(self) -> Result<AcquireBlobLeaseResponse> {
+    pub async fn execute(self) -> azure_core::Result<AcquireBlobLeaseResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/blob/requests/append_block_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/append_block_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::PutBlockResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -41,7 +40,7 @@ impl<'a> AppendBlockBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<PutBlockResponse> {
+    pub async fn execute(&self) -> azure_core::Result<PutBlockResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/break_lease_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/break_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::BreakBlobLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref, LEASE_ACTION},
     prelude::*,
 };
@@ -32,7 +31,7 @@ impl<'a> BreakLeaseBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<BreakBlobLeaseResponse> {
+    pub async fn execute(&self) -> azure_core::Result<BreakBlobLeaseResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/blob/requests/change_lease_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/change_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::ChangeBlobLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, LEASE_ACTION},
     prelude::*,
 };
@@ -31,7 +30,7 @@ impl<'a> ChangeLeaseBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<ChangeBlobLeaseResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ChangeBlobLeaseResponse> {
         let mut url = self.blob_lease_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/blob/requests/clear_page_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/clear_page_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::ClearPageResponse, prelude::*, BA512Range};
 use azure_core::{
-    error::Result,
     headers::{
         add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_TYPE, PAGE_WRITE,
     },
@@ -42,7 +41,7 @@ impl<'a> ClearPageBuilder<'a> {
         lease_id: &'a LeaseId => Some(lease_id),
     }
 
-    pub async fn execute(&self) -> Result<ClearPageResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ClearPageResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/copy_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/copy_blob_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::CopyBlobResponse, prelude::*, RehydratePriority};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref, COPY_SOURCE},
     prelude::*,
 };
@@ -60,7 +59,7 @@ impl<'a> CopyBlobBuilder<'a> {
         rehydrate_priority: RehydratePriority => rehydrate_priority,
     }
 
-    pub async fn execute(&self) -> Result<CopyBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<CopyBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/copy_blob_from_url_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/copy_blob_from_url_builder.rs
@@ -1,7 +1,6 @@
 use super::SourceContentMD5;
 use crate::{blob::responses::CopyBlobFromUrlResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{
         add_mandatory_header, add_optional_header, add_optional_header_ref, COPY_SOURCE,
         REQUIRES_SYNC,
@@ -56,7 +55,7 @@ impl<'a> CopyBlobFromUrlBuilder<'a> {
         source_content_md5: &'a SourceContentMD5 => Some(source_content_md5),
     }
 
-    pub async fn execute(&self) -> Result<CopyBlobFromUrlResponse> {
+    pub async fn execute(&self) -> azure_core::Result<CopyBlobFromUrlResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/delete_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/delete_blob_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::DeleteBlobResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -32,7 +31,7 @@ impl<'a> DeleteBlobBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<DeleteBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<DeleteBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/delete_blob_snapshot_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/delete_blob_snapshot_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::DeleteBlobResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -34,7 +33,7 @@ impl<'a> DeleteBlobSnapshotBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<DeleteBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<DeleteBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/delete_blob_version_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/delete_blob_version_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::DeleteBlobResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -34,7 +33,7 @@ impl<'a> DeleteBlobVersionBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<DeleteBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<DeleteBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_blob_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::GetBlobResponse, prelude::*, Header};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref, AsHeaders, CLIENT_REQUEST_ID},
     prelude::*,
 };
@@ -64,7 +63,7 @@ impl<'a> GetBlobBuilder<'a> {
         lease_id: &'a LeaseId => Some(lease_id),
     }
 
-    pub async fn execute(&self) -> Result<GetBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.blob_versioning.append_to_url_query(&mut url);
@@ -105,7 +104,10 @@ impl<'a> GetBlobBuilder<'a> {
         (self.blob_client.blob_name(), response).try_into()
     }
 
-    pub fn stream(self, chunk_size: u64) -> impl Stream<Item = Result<GetBlobResponse>> + 'a {
+    pub fn stream(
+        self,
+        chunk_size: u64,
+    ) -> impl Stream<Item = azure_core::Result<GetBlobResponse>> + 'a {
         enum States {
             Init,
             Progress(Range),

--- a/sdk/storage_blobs/src/blob/requests/get_blob_metadata_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_blob_metadata_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::GetBlobMetadataResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -33,7 +32,7 @@ impl<'a> GetBlobMetadataBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(self) -> Result<GetBlobMetadataResponse> {
+    pub async fn execute(self) -> azure_core::Result<GetBlobMetadataResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "metadata");

--- a/sdk/storage_blobs/src/blob/requests/get_blob_properties_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_blob_properties_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::GetBlobPropertiesResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -32,7 +31,7 @@ impl<'a> GetBlobPropertiesBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<GetBlobPropertiesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetBlobPropertiesResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/get_block_list_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_block_list_builder.rs
@@ -3,7 +3,6 @@ use crate::{
     prelude::*,
 };
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -37,7 +36,7 @@ impl<'a> GetBlockListBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<GetBlockListResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetBlockListResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "blocklist");

--- a/sdk/storage_blobs/src/blob/requests/get_page_ranges_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/get_page_ranges_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::GetPageRangesResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -31,7 +30,7 @@ impl<'a> GetPageRangesBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<GetPageRangesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetPageRangesResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "pagelist");

--- a/sdk/storage_blobs/src/blob/requests/put_append_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_append_blob_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::PutBlobResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_TYPE},
     prelude::*,
 };
@@ -45,7 +44,7 @@ impl<'a> PutAppendBlobBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<PutBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<PutBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/put_block_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_block_blob_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::PutBlockBlobResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_TYPE},
     prelude::*,
 };
@@ -54,7 +53,7 @@ impl<'a> PutBlockBlobBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<PutBlockBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<PutBlockBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/put_block_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_block_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::PutBlockResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -42,7 +41,7 @@ impl<'a> PutBlockBuilder<'a> {
         lease_id: &'a LeaseId => Some(lease_id),
     }
 
-    pub async fn execute(&self) -> Result<PutBlockResponse> {
+    pub async fn execute(&self) -> azure_core::Result<PutBlockResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/put_block_list_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_block_list_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::PutBlockListResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -54,7 +53,7 @@ impl<'a> PutBlockListBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<PutBlockListResponse> {
+    pub async fn execute(&self) -> azure_core::Result<PutBlockListResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "blocklist");

--- a/sdk/storage_blobs/src/blob/requests/put_page_blob_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/put_page_blob_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::PutBlobResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{
         add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_CONTENT_LENGTH,
         BLOB_TYPE,
@@ -53,7 +52,7 @@ impl<'a> PutPageBlobBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<PutBlobResponse> {
+    pub async fn execute(&self) -> azure_core::Result<PutBlobResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/requests/release_lease_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/release_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::ReleaseBlobLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, LEASE_ACTION},
     prelude::*,
 };
@@ -26,7 +25,7 @@ impl<'a> ReleaseLeaseBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<ReleaseBlobLeaseResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ReleaseBlobLeaseResponse> {
         let mut url = self.blob_lease_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/blob/requests/renew_lease_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/renew_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::RenewBlobLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, LEASE_ACTION},
     prelude::*,
 };
@@ -26,7 +25,7 @@ impl<'a> RenewLeaseBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<RenewBlobLeaseResponse> {
+    pub async fn execute(&self) -> azure_core::Result<RenewBlobLeaseResponse> {
         let mut url = self.blob_lease_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/blob/requests/set_blob_metadata_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/set_blob_metadata_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::SetBlobMetadataResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -33,7 +32,7 @@ impl<'a> SetBlobMetadataBuilder<'a> {
         metadata: &'a Metadata => Some(metadata),
     }
 
-    pub async fn execute(self) -> Result<SetBlobMetadataResponse> {
+    pub async fn execute(self) -> azure_core::Result<SetBlobMetadataResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "metadata");

--- a/sdk/storage_blobs/src/blob/requests/set_blob_tier_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/set_blob_tier_builder.rs
@@ -1,6 +1,6 @@
 use crate::{blob::responses::SetBlobTierResponse, prelude::*};
 use azure_core::{
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     headers::{add_mandatory_header, add_optional_header},
     prelude::*,
 };
@@ -39,7 +39,7 @@ impl<'a> SetBlobTierBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(self) -> Result<SetBlobTierResponse> {
+    pub async fn execute(self) -> azure_core::Result<SetBlobTierResponse> {
         // Get the blob properties first. Need this to determine what HTTP status code to expect later.
         let blob_properties = self.blob_client.get_properties().execute().await?;
         let blob_tier = blob_properties.blob.properties.access_tier;

--- a/sdk/storage_blobs/src/blob/requests/update_page_builder.rs
+++ b/sdk/storage_blobs/src/blob/requests/update_page_builder.rs
@@ -1,6 +1,5 @@
 use crate::{blob::responses::UpdatePageResponse, prelude::*, BA512Range};
 use azure_core::{
-    error::Result,
     headers::{
         add_mandatory_header, add_optional_header, add_optional_header_ref, BLOB_TYPE, PAGE_WRITE,
     },
@@ -52,7 +51,7 @@ impl<'a> UpdatePageBuilder<'a> {
         lease_id: &'a LeaseId => Some(lease_id),
     }
 
-    pub async fn execute(&self) -> Result<UpdatePageResponse> {
+    pub async fn execute(&self) -> azure_core::Result<UpdatePageResponse> {
         let mut url = self.blob_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/responses/copy_blob_from_url_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/copy_blob_from_url_response.rs
@@ -1,6 +1,6 @@
 use crate::blob::{copy_status_from_headers, CopyStatus};
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     headers::{
         date_from_headers, etag_from_headers, last_modified_from_headers, request_id_from_headers,
         server_from_headers, version_from_headers,
@@ -31,7 +31,7 @@ pub struct CopyBlobFromUrlResponse {
 
 impl TryFrom<&HeaderMap> for CopyBlobFromUrlResponse {
     type Error = crate::Error;
-    fn try_from(headers: &HeaderMap) -> Result<Self> {
+    fn try_from(headers: &HeaderMap) -> azure_core::Result<Self> {
         debug!("headers == {:#?}", headers);
         Ok(Self {
             content_md5: content_md5_from_headers_optional(headers)

--- a/sdk/storage_blobs/src/blob/responses/copy_blob_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/copy_blob_response.rs
@@ -1,6 +1,6 @@
 use crate::blob::{copy_status_from_headers, CopyStatus};
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     headers::{
         client_request_id_from_headers_optional, date_from_headers, etag_from_headers,
         last_modified_from_headers, request_id_from_headers, server_from_headers,
@@ -29,7 +29,7 @@ pub struct CopyBlobResponse {
 impl TryFrom<&HeaderMap> for CopyBlobResponse {
     type Error = crate::Error;
 
-    fn try_from(headers: &HeaderMap) -> Result<Self> {
+    fn try_from(headers: &HeaderMap) -> azure_core::Result<Self> {
         trace!("CopyBlobResponse headers == {:#?}", headers);
         Ok(Self {
             etag: etag_from_headers(headers)?,

--- a/sdk/storage_blobs/src/blob/responses/get_blob_properties_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/get_blob_properties_response.rs
@@ -17,7 +17,7 @@ impl GetBlobPropertiesResponse {
     pub(crate) fn from_response(
         headers: &HeaderMap,
         blob: Blob,
-    ) -> crate::Result<GetBlobPropertiesResponse> {
+    ) -> azure_core::Result<GetBlobPropertiesResponse> {
         debug!("headers == {:#?}", headers);
 
         let request_id = request_id_from_headers(headers)?;

--- a/sdk/storage_blobs/src/blob/responses/get_blob_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/get_blob_response.rs
@@ -1,6 +1,6 @@
 use crate::blob::Blob;
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     headers::{date_from_headers, request_id_from_headers},
     prelude::ContentRange,
     RequestId,
@@ -21,7 +21,7 @@ pub struct GetBlobResponse {
 
 impl TryFrom<(&str, Response<Bytes>)> for GetBlobResponse {
     type Error = crate::Error;
-    fn try_from((blob_name, response): (&str, Response<Bytes>)) -> Result<Self> {
+    fn try_from((blob_name, response): (&str, Response<Bytes>)) -> azure_core::Result<Self> {
         debug!("response.headers() == {:#?}", response.headers());
 
         let request_id = request_id_from_headers(response.headers())?;

--- a/sdk/storage_blobs/src/blob/responses/get_block_list_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/get_block_list_response.rs
@@ -23,7 +23,7 @@ impl GetBlockListResponse {
     pub(crate) fn from_response(
         headers: &HeaderMap,
         body: &[u8],
-    ) -> crate::Result<GetBlockListResponse> {
+    ) -> azure_core::Result<GetBlockListResponse> {
         let etag = etag_from_headers_optional(headers)?;
         let last_modified = last_modified_from_headers_optional(headers)?;
         let request_id = request_id_from_headers(headers)?;

--- a/sdk/storage_blobs/src/blob/responses/get_page_ranges_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/get_page_ranges_response.rs
@@ -22,7 +22,7 @@ impl GetPageRangesResponse {
     pub(crate) fn from_response(
         headers: &HeaderMap,
         body: &[u8],
-    ) -> crate::Result<GetPageRangesResponse> {
+    ) -> azure_core::Result<GetPageRangesResponse> {
         let etag = etag_from_headers(headers)?;
         let last_modified = last_modified_from_headers(headers)?;
         let request_id = request_id_from_headers(headers)?;

--- a/sdk/storage_blobs/src/blob/responses/list_blobs_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/list_blobs_response.rs
@@ -1,6 +1,6 @@
 use crate::blob::Blob;
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     headers::{date_from_headers, request_id_from_headers},
     prelude::NextMarker,
     RequestId,
@@ -48,7 +48,7 @@ pub struct BlobPrefix {
 impl TryFrom<&http::Response<Bytes>> for ListBlobsResponse {
     type Error = crate::Error;
 
-    fn try_from(response: &http::Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &http::Response<Bytes>) -> azure_core::Result<Self> {
         let body = response.body();
 
         trace!("body == {:?}", body);

--- a/sdk/storage_blobs/src/blob/responses/put_blob_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/put_blob_response.rs
@@ -18,7 +18,7 @@ pub struct PutBlobResponse {
 }
 
 impl PutBlobResponse {
-    pub fn from_headers(headers: &HeaderMap) -> crate::Result<PutBlobResponse> {
+    pub fn from_headers(headers: &HeaderMap) -> azure_core::Result<PutBlobResponse> {
         debug!("{:#?}", headers);
 
         let etag = etag_from_headers(headers)?;

--- a/sdk/storage_blobs/src/blob/responses/put_block_blob_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/put_block_blob_response.rs
@@ -22,7 +22,7 @@ pub struct PutBlockBlobResponse {
 }
 
 impl PutBlockBlobResponse {
-    pub fn from_headers(headers: &HeaderMap) -> crate::Result<PutBlockBlobResponse> {
+    pub fn from_headers(headers: &HeaderMap) -> azure_core::Result<PutBlockBlobResponse> {
         debug!("headers == {:#?}", headers);
 
         let etag = etag_from_headers(headers)?;

--- a/sdk/storage_blobs/src/blob/responses/put_block_list_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/put_block_list_response.rs
@@ -21,7 +21,7 @@ pub struct PutBlockListResponse {
 }
 
 impl PutBlockListResponse {
-    pub(crate) fn from_headers(headers: &HeaderMap) -> crate::Result<PutBlockListResponse> {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> azure_core::Result<PutBlockListResponse> {
         debug!("headers == {:#?}", headers);
 
         let etag = etag_from_headers(headers)?;

--- a/sdk/storage_blobs/src/blob/responses/put_block_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/put_block_response.rs
@@ -17,7 +17,7 @@ pub struct PutBlockResponse {
 }
 
 impl PutBlockResponse {
-    pub(crate) fn from_headers(headers: &HeaderMap) -> crate::Result<PutBlockResponse> {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> azure_core::Result<PutBlockResponse> {
         debug!("{:#?}", headers);
 
         let (content_md5, content_crc64) =

--- a/sdk/storage_blobs/src/blob/responses/update_page_response.rs
+++ b/sdk/storage_blobs/src/blob/responses/update_page_response.rs
@@ -22,7 +22,7 @@ pub struct UpdatePageResponse {
 }
 
 impl UpdatePageResponse {
-    pub(crate) fn from_headers(headers: &HeaderMap) -> crate::Result<UpdatePageResponse> {
+    pub(crate) fn from_headers(headers: &HeaderMap) -> azure_core::Result<UpdatePageResponse> {
         let etag = etag_from_headers(headers)?;
         let last_modified = last_modified_from_headers(headers)?;
         let content_md5 = content_md5_from_headers(headers).map_kind(ErrorKind::DataConversion)?;

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -1,6 +1,6 @@
 use crate::{blob::requests::*, prelude::*, BA512Range};
 use azure_core::{
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     prelude::*,
     HttpClient,
 };
@@ -67,7 +67,7 @@ impl BlobClient {
         self.container_client.as_ref()
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
+    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -178,7 +178,7 @@ impl BlobClient {
 
     pub fn shared_access_signature(
         &self,
-    ) -> Result<BlobSharedAccessSignatureBuilder<(), SetResources, ()>> {
+    ) -> azure_core::Result<BlobSharedAccessSignatureBuilder<(), SetResources, ()>> {
         let canonicalized_resource = format!(
             "/blob/{}/{}/{}",
             self.container_client.storage_account_client().account(),
@@ -197,7 +197,7 @@ impl BlobClient {
         }
     }
 
-    pub fn generate_signed_blob_url<T>(&self, signature: &T) -> Result<url::Url>
+    pub fn generate_signed_blob_url<T>(&self, signature: &T) -> azure_core::Result<url::Url>
     where
         T: SasToken,
     {
@@ -212,12 +212,12 @@ impl BlobClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> crate::Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.container_client
             .prepare_request(url, method, http_header_adder, request_body)
     }
 
-    pub async fn exists(&self) -> Result<bool> {
+    pub async fn exists(&self) -> azure_core::Result<bool> {
         let result = self.get_properties().execute().await.map(|_| true);
         if let Err(err) = result {
             if let ErrorKind::HttpResponse { status, .. } = err.kind() {

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -1,5 +1,5 @@
 use crate::{blob::requests::*, prelude::*};
-use azure_core::{error::Result, prelude::*, HttpClient};
+use azure_core::{prelude::*, HttpClient};
 use azure_storage::core::prelude::*;
 use bytes::Bytes;
 use http::{
@@ -55,7 +55,7 @@ impl BlobLeaseClient {
         self.blob_client.as_ref()
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
+    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -80,7 +80,7 @@ impl BlobLeaseClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> crate::Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.blob_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -1,6 +1,6 @@
 use crate::{container::requests::*, prelude::PublicAccess};
 use azure_core::{
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     prelude::*,
     HttpClient,
 };
@@ -64,7 +64,7 @@ impl ContainerClient {
         self.storage_client.storage_account_client()
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
+    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -116,7 +116,7 @@ impl ContainerClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> crate::Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.storage_client
             .prepare_request(url, method, http_header_adder, request_body)
             .map_kind(ErrorKind::DataConversion)
@@ -124,7 +124,7 @@ impl ContainerClient {
 
     pub fn shared_access_signature(
         &self,
-    ) -> Result<BlobSharedAccessSignatureBuilder<(), SetResources, ()>> {
+    ) -> azure_core::Result<BlobSharedAccessSignatureBuilder<(), SetResources, ()>> {
         let canonicalized_resource = format!(
             "/blob/{}/{}",
             self.storage_account_client().account(),
@@ -142,7 +142,7 @@ impl ContainerClient {
         }
     }
 
-    pub fn generate_signed_container_url<T>(&self, signature: &T) -> Result<url::Url>
+    pub fn generate_signed_container_url<T>(&self, signature: &T) -> azure_core::Result<url::Url>
     where
         T: SasToken,
     {

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -1,5 +1,5 @@
 use crate::{container::requests::*, prelude::*};
-use azure_core::{error::Result, prelude::*, HttpClient};
+use azure_core::{prelude::*, HttpClient};
 use azure_storage::core::prelude::*;
 use bytes::Bytes;
 use http::{
@@ -50,7 +50,7 @@ impl ContainerLeaseClient {
         self.container_client.as_ref()
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
+    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {
@@ -71,7 +71,7 @@ impl ContainerLeaseClient {
         method: &Method,
         http_header_adder: &dyn Fn(Builder) -> Builder,
         request_body: Option<Bytes>,
-    ) -> crate::Result<(Request<Bytes>, url::Url)> {
+    ) -> azure_core::Result<(Request<Bytes>, url::Url)> {
         self.container_client
             .prepare_request(url, method, http_header_adder, request_body)
     }

--- a/sdk/storage_blobs/src/container/mod.rs
+++ b/sdk/storage_blobs/src/container/mod.rs
@@ -40,7 +40,9 @@ impl AsHeaders for PublicAccess {
     }
 }
 
-pub(crate) fn public_access_from_header(header_map: &HeaderMap) -> crate::Result<PublicAccess> {
+pub(crate) fn public_access_from_header(
+    header_map: &HeaderMap,
+) -> azure_core::Result<PublicAccess> {
     let pa = match header_map.get(BLOB_PUBLIC_ACCESS) {
         Some(pa) => PublicAccess::from_str(pa.to_str().map_kind(ErrorKind::DataConversion)?)
             .map_kind(ErrorKind::DataConversion)?,
@@ -85,7 +87,10 @@ impl Container {
         }
     }
 
-    pub(crate) fn from_response<NAME>(name: NAME, headers: &HeaderMap) -> crate::Result<Container>
+    pub(crate) fn from_response<NAME>(
+        name: NAME,
+        headers: &HeaderMap,
+    ) -> azure_core::Result<Container>
     where
         NAME: Into<String>,
     {
@@ -192,7 +197,7 @@ impl Container {
         })
     }
 
-    fn parse(elem: &Element) -> crate::Result<Container> {
+    fn parse(elem: &Element) -> azure_core::Result<Container> {
         let name = cast_must::<String>(elem, &["Name"]).map_kind(ErrorKind::DataConversion)?;
         let last_modified = cast_must::<DateTime<Utc>>(elem, &["Properties", "Last-Modified"])
             .map_kind(ErrorKind::DataConversion)?;
@@ -283,7 +288,7 @@ impl Container {
 
 pub(crate) fn incomplete_vector_from_container_response(
     body: &str,
-) -> crate::Result<IncompleteVector<Container>> {
+) -> azure_core::Result<IncompleteVector<Container>> {
     let elem: Element = body.parse().map_kind(ErrorKind::Other)?;
 
     let mut v = Vec::new();

--- a/sdk/storage_blobs/src/container/requests/acquire_lease_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/acquire_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::responses::AcquireLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, add_optional_header_ref, LEASE_ACTION},
     prelude::*,
 };
@@ -38,7 +37,7 @@ impl<'a> AcquireLeaseBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<AcquireLeaseResponse> {
+    pub async fn execute(&self) -> azure_core::Result<AcquireLeaseResponse> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/break_lease_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/break_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::responses::BreakLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref, LEASE_ACTION},
     prelude::*,
 };
@@ -33,7 +32,7 @@ impl<'a> BreakLeaseBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(self) -> Result<BreakLeaseResponse> {
+    pub async fn execute(self) -> azure_core::Result<BreakLeaseResponse> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/create_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/create_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::PublicAccess, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, AsHeaders},
     prelude::*,
 };
@@ -33,7 +32,7 @@ impl<'a> CreateBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> azure_core::Result<()> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/delete_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/delete_builder.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -31,7 +30,7 @@ impl<'a> DeleteBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(self) -> Result<()> {
+    pub async fn execute(self) -> azure_core::Result<()> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/get_acl_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/get_acl_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::responses::GetACLResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -31,7 +30,7 @@ impl<'a> GetACLBuilder<'a> {
         lease_id: &'a LeaseId => Some(lease_id),
     }
 
-    pub async fn execute(self) -> Result<GetACLResponse> {
+    pub async fn execute(self) -> azure_core::Result<GetACLResponse> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/get_properties_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/get_properties_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::responses::GetPropertiesResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref},
     prelude::*,
 };
@@ -31,7 +30,7 @@ impl<'a> GetPropertiesBuilder<'a> {
         lease_id: &'a LeaseId => Some(lease_id),
     }
 
-    pub async fn execute(&self) -> Result<GetPropertiesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetPropertiesResponse> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/list_blobs_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/list_blobs_builder.rs
@@ -1,5 +1,5 @@
 use crate::{blob::responses::ListBlobsResponse, prelude::*};
-use azure_core::{error::Result, headers::add_optional_header, prelude::*};
+use azure_core::{headers::add_optional_header, prelude::*};
 use futures::stream::{unfold, Stream};
 use http::{method::Method, status::StatusCode};
 use std::convert::TryInto;
@@ -58,7 +58,7 @@ impl<'a> ListBlobsBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<ListBlobsResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ListBlobsResponse> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");
@@ -124,7 +124,7 @@ impl<'a> ListBlobsBuilder<'a> {
         (&response).try_into()
     }
 
-    pub fn stream(self) -> impl Stream<Item = Result<ListBlobsResponse>> + 'a {
+    pub fn stream(self) -> impl Stream<Item = azure_core::Result<ListBlobsResponse>> + 'a {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/storage_blobs/src/container/requests/list_containers_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/list_containers_builder.rs
@@ -2,7 +2,6 @@ use crate::container::{
     incomplete_vector_from_container_response, responses::ListContainersResponse,
 };
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, request_id_from_headers},
     prelude::*,
 };
@@ -46,7 +45,7 @@ impl<'a> ListContainersBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<ListContainersResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ListContainersResponse> {
         let mut url = self
             .storage_client
             .storage_account_client()
@@ -100,7 +99,7 @@ impl<'a> ListContainersBuilder<'a> {
         })
     }
 
-    pub fn stream(self) -> impl Stream<Item = Result<ListContainersResponse>> + 'a {
+    pub fn stream(self) -> impl Stream<Item = azure_core::Result<ListContainersResponse>> + 'a {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/storage_blobs/src/container/requests/release_lease_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/release_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::responses::ReleaseLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, LEASE_ACTION},
     prelude::*,
 };
@@ -27,7 +26,7 @@ impl<'a> ReleaseLeaseBuilder<'a> {
         timeout: Timeout => Some(timeout),
     }
 
-    pub async fn execute(&self) -> Result<ReleaseLeaseResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ReleaseLeaseResponse> {
         let mut url = self.container_lease_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/renew_lease_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/renew_lease_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::responses::RenewLeaseResponse, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_mandatory_header, add_optional_header, LEASE_ACTION},
     prelude::*,
 };
@@ -22,7 +21,7 @@ impl<'a> RenewLeaseBuilder<'a> {
         }
     }
 
-    pub async fn execute(&self) -> Result<RenewLeaseResponse> {
+    pub async fn execute(&self) -> azure_core::Result<RenewLeaseResponse> {
         let mut url = self.container_lease_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/requests/set_acl_builder.rs
+++ b/sdk/storage_blobs/src/container/requests/set_acl_builder.rs
@@ -1,6 +1,5 @@
 use crate::{container::public_access_from_header, prelude::*};
 use azure_core::{
-    error::Result,
     headers::{add_optional_header, add_optional_header_ref, AsHeaders},
     prelude::*,
 };
@@ -37,7 +36,7 @@ impl<'a> SetACLBuilder<'a> {
         stored_access_policy_list: &'a StoredAccessPolicyList => Some(stored_access_policy_list),
     }
 
-    pub async fn execute(&self) -> Result<PublicAccess> {
+    pub async fn execute(&self) -> azure_core::Result<PublicAccess> {
         let mut url = self.container_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("restype", "container");

--- a/sdk/storage_blobs/src/container/responses/get_acl_response.rs
+++ b/sdk/storage_blobs/src/container/responses/get_acl_response.rs
@@ -1,6 +1,6 @@
 use crate::container::{public_access_from_header, PublicAccess};
 use azure_core::{
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     headers::REQUEST_ID,
     RequestId,
 };
@@ -24,7 +24,7 @@ pub struct GetACLResponse {
 impl TryFrom<(&Bytes, &HeaderMap)> for GetACLResponse {
     type Error = crate::Error;
 
-    fn try_from((body, header_map): (&Bytes, &HeaderMap)) -> Result<Self> {
+    fn try_from((body, header_map): (&Bytes, &HeaderMap)) -> azure_core::Result<Self> {
         GetACLResponse::from_response(body, header_map)
     }
 }
@@ -34,7 +34,7 @@ impl GetACLResponse {
     pub(crate) fn from_response(
         body: &Bytes,
         headers: &HeaderMap,
-    ) -> crate::Result<GetACLResponse> {
+    ) -> azure_core::Result<GetACLResponse> {
         let public_access = public_access_from_header(headers)?;
 
         let etag = match headers.get(header::ETAG) {

--- a/sdk/storage_blobs/src/container/responses/get_properties_response.rs
+++ b/sdk/storage_blobs/src/container/responses/get_properties_response.rs
@@ -1,6 +1,6 @@
 use crate::container::Container;
 use azure_core::{
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, ResultExt},
     headers::REQUEST_ID,
     RequestId,
 };
@@ -19,7 +19,7 @@ pub struct GetPropertiesResponse {
 impl TryFrom<(&str, &HeaderMap)> for GetPropertiesResponse {
     type Error = crate::Error;
 
-    fn try_from((body, header_map): (&str, &HeaderMap)) -> Result<Self> {
+    fn try_from((body, header_map): (&str, &HeaderMap)) -> azure_core::Result<Self> {
         GetPropertiesResponse::from_response(body, header_map)
     }
 }
@@ -28,7 +28,7 @@ impl GetPropertiesResponse {
     pub(crate) fn from_response(
         container_name: &str,
         headers: &HeaderMap,
-    ) -> crate::Result<GetPropertiesResponse> {
+    ) -> azure_core::Result<GetPropertiesResponse> {
         let request_id = match headers.get(REQUEST_ID) {
             Some(request_id) => {
                 Uuid::parse_str(request_id.to_str().map_kind(ErrorKind::DataConversion)?)

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -5,7 +5,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate azure_core;
 
-pub use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+pub use azure_core::error::{Error, ErrorKind, ResultExt};
 
 mod access_tier;
 mod ba512_range;

--- a/sdk/storage_blobs/tests/stream_blob00.rs
+++ b/sdk/storage_blobs/tests/stream_blob00.rs
@@ -1,6 +1,6 @@
 #![cfg(all(test, feature = "test_e2e"))]
 use azure_core::{
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, ResultExt},
     prelude::*,
 };
 use azure_storage::core::prelude::*;
@@ -12,7 +12,7 @@ async fn create_blob_and_stream_back() {
     code().await.unwrap();
 }
 
-async fn code() -> Result<()> {
+async fn code() -> azure_core::Result<()> {
     let container_name = "azuresdkforrust";
     let file_name = "azure_sdk_for_rust_stream_test.txt";
 

--- a/sdk/storage_datalake/examples/directory.rs
+++ b/sdk/storage_datalake/examples/directory.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
 use azure_storage_datalake::prelude::*;
 use chrono::Utc;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let data_lake_client = create_data_lake_client().await.unwrap();
 
     let file_system_name = format!("azurerustsdk-datalake-example00-{}", Utc::now().timestamp());
@@ -66,7 +65,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn create_data_lake_client() -> Result<DataLakeClient> {
+async fn create_data_lake_client() -> azure_core::Result<DataLakeClient> {
     let account_name = std::env::var("ADLSGEN2_STORAGE_ACCOUNT")
         .expect("Set env variable ADLSGEN2_STORAGE_ACCOUNT first!");
     let account_key = std::env::var("ADLSGEN2_STORAGE_MASTER_KEY")

--- a/sdk/storage_datalake/examples/file_create_delete.rs
+++ b/sdk/storage_datalake/examples/file_create_delete.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
 use azure_storage_datalake::prelude::*;
 use chrono::Utc;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let data_lake_client = create_data_lake_client().await.unwrap();
 
     let file_system_name = format!("azurerustsdk-datalake-example01-{}", Utc::now().timestamp());
@@ -69,7 +68,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn create_data_lake_client() -> Result<DataLakeClient> {
+async fn create_data_lake_client() -> azure_core::Result<DataLakeClient> {
     let account_name = std::env::var("ADLSGEN2_STORAGE_ACCOUNT")
         .expect("Set env variable ADLSGEN2_STORAGE_ACCOUNT first!");
     let account_key = std::env::var("ADLSGEN2_STORAGE_MASTER_KEY")

--- a/sdk/storage_datalake/examples/file_rename.rs
+++ b/sdk/storage_datalake/examples/file_rename.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
 use azure_storage_datalake::prelude::*;
 use chrono::Utc;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let data_lake_client = create_data_lake_client().await.unwrap();
 
     let file_system_name = format!("azurerustsdk-datalake-example01-{}", Utc::now().timestamp());
@@ -59,7 +58,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn create_data_lake_client() -> Result<DataLakeClient> {
+async fn create_data_lake_client() -> azure_core::Result<DataLakeClient> {
     let account_name = std::env::var("ADLSGEN2_STORAGE_ACCOUNT")
         .expect("Set env variable ADLSGEN2_STORAGE_ACCOUNT first!");
     let account_key = std::env::var("ADLSGEN2_STORAGE_MASTER_KEY")

--- a/sdk/storage_datalake/examples/file_upload.rs
+++ b/sdk/storage_datalake/examples/file_upload.rs
@@ -1,10 +1,9 @@
-use azure_core::error::Result;
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
 use azure_storage_datalake::prelude::*;
 use chrono::Utc;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let data_lake_client = create_data_lake_client().await.unwrap();
 
     let file_system_name = format!("azurerustsdk-datalake-example01-{}", Utc::now().timestamp());
@@ -61,7 +60,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn create_data_lake_client() -> Result<DataLakeClient> {
+async fn create_data_lake_client() -> azure_core::Result<DataLakeClient> {
     let account_name = std::env::var("ADLSGEN2_STORAGE_ACCOUNT")
         .expect("Set env variable ADLSGEN2_STORAGE_ACCOUNT first!");
     let account_key = std::env::var("ADLSGEN2_STORAGE_MASTER_KEY")

--- a/sdk/storage_datalake/examples/filesystem.rs
+++ b/sdk/storage_datalake/examples/filesystem.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Result;
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
 use azure_storage_datalake::prelude::*;
 use chrono::Utc;
@@ -6,7 +5,7 @@ use futures::stream::StreamExt;
 use std::num::NonZeroU32;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     let data_lake_client = create_data_lake_client().await.unwrap();
 
     let file_system_name = format!("azurerustsdk-datalake-example00-{}", Utc::now().timestamp());
@@ -66,7 +65,7 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
-async fn create_data_lake_client() -> Result<DataLakeClient> {
+async fn create_data_lake_client() -> azure_core::Result<DataLakeClient> {
     let account_name = std::env::var("ADLSGEN2_STORAGE_ACCOUNT")
         .expect("Set env variable ADLSGEN2_STORAGE_ACCOUNT first!");
     let account_key = std::env::var("ADLSGEN2_STORAGE_MASTER_KEY")

--- a/sdk/storage_datalake/src/clients/directory_client.rs
+++ b/sdk/storage_datalake/src/clients/directory_client.rs
@@ -6,7 +6,7 @@ use crate::{
     Properties,
 };
 use azure_core::prelude::IfMatchCondition;
-use azure_core::{error::Result, ClientOptions, Context, Pipeline};
+use azure_core::{ClientOptions, Context, Pipeline};
 use azure_storage::core::storage_shared_key_credential::StorageSharedKeyCredential;
 use url::Url;
 
@@ -17,7 +17,7 @@ pub struct DirectoryClient {
 }
 
 impl PathClient for DirectoryClient {
-    fn url(&self) -> Result<Url> {
+    fn url(&self) -> azure_core::Result<Url> {
         let fs_url = self.file_system_client.url()?;
         let dir_path = vec![fs_url.path(), &self.dir_path].join("/");
         Ok(self.file_system_client.url()?.join(&dir_path)?)

--- a/sdk/storage_datalake/src/clients/file_client.rs
+++ b/sdk/storage_datalake/src/clients/file_client.rs
@@ -1,6 +1,5 @@
 use super::{DataLakeClient, FileSystemClient, PathClient};
 use crate::{operations::*, request_options::*, Properties};
-use azure_core::error::Result;
 use azure_core::prelude::IfMatchCondition;
 use azure_core::{ClientOptions, Context, Pipeline};
 use azure_storage::core::storage_shared_key_credential::StorageSharedKeyCredential;
@@ -14,7 +13,7 @@ pub struct FileClient {
 }
 
 impl PathClient for FileClient {
-    fn url(&self) -> Result<Url> {
+    fn url(&self) -> azure_core::Result<Url> {
         let fs_url = self.file_system_client.url()?;
         let file_path = vec![fs_url.path(), &self.file_path].join("/");
         Ok(self.file_system_client.url()?.join(&file_path)?)

--- a/sdk/storage_datalake/src/clients/file_system_client.rs
+++ b/sdk/storage_datalake/src/clients/file_system_client.rs
@@ -1,7 +1,7 @@
 use super::{DataLakeClient, DirectoryClient, FileClient};
 use crate::operations::*;
 use crate::Properties;
-use azure_core::{error::Result, ClientOptions, Context, Pipeline};
+use azure_core::{ClientOptions, Context, Pipeline};
 use azure_storage::core::storage_shared_key_credential::StorageSharedKeyCredential;
 use url::Url;
 
@@ -36,7 +36,7 @@ impl FileSystemClient {
             .into_file_system_client(file_system_name.into())
     }
 
-    pub(crate) fn url(&self) -> Result<Url> {
+    pub(crate) fn url(&self) -> azure_core::Result<Url> {
         Ok(url::Url::parse(self.data_lake_client.url())?.join(&self.name)?)
     }
 

--- a/sdk/storage_datalake/src/clients/mod.rs
+++ b/sdk/storage_datalake/src/clients/mod.rs
@@ -11,7 +11,7 @@ pub use file_client::FileClient;
 pub use file_system_client::FileSystemClient;
 
 pub trait PathClient: Debug + Clone + Send + Sync {
-    fn url(&self) -> azure_core::error::Result<url::Url>;
+    fn url(&self) -> azure_core::Result<url::Url>;
     fn prepare_request(&self, uri: &str, http_method: http::Method) -> azure_core::Request;
     fn pipeline(&self) -> &azure_core::Pipeline;
     fn context(&self) -> &azure_core::Context;

--- a/sdk/storage_datalake/src/operations/file_system_create.rs
+++ b/sdk/storage_datalake/src/operations/file_system_create.rs
@@ -3,7 +3,6 @@ use crate::util::*;
 use crate::Properties;
 use azure_core::prelude::{ClientRequestId, ContentLength, Timeout};
 use azure_core::{
-    error::Result,
     headers::{etag_from_headers, last_modified_from_headers},
     AppendToUrlQuery, Etag, Response as HttpResponse,
 };
@@ -12,7 +11,8 @@ use chrono::{DateTime, Utc};
 use std::convert::TryInto;
 
 /// A future of a create file system response
-type CreateFileSystem = futures::future::BoxFuture<'static, Result<CreateFileSystemResponse>>;
+type CreateFileSystem =
+    futures::future::BoxFuture<'static, azure_core::Result<CreateFileSystemResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct CreateFileSystemBuilder {
@@ -73,7 +73,7 @@ pub struct CreateFileSystemResponse {
 }
 
 impl CreateFileSystemResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/file_system_delete.rs
+++ b/sdk/storage_datalake/src/operations/file_system_delete.rs
@@ -1,11 +1,12 @@
 use crate::clients::FileSystemClient;
 use azure_core::prelude::*;
-use azure_core::{error::Result, AppendToUrlQuery, Response as HttpResponse};
+use azure_core::{AppendToUrlQuery, Response as HttpResponse};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
 /// A future of a create file system response
-type DeleteFileSystem = futures::future::BoxFuture<'static, Result<DeleteFileSystemResponse>>;
+type DeleteFileSystem =
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteFileSystemResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct DeleteFileSystemBuilder {
@@ -65,7 +66,7 @@ pub struct DeleteFileSystemResponse {
 }
 
 impl DeleteFileSystemResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/file_system_get_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_get_properties.rs
@@ -3,7 +3,7 @@ use crate::{util::*, Properties};
 use azure_core::error::ResultExt;
 use azure_core::prelude::*;
 use azure_core::{
-    error::{ErrorKind, Result},
+    error::ErrorKind,
     headers::{etag_from_headers, last_modified_from_headers},
     AppendToUrlQuery, Etag, Response as HttpResponse,
 };
@@ -13,7 +13,7 @@ use std::convert::TryInto;
 
 /// A future of a file system get properties response
 type GetFileSystemProperties =
-    futures::future::BoxFuture<'static, Result<GetFileSystemPropertiesResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<GetFileSystemPropertiesResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct GetFileSystemPropertiesBuilder {
@@ -73,7 +73,7 @@ pub struct GetFileSystemPropertiesResponse {
 }
 
 impl GetFileSystemPropertiesResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(GetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/file_system_set_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_set_properties.rs
@@ -2,7 +2,6 @@ use crate::clients::FileSystemClient;
 use crate::Properties;
 use azure_core::prelude::*;
 use azure_core::{
-    error::Result,
     headers::{etag_from_headers, last_modified_from_headers},
     AppendToUrlQuery, Etag, Response as HttpResponse,
 };
@@ -12,7 +11,7 @@ use std::convert::TryInto;
 
 /// A future of a file system set properties response
 type SetFileSystemProperties =
-    futures::future::BoxFuture<'static, Result<SetFileSystemPropertiesResponse>>;
+    futures::future::BoxFuture<'static, azure_core::Result<SetFileSystemPropertiesResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct SetFileSystemPropertiesBuilder {
@@ -78,7 +77,7 @@ pub struct SetFileSystemPropertiesResponse {
 }
 
 impl SetFileSystemPropertiesResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(SetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/file_systems_list.rs
+++ b/sdk/storage_datalake/src/operations/file_systems_list.rs
@@ -4,7 +4,7 @@ use azure_core::error::ResultExt;
 use azure_core::AppendToUrlQuery;
 use azure_core::{
     collect_pinned_stream,
-    error::{Error, ErrorKind, Result},
+    error::{Error, ErrorKind},
     prelude::*,
     Pageable, Response,
 };
@@ -91,7 +91,7 @@ pub struct ListFileSystemsResponse {
 }
 
 impl ListFileSystemsResponse {
-    pub(crate) async fn try_from(response: Response) -> Result<Self> {
+    pub(crate) async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
         let file_system_list: FileSystemList =

--- a/sdk/storage_datalake/src/operations/path_delete.rs
+++ b/sdk/storage_datalake/src/operations/path_delete.rs
@@ -1,12 +1,12 @@
 use crate::clients::PathClient;
 use crate::request_options::*;
 use azure_core::prelude::*;
-use azure_core::{error::Result, AppendToUrlQuery, Response as HttpResponse};
+use azure_core::{AppendToUrlQuery, Response as HttpResponse};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
 /// A future of a delete file response
-type PutPath = futures::future::BoxFuture<'static, Result<DeletePathResponse>>;
+type PutPath = futures::future::BoxFuture<'static, azure_core::Result<DeletePathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct DeletePathBuilder<C>
@@ -86,7 +86,7 @@ pub struct DeletePathResponse {
 }
 
 impl DeletePathResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/path_get.rs
+++ b/sdk/storage_datalake/src/operations/path_get.rs
@@ -3,9 +3,7 @@ use azure_core::error::ResultExt;
 use azure_core::headers::{etag_from_headers, last_modified_from_headers};
 use azure_core::prelude::*;
 use azure_core::{
-    collect_pinned_stream,
-    error::{ErrorKind, Result},
-    AppendToUrlQuery, Response as HttpResponse,
+    collect_pinned_stream, error::ErrorKind, AppendToUrlQuery, Response as HttpResponse,
 };
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -14,7 +12,7 @@ use std::convert::TryInto;
 use std::str::FromStr;
 
 /// A future of a delete file response
-type GetFile = futures::future::BoxFuture<'static, Result<GetFileResponse>>;
+type GetFile = futures::future::BoxFuture<'static, azure_core::Result<GetFileResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct GetFileBuilder {
@@ -92,7 +90,7 @@ pub struct GetFileResponse {
 }
 
 impl GetFileResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
 
         let data = collect_pinned_stream(pinned_stream).await?;

--- a/sdk/storage_datalake/src/operations/path_head.rs
+++ b/sdk/storage_datalake/src/operations/path_head.rs
@@ -5,16 +5,13 @@ use azure_core::headers::{
     last_modified_from_headers, CONTENT_LENGTH, CONTENT_TYPE,
 };
 use azure_core::prelude::*;
-use azure_core::{
-    error::{ErrorKind, Result},
-    AppendToUrlQuery, Response as HttpResponse,
-};
+use azure_core::{error::ErrorKind, AppendToUrlQuery, Response as HttpResponse};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use chrono::{DateTime, Utc};
 use std::convert::TryInto;
 
 /// A future of a delete file response
-type HeadPath = futures::future::BoxFuture<'static, Result<HeadPathResponse>>;
+type HeadPath = futures::future::BoxFuture<'static, azure_core::Result<HeadPathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct HeadPathBuilder<C>
@@ -101,7 +98,7 @@ pub struct HeadPathResponse {
 }
 
 impl HeadPathResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/path_list.rs
+++ b/sdk/storage_datalake/src/operations/path_list.rs
@@ -4,10 +4,7 @@ use crate::{
     request_options::*,
 };
 use azure_core::{
-    collect_pinned_stream,
-    error::{Error, Result},
-    prelude::*,
-    AppendToUrlQuery, Pageable, Response,
+    collect_pinned_stream, error::Error, prelude::*, AppendToUrlQuery, Pageable, Response,
 };
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
@@ -101,7 +98,7 @@ pub struct ListPathsResponse {
 }
 
 impl ListPathsResponse {
-    pub(crate) async fn try_from(response: Response) -> Result<Self> {
+    pub(crate) async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, pinned_stream) = response.deconstruct();
         let body = collect_pinned_stream(pinned_stream).await?;
         let path_list: PathList = body.try_into()?;

--- a/sdk/storage_datalake/src/operations/path_patch.rs
+++ b/sdk/storage_datalake/src/operations/path_patch.rs
@@ -3,7 +3,7 @@ use crate::request_options::*;
 use crate::Properties;
 use azure_core::headers::{etag_from_headers, last_modified_from_headers};
 use azure_core::prelude::*;
-use azure_core::{error::Result, AppendToUrlQuery, Response as HttpResponse};
+use azure_core::{AppendToUrlQuery, Response as HttpResponse};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -11,7 +11,7 @@ use futures::future::BoxFuture;
 use std::convert::TryInto;
 
 /// A future of a patch file response
-type PatchPath = BoxFuture<'static, Result<PatchPathResponse>>;
+type PatchPath = BoxFuture<'static, azure_core::Result<PatchPathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct PatchPathBuilder<C>
@@ -120,7 +120,7 @@ pub struct PatchPathResponse {
 }
 
 impl PatchPathResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         let etag = match etag_from_headers(&headers) {

--- a/sdk/storage_datalake/src/operations/path_put.rs
+++ b/sdk/storage_datalake/src/operations/path_put.rs
@@ -3,14 +3,14 @@ use crate::request_options::*;
 use crate::Properties;
 use azure_core::headers::{etag_from_headers, last_modified_from_headers};
 use azure_core::prelude::*;
-use azure_core::{error::Result, AppendToUrlQuery, Response as HttpResponse};
+use azure_core::{AppendToUrlQuery, Response as HttpResponse};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
 use std::convert::TryInto;
 
 /// A future of a delete file response
-type PutPath = BoxFuture<'static, Result<PutPathResponse>>;
+type PutPath = BoxFuture<'static, azure_core::Result<PutPathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct PutPathBuilder<C>
@@ -135,7 +135,7 @@ impl<C: PathClient + 'static> RenamePathBuilder<C> {
         context: Context => context,
     }
 
-    pub fn into_future(self) -> BoxFuture<'static, Result<C>> {
+    pub fn into_future(self) -> BoxFuture<'static, azure_core::Result<C>> {
         let this = self.clone();
         let ctx = self.context.clone();
 
@@ -176,7 +176,7 @@ pub struct PutPathResponse {
 }
 
 impl PutPathResponse {
-    pub async fn try_from(response: HttpResponse) -> Result<Self> {
+    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/util.rs
+++ b/sdk/storage_datalake/src/util.rs
@@ -1,7 +1,7 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use http::HeaderMap;
 
-pub(crate) fn namespace_enabled_from_headers(headers: &HeaderMap) -> Result<bool> {
+pub(crate) fn namespace_enabled_from_headers(headers: &HeaderMap) -> azure_core::Result<bool> {
     headers
         .get("x-ms-namespace-enabled")
         .ok_or_else(|| Error::message(ErrorKind::Other, "Header x-ms-namespace-enabled not found"))?

--- a/sdk/storage_datalake/tests/file_system.rs
+++ b/sdk/storage_datalake/tests/file_system.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "mock_transport_framework")]
 
-use azure_core::error::Result;
 use azure_storage_datalake::prelude::*;
 use futures::stream::StreamExt;
 use std::num::NonZeroU32;
@@ -8,7 +7,7 @@ use std::num::NonZeroU32;
 mod setup;
 
 #[tokio::test]
-async fn file_system_create_delete() -> Result<()> {
+async fn file_system_create_delete() -> azure_core::Result<()> {
     let data_lake_client = setup::create_data_lake_client("datalake_file_system")
         .await
         .unwrap();
@@ -83,7 +82,7 @@ async fn file_system_create_delete() -> Result<()> {
 }
 
 #[tokio::test]
-async fn file_system_list_paths() -> Result<()> {
+async fn file_system_list_paths() -> azure_core::Result<()> {
     let data_lake_client = setup::create_data_lake_client("datalake_file_system_list_paths")
         .await
         .unwrap();

--- a/sdk/storage_datalake/tests/files.rs
+++ b/sdk/storage_datalake/tests/files.rs
@@ -1,12 +1,11 @@
 #![cfg(feature = "mock_transport_framework")]
-use azure_core::error::Result;
 use azure_storage_datalake::Properties;
 use std::{assert_eq, assert_ne};
 
 mod setup;
 
 #[tokio::test]
-async fn file_create_delete() -> Result<()> {
+async fn file_create_delete() -> azure_core::Result<()> {
     let data_lake_client = setup::create_data_lake_client("datalake_file_create_delete")
         .await
         .unwrap();
@@ -42,7 +41,7 @@ async fn file_create_delete() -> Result<()> {
 }
 
 #[tokio::test]
-async fn file_upload() -> Result<()> {
+async fn file_upload() -> azure_core::Result<()> {
     let data_lake_client = setup::create_data_lake_client("datalake_file_read")
         .await
         .unwrap();
@@ -79,7 +78,7 @@ async fn file_upload() -> Result<()> {
 }
 
 #[tokio::test]
-async fn file_read() -> Result<()> {
+async fn file_read() -> azure_core::Result<()> {
     let data_lake_client = setup::create_data_lake_client("datalake_file_upload")
         .await
         .unwrap();
@@ -119,7 +118,7 @@ async fn file_read() -> Result<()> {
 }
 
 #[tokio::test]
-async fn file_rename() -> Result<()> {
+async fn file_rename() -> azure_core::Result<()> {
     let data_lake_client = setup::create_data_lake_client("datalake_file_rename")
         .await
         .unwrap();
@@ -179,7 +178,7 @@ async fn file_rename() -> Result<()> {
 }
 
 #[tokio::test]
-async fn file_get_properties() -> Result<()> {
+async fn file_get_properties() -> azure_core::Result<()> {
     let data_lake_client = setup::create_data_lake_client("datalake_file_properties")
         .await
         .unwrap();

--- a/sdk/storage_datalake/tests/setup.rs
+++ b/sdk/storage_datalake/tests/setup.rs
@@ -1,10 +1,9 @@
 #![cfg(feature = "mock_transport_framework")]
-use azure_core::error::Result;
 use azure_core::ClientOptions;
 use azure_storage::storage_shared_key_credential::StorageSharedKeyCredential;
 use azure_storage_datalake::prelude::*;
 
-pub async fn create_data_lake_client(transaction_name: &str) -> Result<DataLakeClient> {
+pub async fn create_data_lake_client(transaction_name: &str) -> azure_core::Result<DataLakeClient> {
     let account_name = (std::env::var(azure_core::mock::TESTING_MODE_KEY).as_deref()
         == Ok(azure_core::mock::TESTING_MODE_RECORD))
     .then(get_account)

--- a/sdk/storage_queues/examples/delete_message.rs
+++ b/sdk/storage_queues/examples/delete_message.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate log;
-use azure_core::error::Result;
+
 use azure_storage::core::prelude::*;
 use azure_storage_queues::prelude::*;
 use std::time::Duration;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_queues/examples/get_messages.rs
+++ b/sdk/storage_queues/examples/get_messages.rs
@@ -1,12 +1,12 @@
 #[macro_use]
 extern crate log;
-use azure_core::error::Result;
+
 use azure_storage::core::prelude::*;
 use azure_storage_queues::prelude::*;
 use std::time::Duration;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_queues/examples/list_queues.rs
+++ b/sdk/storage_queues/examples/list_queues.rs
@@ -1,11 +1,10 @@
-use azure_core::error::Result;
 use azure_storage::core::prelude::*;
 use azure_storage_queues::prelude::*;
 use futures::stream::StreamExt;
 use std::num::NonZeroU32;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_queues/examples/peek_messages.rs
+++ b/sdk/storage_queues/examples/peek_messages.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate log;
-use azure_core::error::Result;
+
 use azure_storage::core::prelude::*;
 use azure_storage_queues::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_queues/examples/put_message.rs
+++ b/sdk/storage_queues/examples/put_message.rs
@@ -1,11 +1,11 @@
 #[macro_use]
 extern crate log;
-use azure_core::error::Result;
+
 use azure_storage::core::prelude::*;
 use azure_storage_queues::prelude::*;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_queues/examples/queue_create.rs
+++ b/sdk/storage_queues/examples/queue_create.rs
@@ -1,13 +1,13 @@
 #[macro_use]
 extern crate log;
-use azure_core::error::Result;
 use azure_core::prelude::*;
+
 use azure_storage::core::prelude::*;
 use azure_storage_queues::prelude::*;
 use chrono::{Duration, Utc};
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and master key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_queues/src/clients/pop_receipt_client.rs
+++ b/sdk/storage_queues/src/clients/pop_receipt_client.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::requests::*;
-use azure_core::error::Result;
 use azure_core::HttpClient;
+
 use azure_storage::core::clients::StorageClient;
 use std::sync::Arc;
 
@@ -52,7 +52,7 @@ impl PopReceiptClient {
             .http_client()
     }
 
-    pub(crate) fn pop_receipt_url(&self) -> Result<url::Url> {
+    pub(crate) fn pop_receipt_url(&self) -> azure_core::Result<url::Url> {
         let mut url = self.queue_client.url_with_segments(
             ["messages", self.pop_receipt.message_id()]
                 .iter()

--- a/sdk/storage_queues/src/clients/queue_client.rs
+++ b/sdk/storage_queues/src/clients/queue_client.rs
@@ -1,5 +1,5 @@
 use crate::requests::*;
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use azure_storage::core::clients::{AsStorageClient, StorageAccountClient, StorageClient};
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -38,7 +38,7 @@ impl QueueClient {
         self.storage_client.as_ref()
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> Result<url::Url>
+    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {

--- a/sdk/storage_queues/src/queue_stored_access_policy.rs
+++ b/sdk/storage_queues/src/queue_stored_access_policy.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result};
+use azure_core::error::{Error, ErrorKind};
 use azure_storage::StoredAccessPolicy;
 use chrono::{DateTime, FixedOffset};
 use std::convert::TryFrom;
@@ -92,7 +92,7 @@ impl QueueStoredAccessPolicy {
 impl TryFrom<StoredAccessPolicy> for QueueStoredAccessPolicy {
     type Error = Error;
 
-    fn try_from(sap: StoredAccessPolicy) -> Result<Self> {
+    fn try_from(sap: StoredAccessPolicy) -> azure_core::Result<Self> {
         let mut queue_sap = Self::new(sap.id, sap.start, sap.expiry);
 
         for token in sap.permission.chars() {

--- a/sdk/storage_queues/src/requests/clear_messages_builder.rs
+++ b/sdk/storage_queues/src/requests/clear_messages_builder.rs
@@ -1,8 +1,8 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug)]
@@ -26,7 +26,7 @@ impl<'a> ClearMessagesBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<ClearMessagesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ClearMessagesResponse> {
         let mut url = self.queue_client.url_with_segments(Some("messages"))?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_queues/src/requests/create_queue_builder.rs
+++ b/sdk/storage_queues/src/requests/create_queue_builder.rs
@@ -1,6 +1,5 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::{add_mandatory_header, add_optional_header};
 use azure_core::prelude::*;
 use std::convert::TryInto;
@@ -29,7 +28,7 @@ impl<'a> CreateQueueBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<CreateQueueResponse> {
+    pub async fn execute(&self) -> azure_core::Result<CreateQueueResponse> {
         let mut url = self.queue_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_queues/src/requests/delete_message_builder.rs
+++ b/sdk/storage_queues/src/requests/delete_message_builder.rs
@@ -1,8 +1,8 @@
 use crate::clients::PopReceiptClient;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug)]
@@ -26,7 +26,7 @@ impl<'a> DeleteMessageBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<DeleteMessageResponse> {
+    pub async fn execute(&self) -> azure_core::Result<DeleteMessageResponse> {
         let mut url = self.pop_receipt_client.pop_receipt_url()?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_queues/src/requests/delete_queue_builder.rs
+++ b/sdk/storage_queues/src/requests/delete_queue_builder.rs
@@ -1,8 +1,8 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -26,7 +26,7 @@ impl<'a> DeleteQueueBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<DeleteQueueResponse> {
+    pub async fn execute(&self) -> azure_core::Result<DeleteQueueResponse> {
         let mut url = self.queue_client.url_with_segments(None)?;
 
         self.timeout.append_to_url_query(&mut url);

--- a/sdk/storage_queues/src/requests/get_messages_builder.rs
+++ b/sdk/storage_queues/src/requests/get_messages_builder.rs
@@ -1,9 +1,9 @@
 use crate::clients::QueueClient;
 use crate::prelude::*;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -33,7 +33,7 @@ impl<'a> GetMessagesBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<GetMessagesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetMessagesResponse> {
         let mut url = self.queue_client.url_with_segments(Some("messages"))?;
 
         self.visibility_timeout.append_to_url_query(&mut url);

--- a/sdk/storage_queues/src/requests/get_queue_acl_builder.rs
+++ b/sdk/storage_queues/src/requests/get_queue_acl_builder.rs
@@ -1,8 +1,8 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use http::method::Method;
 use http::status::StatusCode;
 use std::convert::TryInto;
@@ -28,7 +28,7 @@ impl<'a> GetQueueACLBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<GetQueueACLResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetQueueACLResponse> {
         let mut url = self.queue_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "acl");

--- a/sdk/storage_queues/src/requests/get_queue_metadata_builder.rs
+++ b/sdk/storage_queues/src/requests/get_queue_metadata_builder.rs
@@ -1,8 +1,8 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use http::method::Method;
 use http::status::StatusCode;
 use std::convert::TryInto;
@@ -28,7 +28,7 @@ impl<'a> GetQueueMetadataBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<GetQueueMetadataResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetQueueMetadataResponse> {
         let mut url = self.queue_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "metadata");

--- a/sdk/storage_queues/src/requests/get_queue_service_properties_builder.rs
+++ b/sdk/storage_queues/src/requests/get_queue_service_properties_builder.rs
@@ -1,7 +1,7 @@
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use azure_storage::core::prelude::*;
 use http::method::Method;
 use http::status::StatusCode;
@@ -28,7 +28,7 @@ impl<'a> GetQueueServicePropertiesBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<GetQueueServicePropertiesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetQueueServicePropertiesResponse> {
         let mut url = self
             .storage_client
             .storage_account_client()

--- a/sdk/storage_queues/src/requests/get_queue_service_stats_builder.rs
+++ b/sdk/storage_queues/src/requests/get_queue_service_stats_builder.rs
@@ -1,7 +1,7 @@
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use azure_storage::core::prelude::*;
 use http::method::Method;
 use http::status::StatusCode;
@@ -28,7 +28,7 @@ impl<'a> GetQueueServiceStatsBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<GetQueueServiceStatsResponse> {
+    pub async fn execute(&self) -> azure_core::Result<GetQueueServiceStatsResponse> {
         let mut url = self
             .storage_client
             .storage_account_client()

--- a/sdk/storage_queues/src/requests/list_queues_builder.rs
+++ b/sdk/storage_queues/src/requests/list_queues_builder.rs
@@ -1,7 +1,7 @@
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use azure_storage::core::prelude::*;
 use futures::stream::{unfold, Stream};
 use http::method::Method;
@@ -41,7 +41,7 @@ impl<'a> ListQueuesBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<ListQueuesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<ListQueuesResponse> {
         let mut url = self
             .storage_client
             .storage_account_client()
@@ -83,7 +83,7 @@ impl<'a> ListQueuesBuilder<'a> {
         (&response).try_into()
     }
 
-    pub fn stream(self) -> impl Stream<Item = Result<ListQueuesResponse>> + 'a {
+    pub fn stream(self) -> impl Stream<Item = azure_core::Result<ListQueuesResponse>> + 'a {
         #[derive(Debug, Clone, PartialEq)]
         enum States {
             Init,

--- a/sdk/storage_queues/src/requests/peek_messages_builder.rs
+++ b/sdk/storage_queues/src/requests/peek_messages_builder.rs
@@ -1,9 +1,9 @@
 use crate::clients::QueueClient;
 use crate::prelude::*;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -30,7 +30,7 @@ impl<'a> PeekMessagesBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self) -> Result<PeekMessagesResponse> {
+    pub async fn execute(&self) -> azure_core::Result<PeekMessagesResponse> {
         let mut url = self.queue_client.url_with_segments(Some("messages"))?;
 
         url.query_pairs_mut().append_pair("peekonly", "true");

--- a/sdk/storage_queues/src/requests/put_message_builder.rs
+++ b/sdk/storage_queues/src/requests/put_message_builder.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -32,7 +32,7 @@ impl<'a> PutMessageBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self, body: impl AsRef<str>) -> Result<PutMessageResponse> {
+    pub async fn execute(&self, body: impl AsRef<str>) -> azure_core::Result<PutMessageResponse> {
         let mut url = self.queue_client.url_with_segments(Some("messages"))?;
 
         self.visibility_timeout.append_to_url_query(&mut url);

--- a/sdk/storage_queues/src/requests/set_queue_acl_builder.rs
+++ b/sdk/storage_queues/src/requests/set_queue_acl_builder.rs
@@ -1,9 +1,9 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
 use crate::QueueStoredAccessPolicy;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use azure_storage::StoredAccessPolicyList;
 use std::convert::TryInto;
 
@@ -37,7 +37,7 @@ impl<'a> SetQueueACLBuilder<'a> {
     pub async fn execute(
         &self,
         queue_stored_access_policies: &[QueueStoredAccessPolicy],
-    ) -> Result<SetQueueACLResponse> {
+    ) -> azure_core::Result<SetQueueACLResponse> {
         let mut url = self.queue_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "acl");

--- a/sdk/storage_queues/src/requests/set_queue_metadata_builder.rs
+++ b/sdk/storage_queues/src/requests/set_queue_metadata_builder.rs
@@ -1,8 +1,8 @@
 use crate::clients::QueueClient;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::{add_mandatory_header, add_optional_header};
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -34,7 +34,10 @@ impl<'a> SetQueueMetadataBuilder<'a> {
     /// back to SetQueueMetadata.
     /// If you just want to clear the metadata, just pass an empty Metadata
     /// struct.
-    pub async fn execute(&self, metadata: &Metadata) -> Result<SetQueueMetadataResponse> {
+    pub async fn execute(
+        &self,
+        metadata: &Metadata,
+    ) -> azure_core::Result<SetQueueMetadataResponse> {
         let mut url = self.queue_client.url_with_segments(None)?;
 
         url.query_pairs_mut().append_pair("comp", "metadata");

--- a/sdk/storage_queues/src/requests/set_queue_service_properties_builder.rs
+++ b/sdk/storage_queues/src/requests/set_queue_service_properties_builder.rs
@@ -1,6 +1,6 @@
 use crate::responses::*;
 use crate::QueueServiceProperties;
-use azure_core::error::{ErrorKind, Result, ResultExt};
+use azure_core::error::{ErrorKind, ResultExt};
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
 use azure_storage::core::clients::StorageClient;
@@ -33,7 +33,7 @@ impl<'a> SetQueueServicePropertiesBuilder<'a> {
     pub async fn execute(
         &self,
         queue_service_properties: &QueueServiceProperties,
-    ) -> Result<SetQueueServicePropertiesResponse> {
+    ) -> azure_core::Result<SetQueueServicePropertiesResponse> {
         let mut url = self
             .storage_client
             .storage_account_client()

--- a/sdk/storage_queues/src/requests/update_message_builder.rs
+++ b/sdk/storage_queues/src/requests/update_message_builder.rs
@@ -1,9 +1,9 @@
 use crate::clients::PopReceiptClient;
 use crate::prelude::*;
 use crate::responses::*;
-use azure_core::error::Result;
 use azure_core::headers::add_optional_header;
 use azure_core::prelude::*;
+
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -32,7 +32,10 @@ impl<'a> UpdateMessageBuilder<'a> {
         client_request_id: ClientRequestId => Some(client_request_id),
     }
 
-    pub async fn execute(&self, new_body: impl AsRef<str>) -> Result<UpdateMessageResponse> {
+    pub async fn execute(
+        &self,
+        new_body: impl AsRef<str>,
+    ) -> azure_core::Result<UpdateMessageResponse> {
         let mut url = self.pop_receipt_client.pop_receipt_url()?;
 
         self.visibility_timeout.append_to_url_query(&mut url);

--- a/sdk/storage_queues/src/responses/clear_messages_response.rs
+++ b/sdk/storage_queues/src/responses/clear_messages_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -12,7 +12,7 @@ pub struct ClearMessagesResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for ClearMessagesResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(ClearMessagesResponse {

--- a/sdk/storage_queues/src/responses/create_queue_response.rs
+++ b/sdk/storage_queues/src/responses/create_queue_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -12,7 +12,7 @@ pub struct CreateQueueResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for CreateQueueResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(CreateQueueResponse {

--- a/sdk/storage_queues/src/responses/delete_message_response.rs
+++ b/sdk/storage_queues/src/responses/delete_message_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -12,7 +12,7 @@ pub struct DeleteMessageResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for DeleteMessageResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(DeleteMessageResponse {

--- a/sdk/storage_queues/src/responses/delete_queue_response.rs
+++ b/sdk/storage_queues/src/responses/delete_queue_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -12,7 +12,7 @@ pub struct DeleteQueueResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for DeleteQueueResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(DeleteQueueResponse {

--- a/sdk/storage_queues/src/responses/get_messages_response.rs
+++ b/sdk/storage_queues/src/responses/get_messages_response.rs
@@ -1,5 +1,5 @@
 use crate::PopReceipt;
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::headers::utc_date_from_rfc2822;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::core::xml::read_xml;
@@ -57,7 +57,7 @@ struct MessagesInternal {
 impl std::convert::TryFrom<&Response<Bytes>> for GetMessagesResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/storage_queues/src/responses/get_queue_acl_response.rs
+++ b/sdk/storage_queues/src/responses/get_queue_acl_response.rs
@@ -1,5 +1,5 @@
 use crate::QueueStoredAccessPolicy;
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::StoredAccessPolicyList;
 use bytes::Bytes;
@@ -15,18 +15,19 @@ pub struct GetQueueACLResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueACLResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body = response.body();
 
         debug!("headers == {:?}", headers);
 
-        let a: Result<Vec<QueueStoredAccessPolicy>> = StoredAccessPolicyList::from_xml(body)
-            .map_kind(ErrorKind::DataConversion)?
-            .stored_access
-            .into_iter()
-            .map(|sap| sap.try_into().map_kind(ErrorKind::DataConversion))
-            .collect();
+        let a: azure_core::Result<Vec<QueueStoredAccessPolicy>> =
+            StoredAccessPolicyList::from_xml(body)
+                .map_kind(ErrorKind::DataConversion)?
+                .stored_access
+                .into_iter()
+                .map(|sap| sap.try_into().map_kind(ErrorKind::DataConversion))
+                .collect();
 
         Ok(GetQueueACLResponse {
             common_storage_response_headers: headers.try_into()?,

--- a/sdk/storage_queues/src/responses/get_queue_metadata_response.rs
+++ b/sdk/storage_queues/src/responses/get_queue_metadata_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_core::prelude::*;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -14,7 +14,7 @@ pub struct GetQueueMetadataResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueMetadataResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         debug!("headers == {:?}", headers);

--- a/sdk/storage_queues/src/responses/get_queue_service_properties_response.rs
+++ b/sdk/storage_queues/src/responses/get_queue_service_properties_response.rs
@@ -1,5 +1,5 @@
 use crate::QueueServiceProperties;
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::core::xml::read_xml;
 use bytes::Bytes;
@@ -15,7 +15,7 @@ pub struct GetQueueServicePropertiesResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueServicePropertiesResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/storage_queues/src/responses/get_queue_service_stats_response.rs
+++ b/sdk/storage_queues/src/responses/get_queue_service_stats_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::core::xml::read_xml;
 use bytes::Bytes;
@@ -37,7 +37,7 @@ struct GeoReplication {
 impl std::convert::TryFrom<&Response<Bytes>> for GetQueueServiceStatsResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/storage_queues/src/responses/list_queues_response.rs
+++ b/sdk/storage_queues/src/responses/list_queues_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::prelude::*;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::xml::read_xml;
@@ -58,7 +58,7 @@ pub struct Queue {
 
 impl std::convert::TryFrom<&Response<Bytes>> for ListQueuesResponse {
     type Error = Error;
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/storage_queues/src/responses/peek_messages_response.rs
+++ b/sdk/storage_queues/src/responses/peek_messages_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::headers::utc_date_from_rfc2822;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::core::xml::read_xml;
@@ -45,7 +45,7 @@ struct PeekMessagesInternal {
 impl std::convert::TryFrom<&Response<Bytes>> for PeekMessagesResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/storage_queues/src/responses/put_message_response.rs
+++ b/sdk/storage_queues/src/responses/put_message_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, ErrorKind, Result, ResultExt};
+use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::headers::utc_date_from_rfc2822;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use azure_storage::xml::read_xml;
@@ -44,7 +44,7 @@ struct QueueMessageInternal {
 
 impl std::convert::TryFrom<&Response<Bytes>> for PutMessageResponse {
     type Error = Error;
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         let headers = response.headers();
         let body = response.body();
 

--- a/sdk/storage_queues/src/responses/set_queue_acl_response.rs
+++ b/sdk/storage_queues/src/responses/set_queue_acl_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -12,7 +12,7 @@ pub struct SetQueueACLResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueACLResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(SetQueueACLResponse {

--- a/sdk/storage_queues/src/responses/set_queue_metadata_response.rs
+++ b/sdk/storage_queues/src/responses/set_queue_metadata_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -12,7 +12,7 @@ pub struct SetQueueMetadataResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueMetadataResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(SetQueueMetadataResponse {

--- a/sdk/storage_queues/src/responses/set_queue_service_properties_response.rs
+++ b/sdk/storage_queues/src/responses/set_queue_service_properties_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
 use http::response::Response;
@@ -12,7 +12,7 @@ pub struct SetQueueServicePropertiesResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for SetQueueServicePropertiesResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(SetQueueServicePropertiesResponse {

--- a/sdk/storage_queues/src/responses/update_message_response.rs
+++ b/sdk/storage_queues/src/responses/update_message_response.rs
@@ -1,4 +1,4 @@
-use azure_core::error::{Error, Result};
+use azure_core::error::Error;
 use azure_core::headers::{get_str_from_headers, rfc2822_from_headers_mandatory};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use bytes::Bytes;
@@ -16,7 +16,7 @@ pub struct UpdateMessageResponse {
 impl std::convert::TryFrom<&Response<Bytes>> for UpdateMessageResponse {
     type Error = Error;
 
-    fn try_from(response: &Response<Bytes>) -> Result<Self> {
+    fn try_from(response: &Response<Bytes>) -> azure_core::Result<Self> {
         debug!("response == {:?}", response);
 
         Ok(UpdateMessageResponse {

--- a/sdk/storage_queues/tests/queue.rs
+++ b/sdk/storage_queues/tests/queue.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_core::error::Result;
 use azure_core::prelude::*;
 use azure_storage::core::prelude::*;
 use azure_storage_queues::prelude::*;
@@ -7,7 +6,7 @@ use chrono::Utc;
 use std::time::Duration;
 
 #[tokio::test]
-async fn queue_create_put_and_get() -> Result<()> {
+async fn queue_create_put_and_get() -> azure_core::Result<()> {
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
     let master_key =


### PR DESCRIPTION
This rather large PR is quite simple. It adds a `pub use` declaration to `azure_core` so that users can access the `Result` type alias from the root of `azure_core` like so: `azure_core::Result`. This is quite a common pattern in the Rust world. 

The rest of the changes are simply moving all uses of `azure_core`'s `Result` type to use this path so that we have consistency across the code base. 