### PR TITLE
Simplify builder for account sas

### DIFF
--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -1,11 +1,7 @@
 use crate::authorization_policy::AuthorizationPolicy;
 use crate::ConnectionString;
 use crate::{
-    core::No,
-    hmac::sign,
-    shared_access_signature::account_sas::{
-        AccountSharedAccessSignatureBuilder, ClientAccountSharedAccessSignature,
-    },
+    hmac::sign, shared_access_signature::account_sas::AccountSharedAccessSignatureBuilder,
 };
 use azure_core::Method;
 use azure_core::{
@@ -518,15 +514,13 @@ impl StorageAccountClient {
             None,
         )
     }
-}
 
-impl ClientAccountSharedAccessSignature for StorageAccountClient {
-    fn shared_access_signature(
+    pub fn shared_access_signature(
         &self,
-    ) -> azure_core::Result<AccountSharedAccessSignatureBuilder<No, No, No, No>> {
-        match self.storage_credentials {
-            StorageCredentials::Key(ref account, ref key) => {
-                Ok(AccountSharedAccessSignatureBuilder::new(account, key))
+    ) -> azure_core::Result<AccountSharedAccessSignatureBuilder> {
+        match &self.storage_credentials {
+            StorageCredentials::Key(account, key) => {
+                Ok(AccountSharedAccessSignatureBuilder::new(account.clone(), key.clone()))
             }
             _ => Err(Error::message(ErrorKind::Other, "failed shared access signature generation. SAS can be generated only from key and account clients")),
         }

--- a/sdk/storage/src/core/mod.rs
+++ b/sdk/storage/src/core/mod.rs
@@ -21,21 +21,6 @@ mod stored_access_policy;
 pub use azure_core::error::{Error, ErrorKind, ResultExt};
 pub mod xml;
 
-#[derive(Debug, Clone, Eq, PartialEq, Copy, Serialize, Deserialize)]
-pub struct Yes;
-#[derive(Debug, Clone, Eq, PartialEq, Copy, Serialize, Deserialize)]
-pub struct No;
-
-pub trait ToAssign: std::fmt::Debug {}
-pub trait Assigned: ToAssign {}
-pub trait NotAssigned: ToAssign {}
-
-impl ToAssign for Yes {}
-impl ToAssign for No {}
-
-impl Assigned for Yes {}
-impl NotAssigned for No {}
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct IPRange {
     pub start: std::net::IpAddr,

--- a/sdk/storage/src/core/prelude.rs
+++ b/sdk/storage/src/core/prelude.rs
@@ -1,11 +1,7 @@
 pub use crate::core::{
     clients::{AsStorageClient, StorageAccountClient, StorageClient},
     shared_access_signature::{
-        account_sas::{
-            AccountSasPermissions, AccountSasResource, AccountSasResourceType,
-            ClientAccountSharedAccessSignature, SasExpirySupport, SasPermissionsSupport,
-            SasProtocolSupport, SasResourceSupport, SasResourceTypeSupport, SasStartSupport,
-        },
+        account_sas::{AccountSasPermissions, AccountSasResource, AccountSasResourceType},
         service_sas::{BlobSasPermissions, BlobSignedResource},
         SasProtocol, SasToken,
     },


### PR DESCRIPTION
This simplifies the `AccountSharedAccessSignatureBuilder` and gets rid of the last remnants of the old type-safe builder infrastructure. 