### PR TITLE
Change prepare_pipeline methods to request methods

### DIFF
--- a/sdk/data_cosmos/src/clients/attachment.rs
+++ b/sdk/data_cosmos/src/clients/attachment.rs
@@ -99,8 +99,8 @@ impl AttachmentClient {
         &self.attachment_name
     }
 
-    pub(crate) fn prepare_pipeline(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn attachments_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/docs/{}/attachments",
                 self.database_client().database_name(),
@@ -111,8 +111,8 @@ impl AttachmentClient {
         )
     }
 
-    pub(crate) fn prepare_pipeline_with_attachment_name(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn attachment_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/docs/{}/attachments/{}",
                 self.database_client().database_name(),

--- a/sdk/data_cosmos/src/clients/collection.rs
+++ b/sdk/data_cosmos/src/clients/collection.rs
@@ -127,27 +127,22 @@ impl CollectionClient {
         &self.collection_name
     }
 
-    pub(crate) fn prepare_request_with_collection_name(
-        &self,
-        http_method: http::Method,
-    ) -> Request {
+    pub(crate) fn collection_request(&self, http_method: http::Method) -> Request {
         let path = &format!(
             "dbs/{}/colls/{}",
             self.database_client().database_name(),
             self.collection_name()
         );
-        self.cosmos_client()
-            .prepare_request_pipeline(path, http_method)
+        self.cosmos_client().request(path, http_method)
     }
 
-    pub(crate) fn prepare_doc_request_pipeline(&self, http_method: http::Method) -> Request {
+    pub(crate) fn docs_request(&self, http_method: http::Method) -> Request {
         let path = &format!(
             "dbs/{}/colls/{}/docs",
             self.database_client().database_name(),
             self.collection_name()
         );
-        self.cosmos_client()
-            .prepare_request_pipeline(path, http_method)
+        self.cosmos_client().request(path, http_method)
     }
 
     pub(crate) fn pipeline(&self) -> &Pipeline {

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -121,11 +121,7 @@ impl CosmosClient {
     /// This function will add the cloud location to the URI suffix and generate
     /// a Request with the specified HTTP Method. It will also set the body
     /// to an empty `Bytes` instance.
-    pub(crate) fn prepare_request_pipeline(
-        &self,
-        uri_path: &str,
-        http_method: http::Method,
-    ) -> Request {
+    pub(crate) fn request(&self, uri_path: &str, http_method: http::Method) -> Request {
         let uri = format!("{}/{}", self.cloud_location.url(), uri_path);
         Request::new(uri.parse().unwrap(), http_method)
     }

--- a/sdk/data_cosmos/src/clients/database.rs
+++ b/sdk/data_cosmos/src/clients/database.rs
@@ -72,13 +72,13 @@ impl DatabaseClient {
         &self.database_name
     }
 
-    pub(crate) fn prepare_pipeline(&self, method: Method) -> Request {
+    pub(crate) fn database_request(&self, method: Method) -> Request {
         self.cosmos_client()
-            .prepare_request_pipeline(&format!("dbs/{}", self.database_name()), method)
+            .request(&format!("dbs/{}", self.database_name()), method)
     }
 
-    pub(crate) fn prepare_collections_pipeline(&self, method: Method) -> Request {
+    pub(crate) fn collections_request(&self, method: Method) -> Request {
         self.cosmos_client()
-            .prepare_request_pipeline(&format!("dbs/{}/colls", self.database_name()), method)
+            .request(&format!("dbs/{}/colls", self.database_name()), method)
     }
 }

--- a/sdk/data_cosmos/src/clients/document.rs
+++ b/sdk/data_cosmos/src/clients/document.rs
@@ -84,11 +84,8 @@ impl DocumentClient {
         &self.partition_key_serialized
     }
 
-    pub(crate) fn prepare_request_pipeline_with_document_name(
-        &self,
-        method: http::Method,
-    ) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn document_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/docs/{}",
                 self.database_client().database_name(),

--- a/sdk/data_cosmos/src/clients/permission.rs
+++ b/sdk/data_cosmos/src/clients/permission.rs
@@ -59,8 +59,8 @@ impl PermissionClient {
         &self.permission_name
     }
 
-    pub(crate) fn prepare_request_with_permission_name(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn permission_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/users/{}/permissions/{}",
                 self.database_client().database_name(),

--- a/sdk/data_cosmos/src/clients/stored_procedure.rs
+++ b/sdk/data_cosmos/src/clients/stored_procedure.rs
@@ -67,11 +67,8 @@ impl StoredProcedureClient {
         &self.stored_procedure_name
     }
 
-    pub(crate) fn prepare_pipeline_with_stored_procedure_name(
-        &self,
-        method: http::Method,
-    ) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn stored_procedure_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/sprocs/{}",
                 self.database_client().database_name(),
@@ -82,8 +79,8 @@ impl StoredProcedureClient {
         )
     }
 
-    pub(crate) fn prepare_request_pipeline(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn stored_procedures_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/sprocs",
                 self.database_client().database_name(),

--- a/sdk/data_cosmos/src/clients/trigger.rs
+++ b/sdk/data_cosmos/src/clients/trigger.rs
@@ -90,8 +90,9 @@ impl TriggerClient {
         &self.trigger_name
     }
 
-    pub(crate) fn prepare_pipeline_with_trigger_name(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    /// Create a request for a specific collection trigger
+    pub(crate) fn trigger_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/triggers/{}",
                 self.database_client().database_name(),
@@ -102,8 +103,9 @@ impl TriggerClient {
         )
     }
 
-    pub(crate) fn prepare_pipeline(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    /// Create a request for collection triggers
+    pub(crate) fn triggers_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/triggers",
                 self.database_client().database_name(),

--- a/sdk/data_cosmos/src/clients/user.rs
+++ b/sdk/data_cosmos/src/clients/user.rs
@@ -66,8 +66,8 @@ impl UserClient {
         &self.user_name
     }
 
-    pub(crate) fn prepare_request_with_user_name(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn user_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/users/{}",
                 self.database_client().database_name(),

--- a/sdk/data_cosmos/src/clients/user_defined_function.rs
+++ b/sdk/data_cosmos/src/clients/user_defined_function.rs
@@ -68,8 +68,8 @@ impl UserDefinedFunctionClient {
         &self.user_defined_function_name
     }
 
-    pub(crate) fn prepare_pipeline(&self, method: http::Method) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn udfs_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/udfs",
                 self.database_client().database_name(),
@@ -79,11 +79,8 @@ impl UserDefinedFunctionClient {
         )
     }
 
-    pub(crate) fn prepare_pipeline_with_user_defined_function_name(
-        &self,
-        method: http::Method,
-    ) -> Request {
-        self.cosmos_client().prepare_request_pipeline(
+    pub(crate) fn udf_request(&self, method: http::Method) -> Request {
+        self.cosmos_client().request(
             &format!(
                 "dbs/{}/colls/{}/udfs/{}",
                 self.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -42,7 +42,7 @@ impl CreateCollectionBuilder {
 
     pub fn into_future(self) -> CreateCollection {
         Box::pin(async move {
-            let mut request = self.client.prepare_collections_pipeline(http::Method::POST);
+            let mut request = self.client.collections_request(http::Method::POST);
             request.insert_headers(&self.offer);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -36,9 +36,7 @@ impl CreateDatabaseBuilder {
 
     pub fn into_future(self) -> CreateDatabase {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_pipeline("dbs", http::Method::POST);
+            let mut request = self.client.request("dbs", http::Method::POST);
 
             let body = CreateDatabaseBody {
                 id: self.database_name.as_str(),

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -65,7 +65,7 @@ impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {
                 Some(s) => s,
                 None => serialize_partition_key(&document.partition_key())?,
             };
-            let mut request = self.client.prepare_doc_request_pipeline(http::Method::POST);
+            let mut request = self.client.docs_request(http::Method::POST);
 
             add_as_partition_key_header_serialized(&partition_key, &mut request);
             request.insert_headers(&self.if_match_condition);

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -43,10 +43,9 @@ impl CreateOrReplaceAttachmentBuilder {
     pub fn into_future(self) -> CreateOrReplaceAttachment {
         Box::pin(async move {
             let mut req = if self.is_create {
-                self.client.prepare_pipeline(http::Method::POST)
+                self.client.attachments_request(http::Method::POST)
             } else {
-                self.client
-                    .prepare_pipeline_with_attachment_name(http::Method::PUT)
+                self.client.attachment_request(http::Method::PUT)
             };
 
             if let Some(cl) = &self.consistency_level {

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -49,10 +49,9 @@ impl CreateOrReplaceSlugAttachmentBuilder {
     pub fn into_future(self) -> CreateOrReplaceSlugAttachment {
         Box::pin(async move {
             let mut request = if self.is_create {
-                self.client.prepare_pipeline(Method::POST)
+                self.client.attachments_request(Method::POST)
             } else {
-                self.client
-                    .prepare_pipeline_with_attachment_name(Method::PUT)
+                self.client.attachment_request(Method::PUT)
             };
 
             request.insert_headers(&self.if_match_condition);

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -47,10 +47,9 @@ impl CreateOrReplaceTriggerBuilder {
     pub fn into_future(self) -> CreateOrReplaceTrigger {
         Box::pin(async move {
             let mut request = if self.is_create {
-                self.client.prepare_pipeline(http::Method::POST)
+                self.client.triggers_request(http::Method::POST)
             } else {
-                self.client
-                    .prepare_pipeline_with_trigger_name(http::Method::PUT)
+                self.client.trigger_request(http::Method::PUT)
             };
 
             if let Some(cl) = &self.consistency_level {

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -36,10 +36,8 @@ impl CreateOrReplaceUserDefinedFunctionBuilder {
     pub fn into_future(self) -> CreateOrReplaceUserDefinedFunction {
         Box::pin(async move {
             let mut request = match self.is_create {
-                true => self.client.prepare_pipeline(http::Method::POST),
-                false => self
-                    .client
-                    .prepare_pipeline_with_user_defined_function_name(http::Method::PUT),
+                true => self.client.udfs_request(http::Method::POST),
+                false => self.client.udf_request(http::Method::PUT),
             };
 
             if let Some(cl) = &self.consistency_level {

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -31,7 +31,7 @@ impl CreatePermissionBuilder {
 
     pub fn into_future(self) -> CreatePermission {
         Box::pin(async move {
-            let mut request = self.client.cosmos_client().prepare_request_pipeline(
+            let mut request = self.client.cosmos_client().request(
                 &format!(
                     "dbs/{}/users/{}/permissions",
                     self.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -31,7 +31,7 @@ impl CreateStoredProcedureBuilder {
 
     pub fn into_future(self) -> CreateStoredProcedure {
         Box::pin(async move {
-            let mut req = self.client.prepare_request_pipeline(http::Method::POST);
+            let mut req = self.client.stored_procedures_request(http::Method::POST);
 
             if let Some(cl) = &self.consistency_level {
                 req.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -24,7 +24,7 @@ impl CreateUserBuilder {
 
     pub fn into_future(self) -> CreateUser {
         Box::pin(async move {
-            let mut request = self.client.cosmos_client().prepare_request_pipeline(
+            let mut request = self.client.cosmos_client().request(
                 &format!(
                     "dbs/{}/users",
                     self.client.database_client().database_name()

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -34,11 +34,8 @@ impl DeleteAttachmentBuilder {
 
     pub fn into_future(self) -> DeleteAttachment {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_pipeline_with_attachment_name(http::Method::DELETE);
+            let mut request = self.client.attachment_request(http::Method::DELETE);
 
-            // add trait headers
             request.insert_headers(&self.if_match_condition);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -27,9 +27,7 @@ impl DeleteCollectionBuilder {
 
     pub fn into_future(self) -> DeleteCollection {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_collection_name(http::Method::DELETE);
+            let mut request = self.client.collection_request(http::Method::DELETE);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -28,7 +28,7 @@ impl DeleteDatabaseBuilder {
 
     pub fn into_future(self) -> DeleteDatabase {
         Box::pin(async move {
-            let mut request = self.client.prepare_pipeline(http::Method::DELETE);
+            let mut request = self.client.database_request(http::Method::DELETE);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -38,9 +38,7 @@ impl DeleteDocumentBuilder {
 
     pub fn into_future(self) -> DeleteDocument {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_pipeline_with_document_name(http::Method::DELETE);
+            let mut request = self.client.document_request(http::Method::DELETE);
 
             request.insert_headers(&self.if_match_condition);
             request.insert_headers(&self.if_modified_since);

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -28,9 +28,7 @@ impl DeletePermissionBuilder {
 
     pub fn into_future(self) -> DeletePermission {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_permission_name(http::Method::DELETE);
+            let mut request = self.client.permission_request(http::Method::DELETE);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -28,9 +28,7 @@ impl DeleteStoredProcedureBuilder {
 
     pub fn into_future(self) -> DeleteStoredProcedure {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_pipeline_with_stored_procedure_name(http::Method::DELETE);
+            let mut request = self.client.stored_procedure_request(http::Method::DELETE);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -30,9 +30,7 @@ impl DeleteTriggerBuilder {
 
     pub fn into_future(self) -> DeleteTrigger {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_pipeline_with_trigger_name(http::Method::DELETE);
+            let mut request = self.client.trigger_request(http::Method::DELETE);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -25,9 +25,7 @@ impl DeleteUserBuilder {
 
     pub fn into_future(self) -> DeleteUser {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_user_name(http::Method::DELETE);
+            let mut request = self.client.user_request(http::Method::DELETE);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -30,9 +30,7 @@ impl DeleteUserDefinedFunctionBuilder {
 
     pub fn into_future(self) -> DeleteUserDefinedFunction {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_pipeline_with_user_defined_function_name(http::Method::DELETE);
+            let mut request = self.client.udf_request(http::Method::DELETE);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -52,9 +52,7 @@ impl ExecuteStoredProcedureBuilder {
         T: DeserializeOwned,
     {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_pipeline_with_stored_procedure_name(http::Method::POST);
+            let mut request = self.client.stored_procedure_request(http::Method::POST);
 
             if let Some(pk) = self.partition_key.as_ref() {
                 crate::cosmos_entity::add_as_partition_key_header_serialized(pk, &mut request)

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -36,9 +36,7 @@ impl GetAttachmentBuilder {
 
     pub fn into_future(self) -> GetAttachment {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_pipeline_with_attachment_name(http::Method::GET);
+            let mut request = self.client.attachment_request(http::Method::GET);
 
             request.insert_headers(&self.if_match_condition);
             if let Some(cl) = &self.consistency_level {

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -30,9 +30,7 @@ impl GetCollectionBuilder {
 
     pub fn into_future(self) -> GetCollection {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_collection_name(http::Method::GET);
+            let mut request = self.client.collection_request(http::Method::GET);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -30,7 +30,7 @@ impl GetDatabaseBuilder {
 
     pub fn into_future(self) -> GetDatabase {
         Box::pin(async move {
-            let mut request = self.client.prepare_pipeline(http::Method::GET);
+            let mut request = self.client.database_request(http::Method::GET);
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);
             }

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -43,9 +43,7 @@ impl GetDocumentBuilder {
     /// generic associated types (GATs) stabilize, this will become possible.
     pub fn into_future<T: DeserializeOwned>(self) -> GetDocument<T> {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_pipeline_with_document_name(http::Method::GET);
+            let mut request = self.client.document_request(http::Method::GET);
 
             request.insert_headers(&self.if_match_condition);
             request.insert_headers(&self.if_modified_since);

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -34,7 +34,7 @@ impl GetPartitionKeyRangesBuilder {
 
     pub fn into_future(self) -> GetPartitionKeyRanges {
         Box::pin(async move {
-            let mut request = self.client.cosmos_client().prepare_request_pipeline(
+            let mut request = self.client.cosmos_client().request(
                 &format!(
                     "dbs/{}/colls/{}/pkranges",
                     self.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -25,9 +25,7 @@ impl GetPermissionBuilder {
 
     pub fn into_future(self) -> GetPermission {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_permission_name(http::Method::GET);
+            let mut request = self.client.permission_request(http::Method::GET);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/get_user.rs
+++ b/sdk/data_cosmos/src/operations/get_user.rs
@@ -24,9 +24,7 @@ impl GetUserBuilder {
 
     pub fn into_future(self) -> GetUser {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_user_name(http::Method::GET);
+            let mut request = self.client.user_request(http::Method::GET);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -46,7 +46,7 @@ impl ListAttachmentsBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.cosmos_client().prepare_request_pipeline(
+                let mut request = this.client.cosmos_client().request(
                     &format!(
                         "dbs/{}/colls/{}/docs/{}/attachments",
                         this.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -37,7 +37,7 @@ impl ListCollectionsBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.prepare_collections_pipeline(http::Method::GET);
+                let mut request = this.client.collections_request(http::Method::GET);
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -36,9 +36,7 @@ impl ListDatabasesBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this
-                    .client
-                    .prepare_request_pipeline("dbs", http::Method::GET);
+                let mut request = this.client.request("dbs", http::Method::GET);
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -51,7 +51,7 @@ impl ListDocumentsBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut req = this.client.cosmos_client().prepare_request_pipeline(
+                let mut req = this.client.cosmos_client().request(
                     &format!(
                         "dbs/{}/colls/{}/docs",
                         this.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -36,7 +36,7 @@ impl ListPermissionsBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.cosmos_client().prepare_request_pipeline(
+                let mut request = this.client.cosmos_client().request(
                     &format!(
                         "dbs/{}/users/{}/permissions",
                         this.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -38,7 +38,7 @@ impl ListStoredProceduresBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.cosmos_client().prepare_request_pipeline(
+                let mut request = this.client.cosmos_client().request(
                     &format!(
                         "dbs/{}/colls/{}/sprocs",
                         this.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -41,7 +41,7 @@ impl ListTriggersBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.cosmos_client().prepare_request_pipeline(
+                let mut request = this.client.cosmos_client().request(
                     &format!(
                         "dbs/{}/colls/{}/triggers",
                         this.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -42,7 +42,7 @@ impl ListUserDefinedFunctionsBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.cosmos_client().prepare_request_pipeline(
+                let mut request = this.client.cosmos_client().request(
                     &format!(
                         "dbs/{}/colls/{}/udfs",
                         this.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -39,7 +39,7 @@ impl ListUsersBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.cosmos_client().prepare_request_pipeline(
+                let mut request = this.client.cosmos_client().request(
                     &format!("dbs/{}/users", this.client.database_name()),
                     http::Method::GET,
                 );

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -78,7 +78,7 @@ impl QueryDocumentsBuilder {
             let this = self.clone();
             let ctx = self.context.clone();
             async move {
-                let mut request = this.client.cosmos_client().prepare_request_pipeline(
+                let mut request = this.client.cosmos_client().request(
                     &format!(
                         "dbs/{}/colls/{}/docs",
                         this.client.database_client().database_name(),

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -35,9 +35,7 @@ impl ReplaceCollectionBuilder {
 
     pub fn into_future(self) -> ReplaceCollection {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_collection_name(http::Method::PUT);
+            let mut request = self.client.collection_request(http::Method::PUT);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -55,9 +55,7 @@ impl<D: Serialize + Send + 'static> ReplaceDocumentBuilder<D> {
 
     pub fn into_future(self) -> ReplaceDocument {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_pipeline_with_document_name(http::Method::PUT);
+            let mut request = self.client.document_request(http::Method::PUT);
 
             let partition_key = self
                 .partition_key

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -31,9 +31,7 @@ impl ReplacePermissionBuilder {
 
     pub fn into_future(self) -> ReplacePermission {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_permission_name(http::Method::PUT);
+            let mut request = self.client.permission_request(http::Method::PUT);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -28,9 +28,7 @@ impl ReplaceStoredProcedureBuilder {
 
     pub fn into_future(self) -> ReplaceStoredProcedure {
         Box::pin(async move {
-            let mut req = self
-                .client
-                .prepare_pipeline_with_stored_procedure_name(http::Method::PUT);
+            let mut req = self.client.stored_procedure_request(http::Method::PUT);
 
             if let Some(cl) = &self.consistency_level {
                 req.insert_headers(cl);

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -26,9 +26,7 @@ impl ReplaceUserBuilder {
 
     pub fn into_future(self) -> ReplaceUser {
         Box::pin(async move {
-            let mut request = self
-                .client
-                .prepare_request_with_user_name(http::Method::PUT);
+            let mut request = self.client.user_request(http::Method::PUT);
 
             if let Some(cl) = &self.consistency_level {
                 request.insert_headers(cl);


### PR DESCRIPTION
*worked on with @yoshuawuyts ♥*

Changes the naming scheme for these internal methods:

`prepare_pipeline_with_attachment_name` => `attachment_request`

Fixes #810 