### PR TITLE
fix blob_storage_request

### DIFF
--- a/sdk/storage/src/account/operations/find_blobs_by_tags.rs
+++ b/sdk/storage/src/account/operations/find_blobs_by_tags.rs
@@ -41,7 +41,7 @@ impl FindBlobsByTagsBuilder {
             let mut request = self
                 .client
                 .storage_account_client()
-                .blob_storage_request(azure_core::Method::GET);
+                .blob_storage_request(azure_core::Method::GET)?;
 
             self.timeout.append_to_url_query(request.url_mut());
             request

--- a/sdk/storage/src/account/operations/get_account_information.rs
+++ b/sdk/storage/src/account/operations/get_account_information.rs
@@ -29,7 +29,7 @@ impl GetAccountInformationBuilder {
             let mut request = self
                 .client
                 .storage_account_client()
-                .blob_storage_request(azure_core::Method::GET);
+                .blob_storage_request(azure_core::Method::GET)?;
 
             for (k, v) in [("restype", "account"), ("comp", "properties")].iter() {
                 request.url_mut().query_pairs_mut().append_pair(k, v);

--- a/sdk/storage/src/authorization_policy.rs
+++ b/sdk/storage/src/authorization_policy.rs
@@ -42,8 +42,7 @@ impl Policy for AuthorizationPolicy {
                         request.method(),
                         account,
                         key,
-                        ctx.get()
-                            .expect("ServiceType must be in the Context at this point"),
+                        ctx.get().unwrap_or(&ServiceType::default()),
                     );
                     request.insert_header(AUTHORIZATION, auth)
                 }

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -1,11 +1,9 @@
 use crate::core::clients::{ServiceType, StorageAccountClient};
 use crate::operations::*;
-use azure_core::Method;
 use azure_core::{
     error::{Error, ErrorKind},
     Context, Request, Response,
 };
-use bytes::Bytes;
 use std::sync::Arc;
 
 pub trait AsStorageClient {
@@ -85,16 +83,6 @@ impl StorageClient {
 
     pub fn find_blobs_by_tags(&self) -> FindBlobsByTagsBuilder {
         FindBlobsByTagsBuilder::new(self.clone())
-    }
-
-    pub fn prepare_request(
-        &self,
-        url: &str,
-        method: Method,
-        request_body: Option<Bytes>,
-    ) -> azure_core::Result<Request> {
-        self.storage_account_client
-            .prepare_request(url, method, ServiceType::Blob, request_body)
     }
 
     pub async fn send(


### PR DESCRIPTION
Fix #861. It is a bug from switching over to pipelines. When `blob_storage_request` was added in dd6b8523033d6443ef6a6e982d9e579fc8cf7caa, it skipped the existing `prepare_request` code that adds the necessary headers.

This now works:
```
cargo run -p azure_storage --example account00
```