### PR TITLE
fixes the device code example

### DIFF
--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -56,7 +56,7 @@ async fn main() -> azure_core::Result<()> {
         }
     };
 
-    println!("{:?}", auth);
+    println!("{:?}", authorization);
 
     // remove the option (this is safe since we
     // unwrapped the errors before).

--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -58,10 +58,6 @@ async fn main() -> azure_core::Result<()> {
 
     println!("{:?}", authorization);
 
-    // remove the option (this is safe since we
-    // unwrapped the errors before).
-    let authorization = authorization.unwrap();
-
     println!(
         "\nReceived valid bearer token: {}",
         &authorization.access_token().secret()

--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -48,11 +48,15 @@ async fn main() -> azure_core::Result<()> {
     // Success or Pending. The loop will continue until we
     // get either a Success or an error.
     let mut stream = Box::pin(device_code_flow.stream());
-    let mut authorization = None;
-    while let Some(Ok(auth)) = stream.next().await {
-        println!("{:?}", auth);
-        authorization = Some(auth);
-    }
+
+    let authorization = loop {
+        let response = stream.next().await.expect("device code flow stream failed");
+        if let Ok(auth) = response {
+            break auth;
+        }
+    };
+
+    println!("{:?}", auth);
 
     // remove the option (this is safe since we
     // unwrapped the errors before).


### PR DESCRIPTION
As is, this example does not continue to poll if the user has not finished their auth in the time it takes for the loop to poll once.