### PR TITLE
drop as_ prefix from as_X_client from storage crates

### DIFF
--- a/sdk/data_tables/examples/table_00.rs
+++ b/sdk/data_tables/examples/table_00.rs
@@ -30,10 +30,10 @@ async fn main() -> azure_core::Result<()> {
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
 
     let table_service = storage_account_client
-        .as_storage_client()
-        .as_table_service_client()?;
+        .storage_client()
+        .table_service_client()?;
 
-    let table_client = table_service.as_table_client(table_name);
+    let table_client = table_service.table_client(table_name);
     let response = table_client.create().execute().await?;
     println!("response = {:?}\n", response);
 
@@ -43,7 +43,7 @@ async fn main() -> azure_core::Result<()> {
         surname: "Cogno".to_owned(),
     };
 
-    let partition_key_client = table_client.as_partition_key_client(&entity.city);
+    let partition_key_client = table_client.partition_key_client(&entity.city);
 
     let mut transaction = Transaction::default();
 
@@ -56,7 +56,7 @@ async fn main() -> azure_core::Result<()> {
     transaction.add(table_client.insert().to_transaction_operation(&entity)?);
 
     entity.surname = "Potter".to_owned();
-    let entity_client = partition_key_client.as_entity_client(&entity.surname)?;
+    let entity_client = partition_key_client.entity_client(&entity.surname)?;
     transaction.add(
         entity_client
             .insert_or_replace()
@@ -94,8 +94,8 @@ async fn main() -> azure_core::Result<()> {
     println!("response = {:?}\n", response);
 
     let entity_client = table_client
-        .as_partition_key_client(&entity.city)
-        .as_entity_client(&entity.surname)?;
+        .partition_key_client(&entity.city)
+        .entity_client(&entity.surname)?;
     // update the name passing the Etag received from the previous call.
     entity.name = "Ryan".to_owned();
     let response = entity_client

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -9,11 +9,11 @@ use std::sync::Arc;
 use url::Url;
 
 pub trait AsEntityClient<RK: Into<String>> {
-    fn as_entity_client(&self, row_key: RK) -> azure_core::Result<Arc<EntityClient>>;
+    fn entity_client(&self, row_key: RK) -> azure_core::Result<Arc<EntityClient>>;
 }
 
 impl<RK: Into<String>> AsEntityClient<RK> for Arc<PartitionKeyClient> {
-    fn as_entity_client(&self, row_key: RK) -> azure_core::Result<Arc<EntityClient>> {
+    fn entity_client(&self, row_key: RK) -> azure_core::Result<Arc<EntityClient>> {
         EntityClient::new(self.clone(), row_key)
     }
 }
@@ -137,9 +137,9 @@ mod integration_tests {
     }
 
     fn get_emulator_client() -> Arc<TableServiceClient> {
-        let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
+        let storage_account = StorageAccountClient::new_emulator_default().storage_client();
         storage_account
-            .as_table_service_client()
+            .table_service_client()
             .expect("a table service client")
     }
 
@@ -147,7 +147,7 @@ mod integration_tests {
     async fn test_update() {
         let table_client = get_emulator_client();
 
-        let table = table_client.as_table_client("EntityClientUpdate");
+        let table = table_client.table_client("EntityClientUpdate");
 
         println!("Delete the table (if it exists)");
         match table.delete().execute().await {
@@ -168,8 +168,8 @@ mod integration_tests {
         };
 
         let entity_client = table
-            .as_partition_key_client(&entity.city)
-            .as_entity_client(&entity.surname)
+            .partition_key_client(&entity.city)
+            .entity_client(&entity.surname)
             .expect("an entity client");
 
         entity_client
@@ -199,7 +199,7 @@ mod integration_tests {
     async fn test_merge() {
         let table_client = get_emulator_client();
 
-        let table = table_client.as_table_client("EntityClientMerge");
+        let table = table_client.table_client("EntityClientMerge");
 
         println!("Delete the table (if it exists)");
         match table.delete().execute().await {
@@ -226,8 +226,8 @@ mod integration_tests {
         };
 
         let entity_client = table
-            .as_partition_key_client(&entity.city)
-            .as_entity_client(&entity.surname)
+            .partition_key_client(&entity.city)
+            .entity_client(&entity.surname)
             .expect("an entity client");
 
         entity_client
@@ -257,7 +257,7 @@ mod integration_tests {
     async fn test_insert_or_replace() {
         let table_client = get_emulator_client();
 
-        let table = table_client.as_table_client("EntityClientInsertOrReplace");
+        let table = table_client.table_client("EntityClientInsertOrReplace");
 
         println!("Delete the table (if it exists)");
         match table.delete().execute().await {
@@ -278,8 +278,8 @@ mod integration_tests {
         };
 
         let entity_client = table
-            .as_partition_key_client(&entity.city)
-            .as_entity_client(&entity.surname)
+            .partition_key_client(&entity.city)
+            .entity_client(&entity.surname)
             .expect("an entity client");
         entity_client
             .insert_or_replace()
@@ -303,7 +303,7 @@ mod integration_tests {
     async fn test_insert_or_merge() {
         let table_client = get_emulator_client();
 
-        let table = table_client.as_table_client("EntityClientInsertOrMerge");
+        let table = table_client.table_client("EntityClientInsertOrMerge");
 
         println!("Delete the table (if it exists)");
         match table.delete().execute().await {
@@ -324,8 +324,8 @@ mod integration_tests {
         };
 
         let entity_client = table
-            .as_partition_key_client(&entity.city)
-            .as_entity_client(&entity.surname)
+            .partition_key_client(&entity.city)
+            .entity_client(&entity.surname)
             .expect("an entity client");
         entity_client
             .insert_or_merge()

--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -7,11 +7,11 @@ use http::method::Method;
 use std::sync::Arc;
 
 pub trait AsPartitionKeyClient<PK: Into<String>> {
-    fn as_partition_key_client(&self, partition_key: PK) -> Arc<PartitionKeyClient>;
+    fn partition_key_client(&self, partition_key: PK) -> Arc<PartitionKeyClient>;
 }
 
 impl<PK: Into<String>> AsPartitionKeyClient<PK> for Arc<TableClient> {
-    fn as_partition_key_client(&self, partition_key: PK) -> Arc<PartitionKeyClient> {
+    fn partition_key_client(&self, partition_key: PK) -> Arc<PartitionKeyClient> {
         PartitionKeyClient::new(self.clone(), partition_key)
     }
 }
@@ -83,9 +83,9 @@ mod integration_tests {
     }
 
     fn get_emulator_client() -> Arc<TableServiceClient> {
-        let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
+        let storage_account = StorageAccountClient::new_emulator_default().storage_client();
         storage_account
-            .as_table_service_client()
+            .table_service_client()
             .expect("a table service client")
     }
 
@@ -93,7 +93,7 @@ mod integration_tests {
     #[tokio::test]
     async fn test_transaction() {
         let table_service = get_emulator_client();
-        let table = table_service.as_table_client("PartitionKeyClientTransaction");
+        let table = table_service.table_client("PartitionKeyClientTransaction");
 
         println!("Delete the table (if it exists)");
         match table.delete().execute().await {
@@ -107,7 +107,7 @@ mod integration_tests {
             .await
             .expect("the table should be created");
 
-        let partition_client = table.as_partition_key_client("Milan");
+        let partition_client = table.partition_key_client("Milan");
 
         println!("Create the transaction");
         let mut transaction = Transaction::default();

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -6,11 +6,11 @@ use http::method::Method;
 use std::sync::Arc;
 
 pub trait AsTableClient<S: Into<String>> {
-    fn as_table_client(&self, s: S) -> Arc<TableClient>;
+    fn table_client(&self, s: S) -> Arc<TableClient>;
 }
 
 impl<S: Into<String>> AsTableClient<S> for Arc<TableServiceClient> {
-    fn as_table_client(&self, s: S) -> Arc<TableClient> {
+    fn table_client(&self, s: S) -> Arc<TableClient> {
         TableClient::new(self.clone(), s)
     }
 }
@@ -95,16 +95,16 @@ mod integration_tests {
     }
 
     fn get_emulator_client() -> Arc<TableServiceClient> {
-        let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
+        let storage_account = StorageAccountClient::new_emulator_default().storage_client();
         storage_account
-            .as_table_service_client()
+            .table_service_client()
             .expect("a table service client")
     }
 
     #[tokio::test]
     async fn test_create_delete() {
         let table_client = get_emulator_client();
-        let table = table_client.as_table_client("TableClientCreateDelete");
+        let table = table_client.table_client("TableClientCreateDelete");
 
         assert_eq!(
             table.table_name(),
@@ -155,7 +155,7 @@ mod integration_tests {
     async fn test_insert() {
         let table_client = get_emulator_client();
 
-        let table = table_client.as_table_client("TableClientInsert");
+        let table = table_client.table_client("TableClientInsert");
         assert_eq!(
             table.table_name(),
             "TableClientInsert",

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -8,11 +8,11 @@ use std::sync::Arc;
 use url::Url;
 
 pub trait AsTableServiceClient {
-    fn as_table_service_client(&self) -> azure_core::Result<Arc<TableServiceClient>>;
+    fn table_service_client(&self) -> azure_core::Result<Arc<TableServiceClient>>;
 }
 
 impl AsTableServiceClient for Arc<StorageClient> {
-    fn as_table_service_client(&self) -> azure_core::Result<Arc<TableServiceClient>> {
+    fn table_service_client(&self) -> azure_core::Result<Arc<TableServiceClient>> {
         TableServiceClient::new(self.clone())
     }
 }
@@ -81,18 +81,18 @@ mod integration_tests {
     use futures::StreamExt;
 
     fn get_emulator_client() -> Arc<StorageClient> {
-        StorageAccountClient::new_emulator_default().as_storage_client()
+        StorageAccountClient::new_emulator_default().storage_client()
     }
 
     #[tokio::test]
     async fn test_list() {
         let storage_account = get_emulator_client();
         let table_client = storage_account
-            .as_table_service_client()
+            .table_service_client()
             .expect("a table service client");
 
         println!("Create a table in the storage account");
-        let table = table_client.as_table_client("TableServiceClientList");
+        let table = table_client.table_client("TableServiceClientList");
         match table.create().execute().await {
             _ => {}
         }

--- a/sdk/storage/examples/account00.rs
+++ b/sdk/storage/examples/account00.rs
@@ -12,7 +12,7 @@ async fn main() -> azure_core::Result<()> {
 
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
+            .storage_client();
 
     let response = storage_client
         .get_account_information()

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -9,11 +9,11 @@ use http::method::Method;
 use std::sync::Arc;
 
 pub trait AsStorageClient {
-    fn as_storage_client(&self) -> Arc<StorageClient>;
+    fn storage_client(&self) -> Arc<StorageClient>;
 }
 
 impl AsStorageClient for Arc<StorageAccountClient> {
-    fn as_storage_client(&self) -> Arc<StorageClient> {
+    fn storage_client(&self) -> Arc<StorageClient> {
         StorageClient::new(self.clone())
     }
 }

--- a/sdk/storage/tests/account.rs
+++ b/sdk/storage/tests/account.rs
@@ -12,7 +12,7 @@ async fn get_account_information() {
 
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
+            .storage_client();
 
     storage_client
         .get_account_information()

--- a/sdk/storage_blobs/examples/blob_00.rs
+++ b/sdk/storage_blobs/examples/blob_00.rs
@@ -28,10 +28,10 @@ async fn main() -> azure_core::Result<()> {
     // let storage_account_client = StorageAccountClient::new_sas_token(http_client.clone(), &account,
     //      "sv=2018-11-09&ss=b&srt=o&se=2021-01-15T12%3A09%3A01Z&sp=r&st=2021-01-15T11%3A09%3A01Z&spr=http,https&sig=some_signature")?;
 
-    let storage_client = storage_account_client.as_storage_client();
+    let storage_client = storage_account_client.storage_client();
     let blob_client = storage_client
-        .as_container_client(&container)
-        .as_blob_client(&blob);
+        .container_client(&container)
+        .blob_client(&blob);
 
     trace!("Requesting blob");
 

--- a/sdk/storage_blobs/examples/blob_01.rs
+++ b/sdk/storage_blobs/examples/blob_01.rs
@@ -19,9 +19,9 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
-    let container_client = storage_client.as_container_client(&container_name);
-    let blob_client = container_client.as_blob_client("SorgeniaReorganizeRebuildIndexes.zip");
+            .storage_client();
+    let container_client = storage_client.container_client(&container_name);
+    let blob_client = container_client.blob_client("SorgeniaReorganizeRebuildIndexes.zip");
 
     // only get the first 8k chunk
     let result = Box::pin(blob_client.get().stream(1024 * 8))

--- a/sdk/storage_blobs/examples/blob_02_bearer_token.rs
+++ b/sdk/storage_blobs/examples/blob_02_bearer_token.rs
@@ -24,8 +24,8 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let blob_client =
         StorageAccountClient::new_bearer_token(http_client.clone(), &account, bearer_token)
-            .as_container_client(&container)
-            .as_blob_client(&blob);
+            .container_client(&container)
+            .blob_client(&blob);
 
     trace!("Requesting blob");
 

--- a/sdk/storage_blobs/examples/blob_04.rs
+++ b/sdk/storage_blobs/examples/blob_04.rs
@@ -20,8 +20,8 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let blob_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container_name)
-            .as_blob_client("test1");
+            .container_client(&container_name)
+            .blob_client("test1");
 
     // this example fills a 1 KB file with ASCII text and
     // sends it in chunks of 256 bytes (4 chunks).

--- a/sdk/storage_blobs/examples/blob_05_default_credential.rs
+++ b/sdk/storage_blobs/examples/blob_05_default_credential.rs
@@ -34,8 +34,8 @@ async fn main() -> azure_core::Result<()> {
         &account,
         bearer_token.token.secret(),
     )
-    .as_container_client(&container)
-    .as_blob_client(&blob);
+    .container_client(&container)
+    .blob_client(&blob);
 
     trace!("Requesting blob");
 

--- a/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
+++ b/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
@@ -28,8 +28,8 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let blob_client =
         StorageAccountClient::new_token_credential(http_client.clone(), &account, auto_creds)
-            .as_container_client(&container)
-            .as_blob_client(&blob);
+            .container_client(&container)
+            .blob_client(&blob);
 
     trace!("Requesting blob");
     let content = blob_client.get_content().await?;

--- a/sdk/storage_blobs/examples/blob_range.rs
+++ b/sdk/storage_blobs/examples/blob_range.rs
@@ -20,8 +20,8 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let blob_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container)
-            .as_blob_client(&blob);
+            .container_client(&container)
+            .blob_client(&blob);
 
     // 1024 G, 512 H and 2048 I
     let mut buf: Vec<u8> = Vec::with_capacity(1024 * 4);

--- a/sdk/storage_blobs/examples/connection_string.rs
+++ b/sdk/storage_blobs/examples/connection_string.rs
@@ -16,9 +16,9 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_connection_string(http_client.clone(), &connection_string)?
-            .as_storage_client();
-    let container_client = storage_client.as_container_client(&container_name);
-    let blob_service = storage_client.as_blob_service_client();
+            .storage_client();
+    let container_client = storage_client.container_client(&container_name);
+    let blob_service = storage_client.blob_service_client();
 
     let mut stream = blob_service.list_containers().into_stream();
     while let Some(result) = stream.next().await {
@@ -42,7 +42,7 @@ async fn main() -> azure_core::Result<()> {
     // create 10 blobs
     for i in 0..10u8 {
         container_client
-            .as_blob_client(format!("blob{}.txt", i))
+            .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()

--- a/sdk/storage_blobs/examples/container_00.rs
+++ b/sdk/storage_blobs/examples/container_00.rs
@@ -18,9 +18,9 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
-    let blob_service_client = storage_client.as_blob_service_client();
-    let container_client = storage_client.as_container_client(container_name);
+            .storage_client();
+    let blob_service_client = storage_client.blob_service_client();
+    let container_client = storage_client.container_client(container_name);
 
     let max_results = NonZeroU32::new(3).unwrap();
     let mut iv = blob_service_client

--- a/sdk/storage_blobs/examples/container_01.rs
+++ b/sdk/storage_blobs/examples/container_01.rs
@@ -19,8 +19,8 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
-    let container_client = storage_client.as_container_client(container_name);
+            .storage_client();
+    let container_client = storage_client.container_client(container_name);
 
     let mut metadata = Metadata::new();
     metadata.insert("prova".to_owned(), "pollo".to_owned());

--- a/sdk/storage_blobs/examples/container_and_blob.rs
+++ b/sdk/storage_blobs/examples/container_and_blob.rs
@@ -19,8 +19,8 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
-    let container_client = storage_client.as_container_client(&container_name);
+            .storage_client();
+    let container_client = storage_client.container_client(&container_name);
 
     // create container
     let res = container_client
@@ -37,7 +37,7 @@ async fn main() -> azure_core::Result<()> {
     let hash = md5::compute(&data[..]);
 
     let res = container_client
-        .as_blob_client("blob0.txt")
+        .blob_client("blob0.txt")
         .put_block_blob(data.clone())
         .content_type("text/plain")
         .hash(hash)
@@ -46,7 +46,7 @@ async fn main() -> azure_core::Result<()> {
     println!("{:?}", res);
 
     let res = container_client
-        .as_blob_client("blob1.txt")
+        .blob_client("blob1.txt")
         .put_block_blob(data.clone())
         .content_type("text/plain")
         .hash(hash)
@@ -55,7 +55,7 @@ async fn main() -> azure_core::Result<()> {
     println!("{:?}", res);
 
     let res = container_client
-        .as_blob_client("blob2.txt")
+        .blob_client("blob2.txt")
         .put_block_blob(data)
         .content_type("text/plain")
         .hash(hash)

--- a/sdk/storage_blobs/examples/copy_blob.rs
+++ b/sdk/storage_blobs/examples/copy_blob.rs
@@ -36,16 +36,16 @@ async fn main() -> azure_core::Result<()> {
         &source_access_key,
     );
     let source_blob = source_storage_account_client
-        .as_container_client(&source_container_name)
-        .as_blob_client(&source_blob_name);
+        .container_client(&source_container_name)
+        .blob_client(&source_blob_name);
 
     let destination_blob = StorageAccountClient::new_access_key(
         http_client.clone(),
         &destination_account,
         &destination_access_key,
     )
-    .as_container_client(&destination_container_name)
-    .as_blob_client(&destination_blob_name);
+    .container_client(&destination_container_name)
+    .blob_client(&destination_blob_name);
 
     // let's get a SAS key for the source
     let sas_url = {

--- a/sdk/storage_blobs/examples/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/examples/copy_blob_from_url.rs
@@ -25,10 +25,10 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_account_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
-    let storage_client = storage_account_client.as_storage_client();
+    let storage_client = storage_account_client.storage_client();
     let blob_client = storage_client
-        .as_container_client(&destination_container)
-        .as_blob_client(&destination_blob);
+        .container_client(&destination_container)
+        .blob_client(&destination_blob);
 
     let source_url = storage_account_client
         .blob_storage_url()

--- a/sdk/storage_blobs/examples/count_blobs.rs
+++ b/sdk/storage_blobs/examples/count_blobs.rs
@@ -16,7 +16,7 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let container_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container);
+            .container_client(&container);
 
     let mut count: usize = 0;
     let mut list_blobs = container_client.list_blobs().into_stream();

--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -76,7 +76,7 @@ async fn main() -> azure_core::Result<()> {
         &storage_account_name,
         authorization.access_token().secret(),
     );
-    let blob_service_client = storage_account_client.as_blob_service_client();
+    let blob_service_client = storage_account_client.blob_service_client();
 
     // now we enumerate the containers in the
     // specified storage account.

--- a/sdk/storage_blobs/examples/emulator_00.rs
+++ b/sdk/storage_blobs/examples/emulator_00.rs
@@ -7,8 +7,8 @@ async fn main() -> azure_core::Result<()> {
     env_logger::init();
 
     // this is how you use the emulator.
-    let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
-    let container_client = storage_account.as_container_client("emulcont");
+    let storage_account = StorageAccountClient::new_emulator_default().storage_client();
+    let container_client = storage_account.container_client("emulcont");
 
     // create container
     let res = container_client

--- a/sdk/storage_blobs/examples/list_blobs_00.rs
+++ b/sdk/storage_blobs/examples/list_blobs_00.rs
@@ -18,9 +18,9 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
-    let blob_service = storage_client.as_blob_service_client();
-    let container_client = storage_client.as_container_client(&container_name);
+            .storage_client();
+    let blob_service = storage_client.blob_service_client();
+    let container_client = storage_client.container_client(&container_name);
 
     let page = blob_service
         .list_containers()
@@ -49,7 +49,7 @@ async fn main() -> azure_core::Result<()> {
     // create 10 blobs
     for i in 0..10u8 {
         container_client
-            .as_blob_client(format!("blob{}.txt", i))
+            .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()

--- a/sdk/storage_blobs/examples/list_blobs_01.rs
+++ b/sdk/storage_blobs/examples/list_blobs_01.rs
@@ -18,9 +18,9 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
-    let blob_service_client = storage_client.as_blob_service_client();
-    let container_client = storage_client.as_container_client(&container_name);
+            .storage_client();
+    let blob_service_client = storage_client.blob_service_client();
+    let container_client = storage_client.container_client(&container_name);
 
     let page = blob_service_client
         .list_containers()
@@ -64,7 +64,7 @@ async fn main() -> azure_core::Result<()> {
     // create 4 root blobs
     for i in 0..4u8 {
         container_client
-            .as_blob_client(format!("blob_at_root{}.txt", i))
+            .blob_client(format!("blob_at_root{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()
@@ -74,7 +74,7 @@ async fn main() -> azure_core::Result<()> {
     // create 3 firstfolder/ blobs
     for i in 0..3u8 {
         container_client
-            .as_blob_client(format!("firstfolder/blob_at_1stfolder{}.txt", i))
+            .blob_client(format!("firstfolder/blob_at_1stfolder{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()
@@ -84,7 +84,7 @@ async fn main() -> azure_core::Result<()> {
     // create 3 secondroot/ blobs
     for i in 0..3u8 {
         container_client
-            .as_blob_client(format!("secondroot/blobsd{}.txt", i))
+            .blob_client(format!("secondroot/blobsd{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()
@@ -94,7 +94,7 @@ async fn main() -> azure_core::Result<()> {
     // create 2 firstfolder/secondfolder blobs
     for i in 0..2u8 {
         container_client
-            .as_blob_client(format!("firstfolder/secondfolder/blob{}.txt", i))
+            .blob_client(format!("firstfolder/secondfolder/blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()
@@ -104,7 +104,7 @@ async fn main() -> azure_core::Result<()> {
     // create 4 firstfolder/thirdfolder blobs
     for i in 0..4u8 {
         container_client
-            .as_blob_client(format!("firstfolder/thirdfolder/blob{}.txt", i))
+            .blob_client(format!("firstfolder/thirdfolder/blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()
@@ -114,7 +114,7 @@ async fn main() -> azure_core::Result<()> {
     // create 4 firstfolder/fourthfolder blobs
     for i in 0..5u8 {
         container_client
-            .as_blob_client(format!(
+            .blob_client(format!(
                 "firstfolder/thirdfolder/fourthfolder/blob{}.txt",
                 i
             ))

--- a/sdk/storage_blobs/examples/list_blobs_02.rs
+++ b/sdk/storage_blobs/examples/list_blobs_02.rs
@@ -17,11 +17,11 @@ async fn main() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
+            .storage_client();
 
     create_container_and_list(storage_client, &container_name).await?;
 
-    let storage_client = StorageAccountClient::new_emulator_default().as_storage_client();
+    let storage_client = StorageAccountClient::new_emulator_default().storage_client();
     create_container_and_list(storage_client, &container_name).await?;
 
     Ok(())
@@ -31,7 +31,7 @@ async fn create_container_and_list(
     storage_client: std::sync::Arc<StorageClient>,
     container_name: &str,
 ) -> azure_core::Result<()> {
-    let container_client = storage_client.as_container_client(container_name);
+    let container_client = storage_client.container_client(container_name);
 
     container_client.create().into_future().await?;
 
@@ -46,7 +46,7 @@ async fn create_container_and_list(
 
     for i in 0..3 {
         container_client
-            .as_blob_client(format!("blob{}.txt", i))
+            .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()

--- a/sdk/storage_blobs/examples/list_containers2.rs
+++ b/sdk/storage_blobs/examples/list_containers2.rs
@@ -21,11 +21,11 @@ async fn main() -> azure_core::Result<()> {
 
     let storage_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_storage_client();
-    let blob_service_client = storage_client.as_blob_service_client();
+            .storage_client();
+    let blob_service_client = storage_client.blob_service_client();
 
     let response = storage_client
-        .as_container_client("azuresdkforrust")
+        .container_client("azuresdkforrust")
         .list_blobs()
         .into_stream()
         .next()
@@ -48,7 +48,7 @@ async fn main() -> azure_core::Result<()> {
     let sas_token = "?sv=2019-12-12&ss=bfqt&srt=sco&sp=rwdlacupx&se=2020-12-05T20:20:58Z&st=2020-12-05T12:20:58Z&spr=https&sig=vxUuKjQW4%2FmB884f%2BdqCp4h3O%2BYuYgIJN8RVGHFVFpY%3D";
     let blob_service_client =
         StorageAccountClient::new_sas_token(http_client.clone(), &account, sas_token)?
-            .as_blob_service_client();
+            .blob_service_client();
     let response = blob_service_client
         .list_containers()
         .into_stream()

--- a/sdk/storage_blobs/examples/list_containers_and_blobs.rs
+++ b/sdk/storage_blobs/examples/list_containers_and_blobs.rs
@@ -18,7 +18,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_account_client =
         StorageAccountClient::new_access_key(http_client, &account, &account_key);
 
-    let blob_service_client = storage_account_client.as_blob_service_client();
+    let blob_service_client = storage_account_client.blob_service_client();
 
     let mut stream = blob_service_client.list_containers().into_stream();
 
@@ -27,7 +27,7 @@ async fn main() -> azure_core::Result<()> {
         for container in entry.containers {
             println!("container: {}", container.name);
 
-            let container_client = storage_account_client.as_container_client(container.name);
+            let container_client = storage_account_client.container_client(container.name);
 
             let mut blob_stream = container_client.list_blobs().into_stream();
             while let Some(blob_entry) = blob_stream.next().await {

--- a/sdk/storage_blobs/examples/put_append_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_append_blob_00.rs
@@ -26,8 +26,8 @@ async fn main() -> azure_core::Result<()> {
 
     let blob_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container)
-            .as_blob_client(&blob_name);
+            .container_client(&container)
+            .blob_client(&blob_name);
 
     //let data = b"something";
 

--- a/sdk/storage_blobs/examples/put_block_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_block_blob_00.rs
@@ -27,8 +27,8 @@ async fn main() -> azure_core::Result<()> {
 
     let blob_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container)
-            .as_blob_client(&blob_name);
+            .container_client(&container)
+            .blob_client(&blob_name);
 
     let data = Bytes::from_static(b"something");
 
@@ -88,7 +88,7 @@ async fn main() -> azure_core::Result<()> {
         .await?;
     println!("Acquire lease == {:?}", res);
 
-    let lease = blob_client.as_blob_lease_client(res.lease_id);
+    let lease = blob_client.blob_lease_client(res.lease_id);
 
     let res = lease.renew().into_future().await?;
     println!("Renew lease == {:?}", res);

--- a/sdk/storage_blobs/examples/put_page_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_page_blob_00.rs
@@ -27,8 +27,8 @@ async fn main() -> azure_core::Result<()> {
 
     let blob_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container_name)
-            .as_blob_client(&blob_name);
+            .container_client(&container_name)
+            .blob_client(&blob_name);
 
     let data = Bytes::from_static(&[51; 2000]);
 

--- a/sdk/storage_blobs/examples/shared_access_signature.rs
+++ b/sdk/storage_blobs/examples/shared_access_signature.rs
@@ -29,8 +29,8 @@ fn code() -> azure_core::Result<()> {
 
     let storage_account_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
-    let container_client = storage_account_client.as_container_client(&container_name);
-    let blob_client = container_client.as_blob_client(&blob_name);
+    let container_client = storage_account_client.container_client(&container_name);
+    let blob_client = container_client.blob_client(&blob_name);
 
     let sas = storage_account_client
         .shared_access_signature()?

--- a/sdk/storage_blobs/examples/stream_blob_00.rs
+++ b/sdk/storage_blobs/examples/stream_blob_00.rs
@@ -28,8 +28,8 @@ async fn main() -> azure_core::Result<()> {
 
     let blob_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container_name)
-            .as_blob_client(file_name);
+            .container_client(&container_name)
+            .blob_client(file_name);
 
     let string = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
 

--- a/sdk/storage_blobs/examples/stream_blob_01.rs
+++ b/sdk/storage_blobs/examples/stream_blob_01.rs
@@ -26,8 +26,8 @@ async fn main() -> azure_core::Result<()> {
 
     let blob_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-            .as_container_client(&container_name)
-            .as_blob_client(file_name);
+            .container_client(&container_name)
+            .blob_client(file_name);
 
     let mut stream = Box::pin(blob_client.get().stream(1024));
     while let Some(res) = stream.next().await {

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -19,11 +19,11 @@ use std::sync::Arc;
 use url::Url;
 
 pub trait AsBlobClient<BN: Into<String>> {
-    fn as_blob_client(&self, blob_name: BN) -> Arc<BlobClient>;
+    fn blob_client(&self, blob_name: BN) -> Arc<BlobClient>;
 }
 
 impl<BN: Into<String>> AsBlobClient<BN> for Arc<ContainerClient> {
-    fn as_blob_client(&self, blob_name: BN) -> Arc<BlobClient> {
+    fn blob_client(&self, blob_name: BN) -> Arc<BlobClient> {
         BlobClient::new(self.clone(), blob_name.into())
     }
 }
@@ -262,10 +262,10 @@ mod tests {
     }
 
     fn build_url(container_name: &str, blob_name: &str, sas: &FakeSas) -> url::Url {
-        let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
+        let storage_account = StorageAccountClient::new_emulator_default().storage_client();
         storage_account
-            .as_container_client(container_name)
-            .as_blob_client(blob_name)
+            .container_client(container_name)
+            .blob_client(blob_name)
             .generate_signed_blob_url(sas)
             .expect("build url failed")
     }
@@ -297,8 +297,8 @@ mod integration_tests {
     use crate::blob::clients::AsBlobClient;
 
     fn get_emulator_client(container_name: &str) -> Arc<ContainerClient> {
-        let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
-        storage_account.as_container_client(container_name)
+        let storage_account = StorageAccountClient::new_emulator_default().storage_client();
+        storage_account.container_client(container_name)
     }
 
     #[tokio::test]
@@ -314,13 +314,13 @@ mod integration_tests {
 
         let md5 = md5::compute("world");
         container_client
-            .as_blob_client("hello.txt")
+            .blob_client("hello.txt")
             .put_block_blob("world")
             .into_future()
             .await
             .expect("put block blob should succeed");
         let properties = container_client
-            .as_blob_client("hello.txt")
+            .blob_client("hello.txt")
             .get_properties()
             .into_future()
             .await

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -6,11 +6,11 @@ use http::method::Method;
 use std::sync::Arc;
 
 pub trait AsBlobLeaseClient {
-    fn as_blob_lease_client(&self, lease_id: LeaseId) -> Arc<BlobLeaseClient>;
+    fn blob_lease_client(&self, lease_id: LeaseId) -> Arc<BlobLeaseClient>;
 }
 
 impl AsBlobLeaseClient for Arc<BlobClient> {
-    fn as_blob_lease_client(&self, lease_id: LeaseId) -> Arc<BlobLeaseClient> {
+    fn blob_lease_client(&self, lease_id: LeaseId) -> Arc<BlobLeaseClient> {
         BlobLeaseClient::new(self.clone(), lease_id)
     }
 }

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -6,18 +6,18 @@ use azure_storage::core::clients::{
 use std::sync::Arc;
 
 pub trait AsBlobServiceClient {
-    fn as_blob_service_client(&self) -> Arc<BlobServiceClient>;
+    fn blob_service_client(&self) -> Arc<BlobServiceClient>;
 }
 
 impl AsBlobServiceClient for Arc<StorageClient> {
-    fn as_blob_service_client(&self) -> Arc<BlobServiceClient> {
+    fn blob_service_client(&self) -> Arc<BlobServiceClient> {
         BlobServiceClient::new(self.clone())
     }
 }
 
 impl AsBlobServiceClient for Arc<StorageAccountClient> {
-    fn as_blob_service_client(&self) -> Arc<BlobServiceClient> {
-        self.as_storage_client().as_blob_service_client()
+    fn blob_service_client(&self) -> Arc<BlobServiceClient> {
+        self.storage_client().blob_service_client()
     }
 }
 

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -18,18 +18,18 @@ use http::method::Method;
 use std::sync::Arc;
 
 pub trait AsContainerClient<CN: Into<String>> {
-    fn as_container_client(&self, container_name: CN) -> Arc<ContainerClient>;
+    fn container_client(&self, container_name: CN) -> Arc<ContainerClient>;
 }
 
 impl<CN: Into<String>> AsContainerClient<CN> for Arc<StorageClient> {
-    fn as_container_client(&self, container_name: CN) -> Arc<ContainerClient> {
+    fn container_client(&self, container_name: CN) -> Arc<ContainerClient> {
         ContainerClient::new(self.clone(), container_name.into())
     }
 }
 
 impl<CN: Into<String>> AsContainerClient<CN> for Arc<StorageAccountClient> {
-    fn as_container_client(&self, container_name: CN) -> Arc<ContainerClient> {
-        self.as_storage_client().as_container_client(container_name)
+    fn container_client(&self, container_name: CN) -> Arc<ContainerClient> {
+        self.storage_client().container_client(container_name)
     }
 }
 
@@ -163,9 +163,9 @@ mod integration_tests {
     use crate::{blob::clients::AsBlobClient, core::prelude::*};
 
     fn get_emulator_client(container_name: &str) -> Arc<ContainerClient> {
-        let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
+        let storage_account = StorageAccountClient::new_emulator_default().storage_client();
 
-        storage_account.as_container_client(container_name)
+        storage_account.container_client(container_name)
     }
 
     #[tokio::test]
@@ -198,7 +198,7 @@ mod integration_tests {
 
         let md5 = md5::compute("world");
         container_client
-            .as_blob_client("hello.txt")
+            .blob_client("hello.txt")
             .put_block_blob("world")
             .into_future()
             .await

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -6,11 +6,11 @@ use http::method::Method;
 use std::sync::Arc;
 
 pub trait AsContainerLeaseClient {
-    fn as_container_lease_client(&self, lease_id: LeaseId) -> Arc<ContainerLeaseClient>;
+    fn container_lease_client(&self, lease_id: LeaseId) -> Arc<ContainerLeaseClient>;
 }
 
 impl AsContainerLeaseClient for Arc<ContainerClient> {
-    fn as_container_lease_client(&self, lease_id: LeaseId) -> Arc<ContainerLeaseClient> {
+    fn container_lease_client(&self, lease_id: LeaseId) -> Arc<ContainerLeaseClient> {
         ContainerLeaseClient::new(self.clone(), lease_id)
     }
 }

--- a/sdk/storage_blobs/tests/append_blob.rs
+++ b/sdk/storage_blobs/tests/append_blob.rs
@@ -22,10 +22,10 @@ async fn put_append_blob() {
     let http_client = azure_core::new_http_client();
 
     let storage = StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-        .as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
-    let blob = container.as_blob_client(blob_name);
+        .storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
+    let blob = container.blob_client(blob_name);
 
     if blob_service
         .list_containers()

--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -24,9 +24,9 @@ use uuid::Uuid;
 async fn create_and_delete_container() {
     let name: &'static str = "azuresdkrustetoets";
 
-    let storage_client = initialize().as_storage_client();
-    let blob_service = storage_client.as_blob_service_client();
-    let container = storage_client.as_container_client(name);
+    let storage_client = initialize().storage_client();
+    let blob_service = storage_client.blob_service_client();
+    let container = storage_client.container_client(name);
 
     container
         .create()
@@ -98,7 +98,7 @@ async fn create_and_delete_container() {
         .await
         .unwrap();
     let lease_id = res.lease_id;
-    let lease = container.as_container_lease_client(res.lease_id);
+    let lease = container.container_lease_client(res.lease_id);
 
     let _res = lease.renew().into_future().await.unwrap();
 
@@ -116,9 +116,9 @@ async fn put_and_get_block_list() {
     let container_name = format!("sdkrust{}", u);
     let name = "asd - ()krustputblock.txt";
 
-    let storage = initialize().as_storage_client();
-    let container = storage.as_container_client(&container_name);
-    let blob = container.as_blob_client(name);
+    let storage = initialize().storage_client();
+    let container = storage.container_client(&container_name);
+    let blob = container.blob_client(name);
 
     container
         .create()
@@ -175,7 +175,7 @@ async fn put_and_get_block_list() {
     println!("Acquire lease == {:?}", res);
 
     let lease_id = res.lease_id;
-    let lease = blob.as_blob_lease_client(lease_id);
+    let lease = blob.blob_lease_client(lease_id);
 
     let res = lease.renew().into_future().await.unwrap();
     println!("Renew lease == {:?}", res);
@@ -206,8 +206,8 @@ async fn put_and_get_block_list() {
 
 #[tokio::test]
 async fn list_containers() {
-    let storage = initialize().as_storage_client();
-    let blob_service = storage.as_blob_service_client();
+    let storage = initialize().storage_client();
+    let blob_service = storage.blob_service_client();
     trace!("running list_containers");
 
     let mut stream = blob_service
@@ -227,10 +227,10 @@ async fn put_block_blob() {
     let container_name: &'static str = "rust-upload-test";
     let data = Bytes::from_static(b"abcdef");
 
-    let storage = initialize().as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
-    let blob = container.as_blob_client(blob_name);
+    let storage = initialize().storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
+    let blob = container.blob_client(blob_name);
 
     if blob_service
         .list_containers()
@@ -271,10 +271,10 @@ async fn copy_blob() {
     let container_name: &'static str = "rust-upload-test";
     let data = Bytes::from_static(b"abcdef");
 
-    let storage = initialize().as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
-    let blob = container.as_blob_client(blob_name);
+    let storage = initialize().storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
+    let blob = container.blob_client(blob_name);
 
     if blob_service
         .list_containers()
@@ -308,7 +308,7 @@ async fn copy_blob() {
 
     trace!("created {:?}", blob_name);
 
-    let cloned_blob = container.as_blob_client("cloned_blob");
+    let cloned_blob = container.blob_client("cloned_blob");
 
     let url = Url::parse(&format!(
         "https://{}.blob.core.windows.net/{}/{}",
@@ -334,10 +334,10 @@ async fn put_block_blob_and_get_properties() {
     let container_name: &'static str = "rust-upload-test";
     let data = Bytes::from_static(b"abcdef");
 
-    let storage = initialize().as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
-    let blob = container.as_blob_client(blob_name);
+    let storage = initialize().storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
+    let blob = container.blob_client(blob_name);
 
     if blob_service
         .list_containers()
@@ -384,10 +384,10 @@ async fn set_blobtier() {
     let container_name: &'static str = "rust-set-blobtier-test";
     let data = Bytes::from_static(b"abcdef");
 
-    let storage = initialize().as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
-    let blob = container.as_blob_client(blob_name);
+    let storage = initialize().storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
+    let blob = container.blob_client(blob_name);
 
     if blob_service
         .list_containers()
@@ -485,9 +485,9 @@ async fn set_blobtier() {
 fn send_check() {
     let client = initialize();
     let blob = client
-        .as_storage_client()
-        .as_container_client("a")
-        .as_blob_client("b");
+        .storage_client()
+        .container_client("a")
+        .blob_client("b");
 
     let _ = requires_send_future(blob.acquire_lease(Duration::from_secs(10)).into_future());
     let _ = requires_send_future(

--- a/sdk/storage_blobs/tests/container.rs
+++ b/sdk/storage_blobs/tests/container.rs
@@ -7,8 +7,8 @@ use std::{sync::Arc, time::Duration};
 async fn lease() {
     let container_name: &'static str = "azuresdkrustetoets2";
 
-    let storage = initialize().as_storage_client();
-    let container = storage.as_container_client(container_name);
+    let storage = initialize().storage_client();
+    let container = storage.container_client(container_name);
 
     container
         .create()
@@ -23,7 +23,7 @@ async fn lease() {
         .await
         .unwrap();
     let lease_id = res.lease_id;
-    let lease = container.as_container_lease_client(lease_id);
+    let lease = container.container_lease_client(lease_id);
 
     let _res = lease.renew().into_future().await.unwrap();
     let _res = lease.release().into_future().await.unwrap();
@@ -35,8 +35,8 @@ async fn lease() {
 async fn break_lease() {
     let container_name: &'static str = "azuresdkrustetoets3";
 
-    let storage = initialize().as_storage_client();
-    let container = storage.as_container_client(container_name);
+    let storage = initialize().storage_client();
+    let container = storage.container_client(container_name);
 
     container
         .create()
@@ -51,7 +51,7 @@ async fn break_lease() {
         .await
         .unwrap();
 
-    let lease = container.as_container_lease_client(res.lease_id);
+    let lease = container.container_lease_client(res.lease_id);
     lease.renew().into_future().await.unwrap();
 
     let res = container

--- a/sdk/storage_blobs/tests/page_blob.rs
+++ b/sdk/storage_blobs/tests/page_blob.rs
@@ -12,10 +12,10 @@ async fn put_page_blob() {
     let blob_name: &'static str = "page_blob.txt";
     let container_name: &'static str = "rust-upload-test";
 
-    let storage = initialize().as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
-    let blob = container.as_blob_client(blob_name);
+    let storage = initialize().storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
+    let blob = container.blob_client(blob_name);
 
     if blob_service
         .list_containers()

--- a/sdk/storage_blobs/tests/stream_blob00.rs
+++ b/sdk/storage_blobs/tests/stream_blob00.rs
@@ -25,10 +25,10 @@ async fn code() -> azure_core::Result<()> {
     let http_client = azure_core::new_http_client();
 
     let storage = StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-        .as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
-    let blob = container.as_blob_client(file_name);
+        .storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
+    let blob = container.blob_client(file_name);
 
     if blob_service
         .list_containers()

--- a/sdk/storage_blobs/tests/stream_list_blobs.rs
+++ b/sdk/storage_blobs/tests/stream_list_blobs.rs
@@ -17,9 +17,9 @@ async fn stream_list_blobs() {
     let http_client = azure_core::new_http_client();
 
     let storage = StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key)
-        .as_storage_client();
-    let blob_service = storage.as_blob_service_client();
-    let container = storage.as_container_client(container_name);
+        .storage_client();
+    let blob_service = storage.blob_service_client();
+    let container = storage.container_client(container_name);
 
     let page = blob_service
         .list_containers()
@@ -50,7 +50,7 @@ async fn stream_list_blobs() {
     // create 10 blobs
     for i in 0..10u8 {
         container
-            .as_blob_client(format!("blob{}.txt", i))
+            .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
             .into_future()

--- a/sdk/storage_queues/examples/delete_message.rs
+++ b/sdk/storage_queues/examples/delete_message.rs
@@ -22,7 +22,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_account =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
 
-    let queue = storage_account.as_queue_client(queue_name);
+    let queue = storage_account.queue_client(queue_name);
 
     trace!("getting messages");
 
@@ -42,7 +42,7 @@ async fn main() -> azure_core::Result<()> {
             println!("deleting message {:?}", message_to_delete);
 
             let delete_response = queue
-                .as_pop_receipt_client(message_to_delete)
+                .pop_receipt_client(message_to_delete)
                 .delete()
                 .execute()
                 .await?;

--- a/sdk/storage_queues/examples/get_messages.rs
+++ b/sdk/storage_queues/examples/get_messages.rs
@@ -22,7 +22,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_account =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
 
-    let queue = storage_account.as_queue_client(queue_name);
+    let queue = storage_account.queue_client(queue_name);
 
     trace!("getting messages");
 
@@ -47,7 +47,7 @@ async fn main() -> azure_core::Result<()> {
     // Note that we have to specify how long the message will stay
     // "hidden" before being visible again in the queue.
     for message_to_update in get_messages_response.messages.into_iter() {
-        let pop_receipt = queue.as_pop_receipt_client(message_to_update);
+        let pop_receipt = queue.pop_receipt_client(message_to_update);
 
         let response = pop_receipt
             .update(Duration::from_secs(4))

--- a/sdk/storage_queues/examples/list_queues.rs
+++ b/sdk/storage_queues/examples/list_queues.rs
@@ -16,7 +16,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_account =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
 
-    let queue_service = storage_account.as_queue_service_client();
+    let queue_service = storage_account.queue_service_client();
 
     println!("getting service stats");
     let response = queue_service.get_queue_service_stats().execute().await?;

--- a/sdk/storage_queues/examples/peek_messages.rs
+++ b/sdk/storage_queues/examples/peek_messages.rs
@@ -21,7 +21,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_account =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
 
-    let queue = storage_account.as_queue_client(queue_name);
+    let queue = storage_account.queue_client(queue_name);
     println!("{:#?}", queue);
 
     trace!("peeking messages");

--- a/sdk/storage_queues/examples/put_message.rs
+++ b/sdk/storage_queues/examples/put_message.rs
@@ -21,7 +21,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_account =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
 
-    let queue = storage_account.as_queue_client(queue_name);
+    let queue = storage_account.queue_client(queue_name);
 
     trace!("putting message");
     let response = queue

--- a/sdk/storage_queues/examples/queue_create.rs
+++ b/sdk/storage_queues/examples/queue_create.rs
@@ -23,7 +23,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_account =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
 
-    let queue = storage_account.as_queue_client(queue_name);
+    let queue = storage_account.queue_client(queue_name);
 
     trace!("creating queue");
 

--- a/sdk/storage_queues/src/clients/pop_receipt_client.rs
+++ b/sdk/storage_queues/src/clients/pop_receipt_client.rs
@@ -9,7 +9,7 @@ pub trait AsPopReceiptClient {
     /// returned client is wrapped in an `Arc` to avoid
     /// unnecessary copying while keeping the clients
     /// type signature simple (without lifetimes).
-    fn as_pop_receipt_client(&self, pop_receipt: impl Into<PopReceipt>) -> Arc<PopReceiptClient>;
+    fn pop_receipt_client(&self, pop_receipt: impl Into<PopReceipt>) -> Arc<PopReceiptClient>;
 }
 
 impl AsPopReceiptClient for Arc<QueueClient> {
@@ -17,7 +17,7 @@ impl AsPopReceiptClient for Arc<QueueClient> {
     /// to obtain a `PopReceiptClient` back. The `PopReceiptClient`
     /// can then delete or update the message
     /// referenced by the passed `PopReceipt`.
-    fn as_pop_receipt_client(&self, pop_receipt: impl Into<PopReceipt>) -> Arc<PopReceiptClient> {
+    fn pop_receipt_client(&self, pop_receipt: impl Into<PopReceipt>) -> Arc<PopReceiptClient> {
         PopReceiptClient::new(self.clone(), pop_receipt)
     }
 }

--- a/sdk/storage_queues/src/clients/queue_client.rs
+++ b/sdk/storage_queues/src/clients/queue_client.rs
@@ -5,18 +5,18 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 pub trait AsQueueClient<QN: Into<String>> {
-    fn as_queue_client(&self, queue_name: QN) -> Arc<QueueClient>;
+    fn queue_client(&self, queue_name: QN) -> Arc<QueueClient>;
 }
 
 impl<QN: Into<String>> AsQueueClient<QN> for Arc<StorageClient> {
-    fn as_queue_client(&self, queue_name: QN) -> Arc<QueueClient> {
+    fn queue_client(&self, queue_name: QN) -> Arc<QueueClient> {
         QueueClient::new(self.clone(), queue_name.into())
     }
 }
 
 impl<QN: Into<String>> AsQueueClient<QN> for Arc<StorageAccountClient> {
-    fn as_queue_client(&self, queue_name: QN) -> Arc<QueueClient> {
-        self.as_storage_client().as_queue_client(queue_name)
+    fn queue_client(&self, queue_name: QN) -> Arc<QueueClient> {
+        self.storage_client().queue_client(queue_name)
     }
 }
 
@@ -117,8 +117,8 @@ mod integration_tests {
     use crate::queue::clients::AsQueueClient;
 
     fn get_emulator_client(queue_name: &str) -> Arc<QueueClient> {
-        let storage_account = StorageAccountClient::new_emulator_default().as_storage_client();
-        storage_account.as_queue_client(queue_name)
+        let storage_account = StorageAccountClient::new_emulator_default().storage_client();
+        storage_account.queue_client(queue_name)
     }
 
     #[tokio::test]

--- a/sdk/storage_queues/src/clients/queue_service_client.rs
+++ b/sdk/storage_queues/src/clients/queue_service_client.rs
@@ -3,18 +3,18 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 pub trait AsQueueServiceClient {
-    fn as_queue_service_client(&self) -> Arc<QueueServiceClient>;
+    fn queue_service_client(&self) -> Arc<QueueServiceClient>;
 }
 
 impl AsQueueServiceClient for Arc<StorageClient> {
-    fn as_queue_service_client(&self) -> Arc<QueueServiceClient> {
+    fn queue_service_client(&self) -> Arc<QueueServiceClient> {
         QueueServiceClient::new(self.clone())
     }
 }
 
 impl AsQueueServiceClient for Arc<StorageAccountClient> {
-    fn as_queue_service_client(&self) -> Arc<QueueServiceClient> {
-        self.as_storage_client().as_queue_service_client()
+    fn queue_service_client(&self) -> Arc<QueueServiceClient> {
+        self.storage_client().queue_service_client()
     }
 }
 

--- a/sdk/storage_queues/tests/queue.rs
+++ b/sdk/storage_queues/tests/queue.rs
@@ -18,8 +18,8 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
     let storage_account_client =
         StorageAccountClient::new_access_key(http_client.clone(), &account, &access_key);
     let queue = storage_account_client
-        .as_storage_client()
-        .as_queue_client(queue_name);
+        .storage_client()
+        .queue_client(queue_name);
 
     println!("creating queue {}", queue_name);
 
@@ -100,7 +100,7 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
     println!("get_messages_response == {:#?}", get_messages_response);
 
     for message_to_update in get_messages_response.messages.into_iter() {
-        let pop_receipt = queue.as_pop_receipt_client(message_to_update);
+        let pop_receipt = queue.pop_receipt_client(message_to_update);
 
         let response = pop_receipt
             .update(Duration::from_secs(4))
@@ -122,7 +122,7 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
         println!("deleting message {:?}", message_to_delete);
 
         let delete_response = queue
-            .as_pop_receipt_client(message_to_delete)
+            .pop_receipt_client(message_to_delete)
             .delete()
             .execute()
             .await?;


### PR DESCRIPTION
Per discussion in #676, this renames the various as_X_client to X_client