### PR TITLE
Panic when there is no ServiceType

### DIFF
--- a/sdk/storage/src/authorization_policy.rs
+++ b/sdk/storage/src/authorization_policy.rs
@@ -42,7 +42,8 @@ impl Policy for AuthorizationPolicy {
                         request.method(),
                         account,
                         key,
-                        ctx.get().unwrap_or(&ServiceType::default()),
+                        ctx.get()
+                            .expect("ServiceType must be in the Context at this point"),
                     );
                     request.insert_header(AUTHORIZATION, auth)
                 }

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -59,12 +59,6 @@ pub enum ServiceType {
     Table,
 }
 
-impl Default for ServiceType {
-    fn default() -> Self {
-        Self::Blob
-    }
-}
-
 #[derive(Debug)]
 pub struct StorageAccountClient {
     storage_credentials: StorageCredentials,


### PR DESCRIPTION
Just like in CosmosDb (for `ResourceType`), we should panic when no `ServiceType` is set. If this panic triggers that's a bug in the SDK. We want to find out this bug is happening ASAP. 