### PR TITLE
Update storage queue to use the new Pageable methods

### DIFF
--- a/sdk/storage_queues/src/operations/list_queues.rs
+++ b/sdk/storage_queues/src/operations/list_queues.rs
@@ -55,7 +55,7 @@ impl ListQueuesBuilder {
 
                 if let Some(continuation) = continuation {
                     url.query_pairs_mut()
-                        .append_pair("marker", &continuation.into_raw());
+                        .append_pair("marker", &continuation.as_string());
                 }
 
                 this.max_results.append_to_url_query(&mut url);
@@ -99,8 +99,8 @@ pub struct ListQueuesResponse {
 }
 
 impl Continuable for ListQueuesResponse {
-    fn continuation(&self) -> Option<String> {
-        self.next_marker.clone().map(|x| x.as_str().to_owned())
+    fn continuation(&self) -> Option<Continuation> {
+        self.next_marker.clone().map(Continuation::from)
     }
 }
 


### PR DESCRIPTION
In pr #851, storage queues were updated to use `Continuation` but was targeted against the previous implementation.  With the merge of #850, the use of `Continuation` needs to be updated.