### PR TITLE
[datalake] add missing file and directory methods

### DIFF
--- a/sdk/storage_datalake/src/clients/directory_client.rs
+++ b/sdk/storage_datalake/src/clients/directory_client.rs
@@ -116,7 +116,19 @@ impl DirectoryClient {
         HeadPathBuilder::new(self.clone(), self.file_system_client.context.clone())
     }
 
-    pub fn set_properties(&self, _properties: Properties) -> SetFileSystemPropertiesBuilder {
-        todo!()
+    pub fn get_status(&self) -> HeadPathBuilder<Self> {
+        HeadPathBuilder::new(self.clone(), self.file_system_client.context.clone())
+            .action(PathGetPropertiesAction::GetStatus)
+    }
+
+    pub fn get_access_control_list(&self) -> HeadPathBuilder<Self> {
+        HeadPathBuilder::new(self.clone(), self.file_system_client.context.clone())
+            .action(PathGetPropertiesAction::GetAccessControl)
+    }
+
+    pub fn set_properties(&self, properties: impl Into<Properties>) -> PatchPathBuilder<Self> {
+        PatchPathBuilder::new(self.clone(), self.file_system_client.context.clone())
+            .properties(properties)
+            .action(PathUpdateAction::SetProperties)
     }
 }

--- a/sdk/storage_datalake/src/clients/directory_client.rs
+++ b/sdk/storage_datalake/src/clients/directory_client.rs
@@ -131,4 +131,18 @@ impl DirectoryClient {
             .properties(properties)
             .action(PathUpdateAction::SetProperties)
     }
+
+    pub fn set_access_control_list(
+        &self,
+        acl: impl Into<AccessControlList>,
+        recursive: bool,
+    ) -> PatchPathBuilder<Self> {
+        let builder =
+            PatchPathBuilder::new(self.clone(), self.file_system_client.context.clone()).acl(acl);
+        if recursive {
+            builder.action(PathUpdateAction::SetAccessControlRecursive)
+        } else {
+            builder.action(PathUpdateAction::SetAccessControl)
+        }
+    }
 }

--- a/sdk/storage_datalake/src/clients/file_client.rs
+++ b/sdk/storage_datalake/src/clients/file_client.rs
@@ -124,7 +124,7 @@ impl FileClient {
             .action(PathGetPropertiesAction::GetAccessControl)
     }
 
-    pub fn set_properties(&self, properties: Properties) -> PatchPathBuilder<Self> {
+    pub fn set_properties(&self, properties: impl Into<Properties>) -> PatchPathBuilder<Self> {
         PatchPathBuilder::new(self.clone(), self.file_system_client.context.clone())
             .properties(properties)
             .action(PathUpdateAction::SetProperties)

--- a/sdk/storage_datalake/src/clients/file_client.rs
+++ b/sdk/storage_datalake/src/clients/file_client.rs
@@ -129,4 +129,13 @@ impl FileClient {
             .properties(properties)
             .action(PathUpdateAction::SetProperties)
     }
+
+    pub fn set_access_control_list(
+        &self,
+        acl: impl Into<AccessControlList>,
+    ) -> PatchPathBuilder<Self> {
+        PatchPathBuilder::new(self.clone(), self.file_system_client.context.clone())
+            .acl(acl)
+            .action(PathUpdateAction::SetAccessControl)
+    }
 }

--- a/sdk/storage_datalake/src/operations/path_patch.rs
+++ b/sdk/storage_datalake/src/operations/path_patch.rs
@@ -20,6 +20,7 @@ where
     C: PathClient,
 {
     client: C,
+    acl: Option<AccessControlList>,
     action: Option<PathUpdateAction>,
     close: Option<Close>,
     continuation: Option<NextMarker>,
@@ -38,6 +39,7 @@ impl<C: PathClient + 'static> PatchPathBuilder<C> {
     pub(crate) fn new(client: C, context: Context) -> Self {
         Self {
             client,
+            acl: None,
             action: None,
             close: None,
             continuation: None,
@@ -54,6 +56,7 @@ impl<C: PathClient + 'static> PatchPathBuilder<C> {
     }
 
     setters! {
+        acl: AccessControlList => Some(acl),
         action: PathUpdateAction => Some(action),
         close: Close => Some(close),
         continuation: NextMarker => Some(continuation),
@@ -86,6 +89,7 @@ impl<C: PathClient + 'static> PatchPathBuilder<C> {
 
             let mut request = Request::new(url, http::Method::PATCH);
 
+            request.insert_headers(&this.acl);
             request.insert_headers(&this.client_request_id);
             request.insert_headers(&this.properties);
             request.insert_headers(&this.if_match_condition);

--- a/sdk/storage_datalake/src/properties.rs
+++ b/sdk/storage_datalake/src/properties.rs
@@ -14,6 +14,12 @@ impl Default for Properties {
     }
 }
 
+impl Into<Properties> for BTreeMap<Cow<'static, str>, Cow<'static, str>> {
+    fn into(self) -> Properties {
+        Properties(self)
+    }
+}
+
 impl Properties {
     pub fn new() -> Self {
         Self(BTreeMap::new())

--- a/sdk/storage_datalake/src/properties.rs
+++ b/sdk/storage_datalake/src/properties.rs
@@ -14,9 +14,9 @@ impl Default for Properties {
     }
 }
 
-impl Into<Properties> for BTreeMap<Cow<'static, str>, Cow<'static, str>> {
-    fn into(self) -> Properties {
-        Properties(self)
+impl From<BTreeMap<Cow<'static, str>, Cow<'static, str>>> for Properties {
+    fn from(value: BTreeMap<Cow<'static, str>, Cow<'static, str>>) -> Self {
+        Self(value)
     }
 }
 

--- a/sdk/storage_datalake/src/request_options.rs
+++ b/sdk/storage_datalake/src/request_options.rs
@@ -217,3 +217,25 @@ impl AppendToUrlQuery for Directory {
         url.query_pairs_mut().append_pair("directory", &self.0);
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct AccessControlList(String);
+
+impl<S> From<S> for AccessControlList
+where
+    S: Into<String>,
+{
+    fn from(s: S) -> Self {
+        Self(s.into())
+    }
+}
+
+impl Header for AccessControlList {
+    fn name(&self) -> azure_core::headers::HeaderName {
+        azure_core::headers::ACL
+    }
+
+    fn value(&self) -> azure_core::headers::HeaderValue {
+        self.0.to_owned().into()
+    }
+}


### PR DESCRIPTION
This PR adds the last remaining methods to the file and directory clients.

From what I can tell the last missing functionality is leases, but I left those for a follow-up PR, since they seem to be usually implemented using a dedicated client.

towards #802, #496