### PR TITLE
add `#[must_use]` across the SDK

### DIFF
--- a/sdk/core/src/auth.rs
+++ b/sdk/core/src/auth.rs
@@ -8,9 +8,11 @@ use std::fmt::Debug;
 pub struct AccessToken(String);
 
 impl AccessToken {
+    #[must_use]
     pub fn new(access_token: String) -> Self {
         Self(access_token)
     }
+    #[must_use]
     pub fn secret(&self) -> &str {
         self.0.as_str()
     }
@@ -27,6 +29,7 @@ pub struct TokenResponse {
 
 impl TokenResponse {
     /// Create a new `TokenResponse`.
+    #[must_use]
     pub fn new(token: AccessToken, expires_on: DateTime<Utc>) -> Self {
         Self { token, expires_on }
     }

--- a/sdk/core/src/bytes_stream.rs
+++ b/sdk/core/src/bytes_stream.rs
@@ -25,6 +25,7 @@ impl BytesStream {
     }
 
     /// Creates a stream that resolves immediately with no data.
+    #[must_use]
     pub fn new_empty() -> Self {
         Self::new(Bytes::new())
     }

--- a/sdk/core/src/context.rs
+++ b/sdk/core/src/context.rs
@@ -16,6 +16,7 @@ impl Default for Context {
 
 impl Context {
     /// Creates a new, empty Context.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             type_map: HashMap::new(),
@@ -60,6 +61,7 @@ impl Context {
     /// Returns a reference of the entity of the specified type signature, if it exists.
     ///
     /// If there is no entity with the specific type signature, `None` is returned instead.
+    #[must_use]
     pub fn get<E>(&self) -> Option<&E>
     where
         E: Send + Sync + 'static,
@@ -70,11 +72,13 @@ impl Context {
     }
 
     /// Returns the number of entities in the type map.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.type_map.len()
     }
 
     /// Returns `true` if the type map is empty, `false` otherwise.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.type_map.is_empty()
     }

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -32,16 +32,19 @@ pub enum ErrorKind {
 }
 
 impl ErrorKind {
+    #[must_use]
     pub fn into_error(self) -> Error {
         Error {
             context: Context::Simple(self),
         }
     }
 
+    #[must_use]
     pub fn http_response(status: u16, error_code: Option<String>) -> Self {
         Self::HttpResponse { status, error_code }
     }
 
+    #[must_use]
     pub fn http_response_from_body(status: u16, body: &[u8]) -> Self {
         let error_code = http_error::get_error_code_from_body(body);
         Self::HttpResponse { status, error_code }
@@ -136,6 +139,7 @@ impl Error {
     }
 
     /// Get the `ErrorKind` of this `Error`
+    #[must_use]
     pub fn kind(&self) -> &ErrorKind {
         match &self.context {
             Context::Simple(kind) => kind,
@@ -169,6 +173,7 @@ impl Error {
     }
 
     /// Returns a reference to the inner error wrapped by this error (if any).
+    #[must_use]
     pub fn get_ref(&self) -> Option<&(dyn std::error::Error + Send + Sync + 'static)> {
         match &self.context {
             Context::Custom(Custom { error, .. }) => Some(error.as_ref()),
@@ -178,6 +183,7 @@ impl Error {
     }
 
     /// Returns a reference to the inner error (if any) downcasted to the type provided
+    #[must_use]
     pub fn downcast_ref<T: std::error::Error + 'static>(&self) -> Option<&T> {
         self.get_ref()?.downcast_ref()
     }

--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -190,6 +190,7 @@ impl From<&http::HeaderMap> for Headers {
 pub struct HeaderName(std::borrow::Cow<'static, str>);
 
 impl HeaderName {
+    #[must_use]
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
@@ -224,6 +225,7 @@ impl From<&HeaderName> for http::header::HeaderName {
 pub struct HeaderValue(std::borrow::Cow<'static, str>);
 
 impl HeaderValue {
+    #[must_use]
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -111,6 +111,7 @@ pub fn request_id_from_headers(headers: &Headers) -> crate::Result<RequestId> {
     get_from_headers(headers, REQUEST_ID)
 }
 
+#[must_use]
 pub fn client_request_id_from_headers_optional(headers: &Headers) -> Option<String> {
     get_option_from_headers(headers, CLIENT_REQUEST_ID)
         .ok()

--- a/sdk/core/src/http_client.rs
+++ b/sdk/core/src/http_client.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 /// Construct a new `HttpClient` with the `reqwest` backend.
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 #[cfg(not(target_arch = "wasm32"))]
+#[must_use]
 pub fn new_http_client() -> std::sync::Arc<dyn HttpClient> {
     std::sync::Arc::new(reqwest::Client::new())
 }

--- a/sdk/core/src/options.rs
+++ b/sdk/core/src/options.rs
@@ -38,6 +38,7 @@ pub struct ClientOptions {
 }
 
 impl ClientOptions {
+    #[must_use]
     pub fn new(transport: TransportOptions) -> Self {
         Self {
             per_call_policies: Vec::new(),
@@ -190,6 +191,7 @@ pub struct TransportOptions {
 
 impl TransportOptions {
     /// Creates a new `TransportOptions` using the given `HttpClient`.
+    #[must_use]
     pub fn new(http_client: Arc<dyn HttpClient>) -> Self {
         #[allow(unreachable_code)]
         Self {

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -42,6 +42,7 @@ impl Pipeline {
     ///
     /// Crates can simply pass `option_env!("CARGO_PKG_NAME")` and `option_env!("CARGO_PKG_VERSION")` for the
     /// `crate_name` and `crate_version` arguments respectively.
+    #[must_use]
     pub fn new(
         crate_name: Option<&'static str>,
         crate_version: Option<&'static str>,
@@ -91,6 +92,7 @@ impl Pipeline {
         std::mem::replace(&mut self.pipeline[position], policy)
     }
 
+    #[must_use]
     pub fn policies(&self) -> &[Arc<dyn Policy>] {
         &self.pipeline
     }

--- a/sdk/core/src/policies/telemetry_policy.rs
+++ b/sdk/core/src/policies/telemetry_policy.rs
@@ -13,6 +13,7 @@ pub struct TelemetryPolicy {
 
 /// Sets the User-Agent header with useful information in a typical format for Azure SDKs.
 impl<'a> TelemetryPolicy {
+    #[must_use]
     pub fn new(
         crate_name: Option<&'a str>,
         crate_version: Option<&'a str>,

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -15,6 +15,7 @@ pub struct TransportPolicy {
 
 impl TransportPolicy {
     #[cfg(not(target_arch = "wasm32"))]
+    #[must_use]
     pub fn new(transport_options: TransportOptions) -> Self {
         Self { transport_options }
     }

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -43,6 +43,7 @@ pub struct Request {
 
 impl Request {
     /// Create a new request with an empty body and no headers
+    #[must_use]
     pub fn new(url: Url, method: Method) -> Self {
         Self {
             url,

--- a/sdk/core/src/request_options/accept.rs
+++ b/sdk/core/src/request_options/accept.rs
@@ -14,6 +14,7 @@ use crate::headers::{self, Header};
 pub struct Accept(String);
 
 impl Accept {
+    #[must_use]
     pub fn new(s: String) -> Self {
         Self(s)
     }

--- a/sdk/core/src/request_options/accept_encoding.rs
+++ b/sdk/core/src/request_options/accept_encoding.rs
@@ -15,6 +15,7 @@ use crate::headers::{self, Header};
 pub struct AcceptEncoding(String);
 
 impl AcceptEncoding {
+    #[must_use]
     pub fn new(s: String) -> Self {
         Self(s)
     }

--- a/sdk/core/src/request_options/activity_id.rs
+++ b/sdk/core/src/request_options/activity_id.rs
@@ -4,6 +4,7 @@ use crate::headers::{self, Header};
 pub struct ActivityId(String);
 
 impl ActivityId {
+    #[must_use]
     pub fn new(id: String) -> Self {
         Self(id)
     }

--- a/sdk/core/src/request_options/app.rs
+++ b/sdk/core/src/request_options/app.rs
@@ -5,6 +5,7 @@ use crate::headers::{self, Header};
 pub struct App(String);
 
 impl App {
+    #[must_use]
     pub fn new(s: String) -> Self {
         Self(s)
     }

--- a/sdk/core/src/request_options/client_request_id.rs
+++ b/sdk/core/src/request_options/client_request_id.rs
@@ -6,6 +6,7 @@ use crate::Header;
 pub struct ClientRequestId(String);
 
 impl ClientRequestId {
+    #[must_use]
     pub fn new(client_request_id: String) -> Self {
         Self(client_request_id)
     }

--- a/sdk/core/src/request_options/client_version.rs
+++ b/sdk/core/src/request_options/client_version.rs
@@ -6,6 +6,7 @@ use crate::Header;
 pub struct ClientVersion(String);
 
 impl ClientVersion {
+    #[must_use]
     pub fn new(client_request_id: String) -> Self {
         Self(client_request_id)
     }

--- a/sdk/core/src/request_options/content_length.rs
+++ b/sdk/core/src/request_options/content_length.rs
@@ -4,6 +4,7 @@ use crate::headers::{self, Header};
 pub struct ContentLength(i32);
 
 impl ContentLength {
+    #[must_use]
     pub fn new(count: i32) -> Self {
         Self(count)
     }

--- a/sdk/core/src/request_options/content_range.rs
+++ b/sdk/core/src/request_options/content_range.rs
@@ -12,6 +12,7 @@ pub struct ContentRange {
 }
 
 impl ContentRange {
+    #[must_use]
     pub fn new(start: u64, end: u64, total_length: u64) -> ContentRange {
         ContentRange {
             start,
@@ -20,18 +21,22 @@ impl ContentRange {
         }
     }
 
+    #[must_use]
     pub fn start(&self) -> u64 {
         self.start
     }
 
+    #[must_use]
     pub fn end(&self) -> u64 {
         self.end
     }
 
+    #[must_use]
     pub fn total_length(&self) -> u64 {
         self.total_length
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.end == self.start
     }

--- a/sdk/core/src/request_options/content_type.rs
+++ b/sdk/core/src/request_options/content_type.rs
@@ -4,10 +4,12 @@ use crate::headers::{self, Header};
 pub struct ContentType<'a>(&'a str);
 
 impl<'a> ContentType<'a> {
+    #[must_use]
     pub fn new(s: &'a str) -> Self {
         Self(s)
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         self.0
     }

--- a/sdk/core/src/request_options/continuation.rs
+++ b/sdk/core/src/request_options/continuation.rs
@@ -4,10 +4,12 @@ use crate::{headers, Header};
 pub struct Continuation(String);
 
 impl Continuation {
+    #[must_use]
     pub fn new(c: String) -> Self {
         Self(c)
     }
 
+    #[must_use]
     pub fn into_raw(self) -> String {
         self.0
     }

--- a/sdk/core/src/request_options/delimiter.rs
+++ b/sdk/core/src/request_options/delimiter.rs
@@ -4,6 +4,7 @@ use crate::AppendToUrlQuery;
 pub struct Delimiter<'a>(&'a str);
 
 impl<'a> Delimiter<'a> {
+    #[must_use]
     pub fn new(delimiter: &'a str) -> Self {
         Self(delimiter)
     }

--- a/sdk/core/src/request_options/if_modified_since.rs
+++ b/sdk/core/src/request_options/if_modified_since.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 pub struct IfModifiedSince(DateTime<Utc>);
 
 impl IfModifiedSince {
+    #[must_use]
     pub fn new(time: DateTime<Utc>) -> Self {
         Self(time)
     }

--- a/sdk/core/src/request_options/max_item_count.rs
+++ b/sdk/core/src/request_options/max_item_count.rs
@@ -6,6 +6,7 @@ pub struct MaxItemCount(i32);
 
 impl MaxItemCount {
     /// Create a new `MaxItemCount`
+    #[must_use]
     pub fn new(count: i32) -> Self {
         Self(count)
     }

--- a/sdk/core/src/request_options/max_results.rs
+++ b/sdk/core/src/request_options/max_results.rs
@@ -11,6 +11,7 @@ use std::num::NonZeroU32;
 pub struct MaxResults(NonZeroU32);
 
 impl MaxResults {
+    #[must_use]
     pub fn new(max_results: NonZeroU32) -> Self {
         Self(max_results)
     }

--- a/sdk/core/src/request_options/metadata.rs
+++ b/sdk/core/src/request_options/metadata.rs
@@ -20,6 +20,7 @@ impl AsMut<HashMap<String, Bytes>> for Metadata {
 }
 
 impl Metadata {
+    #[must_use]
     pub fn new() -> Self {
         Self(HashMap::new())
     }
@@ -32,14 +33,17 @@ impl Metadata {
         self.0.insert(k.into(), v.into())
     }
 
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    #[must_use]
     pub fn get(&self, k: &str) -> Option<Bytes> {
         self.0.get(k).cloned()
     }

--- a/sdk/core/src/request_options/next_marker.rs
+++ b/sdk/core/src/request_options/next_marker.rs
@@ -7,10 +7,12 @@ use serde::{Deserialize, Serialize};
 pub struct NextMarker(String);
 
 impl NextMarker {
+    #[must_use]
     pub fn new(next_marker: String) -> Self {
         Self(next_marker)
     }
 
+    #[must_use]
     pub fn from_possibly_empty_string(next_marker: Option<String>) -> Option<Self> {
         if let Some(nm) = next_marker {
             if nm.is_empty() {
@@ -23,6 +25,7 @@ impl NextMarker {
         }
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/sdk/core/src/request_options/prefix.rs
+++ b/sdk/core/src/request_options/prefix.rs
@@ -4,6 +4,7 @@ use crate::AppendToUrlQuery;
 pub struct Prefix(String);
 
 impl Prefix {
+    #[must_use]
     pub fn new(prefix: String) -> Self {
         Self(prefix)
     }

--- a/sdk/core/src/request_options/range.rs
+++ b/sdk/core/src/request_options/range.rs
@@ -11,14 +11,17 @@ pub struct Range {
 }
 
 impl Range {
+    #[must_use]
     pub fn new(start: u64, end: u64) -> Range {
         Range { start, end }
     }
 
+    #[must_use]
     pub fn len(&self) -> u64 {
         self.end - self.start
     }
 
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.end == self.start
     }

--- a/sdk/core/src/request_options/sequence_number.rs
+++ b/sdk/core/src/request_options/sequence_number.rs
@@ -4,6 +4,7 @@ use crate::headers::{self, Header};
 pub struct SequenceNumber(u64);
 
 impl SequenceNumber {
+    #[must_use]
     pub fn new(max_results: u64) -> Self {
         Self(max_results)
     }

--- a/sdk/core/src/request_options/timeout.rs
+++ b/sdk/core/src/request_options/timeout.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 pub struct Timeout(Duration);
 
 impl Timeout {
+    #[must_use]
     pub fn new(duration: Duration) -> Self {
         Self(duration)
     }

--- a/sdk/core/src/request_options/user.rs
+++ b/sdk/core/src/request_options/user.rs
@@ -5,6 +5,7 @@ use crate::headers::{self, Header};
 pub struct User(String);
 
 impl User {
+    #[must_use]
     pub fn new(s: String) -> Self {
         Self(s)
     }

--- a/sdk/core/src/request_options/user_agent.rs
+++ b/sdk/core/src/request_options/user_agent.rs
@@ -5,6 +5,7 @@ use http::header;
 pub struct UserAgent<'a>(&'a str);
 
 impl<'a> UserAgent<'a> {
+    #[must_use]
     pub fn new(agent: &'a str) -> Self {
         Self(agent)
     }

--- a/sdk/core/src/request_options/version.rs
+++ b/sdk/core/src/request_options/version.rs
@@ -4,6 +4,7 @@ use crate::headers::{self, Header};
 pub struct Version(String);
 
 impl Version {
+    #[must_use]
     pub fn new(s: String) -> Self {
         Self(s)
     }

--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -26,16 +26,19 @@ impl Response {
     }
 
     /// Get the status code from the response.
+    #[must_use]
     pub fn status(&self) -> StatusCode {
         self.status
     }
 
     /// Get the headers from the response.
+    #[must_use]
     pub fn headers(&self) -> &Headers {
         &self.headers
     }
 
     /// Deconstruct the HTTP response into its components.
+    #[must_use]
     pub fn deconstruct(self) -> (StatusCode, Headers, PinnedStream) {
         (self.status, self.headers, self.body)
     }

--- a/sdk/core/src/sleep.rs
+++ b/sdk/core/src/sleep.rs
@@ -4,6 +4,7 @@ use std::task::{Context, Poll};
 use std::thread;
 use std::time::Duration;
 
+#[must_use]
 pub fn sleep(duration: Duration) -> Sleep {
     Sleep {
         thread: None,

--- a/sdk/data_cosmos/src/clients/attachment.rs
+++ b/sdk/data_cosmos/src/clients/attachment.rs
@@ -25,36 +25,43 @@ impl AttachmentClient {
     }
 
     /// Get a [`CosmosClient`].
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.document_client().cosmos_client()
     }
 
     /// Get a [`DatabaseClient`].
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         self.document_client().database_client()
     }
 
     /// Get a [`CollectionClient`].
+    #[must_use]
     pub fn collection_client(&self) -> &CollectionClient {
         self.document_client().collection_client()
     }
 
     /// Get a [`DocumentClient`].
+    #[must_use]
     pub fn document_client(&self) -> &DocumentClient {
         &self.document
     }
 
     /// Get the attachment name.
+    #[must_use]
     pub fn attachment_name(&self) -> &str {
         &self.attachment_name
     }
 
     /// Initiate a request to get an attachment.
+    #[must_use]
     pub fn get(&self) -> GetAttachmentBuilder {
         GetAttachmentBuilder::new(self.clone())
     }
 
     /// Initiate a request to delete an attachment.
+    #[must_use]
     pub fn delete(&self) -> DeleteAttachmentBuilder {
         DeleteAttachmentBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/collection.rs
+++ b/sdk/data_cosmos/src/clients/collection.rs
@@ -27,11 +27,13 @@ impl CollectionClient {
     }
 
     /// Get a [`CosmosClient`].
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.database.cosmos_client()
     }
 
     /// Get a [`DatabaseClient`].
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         &self.database
     }
@@ -67,16 +69,19 @@ impl CollectionClient {
     }
 
     /// Get the collection name
+    #[must_use]
     pub fn collection_name(&self) -> &str {
         &self.collection_name
     }
 
     /// Get a collection
+    #[must_use]
     pub fn get_collection(&self) -> GetCollectionBuilder {
         GetCollectionBuilder::new(self.clone())
     }
 
     /// Delete a collection
+    #[must_use]
     pub fn delete_collection(&self) -> DeleteCollectionBuilder {
         DeleteCollectionBuilder::new(self.clone())
     }
@@ -90,6 +95,7 @@ impl CollectionClient {
     }
 
     /// list documents in a collection
+    #[must_use]
     pub fn list_documents(&self) -> ListDocumentsBuilder {
         ListDocumentsBuilder::new(self.clone())
     }
@@ -108,21 +114,25 @@ impl CollectionClient {
     }
 
     /// list stored procedures in a collection
+    #[must_use]
     pub fn list_stored_procedures(&self) -> ListStoredProceduresBuilder {
         ListStoredProceduresBuilder::new(self.clone())
     }
 
     /// list user defined functions in a collection
+    #[must_use]
     pub fn list_user_defined_functions(&self) -> ListUserDefinedFunctionsBuilder {
         ListUserDefinedFunctionsBuilder::new(self.clone())
     }
 
     /// list triggers in a collection
+    #[must_use]
     pub fn list_triggers(&self) -> ListTriggersBuilder {
         ListTriggersBuilder::new(self.clone())
     }
 
     /// list the partition key ranges in a collection
+    #[must_use]
     pub fn get_partition_key_ranges(&self) -> GetPartitionKeyRangesBuilder {
         GetPartitionKeyRangesBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -23,6 +23,7 @@ pub struct CosmosClient {
 
 impl CosmosClient {
     /// Create a new `CosmosClient` which connects to the account's instance in the public Azure cloud.
+    #[must_use]
     pub fn new(account: String, auth_token: AuthorizationToken, options: CosmosOptions) -> Self {
         let cloud_location = CloudLocation::Public(account);
         let pipeline = new_pipeline_from_options(options, auth_token);
@@ -47,6 +48,7 @@ impl CosmosClient {
     }
 
     /// Create a new `CosmosClient` which connects to the account's instance in the Chinese Azure cloud.
+    #[must_use]
     pub fn new_china(
         account: String,
         auth_token: AuthorizationToken,
@@ -61,6 +63,7 @@ impl CosmosClient {
     }
 
     /// Create a new `CosmosClient` which connects to the account's instance in custom Azure cloud.
+    #[must_use]
     pub fn new_custom(
         account: String,
         auth_token: AuthorizationToken,
@@ -76,6 +79,7 @@ impl CosmosClient {
     }
 
     /// Create a new `CosmosClient` which connects to the account's instance in Azure emulator
+    #[must_use]
     pub fn new_emulator(address: &str, port: u16, options: CosmosOptions) -> Self {
         let auth_token = AuthorizationToken::primary_from_base64(EMULATOR_ACCOUNT_KEY).unwrap();
         let uri = format!("https://{}:{}", address, port);
@@ -107,6 +111,7 @@ impl CosmosClient {
     }
 
     /// List all databases
+    #[must_use]
     pub fn list_databases(&self) -> ListDatabasesBuilder {
         ListDatabasesBuilder::new(self.clone())
     }
@@ -176,6 +181,7 @@ pub struct CosmosOptions {
 
 impl CosmosOptions {
     /// Create new options
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }

--- a/sdk/data_cosmos/src/clients/database.rs
+++ b/sdk/data_cosmos/src/clients/database.rs
@@ -21,6 +21,7 @@ impl DatabaseClient {
     }
 
     /// Get a [`CosmosClient`].
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         &self.client
     }
@@ -39,21 +40,25 @@ impl DatabaseClient {
     }
 
     /// Get the database's name
+    #[must_use]
     pub fn database_name(&self) -> &str {
         &self.database_name
     }
 
     /// Get the database
+    #[must_use]
     pub fn get_database(&self) -> GetDatabaseBuilder {
         GetDatabaseBuilder::new(self.clone())
     }
 
     /// Delete the database
+    #[must_use]
     pub fn delete_database(&self) -> DeleteDatabaseBuilder {
         DeleteDatabaseBuilder::new(self.clone())
     }
 
     /// List collections in the database
+    #[must_use]
     pub fn list_collections(&self) -> ListCollectionsBuilder {
         ListCollectionsBuilder::new(self.clone())
     }
@@ -68,6 +73,7 @@ impl DatabaseClient {
     }
 
     /// List users
+    #[must_use]
     pub fn list_users(&self) -> ListUsersBuilder {
         ListUsersBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/document.rs
+++ b/sdk/data_cosmos/src/clients/document.rs
@@ -29,16 +29,19 @@ impl DocumentClient {
     }
 
     /// Get a [`CosmosClient`]
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection_client().cosmos_client()
     }
 
     /// Get a [`DatabaseClient`]
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection_client().database_client()
     }
 
     /// Get a [`CollectionClient`]
+    #[must_use]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection
     }
@@ -52,16 +55,19 @@ impl DocumentClient {
     }
 
     /// Get the document's name
+    #[must_use]
     pub fn document_name(&self) -> &str {
         &self.document_name
     }
 
     /// Get the partition key
+    #[must_use]
     pub fn partition_key_serialized(&self) -> &str {
         &self.partition_key_serialized
     }
 
     /// Get a document
+    #[must_use]
     pub fn get_document(&self) -> GetDocumentBuilder {
         GetDocumentBuilder::new(self.clone())
     }
@@ -75,11 +81,13 @@ impl DocumentClient {
     }
 
     /// Delete a document
+    #[must_use]
     pub fn delete_document(&self) -> DeleteDocumentBuilder {
         DeleteDocumentBuilder::new(self.clone())
     }
 
     /// List all attachments for a document
+    #[must_use]
     pub fn list_attachments(&self) -> ListAttachmentsBuilder {
         ListAttachmentsBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/permission.rs
+++ b/sdk/data_cosmos/src/clients/permission.rs
@@ -20,41 +20,49 @@ impl PermissionClient {
     }
 
     /// Get a [`CosmosClient`
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.user.cosmos_client()
     }
 
     /// Get a [`DatabaseClient`]
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         self.user.database_client()
     }
 
     /// Get the [`UserClient`]
+    #[must_use]
     pub fn user_client(&self) -> &UserClient {
         &self.user
     }
 
     /// Get the permission's name
+    #[must_use]
     pub fn permission_name(&self) -> &str {
         &self.permission_name
     }
 
     /// Create the permission
+    #[must_use]
     pub fn create_permission(&self, permission_mode: PermissionMode) -> CreatePermissionBuilder {
         CreatePermissionBuilder::new(self.clone(), permission_mode)
     }
 
     /// Replace the permission
+    #[must_use]
     pub fn replace_permission(&self, permission_mode: PermissionMode) -> ReplacePermissionBuilder {
         ReplacePermissionBuilder::new(self.clone(), permission_mode)
     }
 
     /// Get the permission
+    #[must_use]
     pub fn get_permission(&self) -> GetPermissionBuilder {
         GetPermissionBuilder::new(self.clone())
     }
 
     /// Delete the permission
+    #[must_use]
     pub fn delete_permission(&self) -> DeletePermissionBuilder {
         DeletePermissionBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/stored_procedure.rs
+++ b/sdk/data_cosmos/src/clients/stored_procedure.rs
@@ -22,21 +22,25 @@ impl StoredProcedureClient {
     }
 
     /// Get a [`CosmosClient`]
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection.cosmos_client()
     }
 
     /// Get a [`DatabaseClient`]
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection.database_client()
     }
 
     /// Get the [`CollectionClient`]
+    #[must_use]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection
     }
 
     /// Get the stored procedure's name
+    #[must_use]
     pub fn stored_procedure_name(&self) -> &str {
         &self.stored_procedure_name
     }
@@ -58,11 +62,13 @@ impl StoredProcedureClient {
     }
 
     /// Execute the stored procedure
+    #[must_use]
     pub fn execute_stored_procedure(&self) -> ExecuteStoredProcedureBuilder {
         ExecuteStoredProcedureBuilder::new(self.clone())
     }
 
     /// Delete the stored procedure
+    #[must_use]
     pub fn delete_stored_procedure(&self) -> DeleteStoredProcedureBuilder {
         DeleteStoredProcedureBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/trigger.rs
+++ b/sdk/data_cosmos/src/clients/trigger.rs
@@ -24,21 +24,25 @@ impl TriggerClient {
     }
 
     /// Get a [`CosmosClient`]
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection.cosmos_client()
     }
 
     /// Get a [`DatabaseClient`]
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection.database_client()
     }
 
     /// Get a [`CollectionClient`]
+    #[must_use]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection
     }
 
     /// Get the trigger name
+    #[must_use]
     pub fn trigger_name(&self) -> &str {
         &self.trigger_name
     }
@@ -86,6 +90,7 @@ impl TriggerClient {
     }
 
     /// Delete a trigger
+    #[must_use]
     pub fn delete_trigger(&self) -> DeleteTriggerBuilder {
         DeleteTriggerBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/user.rs
+++ b/sdk/data_cosmos/src/clients/user.rs
@@ -19,11 +19,13 @@ impl UserClient {
     }
 
     /// Get a [`CosmosClient`]
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.database_client().cosmos_client()
     }
 
     /// Get a [`DatabaseClient`]
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         &self.database
     }
@@ -37,16 +39,19 @@ impl UserClient {
     }
 
     /// Get the user name
+    #[must_use]
     pub fn user_name(&self) -> &str {
         &self.user_name
     }
 
     /// Create the user
+    #[must_use]
     pub fn create_user(&self) -> CreateUserBuilder {
         CreateUserBuilder::new(self.clone())
     }
 
     /// Get the user
+    #[must_use]
     pub fn get_user(&self) -> GetUserBuilder {
         GetUserBuilder::new(self.clone())
     }
@@ -57,11 +62,13 @@ impl UserClient {
     }
 
     /// Delete the user
+    #[must_use]
     pub fn delete_user(&self) -> DeleteUserBuilder {
         DeleteUserBuilder::new(self.clone())
     }
 
     /// List the user's permissions
+    #[must_use]
     pub fn list_permissions(&self) -> ListPermissionsBuilder {
         ListPermissionsBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/clients/user_defined_function.rs
+++ b/sdk/data_cosmos/src/clients/user_defined_function.rs
@@ -22,21 +22,25 @@ impl UserDefinedFunctionClient {
     }
 
     /// Get a [`CosmosClient`]
+    #[must_use]
     pub fn cosmos_client(&self) -> &CosmosClient {
         self.collection.cosmos_client()
     }
 
     /// Get a [`DatabaseClient`]
+    #[must_use]
     pub fn database_client(&self) -> &DatabaseClient {
         self.collection.database_client()
     }
 
     /// Get a [`CollectionClient`]
+    #[must_use]
     pub fn collection_client(&self) -> &CollectionClient {
         &self.collection
     }
 
     /// Get the user defined function's name
+    #[must_use]
     pub fn user_defined_function_name(&self) -> &str {
         &self.user_defined_function_name
     }
@@ -64,6 +68,7 @@ impl UserDefinedFunctionClient {
     }
 
     /// Delete the user defined function
+    #[must_use]
     pub fn delete_user_defined_function(&self) -> DeleteUserDefinedFunctionBuilder {
         DeleteUserDefinedFunctionBuilder::new(self.clone())
     }

--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -40,6 +40,7 @@ impl CreateCollectionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateCollection {
         Box::pin(async move {
             let mut request = self.client.prepare_collections_pipeline(http::Method::POST);

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -34,6 +34,7 @@ impl CreateDatabaseBuilder {
         self
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateDatabase {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -40,6 +40,7 @@ impl CreateOrReplaceAttachmentBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateOrReplaceAttachment {
         Box::pin(async move {
             let mut req = if self.is_create {

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -44,6 +44,7 @@ impl CreateOrReplaceTriggerBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateOrReplaceTrigger {
         Box::pin(async move {
             let mut request = if self.is_create {

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -33,6 +33,7 @@ impl CreateOrReplaceUserDefinedFunctionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateOrReplaceUserDefinedFunction {
         Box::pin(async move {
             let mut request = match self.is_create {

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -29,6 +29,7 @@ impl CreatePermissionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreatePermission {
         Box::pin(async move {
             let mut request = self.client.cosmos_client().prepare_request_pipeline(

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -29,6 +29,7 @@ impl CreateStoredProcedureBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateStoredProcedure {
         Box::pin(async move {
             let mut req = self.client.prepare_request_pipeline(http::Method::POST);

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -22,6 +22,7 @@ impl CreateUserBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateUser {
         Box::pin(async move {
             let mut request = self.client.cosmos_client().prepare_request_pipeline(

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -32,6 +32,7 @@ impl DeleteAttachmentBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteAttachment {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -12,6 +12,7 @@ pub struct DeleteCollectionBuilder {
 }
 
 impl DeleteCollectionBuilder {
+    #[must_use]
     pub fn new(client: CollectionClient) -> Self {
         Self {
             client,
@@ -25,6 +26,7 @@ impl DeleteCollectionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteCollection {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -26,6 +26,7 @@ impl DeleteDatabaseBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteDatabase {
         Box::pin(async move {
             let mut request = self.client.prepare_pipeline(http::Method::DELETE);

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -36,6 +36,7 @@ impl DeleteDocumentBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteDocument {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -26,6 +26,7 @@ impl DeletePermissionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeletePermission {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -26,6 +26,7 @@ impl DeleteStoredProcedureBuilder {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteStoredProcedure {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -28,6 +28,7 @@ impl DeleteTriggerBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteTrigger {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -23,6 +23,7 @@ impl DeleteUserBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteUser {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -28,6 +28,7 @@ impl DeleteUserDefinedFunctionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteUserDefinedFunction {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -47,6 +47,7 @@ impl ExecuteStoredProcedureBuilder {
         })
     }
 
+    #[must_use]
     pub fn into_future<T>(self) -> ExecuteStoredProcedure<T>
     where
         T: DeserializeOwned,

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -34,6 +34,7 @@ impl GetAttachmentBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetAttachment {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -28,6 +28,7 @@ impl GetCollectionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetCollection {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -28,6 +28,7 @@ impl GetDatabaseBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetDatabase {
         Box::pin(async move {
             let mut request = self.client.prepare_pipeline(http::Method::GET);

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -41,6 +41,7 @@ impl GetDocumentBuilder {
     /// We do not implement `std::future::IntoFuture` because it requires the ability for the
     /// output of the future to be generic which is not possible in Rust (as of 1.59). Once
     /// generic associated types (GATs) stabilize, this will become possible.
+    #[must_use]
     pub fn into_future<T: DeserializeOwned>(self) -> GetDocument<T> {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -32,6 +32,7 @@ impl GetPartitionKeyRangesBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetPartitionKeyRanges {
         Box::pin(async move {
             let mut request = self.client.cosmos_client().prepare_request_pipeline(

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -10,6 +10,7 @@ pub struct GetPermissionBuilder {
 }
 
 impl GetPermissionBuilder {
+    #[must_use]
     pub fn new(client: PermissionClient) -> Self {
         Self {
             client,
@@ -23,6 +24,7 @@ impl GetPermissionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetPermission {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/get_user.rs
+++ b/sdk/data_cosmos/src/operations/get_user.rs
@@ -9,6 +9,7 @@ pub struct GetUserBuilder {
 }
 
 impl GetUserBuilder {
+    #[must_use]
     pub fn new(client: UserClient) -> Self {
         Self {
             client,
@@ -22,6 +23,7 @@ impl GetUserBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetUser {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -41,6 +41,7 @@ impl ListAttachmentsBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListAttachments {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -32,6 +32,7 @@ impl ListCollectionsBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListCollections {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -31,6 +31,7 @@ impl ListDatabasesBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListDatabases {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -43,6 +43,7 @@ impl ListDocumentsBuilder {
         partition_range_id: String => Some(PartitionRangeId::new(partition_range_id)),
     }
 
+    #[must_use]
     pub fn into_stream<T>(self) -> ListDocuments<T>
     where
         T: DeserializeOwned + Send + Sync,

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -31,6 +31,7 @@ impl ListPermissionsBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListPermissions {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -33,6 +33,7 @@ impl ListStoredProceduresBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListStoredProcedures {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -36,6 +36,7 @@ impl ListTriggersBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListTriggers {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -37,6 +37,7 @@ impl ListUserDefinedFunctionsBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListUserDefinedFunctions {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -34,6 +34,7 @@ impl ListUsersBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListUsers {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -67,6 +67,7 @@ impl QueryDocumentsBuilder {
         })
     }
 
+    #[must_use]
     pub fn into_stream<T>(self) -> QueryDocuments<T>
     where
         T: DeserializeOwned + Send + Sync,
@@ -202,6 +203,7 @@ pub struct QueryDocumentsResponse<T> {
 }
 
 impl<T> QueryDocumentsResponse<T> {
+    #[must_use]
     pub fn into_raw(self) -> QueryDocumentsResponseRaw<T> {
         self.into()
     }

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -33,6 +33,7 @@ impl ReplaceCollectionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> ReplaceCollection {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -29,6 +29,7 @@ impl ReplacePermissionBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> ReplacePermission {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -26,6 +26,7 @@ impl ReplaceStoredProcedureBuilder {
         consistency_level: ConsistencyLevel => Some(consistency_level),
     }
 
+    #[must_use]
     pub fn into_future(self) -> ReplaceStoredProcedure {
         Box::pin(async move {
             let mut req = self

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -24,6 +24,7 @@ impl ReplaceUserBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> ReplaceUser {
         Box::pin(async move {
             let mut request = self

--- a/sdk/data_cosmos/src/resources/database.rs
+++ b/sdk/data_cosmos/src/resources/database.rs
@@ -31,6 +31,7 @@ pub struct Database {
 
 impl Database {
     /// The name of the database
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.id
     }

--- a/sdk/data_cosmos/src/resources/document/document_attributes.rs
+++ b/sdk/data_cosmos/src/resources/document/document_attributes.rs
@@ -18,26 +18,31 @@ pub struct DocumentAttributes {
 impl DocumentAttributes {
     /// a unique identifier that is also hierarchical per the resource
     /// stack on the resource model.
+    #[must_use]
     pub fn rid(&self) -> &str {
         &self.rid
     }
 
     /// the last updated timestamp of the resource.
+    #[must_use]
     pub fn ts(&self) -> u64 {
         self.ts
     }
 
     ///  the unique addressable URI for the resource
+    #[must_use]
     pub fn _self(&self) -> &str {
         &self._self
     }
 
     /// resource etag required for optimistic concurrency control
+    #[must_use]
     pub fn etag(&self) -> &str {
         &self.etag
     }
 
     /// the addressable path for the attachments resource
+    #[must_use]
     pub fn attachments(&self) -> &str {
         &self.attachments
     }

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -204,6 +204,7 @@ pub struct PartitionRangeId(String);
 
 impl PartitionRangeId {
     /// A new partition range id from a string
+    #[must_use]
     pub fn new(id: String) -> Self {
         Self(id)
     }

--- a/sdk/data_cosmos/src/resources/document/query.rs
+++ b/sdk/data_cosmos/src/resources/document/query.rs
@@ -11,6 +11,7 @@ pub struct Query {
 
 impl Query {
     /// A new SQL query with no parameters
+    #[must_use]
     pub fn new(query: String) -> Self {
         Self::with_params(query, vec![])
     }
@@ -24,11 +25,13 @@ impl Query {
     }
 
     /// The query as a `&str`
+    #[must_use]
     pub fn query(&self) -> &str {
         &self.query
     }
 
     /// The supplied params
+    #[must_use]
     pub fn params(&self) -> &[Param] {
         &self.parameters
     }
@@ -57,11 +60,13 @@ impl Param {
     }
 
     /// The param name
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.name
     }
 
     /// The param value
+    #[must_use]
     pub fn value(&self) -> &Value {
         &self.value
     }

--- a/sdk/data_cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/authorization_token.rs
@@ -25,6 +25,7 @@ impl AuthorizationToken {
     }
 
     /// Create a resource `AuthorizationToken` for the given resource.
+    #[must_use]
     pub fn new_resource(resource: String) -> AuthorizationToken {
         AuthorizationToken::Resource(resource)
     }

--- a/sdk/data_cosmos/src/resources/permission/mod.rs
+++ b/sdk/data_cosmos/src/resources/permission/mod.rs
@@ -21,6 +21,7 @@ pub struct ExpirySeconds(u64);
 
 impl ExpirySeconds {
     /// Create an `ExpirySeconds` from a `u64`
+    #[must_use]
     pub fn new(secs: u64) -> Self {
         Self(secs)
     }

--- a/sdk/data_cosmos/src/resources/permission/permission.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission.rs
@@ -70,6 +70,7 @@ impl PermissionMode {
     }
 
     /// The kind of permission mode as a string. Either "All" or "Read".
+    #[must_use]
     pub fn kind(&self) -> &str {
         match self {
             Self::All(_) => "All",
@@ -78,6 +79,7 @@ impl PermissionMode {
     }
 
     /// The full addressable path of the resource associated with the permission
+    #[must_use]
     pub fn resource(&self) -> &str {
         match self {
             Self::All(s) => s.as_ref(),

--- a/sdk/data_cosmos/src/resources/stored_procedure.rs
+++ b/sdk/data_cosmos/src/resources/stored_procedure.rs
@@ -28,6 +28,7 @@ pub struct StoredProcedure {
 
 impl StoredProcedure {
     /// The name of the stored procedure
+    #[must_use]
     pub fn name(&self) -> &str {
         &self.id
     }

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -56,22 +56,27 @@ impl EntityClient {
         }))
     }
 
+    #[must_use]
     pub fn row_key(&self) -> &str {
         &self.row_key
     }
 
+    #[must_use]
     pub fn get(&self) -> GetEntityBuilder {
         GetEntityBuilder::new(self)
     }
 
+    #[must_use]
     pub fn update(&self) -> UpdateOrMergeEntityBuilder {
         UpdateOrMergeEntityBuilder::new(self, update_or_merge_entity_builder::Operation::Update)
     }
 
+    #[must_use]
     pub fn merge(&self) -> UpdateOrMergeEntityBuilder {
         UpdateOrMergeEntityBuilder::new(self, update_or_merge_entity_builder::Operation::Merge)
     }
 
+    #[must_use]
     pub fn insert_or_replace(&self) -> InsertOrReplaceOrMergeEntityBuilder {
         InsertOrReplaceOrMergeEntityBuilder::new(
             self,
@@ -79,6 +84,7 @@ impl EntityClient {
         )
     }
 
+    #[must_use]
     pub fn insert_or_merge(&self) -> InsertOrReplaceOrMergeEntityBuilder {
         InsertOrReplaceOrMergeEntityBuilder::new(
             self,
@@ -86,6 +92,7 @@ impl EntityClient {
         )
     }
 
+    #[must_use]
     pub fn delete(&self) -> DeleteEntityBuilder {
         DeleteEntityBuilder::new(self)
     }

--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -33,10 +33,12 @@ impl PartitionKeyClient {
         })
     }
 
+    #[must_use]
     pub fn submit_transaction(&self) -> SubmitTransactionBuilder {
         SubmitTransactionBuilder::new(self)
     }
 
+    #[must_use]
     pub fn partition_key(&self) -> &str {
         &self.partition_key
     }

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -32,22 +32,27 @@ impl TableClient {
         })
     }
 
+    #[must_use]
     pub fn table_name(&self) -> &str {
         &self.table_name
     }
 
+    #[must_use]
     pub fn create(&self) -> CreateTableBuilder {
         CreateTableBuilder::new(self)
     }
 
+    #[must_use]
     pub fn query(&self) -> QueryEntityBuilder {
         QueryEntityBuilder::new(self)
     }
 
+    #[must_use]
     pub fn delete(&self) -> DeleteTableBuilder {
         DeleteTableBuilder::new(self)
     }
 
+    #[must_use]
     pub fn insert(&self) -> InsertEntityBuilder {
         InsertEntityBuilder::new(self)
     }

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -39,6 +39,7 @@ impl TableServiceClient {
         }))
     }
 
+    #[must_use]
     pub fn list(&self) -> ListTablesBuilder {
         ListTablesBuilder::new(self)
     }

--- a/sdk/data_tables/src/continuation_next_partition_and_row_key.rs
+++ b/sdk/data_tables/src/continuation_next_partition_and_row_key.rs
@@ -4,6 +4,7 @@ use azure_core::{headers::Headers, AppendToUrlQuery};
 pub struct ContinuationNextPartitionAndRowKey(String, Option<String>);
 
 impl ContinuationNextPartitionAndRowKey {
+    #[must_use]
     pub fn new(
         continuation_next_partition_key: String,
         continuation_next_row_key: Option<String>,
@@ -11,6 +12,7 @@ impl ContinuationNextPartitionAndRowKey {
         Self(continuation_next_partition_key, continuation_next_row_key)
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/sdk/data_tables/src/continuation_next_table_name.rs
+++ b/sdk/data_tables/src/continuation_next_table_name.rs
@@ -4,10 +4,12 @@ use azure_core::{headers::Headers, AppendToUrlQuery};
 pub struct ContinuationNextTableName(String);
 
 impl ContinuationNextTableName {
+    #[must_use]
     pub fn new(continuation_next_table_name: String) -> Self {
         Self(continuation_next_table_name)
     }
 
+    #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
     }

--- a/sdk/data_tables/src/top.rs
+++ b/sdk/data_tables/src/top.rs
@@ -4,6 +4,7 @@ use azure_core::AppendToUrlQuery;
 pub struct Top(u32);
 
 impl Top {
+    #[must_use]
     pub fn new(s: u32) -> Self {
         Self(s)
     }

--- a/sdk/identity/src/authorization_code_flow.rs
+++ b/sdk/identity/src/authorization_code_flow.rs
@@ -12,6 +12,7 @@ use url::Url;
 ///
 /// The values for `client_id`, `client_secret`, `tenant_id`, and `redirect_url` can all be found
 /// inside of the Azure portal.
+#[must_use]
 pub fn start(
     client_id: ClientId,
     client_secret: Option<ClientSecret>,

--- a/sdk/identity/src/device_code_flow/device_code_responses.rs
+++ b/sdk/identity/src/device_code_flow/device_code_responses.rs
@@ -45,14 +45,17 @@ pub struct DeviceCodeAuthorization {
 
 impl DeviceCodeAuthorization {
     /// Get the access token
+    #[must_use]
     pub fn access_token(&self) -> &AccessToken {
         &self.access_token
     }
     /// Get the refresh token
+    #[must_use]
     pub fn refresh_token(&self) -> Option<&AccessToken> {
         self.refresh_token.as_ref()
     }
     /// Get the id token
+    #[must_use]
     pub fn id_token(&self) -> Option<&AccessToken> {
         self.id_token.as_ref()
     }

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -89,6 +89,7 @@ pub struct DeviceCodePhaseOneResponse<'a> {
 
 impl<'a> DeviceCodePhaseOneResponse<'a> {
     /// The message containing human readable instructions for the user.
+    #[must_use]
     pub fn message(&self) -> &str {
         &self.message
     }

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -80,26 +80,32 @@ pub struct RefreshTokenResponse {
 
 impl RefreshTokenResponse {
     /// Returns the token_type. Always `Bearer` for Azure AD.
+    #[must_use]
     pub fn token_type(&self) -> &str {
         &self.token_type
     }
     /// The scopes that the `access_token` is valid for.
+    #[must_use]
     pub fn scopes(&self) -> &[String] {
         &self.scopes
     }
     /// Number of seconds the `access_token` is valid for.
+    #[must_use]
     pub fn expires_in(&self) -> u64 {
         self.expires_in
     }
     /// Issued for the scopes that were requested.
+    #[must_use]
     pub fn access_token(&self) -> &AccessToken {
         &self.access_token
     }
     /// The new refresh token and should replace old refresh token.
+    #[must_use]
     pub fn refresh_token(&self) -> &AccessToken {
         &self.refresh_token
     }
     /// Indicates the extended lifetime of an `access_token`.
+    #[must_use]
     pub fn ext_expires_in(&self) -> u64 {
         self.ext_expires_in
     }

--- a/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
+++ b/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
@@ -25,6 +25,7 @@ impl std::fmt::Debug for AutoRefreshingTokenCredential {
 
 impl AutoRefreshingTokenCredential {
     /// Create a new `AutoRefreshingTokenCredential` around the provided base provider.
+    #[must_use]
     pub fn new(provider: Arc<dyn TokenCredential>) -> Self {
         Self {
             credential: provider,

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -22,6 +22,7 @@ impl Default for TokenCredentialOptions {
 
 impl TokenCredentialOptions {
     /// Create a new TokenCredentialsOptions. `default()` may also be used.
+    #[must_use]
     pub fn new(authority_host: String) -> Self {
         Self { authority_host }
     }
@@ -32,6 +33,7 @@ impl TokenCredentialOptions {
 
     /// The authority host to use for authentication requests.  The default is
     /// `https://login.microsoftonline.com`.
+    #[must_use]
     pub fn authority_host(&self) -> &str {
         &self.authority_host
     }
@@ -72,6 +74,7 @@ pub struct ClientSecretCredential {
 
 impl ClientSecretCredential {
     /// Create a new ClientSecretCredential
+    #[must_use]
     pub fn new(
         tenant_id: String,
         client_id: String,

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -22,6 +22,7 @@ impl Default for DefaultAzureCredentialBuilder {
 
 impl DefaultAzureCredentialBuilder {
     /// Create a new `DefaultAzureCredentialBuilder`
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
@@ -45,6 +46,7 @@ impl DefaultAzureCredentialBuilder {
     }
 
     /// Create a `DefaultAzureCredential` from this builder.
+    #[must_use]
     pub fn build(&self) -> DefaultAzureCredential {
         let source_count = self.include_azure_cli_credential as usize
             + self.include_azure_cli_credential as usize
@@ -118,6 +120,7 @@ impl DefaultAzureCredential {
     /// Creates a `DefaultAzureCredential` with specified sources.
     ///
     /// These sources will be tried in the order provided in the `TokenCredential` authentication flow.
+    #[must_use]
     pub fn with_sources(sources: Vec<DefaultAzureCredentialEnum>) -> Self {
         DefaultAzureCredential { sources }
     }

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -29,6 +29,7 @@ pub struct EnvironmentCredential {
 
 impl EnvironmentCredential {
     /// Creates a new `EnvironmentCredential` with the given `TokenCredentialOptions`.
+    #[must_use]
     pub fn new(options: TokenCredentialOptions) -> Self {
         Self { options }
     }

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -38,6 +38,7 @@ impl Default for ImdsManagedIdentityCredential {
 
 impl ImdsManagedIdentityCredential {
     /// Creates a new `ImdsManagedIdentityCredential` using the given `HttpClient`.
+    #[must_use]
     pub fn new(http_client: Arc<dyn HttpClient>) -> Self {
         Self {
             http_client,

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -497,6 +497,7 @@ impl ServiceClient {
     /// let device = iot_hub.create_device_identity()
     ///     .execute("some-existing-device", Status::Enabled, AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key"));
     /// ```
+    #[must_use]
     pub fn create_device_identity(&self) -> CreateOrUpdateDeviceIdentityBuilder {
         CreateOrUpdateDeviceIdentityBuilder::new(self, IdentityOperation::Create, None)
     }
@@ -583,6 +584,7 @@ impl ServiceClient {
     /// let device = iot_hub.create_module_identity()
     ///     .execute("some-existing-device", "some-existing-module", "IoTEdge", AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key"));
     /// ```
+    #[must_use]
     pub fn create_module_identity(&self) -> CreateOrUpdateModuleIdentityBuilder {
         CreateOrUpdateModuleIdentityBuilder::new(self, IdentityOperation::Create, None)
     }
@@ -651,6 +653,7 @@ impl ServiceClient {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let query_builder = iot_hub.query();
     /// ```
+    #[must_use]
     pub fn query(&self) -> QueryBuilder<'_> {
         QueryBuilder::new(self)
     }

--- a/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
+++ b/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
@@ -36,6 +36,7 @@ impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device").device_content(serde_json::json!({}));
     /// ```
+    #[must_use]
     pub fn device_content(mut self, device_content: serde_json::Value) -> Self {
         self.device_content = device_content;
         self
@@ -54,6 +55,7 @@ impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device").module_content(serde_json::json!({}));
     /// ```
+    #[must_use]
     pub fn module_content(mut self, module_content: serde_json::Value) -> Self {
         self.module_content = module_content;
         self
@@ -72,6 +74,7 @@ impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
     /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device").modules_content(serde_json::json!({}));
     /// ```
+    #[must_use]
     pub fn modules_content(mut self, modules_content: serde_json::Value) -> Self {
         self.modules_content = modules_content;
         self

--- a/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
@@ -46,6 +46,7 @@ impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
 
     /// Sets the device content for the configuration
     /// The content cannot be updated once it has been created.
+    #[must_use]
     pub fn device_content(mut self, device_content: serde_json::Value) -> Self {
         self.content.device_content = Some(device_content);
         self
@@ -53,6 +54,7 @@ impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
 
     /// Sets the module content for the configuration.
     /// The content cannot be updated once it has been created.
+    #[must_use]
     pub fn module_content(mut self, module_content: serde_json::Value) -> Self {
         self.content.module_content = Some(module_content);
         self
@@ -60,6 +62,7 @@ impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
 
     /// Sets the module content for the configuration
     /// The content cannot be updated once it has been created.
+    #[must_use]
     pub fn modules_content(mut self, modules_content: serde_json::Value) -> Self {
         self.content.modules_content = Some(modules_content);
         self
@@ -76,6 +79,7 @@ impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
     }
 
     /// Add multiple metrics to the configuration.
+    #[must_use]
     pub fn metrics(mut self, metrics: HashMap<String, String>) -> Self {
         self.metrics = metrics;
         self
@@ -92,6 +96,7 @@ impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
     }
 
     /// Add multiple labels to the configuration.
+    #[must_use]
     pub fn labels(mut self, labels: HashMap<String, String>) -> Self {
         self.labels = labels;
         self

--- a/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
@@ -33,6 +33,7 @@ impl<'a> CreateOrUpdateDeviceIdentityBuilder<'a> {
     }
 
     /// Sets a device capability on the device
+    #[must_use]
     pub fn device_capability(mut self, desired_capability: DesiredCapability) -> Self {
         match desired_capability {
             DesiredCapability::IotEdge => self.capabilities.iotedge = true,

--- a/sdk/iot_hub/src/service/requests/update_or_replace_twin_builder.rs
+++ b/sdk/iot_hub/src/service/requests/update_or_replace_twin_builder.rs
@@ -87,6 +87,7 @@ where
     ///                  "ChildProperty": "ChildValue"
     ///                }
     ///              }));
+    #[must_use]
     pub fn properties(mut self, desired_properties: serde_json::Value) -> Self {
         self.desired_properties = Some(desired_properties);
         self

--- a/sdk/iot_hub/src/service/resources/identity.rs
+++ b/sdk/iot_hub/src/service/resources/identity.rs
@@ -116,6 +116,7 @@ impl AuthenticationMechanism {
     }
 
     /// Create a new AuthenticationMechanism using a certificate authority
+    #[must_use]
     pub fn new_using_certificate_authority() -> Self {
         Self {
             authentication_type: AuthenticationType::Authority,

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -214,11 +214,13 @@ pub struct PeekLockResponse {
 
 impl PeekLockResponse {
     /// Get the message in the lock
+    #[must_use]
     pub fn body(&self) -> String {
         self.body.clone()
     }
 
     /// Get the status of the peek
+    #[must_use]
     pub fn status(&self) -> http::StatusCode {
         self.status
     }

--- a/sdk/storage/src/account/operations/find_blobs_by_tags.rs
+++ b/sdk/storage/src/account/operations/find_blobs_by_tags.rs
@@ -37,6 +37,7 @@ impl FindBlobsByTagsBuilder {
     }
 
     // TODO: Make this a stream instead of a `Future`
+    #[must_use]
     pub fn into_future(mut self) -> FindBlobsByTags {
         Box::pin(async move {
             let mut request = self

--- a/sdk/storage/src/account/operations/get_account_information.rs
+++ b/sdk/storage/src/account/operations/get_account_information.rs
@@ -24,6 +24,7 @@ impl GetAccountInformationBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(mut self) -> GetAccountInformation {
         Box::pin(async move {
             let mut request = self

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -129,6 +129,7 @@ impl StorageAccountClient {
     }
 
     /// Create a new client for customized emulator endpoints.
+    #[must_use]
     pub fn new_emulator(
         http_client: Arc<dyn HttpClient>,
         blob_storage_url: &Url,
@@ -148,6 +149,7 @@ impl StorageAccountClient {
     }
 
     /// Create a new client using the default HttpClient and the default emulator endpoints.
+    #[must_use]
     pub fn new_emulator_default() -> Arc<Self> {
         let http_client = azure_core::new_http_client();
         let blob_storage_url = Url::parse("http://127.0.0.1:10000").unwrap();
@@ -388,34 +390,42 @@ impl StorageAccountClient {
         }
     }
 
+    #[must_use]
     pub fn http_client(&self) -> &dyn HttpClient {
         self.http_client.as_ref()
     }
 
+    #[must_use]
     pub fn blob_storage_url(&self) -> &Url {
         &self.blob_storage_url
     }
 
+    #[must_use]
     pub fn table_storage_url(&self) -> &Url {
         &self.table_storage_url
     }
 
+    #[must_use]
     pub fn queue_storage_url(&self) -> &Url {
         &self.queue_storage_url
     }
 
+    #[must_use]
     pub fn queue_storage_secondary_url(&self) -> &Url {
         &self.queue_storage_secondary_url
     }
 
+    #[must_use]
     pub fn filesystem_url(&self) -> &Url {
         &self.filesystem_url
     }
 
+    #[must_use]
     pub fn account(&self) -> &str {
         &self.account
     }
 
+    #[must_use]
     pub fn storage_credentials(&self) -> &StorageCredentials {
         &self.storage_credentials
     }

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -29,11 +29,13 @@ impl StorageClient {
     }
 
     #[allow(dead_code)]
+    #[must_use]
     pub fn storage_account_client(&self) -> &StorageAccountClient {
         self.storage_account_client.as_ref()
     }
 
     #[allow(dead_code)]
+    #[must_use]
     pub fn http_client(&self) -> &dyn azure_core::HttpClient {
         self.storage_account_client.http_client()
     }
@@ -77,10 +79,12 @@ impl StorageClient {
     }
 
     #[cfg(feature = "account")]
+    #[must_use]
     pub fn get_account_information(&self) -> GetAccountInformationBuilder {
         GetAccountInformationBuilder::new(self.clone())
     }
 
+    #[must_use]
     pub fn find_blobs_by_tags(&self) -> FindBlobsByTagsBuilder {
         FindBlobsByTagsBuilder::new(self.clone())
     }

--- a/sdk/storage/src/core/connection_string_builder.rs
+++ b/sdk/storage/src/core/connection_string_builder.rs
@@ -4,10 +4,12 @@ use crate::core::connection_string::*;
 pub struct ConnectionStringBuilder<'a>(ConnectionString<'a>);
 
 impl<'a> ConnectionStringBuilder<'a> {
+    #[must_use]
     pub fn new() -> Self {
         Self(ConnectionString::default())
     }
 
+    #[must_use]
     pub fn build(&self) -> String {
         let mut kv_pairs = Vec::new();
 

--- a/sdk/storage/src/core/parsing_xml.rs
+++ b/sdk/storage/src/core/parsing_xml.rs
@@ -87,6 +87,7 @@ pub fn traverse<'a>(
 }
 
 #[inline]
+#[must_use]
 pub fn find_subnodes<'a>(node: &'a Element, subnode: &str) -> Vec<&'a Element> {
     node.children
         .iter()

--- a/sdk/storage/src/core/shared_access_signature/account_sas.rs
+++ b/sdk/storage/src/core/shared_access_signature/account_sas.rs
@@ -145,6 +145,7 @@ pub struct AccountSharedAccessSignature {
 
 impl AccountSharedAccessSignature {
     #[allow(clippy::new_ret_no_self)]
+    #[must_use]
     pub fn new<'a>(
         account: &'a str,
         key: &'a str,
@@ -249,6 +250,7 @@ pub struct AccountSharedAccessSignatureBuilder<
 }
 
 impl<'a> AccountSharedAccessSignatureBuilder<'a, No, No, No, No> {
+    #[must_use]
     pub fn new(account: &'a str, key: &'a str) -> Self {
         Self {
             account,
@@ -268,6 +270,7 @@ impl<'a> AccountSharedAccessSignatureBuilder<'a, No, No, No, No> {
         }
     }
 
+    #[must_use]
     pub fn finalize(&self) -> AccountSharedAccessSignature {
         AccountSharedAccessSignature {
             account: self.account.to_owned(),

--- a/sdk/storage/src/core/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/core/shared_access_signature/service_sas.rs
@@ -186,6 +186,7 @@ pub struct BlobSharedAccessSignatureBuilder<T1, T2, T3> {
 }
 
 impl BlobSharedAccessSignatureBuilder<(), (), ()> {
+    #[must_use]
     pub fn new(
         key: String,
         canonicalized_resource: String,
@@ -206,6 +207,7 @@ impl BlobSharedAccessSignatureBuilder<(), (), ()> {
 }
 
 impl<T1, T2, T3> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
+    #[must_use]
     pub fn with_start(
         self,
         signed_start: DateTime<Utc>,
@@ -223,6 +225,7 @@ impl<T1, T2, T3> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
             signed_ip: self.signed_ip,
         }
     }
+    #[must_use]
     pub fn with_ip(self, signed_ip: String) -> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
         BlobSharedAccessSignatureBuilder {
             _phantom: PhantomData,
@@ -237,6 +240,7 @@ impl<T1, T2, T3> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
             signed_ip: Some(signed_ip),
         }
     }
+    #[must_use]
     pub fn with_identifier(
         self,
         signed_identifier: String,
@@ -254,6 +258,7 @@ impl<T1, T2, T3> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
             signed_ip: self.signed_ip,
         }
     }
+    #[must_use]
     pub fn with_protocol(
         self,
         signed_protocol: SasProtocol,
@@ -274,6 +279,7 @@ impl<T1, T2, T3> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
 }
 
 impl BlobSharedAccessSignatureBuilder<SetPerms, SetResources, SetExpiry> {
+    #[must_use]
     pub fn finalize(self) -> BlobSharedAccessSignature {
         BlobSharedAccessSignature {
             key: self.key.clone(),
@@ -290,6 +296,7 @@ impl BlobSharedAccessSignatureBuilder<SetPerms, SetResources, SetExpiry> {
 }
 
 impl<T1, T2> BlobSharedAccessSignatureBuilder<(), T1, T2> {
+    #[must_use]
     pub fn with_permissions(
         self,
         permissions: BlobSasPermissions,
@@ -310,6 +317,7 @@ impl<T1, T2> BlobSharedAccessSignatureBuilder<(), T1, T2> {
 }
 
 impl<T1, T2> BlobSharedAccessSignatureBuilder<T1, (), T2> {
+    #[must_use]
     pub fn with_resources(
         self,
         signed_resource: BlobSignedResource,
@@ -330,6 +338,7 @@ impl<T1, T2> BlobSharedAccessSignatureBuilder<T1, (), T2> {
 }
 
 impl<T1, T2> BlobSharedAccessSignatureBuilder<T1, T2, ()> {
+    #[must_use]
     pub fn with_expiry(
         self,
         signed_expiry: DateTime<Utc>,

--- a/sdk/storage/src/core/storage_shared_key_credential.rs
+++ b/sdk/storage/src/core/storage_shared_key_credential.rs
@@ -9,6 +9,7 @@ pub struct StorageSharedKeyCredential {
 
 impl StorageSharedKeyCredential {
     /// Initializes a new instance of the StorageSharedKeyCredential class.
+    #[must_use]
     pub fn new(account_name: String, account_key: String) -> Self {
         Self {
             account_name,

--- a/sdk/storage/src/core/stored_access_policy.rs
+++ b/sdk/storage/src/core/stored_access_policy.rs
@@ -37,6 +37,7 @@ impl StoredAccessPolicy {
 }
 
 impl StoredAccessPolicyList {
+    #[must_use]
     pub fn new() -> StoredAccessPolicyList {
         StoredAccessPolicyList::default()
     }
@@ -81,6 +82,7 @@ impl StoredAccessPolicyList {
         Ok(sal)
     }
 
+    #[must_use]
     pub fn to_xml(&self) -> String {
         let mut s = String::new();
         s.push_str("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<SignedIdentifiers>\n");

--- a/sdk/storage_blobs/src/ba512_range.rs
+++ b/sdk/storage_blobs/src/ba512_range.rs
@@ -12,9 +12,11 @@ pub struct BA512Range {
 }
 
 impl BA512Range {
+    #[must_use]
     pub fn start(&self) -> u64 {
         self.start
     }
+    #[must_use]
     pub fn end(&self) -> u64 {
         self.end
     }
@@ -35,6 +37,7 @@ impl BA512Range {
     }
 
     #[inline]
+    #[must_use]
     pub fn size(&self) -> u64 {
         self.end - self.start + 1
     }

--- a/sdk/storage_blobs/src/blob/block_list.rs
+++ b/sdk/storage_blobs/src/blob/block_list.rs
@@ -16,6 +16,7 @@ impl From<BlockWithSizeList> for BlockList {
 }
 
 impl BlockList {
+    #[must_use]
     pub fn to_xml(&self) -> String {
         let mut s = String::new();
         s.push_str("<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<BlockList>\n");

--- a/sdk/storage_blobs/src/blob/block_list_type.rs
+++ b/sdk/storage_blobs/src/blob/block_list_type.rs
@@ -8,6 +8,7 @@ pub enum BlockListType {
 }
 
 impl BlockListType {
+    #[must_use]
     pub fn to_str(&self) -> &str {
         match self {
             BlockListType::All => "all",

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -41,6 +41,7 @@ impl BlobClient {
         })
     }
 
+    #[must_use]
     pub fn blob_name(&self) -> &str {
         &self.blob_name
     }
@@ -74,22 +75,27 @@ impl BlobClient {
             .map_kind(ErrorKind::DataConversion)
     }
 
+    #[must_use]
     pub fn get(&self) -> GetBlobBuilder {
         GetBlobBuilder::new(self)
     }
 
+    #[must_use]
     pub fn get_properties(&self) -> GetBlobPropertiesBuilder {
         GetBlobPropertiesBuilder::new(self)
     }
 
+    #[must_use]
     pub fn get_metadata(&self) -> GetBlobMetadataBuilder {
         GetBlobMetadataBuilder::new(self)
     }
 
+    #[must_use]
     pub fn set_metadata(&self) -> SetBlobMetadataBuilder {
         SetBlobMetadataBuilder::new(self)
     }
 
+    #[must_use]
     pub fn set_blobtier(&self) -> SetBlobTierBuilder {
         SetBlobTierBuilder::new(self)
     }
@@ -102,42 +108,52 @@ impl BlobClient {
         UpdatePageBuilder::new(self, ba512_range, content)
     }
 
+    #[must_use]
     pub fn get_page_ranges(&self) -> GetPageRangesBuilder {
         GetPageRangesBuilder::new(self)
     }
 
+    #[must_use]
     pub fn delete(&self) -> DeleteBlobBuilder {
         DeleteBlobBuilder::new(self)
     }
 
+    #[must_use]
     pub fn delete_snapshot(&self, snapshot: Snapshot) -> DeleteBlobSnapshotBuilder {
         DeleteBlobSnapshotBuilder::new(self, snapshot)
     }
 
+    #[must_use]
     pub fn delete_version_id(&self, version_id: VersionId) -> DeleteBlobVersionBuilder {
         DeleteBlobVersionBuilder::new(self, version_id)
     }
 
+    #[must_use]
     pub fn copy<'a>(&'a self, copy_source: &'a Url) -> CopyBlobBuilder<'a> {
         CopyBlobBuilder::new(self, copy_source)
     }
 
+    #[must_use]
     pub fn copy_from_url<'a>(&'a self, copy_source: &'a str) -> CopyBlobFromUrlBuilder<'a> {
         CopyBlobFromUrlBuilder::new(self, copy_source)
     }
 
+    #[must_use]
     pub fn put_page_blob(&self, length: u128) -> PutPageBlobBuilder {
         PutPageBlobBuilder::new(self, length)
     }
 
+    #[must_use]
     pub fn put_append_blob(&self) -> PutAppendBlobBuilder {
         PutAppendBlobBuilder::new(self)
     }
 
+    #[must_use]
     pub fn get_block_list(&self) -> GetBlockListBuilder {
         GetBlockListBuilder::new(self)
     }
 
+    #[must_use]
     pub fn put_block_list<'a>(&'a self, block_list: &'a BlockList) -> PutBlockListBuilder {
         PutBlockListBuilder::new(self, block_list)
     }
@@ -158,6 +174,7 @@ impl BlobClient {
         PutBlockBuilder::new(self, block_id, body)
     }
 
+    #[must_use]
     pub fn clear_page(&self, ba512_range: BA512Range) -> ClearPageBuilder {
         ClearPageBuilder::new(self, ba512_range)
     }
@@ -169,6 +186,7 @@ impl BlobClient {
         AcquireLeaseBuilder::new(self, lease_duration.into())
     }
 
+    #[must_use]
     pub fn break_lease(&self) -> BreakLeaseBuilder {
         BreakLeaseBuilder::new(self)
     }

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -29,6 +29,7 @@ impl BlobLeaseClient {
         })
     }
 
+    #[must_use]
     pub fn lease_id(&self) -> &LeaseId {
         &self.lease_id
     }
@@ -59,14 +60,17 @@ impl BlobLeaseClient {
         self.blob_client.url_with_segments(segments)
     }
 
+    #[must_use]
     pub fn change<'a>(&'a self, proposed_lease_id: &'a ProposedLeaseId) -> ChangeLeaseBuilder<'a> {
         ChangeLeaseBuilder::new(self, proposed_lease_id)
     }
 
+    #[must_use]
     pub fn release(&self) -> ReleaseLeaseBuilder {
         ReleaseLeaseBuilder::new(self)
     }
 
+    #[must_use]
     pub fn renew(&self) -> RenewLeaseBuilder {
         RenewLeaseBuilder::new(self)
     }

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -27,6 +27,7 @@ impl BlobServiceClient {
         Arc::new(Self { storage_client })
     }
 
+    #[must_use]
     pub fn list_containers(&self) -> crate::container::requests::ListContainersBuilder {
         crate::container::requests::ListContainersBuilder::new(&self.storage_client)
     }

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -45,6 +45,7 @@ impl ContainerClient {
         })
     }
 
+    #[must_use]
     pub fn container_name(&self) -> &str {
         &self.container_name
     }
@@ -72,26 +73,32 @@ impl ContainerClient {
         )
     }
 
+    #[must_use]
     pub fn create(&self) -> CreateBuilder {
         CreateBuilder::new(self)
     }
 
+    #[must_use]
     pub fn delete(&self) -> DeleteBuilder {
         DeleteBuilder::new(self)
     }
 
+    #[must_use]
     pub fn get_acl(&self) -> GetACLBuilder {
         GetACLBuilder::new(self)
     }
 
+    #[must_use]
     pub fn set_acl(&self, public_access: PublicAccess) -> SetACLBuilder {
         SetACLBuilder::new(self, public_access)
     }
 
+    #[must_use]
     pub fn get_properties(&self) -> GetPropertiesBuilder {
         GetPropertiesBuilder::new(self)
     }
 
+    #[must_use]
     pub fn list_blobs(&self) -> ListBlobsBuilder {
         ListBlobsBuilder::new(self)
     }
@@ -103,6 +110,7 @@ impl ContainerClient {
         AcquireLeaseBuilder::new(self, lease_duration.into())
     }
 
+    #[must_use]
     pub fn break_lease(&self) -> BreakLeaseBuilder {
         BreakLeaseBuilder::new(self)
     }

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -29,6 +29,7 @@ impl ContainerLeaseClient {
         })
     }
 
+    #[must_use]
     pub fn lease_id(&self) -> &LeaseId {
         &self.lease_id
     }
@@ -54,10 +55,12 @@ impl ContainerLeaseClient {
         self.container_client.url_with_segments(segments)
     }
 
+    #[must_use]
     pub fn release(&self) -> ReleaseLeaseBuilder {
         ReleaseLeaseBuilder::new(self)
     }
 
+    #[must_use]
     pub fn renew(&self) -> RenewLeaseBuilder {
         RenewLeaseBuilder::new(self)
     }

--- a/sdk/storage_blobs/src/condition_append_position.rs
+++ b/sdk/storage_blobs/src/condition_append_position.rs
@@ -4,6 +4,7 @@ use azure_core::headers::{self, Header};
 pub struct ConditionAppendPosition(u64);
 
 impl ConditionAppendPosition {
+    #[must_use]
     pub fn new(max_size: u64) -> Self {
         Self(max_size)
     }

--- a/sdk/storage_blobs/src/condition_max_size.rs
+++ b/sdk/storage_blobs/src/condition_max_size.rs
@@ -4,6 +4,7 @@ use azure_core::headers::{self, Header};
 pub struct ConditionMaxSize(u64);
 
 impl ConditionMaxSize {
+    #[must_use]
     pub fn new(max_size: u64) -> Self {
         Self(max_size)
     }

--- a/sdk/storage_blobs/src/container/mod.rs
+++ b/sdk/storage_blobs/src/container/mod.rs
@@ -69,6 +69,7 @@ impl AsRef<str> for Container {
 }
 
 impl Container {
+    #[must_use]
     pub fn new(name: &str) -> Container {
         Container {
             name: name.to_owned(),

--- a/sdk/storage_blobs/src/container/responses/list_containers_response.rs
+++ b/sdk/storage_blobs/src/container/responses/list_containers_response.rs
@@ -9,6 +9,7 @@ pub struct ListContainersResponse {
 }
 
 impl ListContainersResponse {
+    #[must_use]
     pub fn is_complete(&self) -> bool {
         self.incomplete_vector.is_complete()
     }

--- a/sdk/storage_blobs/src/snapshot.rs
+++ b/sdk/storage_blobs/src/snapshot.rs
@@ -9,6 +9,7 @@ use azure_core::AppendToUrlQuery;
 pub struct Snapshot(String);
 
 impl Snapshot {
+    #[must_use]
     pub fn new(snapshot: String) -> Self {
         Self(snapshot)
     }

--- a/sdk/storage_blobs/src/version_id.rs
+++ b/sdk/storage_blobs/src/version_id.rs
@@ -9,6 +9,7 @@ use azure_core::AppendToUrlQuery;
 pub struct VersionId(String);
 
 impl VersionId {
+    #[must_use]
     pub fn new(version_id: String) -> Self {
         Self(version_id)
     }

--- a/sdk/storage_datalake/src/clients/data_lake_client.rs
+++ b/sdk/storage_datalake/src/clients/data_lake_client.rs
@@ -21,6 +21,7 @@ pub struct DataLakeClient {
 }
 
 impl DataLakeClient {
+    #[must_use]
     pub fn new_with_shared_key(
         credential: StorageSharedKeyCredential,
         custom_dns_suffix: Option<String>,
@@ -87,10 +88,12 @@ impl DataLakeClient {
         }
     }
 
+    #[must_use]
     pub fn new(credential: StorageSharedKeyCredential, custom_dns_suffix: Option<String>) -> Self {
         Self::new_with_shared_key(credential, custom_dns_suffix, ClientOptions::default())
     }
 
+    #[must_use]
     pub fn custom_dns_suffix(&self) -> Option<&str> {
         self.custom_dns_suffix.as_deref()
     }
@@ -99,6 +102,7 @@ impl DataLakeClient {
         &self.url
     }
 
+    #[must_use]
     pub fn list_file_systems(&self) -> ListFileSystemsBuilder {
         ListFileSystemsBuilder::new(self.clone(), Some(self.context.clone()))
     }
@@ -124,6 +128,7 @@ impl DataLakeClient {
     //         .into()
     // }
 
+    #[must_use]
     pub fn pipeline(&self) -> &Pipeline {
         &self.pipeline
     }

--- a/sdk/storage_datalake/src/clients/directory_client.rs
+++ b/sdk/storage_datalake/src/clients/directory_client.rs
@@ -59,6 +59,7 @@ impl DirectoryClient {
             .into_directory_client(path)
     }
 
+    #[must_use]
     pub fn list_paths(&self) -> ListPathsBuilder {
         let fs_url = self.file_system_client.url().unwrap();
         // the path will contain a leading '/' as we extract if from the path component of the url
@@ -68,11 +69,13 @@ impl DirectoryClient {
             .recursive(true)
     }
 
+    #[must_use]
     pub fn create(&self) -> PutPathBuilder<Self> {
         PutPathBuilder::new(self.clone(), self.file_system_client.context.clone())
             .resource(ResourceType::Directory)
     }
 
+    #[must_use]
     pub fn create_if_not_exists(&self) -> PutPathBuilder<Self> {
         self.create()
             .if_match_condition(IfMatchCondition::NotMatch("*".to_string()))
@@ -112,10 +115,12 @@ impl DirectoryClient {
         )
     }
 
+    #[must_use]
     pub fn get_properties(&self) -> HeadPathBuilder<Self> {
         HeadPathBuilder::new(self.clone(), self.file_system_client.context.clone())
     }
 
+    #[must_use]
     pub fn set_properties(&self, _properties: Properties) -> SetFileSystemPropertiesBuilder {
         todo!()
     }

--- a/sdk/storage_datalake/src/clients/file_client.rs
+++ b/sdk/storage_datalake/src/clients/file_client.rs
@@ -55,11 +55,13 @@ impl FileClient {
             .into_file_client(path)
     }
 
+    #[must_use]
     pub fn create(&self) -> PutPathBuilder<Self> {
         PutPathBuilder::new(self.clone(), self.file_system_client.context.clone())
             .resource(ResourceType::File)
     }
 
+    #[must_use]
     pub fn create_if_not_exists(&self) -> PutPathBuilder<Self> {
         self.create()
             .if_match_condition(IfMatchCondition::NotMatch("*".to_string()))
@@ -75,12 +77,14 @@ impl FileClient {
             .bytes(bytes.into())
     }
 
+    #[must_use]
     pub fn flush(&self, position: i64) -> PatchPathBuilder<Self> {
         PatchPathBuilder::new(self.clone(), self.file_system_client.context.clone())
             .action(PathUpdateAction::Flush)
             .position(position)
     }
 
+    #[must_use]
     pub fn read(&self) -> GetFileBuilder {
         GetFileBuilder::new(self.clone(), self.file_system_client.context.clone())
     }
@@ -106,24 +110,29 @@ impl FileClient {
             .if_match_condition(IfMatchCondition::NotMatch("*".to_string()))
     }
 
+    #[must_use]
     pub fn delete(&self) -> DeletePathBuilder<Self> {
         DeletePathBuilder::new(self.clone(), None, self.file_system_client.context.clone())
     }
 
+    #[must_use]
     pub fn get_properties(&self) -> HeadPathBuilder<Self> {
         HeadPathBuilder::new(self.clone(), self.file_system_client.context.clone())
     }
 
+    #[must_use]
     pub fn get_status(&self) -> HeadPathBuilder<Self> {
         HeadPathBuilder::new(self.clone(), self.file_system_client.context.clone())
             .action(PathGetPropertiesAction::GetStatus)
     }
 
+    #[must_use]
     pub fn get_access_control_list(&self) -> HeadPathBuilder<Self> {
         HeadPathBuilder::new(self.clone(), self.file_system_client.context.clone())
             .action(PathGetPropertiesAction::GetAccessControl)
     }
 
+    #[must_use]
     pub fn set_properties(&self, properties: Properties) -> PatchPathBuilder<Self> {
         PatchPathBuilder::new(self.clone(), self.file_system_client.context.clone())
             .properties(properties)

--- a/sdk/storage_datalake/src/clients/file_system_client.rs
+++ b/sdk/storage_datalake/src/clients/file_system_client.rs
@@ -68,22 +68,27 @@ impl FileSystemClient {
         FileClient::new(self, path.into())
     }
 
+    #[must_use]
     pub fn list_paths(&self) -> ListPathsBuilder {
         ListPathsBuilder::new(self.clone(), self.context.clone()).recursive(true)
     }
 
+    #[must_use]
     pub fn create(&self) -> CreateFileSystemBuilder {
         CreateFileSystemBuilder::new(self.clone())
     }
 
+    #[must_use]
     pub fn delete(&self) -> DeleteFileSystemBuilder {
         DeleteFileSystemBuilder::new(self.clone())
     }
 
+    #[must_use]
     pub fn get_properties(&self) -> GetFileSystemPropertiesBuilder {
         GetFileSystemPropertiesBuilder::new(self.clone())
     }
 
+    #[must_use]
     pub fn set_properties(&self, properties: Properties) -> SetFileSystemPropertiesBuilder {
         SetFileSystemPropertiesBuilder::new(self.clone(), Some(properties))
     }

--- a/sdk/storage_datalake/src/operations/file_system_create.rs
+++ b/sdk/storage_datalake/src/operations/file_system_create.rs
@@ -39,6 +39,7 @@ impl CreateFileSystemBuilder {
         properties: Properties => Some(properties),
     }
 
+    #[must_use]
     pub fn into_future(self) -> CreateFileSystem {
         let this = self.clone();
         let ctx = self.client.context.clone();

--- a/sdk/storage_datalake/src/operations/file_system_delete.rs
+++ b/sdk/storage_datalake/src/operations/file_system_delete.rs
@@ -32,6 +32,7 @@ impl DeleteFileSystemBuilder {
         timeout: Timeout => Some(timeout),
     }
 
+    #[must_use]
     pub fn into_future(self) -> DeleteFileSystem {
         let this = self.clone();
         let ctx = self.client.context.clone();

--- a/sdk/storage_datalake/src/operations/file_system_get_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_get_properties.rs
@@ -36,6 +36,7 @@ impl GetFileSystemPropertiesBuilder {
         timeout: Timeout => Some(timeout),
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetFileSystemProperties {
         let this = self.clone();
         let ctx = self.client.context.clone();

--- a/sdk/storage_datalake/src/operations/file_system_set_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_set_properties.rs
@@ -40,6 +40,7 @@ impl SetFileSystemPropertiesBuilder {
         timeout: Timeout => Some(timeout),
     }
 
+    #[must_use]
     pub fn into_future(self) -> SetFileSystemProperties {
         let this = self.clone();
         let ctx = self.client.context.clone();

--- a/sdk/storage_datalake/src/operations/file_systems_list.rs
+++ b/sdk/storage_datalake/src/operations/file_systems_list.rs
@@ -46,6 +46,7 @@ impl ListFileSystemsBuilder {
         context: Context => Some(context),
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListFileSystems {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/storage_datalake/src/operations/path_get.rs
+++ b/sdk/storage_datalake/src/operations/path_get.rs
@@ -50,6 +50,7 @@ impl GetFileBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_future(self) -> GetFile {
         let this = self.clone();
         let ctx = self.context.clone();

--- a/sdk/storage_datalake/src/operations/path_list.rs
+++ b/sdk/storage_datalake/src/operations/path_list.rs
@@ -51,6 +51,7 @@ impl ListPathsBuilder {
         context: Context => context,
     }
 
+    #[must_use]
     pub fn into_stream(self) -> ListPaths {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/storage_datalake/src/properties.rs
+++ b/sdk/storage_datalake/src/properties.rs
@@ -15,6 +15,7 @@ impl Default for Properties {
 }
 
 impl Properties {
+    #[must_use]
     pub fn new() -> Self {
         Self(BTreeMap::new())
     }
@@ -27,6 +28,7 @@ impl Properties {
         self.0.insert(k.into(), v.into())
     }
 
+    #[must_use]
     pub fn get(&self, key: &str) -> std::option::Option<&Cow<'_, str>> {
         self.0.get(key)
     }

--- a/sdk/storage_datalake/src/request_options.rs
+++ b/sdk/storage_datalake/src/request_options.rs
@@ -113,6 +113,7 @@ impl AppendToUrlQuery for PathUpdateAction {
 pub struct Position(i64);
 
 impl Position {
+    #[must_use]
     pub fn new(position: i64) -> Self {
         Self(position)
     }
@@ -135,6 +136,7 @@ impl AppendToUrlQuery for Position {
 pub struct Close(bool);
 
 impl Close {
+    #[must_use]
     pub fn new(close: bool) -> Self {
         Self(close)
     }
@@ -157,6 +159,7 @@ impl AppendToUrlQuery for Close {
 pub struct RetainUncommittedData(bool);
 
 impl RetainUncommittedData {
+    #[must_use]
     pub fn new(close: bool) -> Self {
         Self(close)
     }

--- a/sdk/storage_queues/src/clients/pop_receipt_client.rs
+++ b/sdk/storage_queues/src/clients/pop_receipt_client.rs
@@ -58,6 +58,7 @@ impl PopReceiptClient {
 
     /// Deletes the message. The message must not have been
     /// made visible again or this call would fail.
+    #[must_use]
     pub fn delete(&self) -> DeleteMessageBuilder {
         DeleteMessageBuilder::new(self)
     }

--- a/sdk/storage_queues/src/clients/queue_client.rs
+++ b/sdk/storage_queues/src/clients/queue_client.rs
@@ -47,27 +47,32 @@ impl QueueClient {
             .map_kind(ErrorKind::DataConversion)
     }
 
+    #[must_use]
     pub fn queue_name(&self) -> &str {
         &self.queue_name
     }
 
     /// Creates the queue.
+    #[must_use]
     pub fn create(&self) -> CreateQueueBuilder {
         CreateQueueBuilder::new(self)
     }
 
     /// Deletes the queue.
+    #[must_use]
     pub fn delete(&self) -> DeleteQueueBuilder {
         DeleteQueueBuilder::new(self)
     }
 
     /// Sets or clears the queue metadata. The metadata
     /// will be passed to the `execute` function of the returned struct.
+    #[must_use]
     pub fn set_metadata(&self) -> SetQueueMetadataBuilder {
         SetQueueMetadataBuilder::new(self)
     }
 
     /// Get the queue metadata.
+    #[must_use]
     pub fn get_metadata(&self) -> GetQueueMetadataBuilder {
         GetQueueMetadataBuilder::new(self)
     }
@@ -75,6 +80,7 @@ impl QueueClient {
     /// Get the queue ACL. This call returns
     /// all the stored access policies associated
     /// to the current queue.
+    #[must_use]
     pub fn get_acl(&self) -> GetQueueACLBuilder {
         GetQueueACLBuilder::new(self)
     }
@@ -83,27 +89,32 @@ impl QueueClient {
     /// to change or remove already existing stored
     /// access policies by modifying the list returned
     /// by `get_acl`.
+    #[must_use]
     pub fn set_acl(&self) -> SetQueueACLBuilder {
         SetQueueACLBuilder::new(self)
     }
 
     /// Puts a message in the queue. The body will be passed
     /// to the `execute` function of the returned struct.
+    #[must_use]
     pub fn put_message(&self) -> PutMessageBuilder {
         PutMessageBuilder::new(self)
     }
 
     /// Peeks, without removing, one or more messages.
+    #[must_use]
     pub fn peek_messages(&self) -> PeekMessagesBuilder {
         PeekMessagesBuilder::new(self)
     }
 
     /// Gets, shadowing them, one or more messages.
+    #[must_use]
     pub fn get_messages(&self) -> GetMessagesBuilder {
         GetMessagesBuilder::new(self)
     }
 
     /// Removes all messages from the queue.
+    #[must_use]
     pub fn clear_messages(&self) -> ClearMessagesBuilder {
         ClearMessagesBuilder::new(self)
     }

--- a/sdk/storage_queues/src/clients/queue_service_client.rs
+++ b/sdk/storage_queues/src/clients/queue_service_client.rs
@@ -28,22 +28,26 @@ impl QueueServiceClient {
         Arc::new(Self { storage_client })
     }
 
+    #[must_use]
     pub fn list_queues(&self) -> crate::requests::ListQueuesBuilder {
         crate::requests::ListQueuesBuilder::new(&self.storage_client)
     }
 
+    #[must_use]
     pub fn get_queue_service_properties(
         &self,
     ) -> crate::requests::GetQueueServicePropertiesBuilder {
         crate::requests::GetQueueServicePropertiesBuilder::new(&self.storage_client)
     }
 
+    #[must_use]
     pub fn set_queue_service_properties(
         &self,
     ) -> crate::requests::SetQueueServicePropertiesBuilder {
         crate::requests::SetQueueServicePropertiesBuilder::new(&self.storage_client)
     }
 
+    #[must_use]
     pub fn get_queue_service_stats(&self) -> crate::requests::GetQueueServiceStatsBuilder {
         crate::requests::GetQueueServiceStatsBuilder::new(&self.storage_client)
     }

--- a/sdk/storage_queues/src/queue_stored_access_policy.rs
+++ b/sdk/storage_queues/src/queue_stored_access_policy.rs
@@ -31,6 +31,7 @@ impl QueueStoredAccessPolicy {
         }
     }
 
+    #[must_use]
     pub fn enable_read(self) -> Self {
         Self {
             is_read_enabled: true,
@@ -38,6 +39,7 @@ impl QueueStoredAccessPolicy {
         }
     }
 
+    #[must_use]
     pub fn enable_add(self) -> Self {
         Self {
             is_add_enabled: true,
@@ -45,6 +47,7 @@ impl QueueStoredAccessPolicy {
         }
     }
 
+    #[must_use]
     pub fn enable_update(self) -> Self {
         Self {
             is_update_enabled: true,
@@ -52,6 +55,7 @@ impl QueueStoredAccessPolicy {
         }
     }
 
+    #[must_use]
     pub fn enable_process(self) -> Self {
         Self {
             is_process_enabled: true,
@@ -59,6 +63,7 @@ impl QueueStoredAccessPolicy {
         }
     }
 
+    #[must_use]
     pub fn enable_all(self) -> Self {
         Self {
             is_add_enabled: true,
@@ -69,6 +74,7 @@ impl QueueStoredAccessPolicy {
         }
     }
 
+    #[must_use]
     pub fn to_permission_string(&self) -> String {
         let mut permission = String::with_capacity(4);
 

--- a/sdk/storage_queues/src/responses/list_queues_response.rs
+++ b/sdk/storage_queues/src/responses/list_queues_response.rs
@@ -17,6 +17,7 @@ pub struct ListQueuesResponse {
 }
 
 impl ListQueuesResponse {
+    #[must_use]
     pub fn next_marker(&self) -> &Option<NextMarker> {
         &self.next_marker
     }


### PR DESCRIPTION
adding `#[must_use]` to identify inadvertent footguns in the SDK.

This comes about as a continued attempt to automation prevent issues found during a review of code that uses this SDK.