### PR TITLE
pass Headers as part of prepare_request

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -181,6 +181,18 @@ impl HeaderName {
         Self(std::borrow::Cow::Borrowed(s))
     }
 
+    fn from_cow<C>(c: C) -> Self
+    where
+        C: Into<std::borrow::Cow<'static, str>>,
+    {
+        let c = c.into();
+        assert!(
+            c.chars().all(|c| c.is_lowercase() || !c.is_alphabetic()),
+            "header names must be lowercase: {c}"
+        );
+        Self(c)
+    }
+
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
@@ -188,14 +200,13 @@ impl HeaderName {
 
 impl From<&'static str> for HeaderName {
     fn from(s: &'static str) -> Self {
-        assert_eq!(s.to_lowercase(), s, "header names must be lower-case");
-        Self::from_static(s)
+        Self::from_cow(s)
     }
 }
 
 impl From<String> for HeaderName {
     fn from(s: String) -> Self {
-        Self(std::borrow::Cow::Owned(s.to_lowercase()))
+        Self::from_cow(s.to_lowercase())
     }
 }
 
@@ -208,6 +219,13 @@ impl HeaderValue {
         Self(std::borrow::Cow::Borrowed(s))
     }
 
+    fn from_cow<C>(c: C) -> Self
+    where
+        C: Into<std::borrow::Cow<'static, str>>,
+    {
+        Self(c.into())
+    }
+
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
     }
@@ -215,13 +233,13 @@ impl HeaderValue {
 
 impl From<&'static str> for HeaderValue {
     fn from(s: &'static str) -> Self {
-        Self::from_static(s)
+        Self::from_cow(s)
     }
 }
 
 impl From<String> for HeaderValue {
     fn from(s: String) -> Self {
-        Self(std::borrow::Cow::Owned(s))
+        Self::from_cow(s)
     }
 }
 

--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -51,12 +51,12 @@ pub trait Header {
 }
 
 /// A collection of headers
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Headers(std::collections::HashMap<HeaderName, HeaderValue>);
 
 impl Headers {
     pub fn new() -> Self {
-        Self(Default::default())
+        Self::default()
     }
 
     /// Get a header value as a String or error if it is not found
@@ -140,6 +140,7 @@ impl Headers {
         self.0.insert(key.into(), value.into());
     }
 
+    /// Add headers to the headers collection
     pub fn add<H>(&mut self, header: H)
     where
         H: AsHeaders,
@@ -152,12 +153,6 @@ impl Headers {
     /// Iterate over all the header name/value pairs
     pub fn iter(&self) -> impl Iterator<Item = (&HeaderName, &HeaderValue)> {
         self.0.iter()
-    }
-}
-
-impl Default for Headers {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -98,7 +98,7 @@ impl EntityClient {
         self.partition_key_client.http_client()
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -106,7 +106,7 @@ impl EntityClient {
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.partition_key_client
-            .prepare_request(url, method, headers, request_body)
+            .finalize_request(url, method, headers, request_body)
     }
 }
 

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -1,8 +1,8 @@
 use crate::{prelude::*, requests::*};
-use azure_core::Method;
 use azure_core::{
     error::{Error, ErrorKind},
-    Request,
+    headers::Headers,
+    Method, Request,
 };
 use bytes::Bytes;
 use std::sync::Arc;
@@ -102,10 +102,11 @@ impl EntityClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.partition_key_client
-            .prepare_request(url, method, request_body)
+            .prepare_request(url, method, headers, request_body)
     }
 }
 

--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -51,7 +51,7 @@ impl PartitionKeyClient {
         self.table_client.http_client()
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -59,7 +59,7 @@ impl PartitionKeyClient {
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.table_client
-            .prepare_request(url, method, headers, request_body)
+            .finalize_request(url, method, headers, request_body)
     }
 }
 

--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -1,8 +1,5 @@
 use crate::{prelude::*, requests::*};
-
-use azure_core::Method;
-use azure_core::Request;
-use azure_core::Url;
+use azure_core::{headers::Headers, Method, Request, Url};
 use azure_storage::core::clients::StorageAccountClient;
 use bytes::Bytes;
 use std::sync::Arc;
@@ -58,9 +55,11 @@ impl PartitionKeyClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
-        self.table_client.prepare_request(url, method, request_body)
+        self.table_client
+            .prepare_request(url, method, headers, request_body)
     }
 }
 

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -63,7 +63,7 @@ impl TableClient {
         self.table_service_client.http_client()
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -71,7 +71,7 @@ impl TableClient {
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.table_service_client
-            .prepare_request(url, method, headers, request_body)
+            .finalize_request(url, method, headers, request_body)
     }
 }
 

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -1,7 +1,5 @@
 use crate::{clients::TableServiceClient, requests::*};
-use azure_core::Method;
-use azure_core::Request;
-use azure_core::Url;
+use azure_core::{headers::Headers, Method, Request, Url};
 use azure_storage::core::clients::StorageAccountClient;
 use bytes::Bytes;
 use std::sync::Arc;
@@ -69,10 +67,11 @@ impl TableClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.table_service_client
-            .prepare_request(url, method, request_body)
+            .prepare_request(url, method, headers, request_body)
     }
 }
 

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -1,7 +1,9 @@
 use crate::requests::ListTablesBuilder;
-use azure_core::error::{ErrorKind, ResultExt};
-use azure_core::Method;
-use azure_core::Request;
+use azure_core::{
+    error::{ErrorKind, ResultExt},
+    headers::Headers,
+    Method, Request,
+};
 use azure_storage::core::clients::{StorageAccountClient, StorageClient};
 use bytes::Bytes;
 use std::sync::Arc;
@@ -59,6 +61,7 @@ impl TableServiceClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.storage_client
@@ -66,6 +69,7 @@ impl TableServiceClient {
             .prepare_request(
                 url,
                 method,
+                headers,
                 azure_storage::core::clients::ServiceType::Table,
                 request_body,
             )

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -57,7 +57,7 @@ impl TableServiceClient {
         self.storage_client.http_client()
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -66,7 +66,7 @@ impl TableServiceClient {
     ) -> azure_core::Result<Request> {
         self.storage_client
             .storage_account_client()
-            .prepare_request(
+            .finalize_request(
                 url,
                 method,
                 headers,

--- a/sdk/data_tables/src/requests/create_table_builder.rs
+++ b/sdk/data_tables/src/requests/create_table_builder.rs
@@ -39,7 +39,7 @@ impl<'a> CreateTableBuilder<'a> {
         headers.insert(CONTENT_TYPE, "application/json");
         headers.insert(PREFER, "return-content");
 
-        let request = self.table_client.prepare_request(
+        let request = self.table_client.finalize_request(
             url,
             Method::Post,
             headers,

--- a/sdk/data_tables/src/requests/create_table_builder.rs
+++ b/sdk/data_tables/src/requests/create_table_builder.rs
@@ -1,6 +1,5 @@
 use crate::{prelude::*, responses::*};
-use azure_core::prelude::*;
-use azure_core::Method;
+use azure_core::{headers::*, prelude::*, Method};
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -34,15 +33,18 @@ impl<'a> CreateTableBuilder<'a> {
             table_name: self.table_client.table_name(),
         })?;
 
-        let mut request = self.table_client.prepare_request(
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.insert(ACCEPT, "application/json;odata=fullmetadata");
+        headers.insert(CONTENT_TYPE, "application/json");
+        headers.insert(PREFER, "return-content");
+
+        let request = self.table_client.prepare_request(
             url,
             Method::Post,
+            headers,
             Some(bytes::Bytes::from(request_body_serialized)),
         )?;
-        request.add_optional_header(&self.client_request_id);
-        request.insert_header("Accept", "application/json;odata=fullmetadata");
-        request.insert_header("Content-Type", "application/json");
-        request.insert_header("Prefer", "return-content");
 
         let response = self
             .table_client

--- a/sdk/data_tables/src/requests/delete_entity_builder.rs
+++ b/sdk/data_tables/src/requests/delete_entity_builder.rs
@@ -41,7 +41,7 @@ impl<'a> DeleteEntityBuilder<'a> {
 
         let request = self
             .entity_client
-            .prepare_request(url, Method::Delete, headers, None)?;
+            .finalize_request(url, Method::Delete, headers, None)?;
 
         let response = self
             .entity_client

--- a/sdk/data_tables/src/requests/delete_entity_builder.rs
+++ b/sdk/data_tables/src/requests/delete_entity_builder.rs
@@ -3,8 +3,7 @@ use crate::{
     responses::*,
     TransactionOperation,
 };
-use azure_core::Method;
-use azure_core::{prelude::*, Request};
+use azure_core::{headers::*, prelude::*, Method, Request};
 use std::convert::TryInto;
 
 #[derive(Debug, Clone)]
@@ -36,11 +35,13 @@ impl<'a> DeleteEntityBuilder<'a> {
 
         self.timeout.append_to_url_query(&mut url);
 
-        let mut request = self
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.add(self.if_match.clone());
+
+        let request = self
             .entity_client
-            .prepare_request(url, Method::Delete, None)?;
-        request.add_optional_header(&self.client_request_id);
-        request.add_mandatory_header(&self.if_match);
+            .prepare_request(url, Method::Delete, headers, None)?;
 
         let response = self
             .entity_client
@@ -56,9 +57,8 @@ impl<'a> DeleteEntityBuilder<'a> {
 
         let mut request = Request::new(url.clone(), Method::Delete);
         request.add_optional_header(&self.client_request_id);
-        request.insert_header("Accept", "application/json;odata=minimalmetadata");
-        request.insert_header("If-Match", "*");
-
+        request.insert_header(ACCEPT, "application/json;odata=minimalmetadata");
+        request.insert_header(IF_MATCH, "*");
         request.set_body("");
 
         Ok(TransactionOperation::new(request))

--- a/sdk/data_tables/src/requests/delete_table_builder.rs
+++ b/sdk/data_tables/src/requests/delete_table_builder.rs
@@ -2,6 +2,7 @@ use crate::{prelude::*, responses::*};
 use azure_core::Method;
 use azure_core::{
     error::{Error, ErrorKind},
+    headers::*,
     prelude::*,
 };
 use std::convert::TryInto;
@@ -31,11 +32,13 @@ impl<'a> DeleteTableBuilder<'a> {
             .pop()
             .push(&format!("Tables('{}')", self.table_client.table_name()));
 
-        let mut request = self
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.insert(ACCEPT, "application/json");
+
+        let request = self
             .table_client
-            .prepare_request(url, Method::Delete, None)?;
-        request.add_optional_header(&self.client_request_id);
-        request.insert_header("Accept", "application/json");
+            .prepare_request(url, Method::Delete, headers, None)?;
 
         let response = self
             .table_client

--- a/sdk/data_tables/src/requests/delete_table_builder.rs
+++ b/sdk/data_tables/src/requests/delete_table_builder.rs
@@ -38,7 +38,7 @@ impl<'a> DeleteTableBuilder<'a> {
 
         let request = self
             .table_client
-            .prepare_request(url, Method::Delete, headers, None)?;
+            .finalize_request(url, Method::Delete, headers, None)?;
 
         let response = self
             .table_client

--- a/sdk/data_tables/src/requests/get_entity_builder.rs
+++ b/sdk/data_tables/src/requests/get_entity_builder.rs
@@ -38,7 +38,7 @@ impl<'a> GetEntityBuilder<'a> {
 
         let request = self
             .entity_client
-            .prepare_request(url, Method::Get, headers, None)?;
+            .finalize_request(url, Method::Get, headers, None)?;
 
         let response = self
             .entity_client

--- a/sdk/data_tables/src/requests/get_entity_builder.rs
+++ b/sdk/data_tables/src/requests/get_entity_builder.rs
@@ -1,6 +1,5 @@
 use crate::{prelude::*, responses::*};
-use azure_core::Method;
-use azure_core::{error::Result, prelude::*, AppendToUrlQuery};
+use azure_core::{error::Result, headers::*, prelude::*, AppendToUrlQuery, Method};
 use serde::de::DeserializeOwned;
 use std::convert::TryInto;
 
@@ -33,9 +32,13 @@ impl<'a> GetEntityBuilder<'a> {
 
         self.select.append_to_url_query(&mut url);
 
-        let mut request = self.entity_client.prepare_request(url, Method::Get, None)?;
-        request.add_optional_header(&self.client_request_id);
-        request.insert_header("Accept", "application/json;odata=fullmetadata");
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.insert(ACCEPT, "application/json;odata=fullmetadata");
+
+        let request = self
+            .entity_client
+            .prepare_request(url, Method::Get, headers, None)?;
 
         let response = self
             .entity_client

--- a/sdk/data_tables/src/requests/insert_entity_builder.rs
+++ b/sdk/data_tables/src/requests/insert_entity_builder.rs
@@ -2,6 +2,7 @@ use crate::{prelude::*, responses::*, TransactionOperation};
 use azure_core::Method;
 use azure_core::{
     error::{Error, ErrorKind},
+    headers::*,
     prelude::*,
     Request,
 };
@@ -46,15 +47,18 @@ impl<'a> InsertEntityBuilder<'a> {
 
         let request_body_serialized = serde_json::to_string(entity)?;
 
-        let mut request = self.table_client.prepare_request(
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.add(self.return_entity.clone());
+        headers.insert(ACCEPT, "application/json;odata=fullmetadata");
+        headers.insert(CONTENT_TYPE, "application/json");
+
+        let request = self.table_client.prepare_request(
             url,
             Method::Post,
+            headers,
             Some(bytes::Bytes::from(request_body_serialized)),
         )?;
-        request.add_optional_header(&self.client_request_id);
-        request.add_mandatory_header(&self.return_entity);
-        request.insert_header("Accept", "application/json;odata=fullmetadata");
-        request.insert_header("Content-Type", "application/json");
 
         let response = self
             .table_client
@@ -80,8 +84,8 @@ impl<'a> InsertEntityBuilder<'a> {
 
         let mut request = Request::new(url, Method::Post);
         request.add_optional_header(&self.client_request_id);
-        request.insert_header("Accept", "application/json;odata=fullmetadata");
-        request.insert_header("Content-Type", "application/json");
+        request.insert_header(ACCEPT, "application/json;odata=fullmetadata");
+        request.insert_header(CONTENT_TYPE, "application/json");
 
         request.set_body(serde_json::to_vec(entity)?);
 

--- a/sdk/data_tables/src/requests/insert_entity_builder.rs
+++ b/sdk/data_tables/src/requests/insert_entity_builder.rs
@@ -53,7 +53,7 @@ impl<'a> InsertEntityBuilder<'a> {
         headers.insert(ACCEPT, "application/json;odata=fullmetadata");
         headers.insert(CONTENT_TYPE, "application/json");
 
-        let request = self.table_client.prepare_request(
+        let request = self.table_client.finalize_request(
             url,
             Method::Post,
             headers,

--- a/sdk/data_tables/src/requests/insert_or_replace_or_merge_entity_builder.rs
+++ b/sdk/data_tables/src/requests/insert_or_replace_or_merge_entity_builder.rs
@@ -46,7 +46,7 @@ impl<'a> InsertOrReplaceOrMergeEntityBuilder<'a> {
         headers.add(self.client_request_id.clone());
         headers.insert(CONTENT_TYPE, "application/json");
 
-        let request = self.entity_client.prepare_request(
+        let request = self.entity_client.finalize_request(
             url,
             match self.operation {
                 Operation::InsertOrMerge => Method::Merge,

--- a/sdk/data_tables/src/requests/list_tables_builder.rs
+++ b/sdk/data_tables/src/requests/list_tables_builder.rs
@@ -49,9 +49,9 @@ impl<'a> ListTablesBuilder<'a> {
         headers.add(self.client_request_id.clone());
         headers.insert(ACCEPT, "application/json;odata=fullmetadata");
 
-        let request = self
-            .table_service_client
-            .prepare_request(url, Method::Get, headers, None)?;
+        let request =
+            self.table_service_client
+                .finalize_request(url, Method::Get, headers, None)?;
 
         let response = self
             .table_service_client

--- a/sdk/data_tables/src/requests/list_tables_builder.rs
+++ b/sdk/data_tables/src/requests/list_tables_builder.rs
@@ -1,6 +1,5 @@
 use crate::{prelude::*, responses::*, ContinuationNextTableName};
-use azure_core::Method;
-use azure_core::{prelude::*, AppendToUrlQuery};
+use azure_core::{headers::*, prelude::*, AppendToUrlQuery, Method};
 use futures::stream::{unfold, Stream};
 use std::convert::TryInto;
 
@@ -46,11 +45,13 @@ impl<'a> ListTablesBuilder<'a> {
         self.continuation_next_table_name
             .append_to_url_query(&mut url);
 
-        let mut request = self
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.insert(ACCEPT, "application/json;odata=fullmetadata");
+
+        let request = self
             .table_service_client
-            .prepare_request(url, Method::Get, None)?;
-        request.add_optional_header(&self.client_request_id);
-        request.insert_header("Accept", "application/json;odata=fullmetadata");
+            .prepare_request(url, Method::Get, headers, None)?;
 
         let response = self
             .table_service_client

--- a/sdk/data_tables/src/requests/query_entity_builder.rs
+++ b/sdk/data_tables/src/requests/query_entity_builder.rs
@@ -1,9 +1,9 @@
 use crate::{prelude::*, responses::*, ContinuationNextPartitionAndRowKey};
-use azure_core::Method;
 use azure_core::{
     error::{Error, ErrorKind},
+    headers::*,
     prelude::*,
-    AppendToUrlQuery,
+    AppendToUrlQuery, Method,
 };
 use futures::stream::{unfold, Stream};
 use serde::de::DeserializeOwned;
@@ -55,9 +55,13 @@ impl<'a> QueryEntityBuilder<'a> {
         self.continuation_next_partition_and_row_key
             .append_to_url_query(&mut url);
 
-        let mut request = self.table_client.prepare_request(url, Method::Get, None)?;
-        request.add_optional_header(&self.client_request_id);
-        request.insert_header("Accept", "application/json;odata=fullmetadata");
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.insert(ACCEPT, "application/json;odata=fullmetadata");
+
+        let request = self
+            .table_client
+            .prepare_request(url, Method::Get, headers, None)?;
 
         let response = self
             .table_client

--- a/sdk/data_tables/src/requests/query_entity_builder.rs
+++ b/sdk/data_tables/src/requests/query_entity_builder.rs
@@ -61,7 +61,7 @@ impl<'a> QueryEntityBuilder<'a> {
 
         let request = self
             .table_client
-            .prepare_request(url, Method::Get, headers, None)?;
+            .finalize_request(url, Method::Get, headers, None)?;
 
         let response = self
             .table_client

--- a/sdk/data_tables/src/requests/submit_transaction_builder.rs
+++ b/sdk/data_tables/src/requests/submit_transaction_builder.rs
@@ -1,8 +1,9 @@
 use crate::{prelude::*, responses::*};
-use azure_core::Method;
 use azure_core::{
     error::{Error, ErrorKind},
+    headers::*,
     prelude::*,
+    Method,
 };
 use std::convert::TryInto;
 
@@ -41,19 +42,22 @@ impl<'a> SubmitTransactionBuilder<'a> {
 
         let payload = batch.to_string()?;
 
-        let mut request = self.partition_key_client.prepare_request(
-            url,
-            Method::Post,
-            Some(bytes::Bytes::from(payload)),
-        )?;
-        request.add_optional_header(&self.client_request_id);
-        request.insert_header(
-            "Content-Type",
+        let mut headers = Headers::new();
+        headers.add(self.client_request_id.clone());
+        headers.insert(
+            CONTENT_TYPE,
             &format!(
                 "multipart/mixed; boundary=batch_{}",
                 batch.batch_uuid().hyphenated()
             ),
         );
+
+        let request = self.partition_key_client.prepare_request(
+            url,
+            Method::Post,
+            headers,
+            Some(bytes::Bytes::from(payload)),
+        )?;
 
         let response = self
             .partition_key_client

--- a/sdk/data_tables/src/requests/submit_transaction_builder.rs
+++ b/sdk/data_tables/src/requests/submit_transaction_builder.rs
@@ -52,7 +52,7 @@ impl<'a> SubmitTransactionBuilder<'a> {
             ),
         );
 
-        let request = self.partition_key_client.prepare_request(
+        let request = self.partition_key_client.finalize_request(
             url,
             Method::Post,
             headers,

--- a/sdk/data_tables/src/requests/update_or_merge_entity_builder.rs
+++ b/sdk/data_tables/src/requests/update_or_merge_entity_builder.rs
@@ -50,7 +50,7 @@ impl<'a> UpdateOrMergeEntityBuilder<'a> {
         headers.insert(CONTENT_TYPE, "application/json");
         headers.add(if_match_condition.clone());
 
-        let request = self.entity_client.prepare_request(
+        let request = self.entity_client.finalize_request(
             url,
             match self.operation {
                 Operation::Merge => Method::Merge,
@@ -88,8 +88,8 @@ impl<'a> UpdateOrMergeEntityBuilder<'a> {
         );
         request.add_optional_header(&self.client_request_id);
         request.add_mandatory_header(if_match_condition);
-        request.insert_header("Accept", "application/json;odata=fullmetadata");
-        request.insert_header("Content-Type", "application/json");
+        request.insert_header(ACCEPT, "application/json;odata=fullmetadata");
+        request.insert_header(CONTENT_TYPE, "application/json");
 
         request.set_body(serde_json::to_vec(entity)?);
 

--- a/sdk/data_tables/src/return_entity.rs
+++ b/sdk/data_tables/src/return_entity.rs
@@ -1,4 +1,4 @@
-use azure_core::headers::{self, Header};
+use azure_core::headers::{Header, HeaderName, HeaderValue, PREFER};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ReturnEntity(bool);
@@ -10,11 +10,11 @@ impl ReturnEntity {
 }
 
 impl Header for ReturnEntity {
-    fn name(&self) -> headers::HeaderName {
-        "Prefer".into()
+    fn name(&self) -> HeaderName {
+        PREFER
     }
 
-    fn value(&self) -> headers::HeaderValue {
+    fn value(&self) -> HeaderValue {
         match self.0 {
             true => "return-content",
             false => "return-no-content",

--- a/sdk/device_update/src/client.rs
+++ b/sdk/device_update/src/client.rs
@@ -98,9 +98,9 @@ impl DeviceUpdateClient {
             .bearer_auth(self.get_token().await?.token.secret());
 
         if let Some(body) = json_body {
-            req = req.header("Content-Type", "application/json").body(body);
+            req = req.header("content-type", "application/json").body(body);
         } else {
-            req = req.header("Content-Length", 0);
+            req = req.header("content-length", 0);
         }
 
         let resp = req.send().await.with_context(ErrorKind::Io, || {
@@ -130,7 +130,7 @@ impl DeviceUpdateClient {
         let resp = reqwest::Client::new()
             .delete(&uri)
             .bearer_auth(self.get_token().await?.token.secret())
-            .header("Content-Type", "application/json")
+            .header("content-type", "application/json")
             .send()
             .await
             .with_context(ErrorKind::Io, || {

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -802,7 +802,11 @@ impl ServiceClient {
     }
 
     /// Prepares a request that can be used by any request builders.
-    pub(crate) fn prepare_request(&self, uri: &str, method: Method) -> azure_core::Result<Request> {
+    pub(crate) fn finalize_request(
+        &self,
+        uri: &str,
+        method: Method,
+    ) -> azure_core::Result<Request> {
         let mut request = Request::new(Url::parse(uri)?, method);
         request.insert_header(headers::AUTHORIZATION, &self.sas_token);
         request.insert_header(headers::CONTENT_TYPE, content_type::APPLICATION_JSON);

--- a/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
+++ b/sdk/iot_hub/src/service/requests/apply_on_edge_device_builder.rs
@@ -96,7 +96,7 @@ impl<'a> ApplyOnEdgeDeviceBuilder<'a> {
             self.service_client.iot_hub_name, self.device_id, API_VERSION
         );
 
-        let mut request = self.service_client.prepare_request(&uri, Method::Post)?;
+        let mut request = self.service_client.finalize_request(&uri, Method::Post)?;
         let body = ApplyOnEdgeDeviceBody {
             device_content: self.device_content,
             module_content: self.module_content,

--- a/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_configuration_builder.rs
@@ -105,7 +105,7 @@ impl<'a> CreateOrUpdateConfigurationBuilder<'a> {
             self.service_client.iot_hub_name, &self.configuration_id, API_VERSION
         );
 
-        let mut request = self.service_client.prepare_request(&uri, Method::Put)?;
+        let mut request = self.service_client.finalize_request(&uri, Method::Put)?;
 
         match &self.etag {
             Some(etag) => {

--- a/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_device_identity_builder.rs
@@ -58,7 +58,7 @@ impl<'a> CreateOrUpdateDeviceIdentityBuilder<'a> {
             API_VERSION
         );
 
-        let mut request = self.service_client.prepare_request(&uri, Method::Put)?;
+        let mut request = self.service_client.finalize_request(&uri, Method::Put)?;
 
         if self.operation == IdentityOperation::Update {
             match &self.etag {

--- a/sdk/iot_hub/src/service/requests/create_or_update_module_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/create_or_update_module_identity_builder.rs
@@ -49,7 +49,7 @@ impl<'a> CreateOrUpdateModuleIdentityBuilder<'a> {
             API_VERSION
         );
 
-        let mut request = self.service_client.prepare_request(&uri, Method::Put)?;
+        let mut request = self.service_client.finalize_request(&uri, Method::Put)?;
 
         if self.operation == IdentityOperation::Update {
             match &self.etag {

--- a/sdk/iot_hub/src/service/requests/delete_configuration_builder.rs
+++ b/sdk/iot_hub/src/service/requests/delete_configuration_builder.rs
@@ -30,7 +30,7 @@ impl<'a> DeleteConfigurationBuilder<'a> {
             self.service_client.iot_hub_name, self.configuration_id, API_VERSION
         );
 
-        let mut request = self.service_client.prepare_request(&uri, Method::Delete)?;
+        let mut request = self.service_client.finalize_request(&uri, Method::Delete)?;
         request.insert_header(headers::IF_MATCH, format!("\"{}\"", &self.if_match));
 
         request.set_body(azure_core::EMPTY_BODY);

--- a/sdk/iot_hub/src/service/requests/delete_identity_builder.rs
+++ b/sdk/iot_hub/src/service/requests/delete_identity_builder.rs
@@ -38,7 +38,7 @@ impl<'a> DeleteIdentityBuilder<'a> {
             ),
         };
 
-        let mut request = self.service_client.prepare_request(&uri, Method::Delete)?;
+        let mut request = self.service_client.finalize_request(&uri, Method::Delete)?;
         request.insert_header(headers::IF_MATCH, format!("\"{}\"", &self.if_match));
 
         request.set_body(azure_core::EMPTY_BODY);

--- a/sdk/iot_hub/src/service/requests/get_configuration.rs
+++ b/sdk/iot_hub/src/service/requests/get_configuration.rs
@@ -22,7 +22,7 @@ where
         ),
     };
 
-    let mut request = service_client.prepare_request(&uri, Method::Get)?;
+    let mut request = service_client.finalize_request(&uri, Method::Get)?;
     request.set_body(azure_core::EMPTY_BODY);
 
     service_client

--- a/sdk/iot_hub/src/service/requests/get_identity.rs
+++ b/sdk/iot_hub/src/service/requests/get_identity.rs
@@ -23,7 +23,7 @@ where
         ),
     };
 
-    let mut request = service_client.prepare_request(&uri, Method::Get)?;
+    let mut request = service_client.finalize_request(&uri, Method::Get)?;
     request.set_body(azure_core::EMPTY_BODY);
 
     service_client

--- a/sdk/iot_hub/src/service/requests/get_twin.rs
+++ b/sdk/iot_hub/src/service/requests/get_twin.rs
@@ -24,7 +24,7 @@ where
         ),
     };
 
-    let mut request = service_client.prepare_request(&uri, Method::Get)?;
+    let mut request = service_client.finalize_request(&uri, Method::Get)?;
     request.set_body(azure_core::EMPTY_BODY);
 
     service_client

--- a/sdk/iot_hub/src/service/requests/invoke_method_builder.rs
+++ b/sdk/iot_hub/src/service/requests/invoke_method_builder.rs
@@ -74,7 +74,7 @@ impl<'a> InvokeMethodBuilder<'a> {
             ),
         };
 
-        let mut request = self.iot_hub_service.prepare_request(&uri, Method::Post)?;
+        let mut request = self.iot_hub_service.finalize_request(&uri, Method::Post)?;
         let method = InvokeMethodBody {
             connect_timeout_in_seconds: self.connect_time_out,
             method_name: &self.method_name,

--- a/sdk/iot_hub/src/service/requests/query_builder.rs
+++ b/sdk/iot_hub/src/service/requests/query_builder.rs
@@ -61,7 +61,7 @@ impl<'a> QueryBuilder<'a> {
         };
         let body = azure_core::to_json(&query_body)?;
 
-        let mut request = self.service_client.prepare_request(&uri, Method::Post)?;
+        let mut request = self.service_client.finalize_request(&uri, Method::Post)?;
         request.add_optional_header(&self.continuation);
         request.add_mandatory_header(&self.max_item_count);
         request.set_body(body);

--- a/sdk/iot_hub/src/service/requests/update_or_replace_twin_builder.rs
+++ b/sdk/iot_hub/src/service/requests/update_or_replace_twin_builder.rs
@@ -147,7 +147,7 @@ where
             ),
         };
 
-        let mut request = self.service_client.prepare_request(&uri, self.method)?;
+        let mut request = self.service_client.finalize_request(&uri, self.method)?;
         if let Some(if_match) = self.if_match {
             request.insert_header(headers::IF_MATCH, format!("\"{}\"", if_match));
         }

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -15,7 +15,7 @@ pub use self::client::Client;
 const DEFAULT_SAS_DURATION: i64 = 1;
 
 /// Prepares an HTTP request
-fn prepare_request(
+fn finalize_request(
     url: &str,
     method: azure_core::Method,
     body: Option<String>,
@@ -90,7 +90,7 @@ async fn send_message(
         namespace, queue
     );
 
-    let req = prepare_request(
+    let req = finalize_request(
         &url,
         Method::Post,
         Some(msg.to_string()),
@@ -118,7 +118,7 @@ async fn receive_and_delete_message(
         namespace, queue
     );
 
-    let req = prepare_request(&url, Method::Delete, None, policy_name, signing_key)?;
+    let req = finalize_request(&url, Method::Delete, None, policy_name, signing_key)?;
 
     http_client
         .as_ref()
@@ -144,7 +144,7 @@ async fn peek_lock_message(
 ) -> azure_core::Result<CollectedResponse> {
     let url = craft_peek_lock_url(namespace, queue, lock_expiry)?;
 
-    let req = prepare_request(url.as_ref(), Method::Post, None, policy_name, signing_key)?;
+    let req = finalize_request(url.as_ref(), Method::Post, None, policy_name, signing_key)?;
 
     http_client
         .as_ref()
@@ -166,7 +166,7 @@ async fn peek_lock_message2(
 ) -> azure_core::Result<PeekLockResponse> {
     let url = craft_peek_lock_url(namespace, queue, lock_expiry)?;
 
-    let req = prepare_request(url.as_ref(), Method::Post, None, policy_name, signing_key)?;
+    let req = finalize_request(url.as_ref(), Method::Post, None, policy_name, signing_key)?;
 
     let res = http_client.execute_request(&req).await?;
 
@@ -210,7 +210,7 @@ impl PeekLockResponse {
 
     /// Delete message in the lock
     pub async fn delete_message(&self) -> azure_core::Result<CollectedResponse> {
-        let req = prepare_request(
+        let req = finalize_request(
             &self.lock_location.clone(),
             Method::Delete,
             None,
@@ -226,7 +226,7 @@ impl PeekLockResponse {
 
     /// Unlock a message in the lock
     pub async fn unlock_message(&self) -> Result<(), Error> {
-        let req = prepare_request(
+        let req = finalize_request(
             &self.lock_location.clone(),
             Method::Put,
             None,
@@ -243,7 +243,7 @@ impl PeekLockResponse {
 
     /// Renew a message's lock
     pub async fn renew_message_lock(&self) -> Result<(), Error> {
-        let req = prepare_request(
+        let req = finalize_request(
             &self.lock_location.clone(),
             Method::Post,
             None,

--- a/sdk/security_keyvault/src/client.rs
+++ b/sdk/security_keyvault/src/client.rs
@@ -85,7 +85,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
         let resp = reqwest::Client::new()
             .put(&uri)
             .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
+            .header("content-type", "application/json")
             .body(body)
             .send()
             .await
@@ -108,9 +108,9 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
             .bearer_auth(self.token.as_ref().unwrap().token.secret());
 
         if let Some(body) = json_body {
-            req = req.header("Content-Type", "application/json").body(body);
+            req = req.header("content-type", "application/json").body(body);
         } else {
-            req = req.header("Content-Length", 0);
+            req = req.header("content-length", 0);
         }
 
         let resp = req.send().await.with_context(ErrorKind::Io, || {
@@ -146,7 +146,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
         let resp = reqwest::Client::new()
             .patch(&uri)
             .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
+            .header("content-type", "application/json")
             .body(body)
             .send()
             .await
@@ -177,7 +177,7 @@ impl<'a, T: TokenCredential> KeyClient<'a, T> {
         let resp = reqwest::Client::new()
             .delete(&uri)
             .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
+            .header("content-type", "application/json")
             .send()
             .await
             .unwrap();
@@ -267,7 +267,7 @@ impl<'a, T: TokenCredential> CertificateClient<'a, T> {
         let resp = reqwest::Client::new()
             .put(&uri)
             .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
+            .header("content-type", "application/json")
             .body(body)
             .send()
             .await
@@ -290,7 +290,7 @@ impl<'a, T: TokenCredential> CertificateClient<'a, T> {
             .bearer_auth(self.token.as_ref().unwrap().token.secret());
 
         if let Some(body) = json_body {
-            req = req.header("Content-Type", "application/json").body(body);
+            req = req.header("content-type", "application/json").body(body);
         } else {
             req = req.header("Content-Length", 0);
         }
@@ -330,7 +330,7 @@ impl<'a, T: TokenCredential> CertificateClient<'a, T> {
         let resp = reqwest::Client::new()
             .patch(&uri)
             .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
+            .header("content-type", "application/json")
             .body(body)
             .send()
             .await
@@ -363,7 +363,7 @@ impl<'a, T: TokenCredential> CertificateClient<'a, T> {
         let resp = reqwest::Client::new()
             .delete(&uri)
             .bearer_auth(self.token.as_ref().unwrap().token.secret())
-            .header("Content-Type", "application/json")
+            .header("content-type", "application/json")
             .send()
             .await
             .unwrap();

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -414,6 +414,7 @@ impl StorageAccountClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         service_type: ServiceType,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
@@ -421,6 +422,9 @@ impl StorageAccountClient {
         let time = format!("{}", dt.format("%a, %d %h %Y %T GMT"));
 
         let mut request = Request::new(url, method);
+        for (k, v) in headers {
+            request.insert_header(k, v);
+        }
 
         // if we have a SAS token (in form of query pairs), let's add it to the url here
         if let StorageCredentials::SASToken(query_pairs) = &self.storage_credentials {
@@ -504,6 +508,7 @@ impl StorageAccountClient {
         self.prepare_request(
             self.blob_storage_url().clone(),
             http_method,
+            Headers::new(),
             ServiceType::Blob,
             None,
         )

--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -410,7 +410,7 @@ impl StorageAccountClient {
         &self.storage_credentials
     }
 
-    pub fn prepare_request(
+    pub fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -505,7 +505,7 @@ impl StorageAccountClient {
         &self,
         http_method: azure_core::Method,
     ) -> azure_core::Result<Request> {
-        self.prepare_request(
+        self.finalize_request(
             self.blob_storage_url().clone(),
             http_method,
             Headers::new(),

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -70,14 +70,14 @@ impl StorageClient {
         FindBlobsByTagsBuilder::new(self.clone())
     }
 
-    pub fn prepare_request(
+    pub fn finalize_request(
         &self,
         url: Url,
         method: Method,
         headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
-        self.storage_account_client.prepare_request(
+        self.storage_account_client.finalize_request(
             url,
             method,
             headers,

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -2,6 +2,7 @@ use crate::core::clients::{ServiceType, StorageAccountClient};
 use crate::operations::*;
 use azure_core::{
     error::{Error, ErrorKind},
+    headers::Headers,
     Context, Request, Response,
 };
 use azure_core::{Method, Url};
@@ -73,10 +74,16 @@ impl StorageClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
-        self.storage_account_client
-            .prepare_request(url, method, ServiceType::Blob, request_body)
+        self.storage_account_client.prepare_request(
+            url,
+            method,
+            headers,
+            ServiceType::Blob,
+            request_body,
+        )
     }
 
     pub async fn send(

--- a/sdk/storage_blobs/src/blob/operations/acquire_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/acquire_lease.rs
@@ -1,12 +1,5 @@
 use crate::prelude::*;
-use azure_core::{
-    headers::{
-        date_from_headers, etag_from_headers, last_modified_from_headers, lease_id_from_headers,
-        request_id_from_headers, LEASE_ACTION,
-    },
-    prelude::*,
-    RequestId,
-};
+use azure_core::{headers::*, prelude::*, RequestId};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
@@ -44,13 +37,15 @@ impl AcquireLeaseBuilder {
             url.query_pairs_mut().append_pair("comp", "lease");
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "acquire");
+            headers.add(self.lease_duration);
+            headers.add(self.proposed_lease_id);
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "acquire");
-            request.add_mandatory_header(&self.lease_duration);
-            request.add_optional_header(&self.proposed_lease_id);
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/acquire_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/acquire_lease.rs
@@ -45,7 +45,7 @@ impl AcquireLeaseBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/append_block.rs
+++ b/sdk/storage_blobs/src/blob/operations/append_block.rs
@@ -1,5 +1,5 @@
 use crate::{blob::operations::put_block::PutBlockResponse, prelude::*};
-use azure_core::prelude::*;
+use azure_core::{headers::*, prelude::*};
 use bytes::Bytes;
 
 #[derive(Debug, Clone)]
@@ -43,15 +43,18 @@ impl AppendBlockBuilder {
             self.timeout.append_to_url_query(&mut url);
             url.query_pairs_mut().append_pair("comp", "appendblock");
 
+            let mut headers = Headers::new();
+            headers.add(self.hash);
+            headers.add(self.condition_max_size);
+            headers.add(self.condition_append_position);
+            headers.add(self.lease_id);
+
             let mut request = self.blob_client.prepare_request(
                 url,
                 azure_core::Method::Put,
+                headers,
                 Some(self.body.clone()),
             )?;
-            request.add_optional_header(&self.hash);
-            request.add_optional_header(&self.condition_max_size);
-            request.add_optional_header(&self.condition_append_position);
-            request.add_optional_header(&self.lease_id);
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/append_block.rs
+++ b/sdk/storage_blobs/src/blob/operations/append_block.rs
@@ -49,7 +49,7 @@ impl AppendBlockBuilder {
             headers.add(self.condition_append_position);
             headers.add(self.lease_id);
 
-            let mut request = self.blob_client.prepare_request(
+            let mut request = self.blob_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/blob/operations/break_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/break_lease.rs
@@ -42,7 +42,7 @@ impl BreakLeaseBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/break_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/break_lease.rs
@@ -35,12 +35,14 @@ impl BreakLeaseBuilder {
             url.query_pairs_mut().append_pair("comp", "lease");
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "break");
+            headers.add(self.lease_break_period);
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "break");
-            request.add_optional_header(&self.lease_break_period);
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/change_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/change_lease.rs
@@ -39,7 +39,7 @@ impl ChangeLeaseBuilder {
             headers.add(self.blob_lease_client.lease_id());
             headers.add(self.proposed_lease_id);
 
-            let mut request = self.blob_lease_client.prepare_request(
+            let mut request = self.blob_lease_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/blob/operations/change_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/change_lease.rs
@@ -34,12 +34,17 @@ impl ChangeLeaseBuilder {
             url.query_pairs_mut().append_pair("comp", "lease");
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.blob_lease_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "change");
-            request.add_mandatory_header(self.blob_lease_client.lease_id());
-            request.add_mandatory_header(&self.proposed_lease_id);
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "change");
+            headers.add(self.blob_lease_client.lease_id());
+            headers.add(self.proposed_lease_id);
+
+            let mut request = self.blob_lease_client.prepare_request(
+                url,
+                azure_core::Method::Put,
+                headers,
+                None,
+            )?;
 
             let response = self
                 .blob_lease_client

--- a/sdk/storage_blobs/src/blob/operations/clear_page.rs
+++ b/sdk/storage_blobs/src/blob/operations/clear_page.rs
@@ -47,17 +47,18 @@ impl ClearPageBuilder {
             self.timeout.append_to_url_query(&mut url);
             url.query_pairs_mut().append_pair("comp", "page");
 
+            let mut headers = Headers::new();
+            headers.insert(PAGE_WRITE, "clear");
+            headers.insert(BLOB_TYPE, "PageBlob");
+            headers.add(self.ba512_range);
+            headers.add(self.sequence_number_condition);
+            headers.add(self.if_modified_since_condition);
+            headers.add(self.if_match_condition);
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-
-            request.insert_header(PAGE_WRITE, "clear");
-            request.insert_header(BLOB_TYPE, "PageBlob");
-            request.add_mandatory_header(&self.ba512_range);
-            request.add_optional_header(&self.sequence_number_condition);
-            request.add_optional_header(&self.if_modified_since_condition);
-            request.add_optional_header(&self.if_match_condition);
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/clear_page.rs
+++ b/sdk/storage_blobs/src/blob/operations/clear_page.rs
@@ -58,7 +58,7 @@ impl ClearPageBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/copy_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob.rs
@@ -66,24 +66,26 @@ impl CopyBlobBuilder {
             let mut url = self.blob_client.url_with_segments(None)?;
 
             self.timeout.append_to_url_query(&mut url);
-            let mut request =
-                self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.insert_header(COPY_SOURCE, self.source_url.as_str().to_owned());
+            let mut headers = Headers::new();
+            headers.insert(COPY_SOURCE, self.source_url.as_str().to_owned());
             if let Some(metadata) = &self.metadata {
                 for m in metadata.iter() {
-                    request.add_mandatory_header(&m);
+                    headers.add(m);
                 }
             }
-            request.add_optional_header(&self.sequence_number_condition);
-            request.add_optional_header(&self.if_modified_since_condition);
-            request.add_optional_header(&self.if_match_condition);
-            request.add_optional_header(&self.access_tier);
-            request.add_optional_header(&self.lease_id);
-            request.add_optional_header(&self.if_source_since_condition);
-            request.add_optional_header(&self.if_source_match_condition);
-            request.add_optional_header(&self.source_lease_id);
-            request.add_mandatory_header(&self.rehydrate_priority);
+            headers.add(self.sequence_number_condition);
+            headers.add(self.if_modified_since_condition);
+            headers.add(self.if_match_condition);
+            headers.add(self.access_tier);
+            headers.add(self.lease_id);
+            headers.add(self.if_source_since_condition);
+            headers.add(self.if_source_match_condition);
+            headers.add(self.source_lease_id);
+            headers.add(self.rehydrate_priority);
+
+            let mut request =
+                self.blob_client
+                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/copy_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob.rs
@@ -85,7 +85,7 @@ impl CopyBlobBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
@@ -80,7 +80,7 @@ impl CopyBlobFromUrlBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/delete_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob.rs
@@ -38,9 +38,12 @@ impl DeleteBlobBuilder {
             headers.add(self.lease_id);
             headers.add(self.delete_snapshots_method);
 
-            let mut request =
-                self.blob_client
-                    .prepare_request(url, azure_core::Method::Delete, headers, None)?;
+            let mut request = self.blob_client.finalize_request(
+                url,
+                azure_core::Method::Delete,
+                headers,
+                None,
+            )?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/delete_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob.rs
@@ -34,11 +34,13 @@ impl DeleteBlobBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+            headers.add(self.delete_snapshots_method);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Delete, None)?;
-            request.add_optional_header(&self.lease_id);
-            request.add_mandatory_header(&self.delete_snapshots_method);
+                    .prepare_request(url, azure_core::Method::Delete, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
@@ -1,5 +1,5 @@
 use crate::{blob::operations::DeleteBlobResponse, prelude::*};
-use azure_core::prelude::*;
+use azure_core::{headers::Headers, prelude::*};
 
 #[derive(Debug, Clone)]
 pub struct DeleteBlobSnapshotBuilder {
@@ -39,10 +39,12 @@ impl DeleteBlobSnapshotBuilder {
                 url.query_pairs_mut().append_pair("deletetype", "permanent");
             }
 
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Delete, None)?;
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Delete, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
@@ -42,9 +42,12 @@ impl DeleteBlobSnapshotBuilder {
             let mut headers = Headers::new();
             headers.add(self.lease_id);
 
-            let mut request =
-                self.blob_client
-                    .prepare_request(url, azure_core::Method::Delete, headers, None)?;
+            let mut request = self.blob_client.finalize_request(
+                url,
+                azure_core::Method::Delete,
+                headers,
+                None,
+            )?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/delete_blob_version.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_version.rs
@@ -42,9 +42,12 @@ impl DeleteBlobVersionBuilder {
             let mut headers = Headers::new();
             headers.add(self.lease_id);
 
-            let mut request =
-                self.blob_client
-                    .prepare_request(url, azure_core::Method::Delete, headers, None)?;
+            let mut request = self.blob_client.finalize_request(
+                url,
+                azure_core::Method::Delete,
+                headers,
+                None,
+            )?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/delete_blob_version.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_version.rs
@@ -1,5 +1,5 @@
 use crate::{blob::operations::DeleteBlobResponse, prelude::*};
-use azure_core::prelude::*;
+use azure_core::{headers::Headers, prelude::*};
 
 #[derive(Debug, Clone)]
 pub struct DeleteBlobVersionBuilder {
@@ -39,10 +39,12 @@ impl DeleteBlobVersionBuilder {
                 url.query_pairs_mut().append_pair("deletetype", "permanent");
             }
 
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Delete, None)?;
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Delete, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -58,15 +58,19 @@ impl GetBlobBuilder {
                 this.blob_versioning.append_to_url_query(&mut url);
                 this.timeout.append_to_url_query(&mut url);
 
-                let mut request =
-                    this.blob_client
-                        .prepare_request(url, azure_core::Method::Get, None)?;
-
+                let mut headers = Headers::new();
                 for (name, value) in range.as_headers() {
-                    request.insert_header(name, value);
+                    headers.insert(name, value);
                 }
 
-                request.add_optional_header(&this.lease_id);
+                headers.add(this.lease_id);
+
+                let mut request = this.blob_client.prepare_request(
+                    url,
+                    azure_core::Method::Get,
+                    headers,
+                    None,
+                )?;
 
                 let response = this.blob_client.send(&mut ctx, &mut request).await?;
 

--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -65,7 +65,7 @@ impl GetBlobBuilder {
 
                 headers.add(this.lease_id);
 
-                let mut request = this.blob_client.prepare_request(
+                let mut request = this.blob_client.finalize_request(
                     url,
                     azure_core::Method::Get,
                     headers,

--- a/sdk/storage_blobs/src/blob/operations/get_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_block_list.rs
@@ -43,10 +43,12 @@ impl GetBlockListBuilder {
             self.block_list_type.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Get, None)?;
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Get, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_block_list.rs
@@ -48,7 +48,7 @@ impl GetBlockListBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Get, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Get, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_metadata.rs
@@ -42,7 +42,7 @@ impl GetMetadataBuilder {
 
             let mut request = self
                 .blob_client
-                .prepare_request(url, Method::Get, headers, None)?;
+                .finalize_request(url, Method::Get, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_metadata.rs
@@ -37,8 +37,12 @@ impl GetMetadataBuilder {
             self.blob_versioning.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.blob_client.prepare_request(url, Method::Get, None)?;
-            request.add_optional_header(&self.lease_id);
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
+            let mut request = self
+                .blob_client
+                .prepare_request(url, Method::Get, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
@@ -36,10 +36,12 @@ impl<'a> GetPageRangesBuilder {
             self.blob_versioning.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Get, None)?;
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Get, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
@@ -41,7 +41,7 @@ impl<'a> GetPageRangesBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Get, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Get, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_properties.rs
@@ -40,7 +40,7 @@ impl GetPropertiesBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Head, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Head, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_properties.rs
@@ -35,10 +35,12 @@ impl GetPropertiesBuilder {
             self.timeout.append_to_url_query(&mut url);
             self.blob_versioning.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Head, None)?;
-            request.add_optional_header(&self.lease_id);
+                    .prepare_request(url, azure_core::Method::Head, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/put_append_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_append_blob.rs
@@ -48,20 +48,22 @@ impl PutAppendBlobBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.insert_header(BLOB_TYPE, "AppendBlob");
-            request.add_optional_header(&self.content_type);
-            request.add_optional_header(&self.content_encoding);
-            request.add_optional_header(&self.content_language);
-            request.add_optional_header(&self.content_disposition);
+            let mut headers = Headers::new();
+            headers.insert(BLOB_TYPE, "AppendBlob");
+            headers.add(self.content_type);
+            headers.add(self.content_encoding);
+            headers.add(self.content_language);
+            headers.add(self.content_disposition);
             if let Some(metadata) = &self.metadata {
                 for m in metadata.iter() {
-                    request.add_mandatory_header(&m);
+                    headers.add(m);
                 }
             }
-            request.add_optional_header(&self.lease_id);
+            headers.add(self.lease_id);
+
+            let mut request =
+                self.blob_client
+                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/put_append_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_append_blob.rs
@@ -63,7 +63,7 @@ impl PutAppendBlobBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/put_block.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block.rs
@@ -45,7 +45,7 @@ impl<'a> PutBlockBuilder {
             let mut headers = Headers::new();
             headers.add(self.lease_id);
 
-            let mut request = self.blob_client.prepare_request(
+            let mut request = self.blob_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/blob/operations/put_block.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block.rs
@@ -42,12 +42,15 @@ impl<'a> PutBlockBuilder {
             self.block_id.append_to_url_query(&mut url);
             url.query_pairs_mut().append_pair("comp", "block");
 
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
             let mut request = self.blob_client.prepare_request(
                 url,
                 azure_core::Method::Put,
+                headers,
                 Some(self.body.clone()),
             )?;
-            request.add_optional_header(&self.lease_id);
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/put_block_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_blob.rs
@@ -57,24 +57,27 @@ impl PutBlockBlobBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.insert(BLOB_TYPE, "BlockBlob");
+            headers.add(self.hash);
+            headers.add(self.content_type);
+            headers.add(self.content_encoding);
+            headers.add(self.content_language);
+            headers.add(self.content_disposition);
+            if let Some(metadata) = &self.metadata {
+                for m in metadata.iter() {
+                    headers.add(m);
+                }
+            }
+            headers.add(self.access_tier);
+            headers.add(self.lease_id);
+
             let mut request = self.blob_client.prepare_request(
                 url,
                 azure_core::Method::Put,
+                headers,
                 Some(self.body.clone()),
             )?;
-            request.insert_header(BLOB_TYPE, "BlockBlob");
-            request.add_optional_header(&self.hash);
-            request.add_optional_header(&self.content_type);
-            request.add_optional_header(&self.content_encoding);
-            request.add_optional_header(&self.content_language);
-            request.add_optional_header(&self.content_disposition);
-            if let Some(metadata) = &self.metadata {
-                for m in metadata.iter() {
-                    request.add_mandatory_header(&m);
-                }
-            }
-            request.add_optional_header(&self.access_tier);
-            request.add_optional_header(&self.lease_id);
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/put_block_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_blob.rs
@@ -72,7 +72,7 @@ impl PutBlockBlobBuilder {
             headers.add(self.access_tier);
             headers.add(self.lease_id);
 
-            let mut request = self.blob_client.prepare_request(
+            let mut request = self.blob_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/blob/operations/put_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_list.rs
@@ -83,7 +83,7 @@ impl PutBlockListBuilder {
             headers.add(self.access_tier);
             headers.add(self.lease_id);
 
-            let mut request = self.blob_client.prepare_request(
+            let mut request = self.blob_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/blob/operations/put_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_list.rs
@@ -68,22 +68,27 @@ impl PutBlockListBuilder {
                 base64::encode(hash.0)
             };
 
-            let mut request =
-                self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, Some(body_bytes))?;
-            request.insert_header("Content-MD5", &md5);
-            request.add_optional_header(&self.content_type);
-            request.add_optional_header(&self.content_encoding);
-            request.add_optional_header(&self.content_language);
-            request.add_optional_header(&self.content_disposition);
-            request.add_optional_header(&self.content_md5);
+            let mut headers = Headers::new();
+            headers.insert("Content-MD5", &md5);
+            headers.add(self.content_type);
+            headers.add(self.content_encoding);
+            headers.add(self.content_language);
+            headers.add(self.content_disposition);
+            headers.add(self.content_md5);
             if let Some(metadata) = &self.metadata {
                 for m in metadata.iter() {
-                    request.add_mandatory_header(&m);
+                    headers.add(m);
                 }
             }
-            request.add_optional_header(&self.access_tier);
-            request.add_optional_header(&self.lease_id);
+            headers.add(self.access_tier);
+            headers.add(self.lease_id);
+
+            let mut request = self.blob_client.prepare_request(
+                url,
+                azure_core::Method::Put,
+                headers,
+                Some(body_bytes),
+            )?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/put_page_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_page_blob.rs
@@ -72,7 +72,7 @@ impl PutPageBlobBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/release_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/release_lease.rs
@@ -33,7 +33,7 @@ impl ReleaseLeaseBuilder {
             headers.insert(LEASE_ACTION, "release");
             headers.add(self.blob_lease_client.lease_id());
 
-            let mut request = self.blob_lease_client.prepare_request(
+            let mut request = self.blob_lease_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/blob/operations/release_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/release_lease.rs
@@ -1,9 +1,5 @@
 use crate::prelude::*;
-use azure_core::{
-    headers::{LEASE_ACTION, *},
-    prelude::*,
-    RequestId,
-};
+use azure_core::{headers::*, prelude::*, RequestId};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
@@ -23,7 +19,6 @@ impl ReleaseLeaseBuilder {
     }
 
     setters! {
-
         timeout: Timeout => Some(timeout),
     }
 
@@ -34,11 +29,16 @@ impl ReleaseLeaseBuilder {
             url.query_pairs_mut().append_pair("comp", "lease");
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.blob_lease_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "release");
-            request.add_mandatory_header(self.blob_lease_client.lease_id());
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "release");
+            headers.add(self.blob_lease_client.lease_id());
+
+            let mut request = self.blob_lease_client.prepare_request(
+                url,
+                azure_core::Method::Put,
+                headers,
+                None,
+            )?;
 
             let response = self
                 .blob_lease_client

--- a/sdk/storage_blobs/src/blob/operations/renew_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/renew_lease.rs
@@ -1,9 +1,5 @@
 use crate::prelude::*;
-use azure_core::{
-    headers::{LEASE_ACTION, *},
-    prelude::*,
-    RequestId,
-};
+use azure_core::{headers::*, prelude::*, RequestId};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
@@ -34,11 +30,16 @@ impl RenewLeaseBuilder {
             url.query_pairs_mut().append_pair("comp", "lease");
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.blob_lease_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "renew");
-            request.add_mandatory_header(self.blob_lease_client.lease_id());
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "renew");
+            headers.add(self.blob_lease_client.lease_id());
+
+            let mut request = self.blob_lease_client.prepare_request(
+                url,
+                azure_core::Method::Put,
+                headers,
+                None,
+            )?;
 
             let response = self
                 .blob_lease_client

--- a/sdk/storage_blobs/src/blob/operations/renew_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/renew_lease.rs
@@ -34,7 +34,7 @@ impl RenewLeaseBuilder {
             headers.insert(LEASE_ACTION, "renew");
             headers.add(self.blob_lease_client.lease_id());
 
-            let mut request = self.blob_lease_client.prepare_request(
+            let mut request = self.blob_lease_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
@@ -46,7 +46,7 @@ impl SetBlobTierBuilder {
 
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
+                    .finalize_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
@@ -40,11 +40,13 @@ impl SetBlobTierBuilder {
             self.blob_versioning.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.add(self.access_tier);
+            headers.add(self.rehydrate_priority);
+
             let mut request =
                 self.blob_client
-                    .prepare_request(url, azure_core::Method::Put, None)?;
-            request.add_mandatory_header(&self.access_tier);
-            request.add_optional_header(&self.rehydrate_priority);
+                    .prepare_request(url, azure_core::Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/set_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_metadata.rs
@@ -47,7 +47,7 @@ impl SetMetadataBuilder {
 
             let mut request = self
                 .blob_client
-                .prepare_request(url, Method::Put, headers, None)?;
+                .finalize_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/set_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_metadata.rs
@@ -37,13 +37,17 @@ impl SetMetadataBuilder {
             url.query_pairs_mut().append_pair("comp", "metadata");
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.blob_client.prepare_request(url, Method::Put, None)?;
-            request.add_optional_header(&self.lease_id);
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
             if let Some(metadata) = &self.metadata {
                 for m in metadata.iter() {
-                    request.add_mandatory_header(&m);
+                    headers.add(m);
                 }
             }
+
+            let mut request = self
+                .blob_client
+                .prepare_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/set_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_properties.rs
@@ -82,14 +82,18 @@ impl SetPropertiesBuilder {
             url.query_pairs_mut().append_pair("comp", "properties");
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.blob_client.prepare_request(url, Method::Put, None)?;
-            request.add_optional_header(&self.lease_id);
-            request.add_optional_header(&self.cache_control);
-            request.add_optional_header(&self.content_type);
-            request.add_optional_header(&self.content_encoding);
-            request.add_optional_header(&self.content_language);
-            request.add_optional_header(&self.content_disposition);
-            request.add_optional_header(&self.content_md5);
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+            headers.add(self.cache_control);
+            headers.add(self.content_type);
+            headers.add(self.content_encoding);
+            headers.add(self.content_language);
+            headers.add(self.content_disposition);
+            headers.add(self.content_md5);
+
+            let mut request = self
+                .blob_client
+                .prepare_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/set_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_properties.rs
@@ -93,7 +93,7 @@ impl SetPropertiesBuilder {
 
             let mut request = self
                 .blob_client
-                .prepare_request(url, Method::Put, headers, None)?;
+                .finalize_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/update_page.rs
+++ b/sdk/storage_blobs/src/blob/operations/update_page.rs
@@ -50,19 +50,22 @@ impl UpdatePageBuilder {
             self.timeout.append_to_url_query(&mut url);
             url.query_pairs_mut().append_pair("comp", "page");
 
+            let mut headers = Headers::new();
+            headers.insert(PAGE_WRITE, "update");
+            headers.insert(BLOB_TYPE, "PageBlob");
+            headers.add(self.ba512_range);
+            headers.add(self.sequence_number_condition);
+            headers.add(self.hash);
+            headers.add(self.if_modified_since_condition);
+            headers.add(self.if_match_condition);
+            headers.add(self.lease_id);
+
             let mut request = self.blob_client.prepare_request(
                 url,
                 azure_core::Method::Put,
+                headers,
                 Some(self.content.clone()),
             )?;
-            request.insert_header(PAGE_WRITE, "update");
-            request.insert_header(BLOB_TYPE, "PageBlob");
-            request.add_mandatory_header(&self.ba512_range);
-            request.add_optional_header(&self.sequence_number_condition);
-            request.add_optional_header(&self.hash);
-            request.add_optional_header(&self.if_modified_since_condition);
-            request.add_optional_header(&self.if_match_condition);
-            request.add_optional_header(&self.lease_id);
 
             let response = self
                 .blob_client

--- a/sdk/storage_blobs/src/blob/operations/update_page.rs
+++ b/sdk/storage_blobs/src/blob/operations/update_page.rs
@@ -60,7 +60,7 @@ impl UpdatePageBuilder {
             headers.add(self.if_match_condition);
             headers.add(self.lease_id);
 
-            let mut request = self.blob_client.prepare_request(
+            let mut request = self.blob_client.finalize_request(
                 url,
                 azure_core::Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -2,6 +2,7 @@ use crate::{blob::operations::*, prelude::*, BA512Range};
 use azure_core::Method;
 use azure_core::{
     error::{Error, ErrorKind},
+    headers::Headers,
     prelude::*,
     Request, Response,
 };
@@ -226,10 +227,11 @@ impl BlobClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.container_client
-            .prepare_request(url, method, request_body)
+            .prepare_request(url, method, headers, request_body)
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -223,7 +223,7 @@ impl BlobClient {
         Ok(url)
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -231,7 +231,7 @@ impl BlobClient {
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.container_client
-            .prepare_request(url, method, headers, request_body)
+            .finalize_request(url, method, headers, request_body)
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -1,5 +1,5 @@
 use crate::{blob::operations::*, prelude::*};
-use azure_core::{prelude::*, Context, Method, Request, Response, Url};
+use azure_core::{headers::Headers, prelude::*, Context, Method, Request, Response, Url};
 use azure_storage::core::prelude::*;
 use bytes::Bytes;
 use std::sync::Arc;
@@ -28,8 +28,8 @@ impl BlobLeaseClient {
         })
     }
 
-    pub fn lease_id(&self) -> &LeaseId {
-        &self.lease_id
+    pub fn lease_id(&self) -> LeaseId {
+        self.lease_id
     }
 
     #[allow(dead_code)]
@@ -70,9 +70,11 @@ impl BlobLeaseClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
-        self.blob_client.prepare_request(url, method, request_body)
+        self.blob_client
+            .prepare_request(url, method, headers, request_body)
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -66,7 +66,7 @@ impl BlobLeaseClient {
         RenewLeaseBuilder::new(self.clone())
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -74,7 +74,7 @@ impl BlobLeaseClient {
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.blob_client
-            .prepare_request(url, method, headers, request_body)
+            .finalize_request(url, method, headers, request_body)
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -116,7 +116,7 @@ impl ContainerClient {
             .await
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -124,7 +124,7 @@ impl ContainerClient {
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.storage_client
-            .prepare_request(url, method, headers, request_body)
+            .finalize_request(url, method, headers, request_body)
     }
 
     pub fn shared_access_signature(

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -1,6 +1,7 @@
 use crate::{container::operations::*, prelude::PublicAccess};
 use azure_core::{
     error::{Error, ErrorKind},
+    headers::Headers,
     prelude::*,
     Request, Response,
 };
@@ -119,10 +120,11 @@ impl ContainerClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.storage_client
-            .prepare_request(url, method, request_body)
+            .prepare_request(url, method, headers, request_body)
     }
 
     pub fn shared_access_signature(

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -57,7 +57,7 @@ impl ContainerLeaseClient {
         RenewLeaseBuilder::new(self.clone())
     }
 
-    pub(crate) fn prepare_request(
+    pub(crate) fn finalize_request(
         &self,
         url: Url,
         method: Method,
@@ -65,7 +65,7 @@ impl ContainerLeaseClient {
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.container_client
-            .prepare_request(url, method, headers, request_body)
+            .finalize_request(url, method, headers, request_body)
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -1,5 +1,5 @@
 use crate::{container::operations::*, prelude::*};
-use azure_core::{prelude::*, Context, Method, Request, Response, Url};
+use azure_core::{headers::Headers, prelude::*, Context, Method, Request, Response, Url};
 use azure_storage::core::prelude::*;
 use bytes::Bytes;
 use std::sync::Arc;
@@ -28,8 +28,8 @@ impl ContainerLeaseClient {
         })
     }
 
-    pub fn lease_id(&self) -> &LeaseId {
-        &self.lease_id
+    pub fn lease_id(&self) -> LeaseId {
+        self.lease_id
     }
 
     #[allow(dead_code)]
@@ -61,10 +61,11 @@ impl ContainerLeaseClient {
         &self,
         url: Url,
         method: Method,
+        headers: Headers,
         request_body: Option<Bytes>,
     ) -> azure_core::Result<Request> {
         self.container_client
-            .prepare_request(url, method, request_body)
+            .prepare_request(url, method, headers, request_body)
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/container/operations/acquire_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/acquire_lease.rs
@@ -41,13 +41,15 @@ impl AcquireLeaseBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self
-                .container_client
-                .prepare_request(url, Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "acquire");
-            request.add_mandatory_header(&self.lease_duration);
-            request.add_optional_header(&self.lease_id);
-            request.add_optional_header(&self.proposed_lease_id);
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "acquire");
+            headers.add(self.lease_duration);
+            headers.add(self.lease_id);
+            headers.add(self.proposed_lease_id);
+
+            let mut request =
+                self.container_client
+                    .prepare_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/acquire_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/acquire_lease.rs
@@ -49,7 +49,7 @@ impl AcquireLeaseBuilder {
 
             let mut request =
                 self.container_client
-                    .prepare_request(url, Method::Put, headers, None)?;
+                    .finalize_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/break_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/break_lease.rs
@@ -1,10 +1,6 @@
 use crate::prelude::*;
 use azure_core::Method;
-use azure_core::{
-    headers::{LEASE_ACTION, *},
-    prelude::*,
-    RequestId,
-};
+use azure_core::{headers::*, prelude::*, RequestId};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
@@ -43,12 +39,14 @@ impl BreakLeaseBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self
-                .container_client
-                .prepare_request(url, Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "break");
-            request.add_optional_header(&self.lease_id);
-            request.add_optional_header(&self.lease_break_period);
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "break");
+            headers.add(self.lease_id);
+            headers.add(self.lease_break_period);
+
+            let mut request =
+                self.container_client
+                    .prepare_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/break_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/break_lease.rs
@@ -46,7 +46,7 @@ impl BreakLeaseBuilder {
 
             let mut request =
                 self.container_client
-                    .prepare_request(url, Method::Put, headers, None)?;
+                    .finalize_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/create.rs
+++ b/sdk/storage_blobs/src/container/operations/create.rs
@@ -50,7 +50,7 @@ impl CreateBuilder {
 
             let mut request =
                 self.container_client
-                    .prepare_request(url, Method::Put, headers, None)?;
+                    .finalize_request(url, Method::Put, headers, None)?;
 
             let _response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/delete.rs
+++ b/sdk/storage_blobs/src/container/operations/delete.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-use azure_core::prelude::*;
-use azure_core::Method;
+use azure_core::{headers::Headers, prelude::*, Method};
 
 #[derive(Debug, Clone)]
 pub struct DeleteBuilder {
@@ -33,10 +32,12 @@ impl DeleteBuilder {
 
             url.query_pairs_mut().append_pair("restype", "container");
 
-            let mut request = self
-                .container_client
-                .prepare_request(url, Method::Delete, None)?;
-            request.add_optional_header(&self.lease_id);
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
+            let mut request =
+                self.container_client
+                    .prepare_request(url, Method::Delete, headers, None)?;
 
             let _response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/delete.rs
+++ b/sdk/storage_blobs/src/container/operations/delete.rs
@@ -37,7 +37,7 @@ impl DeleteBuilder {
 
             let mut request =
                 self.container_client
-                    .prepare_request(url, Method::Delete, headers, None)?;
+                    .finalize_request(url, Method::Delete, headers, None)?;
 
             let _response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/get_acl.rs
+++ b/sdk/storage_blobs/src/container/operations/get_acl.rs
@@ -2,13 +2,12 @@ use crate::{
     container::{public_access_from_header, PublicAccess},
     prelude::*,
 };
-use azure_core::Method;
 use azure_core::{
     collect_pinned_stream,
     error::{ErrorKind, ResultExt},
-    headers,
+    headers::*,
     prelude::*,
-    RequestId, Response,
+    Method, RequestId, Response,
 };
 use azure_storage::core::StoredAccessPolicyList;
 use chrono::{DateTime, FixedOffset};
@@ -43,10 +42,12 @@ impl GetACLBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self
-                .container_client
-                .prepare_request(url, Method::Get, None)?;
-            request.add_optional_header(&self.lease_id);
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
+            let mut request =
+                self.container_client
+                    .prepare_request(url, Method::Get, headers, None)?;
 
             let response = self
                 .container_client
@@ -76,15 +77,15 @@ impl GetACLResponse {
         // todo: parse SAS policies
         let public_access = public_access_from_header(&headers)?;
 
-        let etag = headers.get_string(&headers::ETAG)?;
+        let etag = headers.get_string(&ETAG)?;
 
-        let last_modified = headers.get_str(&headers::LAST_MODIFIED)?;
+        let last_modified = headers.get_str(&LAST_MODIFIED)?;
         let last_modified =
             DateTime::parse_from_rfc2822(last_modified).map_kind(ErrorKind::DataConversion)?;
 
-        let request_id = headers.get_as(&headers::REQUEST_ID)?;
+        let request_id = headers.get_as(&REQUEST_ID)?;
 
-        let date = headers.get_str(&headers::DATE)?;
+        let date = headers.get_str(&DATE)?;
         let date = DateTime::parse_from_rfc2822(date).map_kind(ErrorKind::DataConversion)?;
 
         let stored_access_policy_list = StoredAccessPolicyList::from_xml(&body)?;

--- a/sdk/storage_blobs/src/container/operations/get_acl.rs
+++ b/sdk/storage_blobs/src/container/operations/get_acl.rs
@@ -47,7 +47,7 @@ impl GetACLBuilder {
 
             let mut request =
                 self.container_client
-                    .prepare_request(url, Method::Get, headers, None)?;
+                    .finalize_request(url, Method::Get, headers, None)?;
 
             let response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/container/operations/get_properties.rs
@@ -43,7 +43,7 @@ impl GetPropertiesBuilder {
 
             let mut request =
                 self.container_client
-                    .prepare_request(url, Method::Head, headers, None)?;
+                    .finalize_request(url, Method::Head, headers, None)?;
 
             let response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/container/operations/get_properties.rs
@@ -38,10 +38,12 @@ impl GetPropertiesBuilder {
             let mut url = self.container_client.url_with_segments(None)?;
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self
-                .container_client
-                .prepare_request(url, Method::Head, None)?;
-            request.add_optional_header(&self.lease_id);
+            let mut headers = Headers::new();
+            headers.add(self.lease_id);
+
+            let mut request =
+                self.container_client
+                    .prepare_request(url, Method::Head, headers, None)?;
 
             let response = self
                 .container_client

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -112,7 +112,7 @@ impl ListBlobsBuilder {
 
                 this.timeout.append_to_url_query(&mut url);
 
-                let mut request = this.container_client.prepare_request(
+                let mut request = this.container_client.finalize_request(
                     url,
                     Method::Get,
                     Headers::new(),

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -3,7 +3,7 @@ use azure_core::Method;
 use azure_core::{
     collect_pinned_stream,
     error::Error,
-    headers::{date_from_headers, request_id_from_headers},
+    headers::{date_from_headers, request_id_from_headers, Headers},
     prelude::*,
     Pageable, RequestId, Response as AzureResponse,
 };
@@ -112,9 +112,12 @@ impl ListBlobsBuilder {
 
                 this.timeout.append_to_url_query(&mut url);
 
-                let mut request = this
-                    .container_client
-                    .prepare_request(url, Method::Get, None)?;
+                let mut request = this.container_client.prepare_request(
+                    url,
+                    Method::Get,
+                    Headers::new(),
+                    None,
+                )?;
 
                 let response = this.container_client.send(&mut ctx, &mut request).await?;
 

--- a/sdk/storage_blobs/src/container/operations/list_containers.rs
+++ b/sdk/storage_blobs/src/container/operations/list_containers.rs
@@ -74,7 +74,7 @@ impl ListContainersBuilder {
                 this.max_results.append_to_url_query(&mut url);
                 this.timeout.append_to_url_query(&mut url);
 
-                let mut request = this.client.storage_client.prepare_request(
+                let mut request = this.client.storage_client.finalize_request(
                     url,
                     Method::Get,
                     Headers::new(),

--- a/sdk/storage_blobs/src/container/operations/list_containers.rs
+++ b/sdk/storage_blobs/src/container/operations/list_containers.rs
@@ -2,6 +2,7 @@ use crate::clients::BlobServiceClient;
 use crate::container::Container;
 use azure_core::{
     error::{Error, ErrorKind, ResultExt},
+    headers::Headers,
     prelude::*,
     Method, Pageable, Response,
 };
@@ -73,10 +74,12 @@ impl ListContainersBuilder {
                 this.max_results.append_to_url_query(&mut url);
                 this.timeout.append_to_url_query(&mut url);
 
-                let mut request =
-                    this.client
-                        .storage_client
-                        .prepare_request(url, Method::Get, None)?;
+                let mut request = this.client.storage_client.prepare_request(
+                    url,
+                    Method::Get,
+                    Headers::new(),
+                    None,
+                )?;
 
                 let response = this.client.send(&mut ctx, &mut request).await?;
 

--- a/sdk/storage_blobs/src/container/operations/release_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/release_lease.rs
@@ -1,10 +1,6 @@
 use crate::prelude::*;
 use azure_core::Method;
-use azure_core::{
-    headers::{LEASE_ACTION, *},
-    prelude::*,
-    RequestId,
-};
+use azure_core::{headers::*, prelude::*, RequestId};
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
@@ -37,11 +33,13 @@ impl ReleaseLeaseBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "release");
+            headers.add(self.container_lease_client.lease_id());
+
             let mut request =
                 self.container_lease_client
-                    .prepare_request(url, Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "release");
-            request.add_mandatory_header(self.container_lease_client.lease_id());
+                    .prepare_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_lease_client

--- a/sdk/storage_blobs/src/container/operations/release_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/release_lease.rs
@@ -39,7 +39,7 @@ impl ReleaseLeaseBuilder {
 
             let mut request =
                 self.container_lease_client
-                    .prepare_request(url, Method::Put, headers, None)?;
+                    .finalize_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_lease_client

--- a/sdk/storage_blobs/src/container/operations/renew_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/renew_lease.rs
@@ -1,6 +1,6 @@
 use crate::{container::operations::AcquireLeaseResponse, prelude::*};
 use azure_core::Method;
-use azure_core::{headers::LEASE_ACTION, prelude::*};
+use azure_core::{headers::*, prelude::*};
 
 pub type RenewLeaseResponse = AcquireLeaseResponse;
 
@@ -34,11 +34,13 @@ impl RenewLeaseBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
+            let mut headers = Headers::new();
+            headers.insert(LEASE_ACTION, "renew");
+            headers.add(self.container_lease_client.lease_id());
+
             let mut request =
                 self.container_lease_client
-                    .prepare_request(url, Method::Put, None)?;
-            request.insert_header(LEASE_ACTION, "renew");
-            request.add_mandatory_header(self.container_lease_client.lease_id());
+                    .prepare_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_lease_client

--- a/sdk/storage_blobs/src/container/operations/renew_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/renew_lease.rs
@@ -40,7 +40,7 @@ impl RenewLeaseBuilder {
 
             let mut request =
                 self.container_lease_client
-                    .prepare_request(url, Method::Put, headers, None)?;
+                    .finalize_request(url, Method::Put, headers, None)?;
 
             let response = self
                 .container_lease_client

--- a/sdk/storage_blobs/src/container/operations/set_acl.rs
+++ b/sdk/storage_blobs/src/container/operations/set_acl.rs
@@ -50,7 +50,7 @@ impl SetACLBuilder {
             }
             headers.add(self.lease_id);
 
-            let mut request = self.container_client.prepare_request(
+            let mut request = self.container_client.finalize_request(
                 url,
                 Method::Put,
                 headers,

--- a/sdk/storage_blobs/src/container/operations/set_acl.rs
+++ b/sdk/storage_blobs/src/container/operations/set_acl.rs
@@ -1,6 +1,6 @@
 use crate::{container::public_access_from_header, prelude::*};
 use azure_core::Method;
-use azure_core::{headers::AsHeaders, prelude::*};
+use azure_core::{headers::*, prelude::*};
 use azure_storage::core::StoredAccessPolicyList;
 use bytes::Bytes;
 
@@ -44,13 +44,18 @@ impl SetACLBuilder {
 
             let xml = self.stored_access_policy_list.map(|xml| xml.to_xml());
 
-            let mut request =
-                self.container_client
-                    .prepare_request(url, Method::Put, xml.map(Bytes::from))?;
+            let mut headers = Headers::new();
             for (name, value) in self.public_access.as_headers() {
-                request.insert_header(name, value);
+                headers.insert(name, value);
             }
-            request.add_optional_header(&self.lease_id);
+            headers.add(self.lease_id);
+
+            let mut request = self.container_client.prepare_request(
+                url,
+                Method::Put,
+                headers,
+                xml.map(Bytes::from),
+            )?;
 
             let response = self
                 .container_client

--- a/sdk/storage_datalake/src/clients/data_lake_client.rs
+++ b/sdk/storage_datalake/src/clients/data_lake_client.rs
@@ -110,7 +110,7 @@ impl DataLakeClient {
         FileSystemClient::new(self, file_system_name.into())
     }
 
-    // pub(crate) fn prepare_request(
+    // pub(crate) fn finalize_request(
     //     &self,
     //     url: Url,
     //     http_method: azure_core::Method,

--- a/sdk/storage_datalake/src/clients/file_system_client.rs
+++ b/sdk/storage_datalake/src/clients/file_system_client.rs
@@ -88,12 +88,12 @@ impl FileSystemClient {
         SetFileSystemPropertiesBuilder::new(self.clone(), Some(properties))
     }
 
-    // pub(crate) fn prepare_request(
+    // pub(crate) fn finalize_request(
     //     &self,
     //     uri: &str,
     //     http_method: azure_core::Method,
     // ) -> azure_core::Request {
-    //     self.data_lake_client.prepare_request(uri, http_method)
+    //     self.data_lake_client.finalize_request(uri, http_method)
     // }
 
     pub(crate) fn pipeline(&self) -> &Pipeline {

--- a/sdk/storage_queues/src/operations/clear_messages.rs
+++ b/sdk/storage_queues/src/operations/clear_messages.rs
@@ -30,7 +30,7 @@ impl ClearMessagesBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Delete,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/clear_messages.rs
+++ b/sdk/storage_queues/src/operations/clear_messages.rs
@@ -1,5 +1,5 @@
 use crate::clients::QueueClient;
-use azure_core::{error::Error, prelude::*, Method, Response as AzureResponse};
+use azure_core::{error::Error, headers::Headers, prelude::*, Method, Response as AzureResponse};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
@@ -30,10 +30,12 @@ impl ClearMessagesBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Delete, None)?;
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Delete,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .queue_client

--- a/sdk/storage_queues/src/operations/create_queue.rs
+++ b/sdk/storage_queues/src/operations/create_queue.rs
@@ -1,5 +1,5 @@
 use crate::clients::QueueClient;
-use azure_core::{error::Error, prelude::*, Method, Response as AzureResponse};
+use azure_core::{error::Error, headers::Headers, prelude::*, Method, Response as AzureResponse};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
@@ -33,16 +33,19 @@ impl CreateQueueBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Put, None)?;
-
+            let mut headers = Headers::new();
             if let Some(metadata) = &self.metadata {
                 for m in metadata.iter() {
-                    request.add_mandatory_header(&m);
+                    headers.add(m);
                 }
             }
+
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Put,
+                headers,
+                None,
+            )?;
 
             let response = self
                 .queue_client

--- a/sdk/storage_queues/src/operations/create_queue.rs
+++ b/sdk/storage_queues/src/operations/create_queue.rs
@@ -40,7 +40,7 @@ impl CreateQueueBuilder {
                 }
             }
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Put,
                 headers,

--- a/sdk/storage_queues/src/operations/delete_message.rs
+++ b/sdk/storage_queues/src/operations/delete_message.rs
@@ -1,5 +1,7 @@
 use crate::clients::PopReceiptClient;
-use azure_core::{error::Error, prelude::*, Context, Method, Response as AzureResponse};
+use azure_core::{
+    error::Error, headers::Headers, prelude::*, Context, Method, Response as AzureResponse,
+};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
@@ -33,6 +35,7 @@ impl DeleteMessageBuilder {
             let mut request = self.pop_receipt_client.storage_client().prepare_request(
                 url,
                 Method::Delete,
+                Headers::new(),
                 None,
             )?;
 

--- a/sdk/storage_queues/src/operations/delete_message.rs
+++ b/sdk/storage_queues/src/operations/delete_message.rs
@@ -32,7 +32,7 @@ impl DeleteMessageBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.pop_receipt_client.storage_client().prepare_request(
+            let mut request = self.pop_receipt_client.storage_client().finalize_request(
                 url,
                 Method::Delete,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/delete_queue.rs
+++ b/sdk/storage_queues/src/operations/delete_queue.rs
@@ -32,7 +32,7 @@ impl DeleteQueueBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Delete,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/delete_queue.rs
+++ b/sdk/storage_queues/src/operations/delete_queue.rs
@@ -1,5 +1,7 @@
 use crate::clients::QueueClient;
-use azure_core::{error::Error, prelude::*, Context, Method, Response as AzureResponse};
+use azure_core::{
+    error::Error, headers::Headers, prelude::*, Context, Method, Response as AzureResponse,
+};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
@@ -30,10 +32,12 @@ impl DeleteQueueBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Delete, None)?;
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Delete,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .queue_client

--- a/sdk/storage_queues/src/operations/get_messages.rs
+++ b/sdk/storage_queues/src/operations/get_messages.rs
@@ -1,5 +1,7 @@
 use crate::{clients::QueueClient, prelude::*, PopReceipt};
-use azure_core::{collect_pinned_stream, prelude::*, Context, Method, Response as AzureResponse};
+use azure_core::{
+    collect_pinned_stream, headers::Headers, prelude::*, Context, Method, Response as AzureResponse,
+};
 use azure_storage::core::{headers::CommonStorageResponseHeaders, xml::read_xml};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -40,10 +42,12 @@ impl GetMessagesBuilder {
             self.number_of_messages.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Get, None)?;
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Get,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .queue_client

--- a/sdk/storage_queues/src/operations/get_messages.rs
+++ b/sdk/storage_queues/src/operations/get_messages.rs
@@ -42,7 +42,7 @@ impl GetMessagesBuilder {
             self.number_of_messages.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Get,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/get_queue_acl.rs
+++ b/sdk/storage_queues/src/operations/get_queue_acl.rs
@@ -34,7 +34,7 @@ impl GetQueueACLBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Get,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/get_queue_acl.rs
+++ b/sdk/storage_queues/src/operations/get_queue_acl.rs
@@ -1,5 +1,7 @@
 use crate::{clients::QueueClient, QueueStoredAccessPolicy};
-use azure_core::{collect_pinned_stream, prelude::*, Context, Method, Response as AzureResponse};
+use azure_core::{
+    collect_pinned_stream, headers::Headers, prelude::*, Context, Method, Response as AzureResponse,
+};
 use azure_storage::{core::headers::CommonStorageResponseHeaders, StoredAccessPolicyList};
 use std::convert::TryInto;
 
@@ -32,10 +34,12 @@ impl GetQueueACLBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Get, None)?;
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Get,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .queue_client

--- a/sdk/storage_queues/src/operations/get_queue_metadata.rs
+++ b/sdk/storage_queues/src/operations/get_queue_metadata.rs
@@ -1,5 +1,7 @@
 use crate::clients::QueueClient;
-use azure_core::{error::Error, prelude::*, Context, Method, Response as AzureResponse};
+use azure_core::{
+    error::Error, headers::Headers, prelude::*, Context, Method, Response as AzureResponse,
+};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
@@ -32,10 +34,12 @@ impl GetQueueMetadataBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Get, None)?;
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Get,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .queue_client

--- a/sdk/storage_queues/src/operations/get_queue_metadata.rs
+++ b/sdk/storage_queues/src/operations/get_queue_metadata.rs
@@ -34,7 +34,7 @@ impl GetQueueMetadataBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Get,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/get_queue_service_properties.rs
+++ b/sdk/storage_queues/src/operations/get_queue_service_properties.rs
@@ -1,5 +1,7 @@
 use crate::{QueueServiceClient, QueueServiceProperties};
-use azure_core::{collect_pinned_stream, prelude::*, Context, Method, Response as AzureResponse};
+use azure_core::{
+    collect_pinned_stream, headers::Headers, prelude::*, Context, Method, Response as AzureResponse,
+};
 use azure_storage::core::{headers::CommonStorageResponseHeaders, xml::read_xml};
 use std::convert::TryInto;
 
@@ -38,10 +40,12 @@ impl GetQueueServicePropertiesBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.service_client
-                    .storage_client
-                    .prepare_request(url, Method::Get, None)?;
+            let mut request = self.service_client.storage_client.prepare_request(
+                url,
+                Method::Get,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .service_client

--- a/sdk/storage_queues/src/operations/get_queue_service_properties.rs
+++ b/sdk/storage_queues/src/operations/get_queue_service_properties.rs
@@ -40,7 +40,7 @@ impl GetQueueServicePropertiesBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.service_client.storage_client.prepare_request(
+            let mut request = self.service_client.storage_client.finalize_request(
                 url,
                 Method::Get,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/get_queue_service_stats.rs
+++ b/sdk/storage_queues/src/operations/get_queue_service_stats.rs
@@ -2,6 +2,7 @@ use crate::QueueServiceClient;
 use azure_core::{
     collect_pinned_stream,
     error::{ErrorKind, ResultExt},
+    headers::Headers,
     prelude::*,
     Method, Response as AzureResponse,
 };
@@ -44,10 +45,12 @@ impl GetQueueServiceStatsBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.service_client
-                    .storage_client
-                    .prepare_request(url, Method::Get, None)?;
+            let mut request = self.service_client.storage_client.prepare_request(
+                url,
+                Method::Get,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .service_client

--- a/sdk/storage_queues/src/operations/get_queue_service_stats.rs
+++ b/sdk/storage_queues/src/operations/get_queue_service_stats.rs
@@ -45,7 +45,7 @@ impl GetQueueServiceStatsBuilder {
 
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.service_client.storage_client.prepare_request(
+            let mut request = self.service_client.storage_client.finalize_request(
                 url,
                 Method::Get,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/list_queues.rs
+++ b/sdk/storage_queues/src/operations/list_queues.rs
@@ -1,6 +1,6 @@
 use crate::QueueServiceClient;
 use azure_core::{
-    collect_pinned_stream, error::Error, prelude::*, Context, Method, Pageable,
+    collect_pinned_stream, error::Error, headers::Headers, prelude::*, Context, Method, Pageable,
     Response as AzureResponse,
 };
 use azure_storage::{core::headers::CommonStorageResponseHeaders, xml::read_xml};
@@ -65,10 +65,12 @@ impl ListQueuesBuilder {
                 this.timeout.append_to_url_query(&mut url);
                 AppendToUrlQuery::append_to_url_query(&this.timeout, &mut url);
 
-                let mut request =
-                    this.service_client
-                        .storage_client
-                        .prepare_request(url, Method::Get, None)?;
+                let mut request = this.service_client.storage_client.prepare_request(
+                    url,
+                    Method::Get,
+                    Headers::new(),
+                    None,
+                )?;
 
                 let response = this
                     .service_client

--- a/sdk/storage_queues/src/operations/list_queues.rs
+++ b/sdk/storage_queues/src/operations/list_queues.rs
@@ -65,7 +65,7 @@ impl ListQueuesBuilder {
                 this.timeout.append_to_url_query(&mut url);
                 AppendToUrlQuery::append_to_url_query(&this.timeout, &mut url);
 
-                let mut request = this.service_client.storage_client.prepare_request(
+                let mut request = this.service_client.storage_client.finalize_request(
                     url,
                     Method::Get,
                     Headers::new(),

--- a/sdk/storage_queues/src/operations/peek_messages.rs
+++ b/sdk/storage_queues/src/operations/peek_messages.rs
@@ -1,7 +1,7 @@
 use crate::{clients::QueueClient, prelude::*};
 use azure_core::{
-    collect_pinned_stream, headers::utc_date_from_rfc2822, prelude::*, Context, Method,
-    Response as AzureResponse,
+    collect_pinned_stream, headers::utc_date_from_rfc2822, headers::Headers, prelude::*, Context,
+    Method, Response as AzureResponse,
 };
 use azure_storage::core::{headers::CommonStorageResponseHeaders, xml::read_xml};
 use chrono::{DateTime, Utc};
@@ -39,10 +39,12 @@ impl PeekMessagesBuilder {
             self.number_of_messages.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Get, None)?;
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Get,
+                Headers::new(),
+                None,
+            )?;
 
             let response = self
                 .queue_client

--- a/sdk/storage_queues/src/operations/peek_messages.rs
+++ b/sdk/storage_queues/src/operations/peek_messages.rs
@@ -39,7 +39,7 @@ impl PeekMessagesBuilder {
             self.number_of_messages.append_to_url_query(&mut url);
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Get,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/put_message.rs
+++ b/sdk/storage_queues/src/operations/put_message.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use azure_core::{
-    collect_pinned_stream, headers::utc_date_from_rfc2822, prelude::*, Context, Method,
-    Response as AzureResponse,
+    collect_pinned_stream, headers::utc_date_from_rfc2822, headers::Headers, prelude::*, Context,
+    Method, Response as AzureResponse,
 };
 use azure_storage::{core::headers::CommonStorageResponseHeaders, xml::read_xml};
 use chrono::{DateTime, Utc};
@@ -55,6 +55,7 @@ impl PutMessageBuilder {
             let mut request = self.queue_client.storage_client().prepare_request(
                 url,
                 Method::Post,
+                Headers::new(),
                 Some(message.into()),
             )?;
 

--- a/sdk/storage_queues/src/operations/put_message.rs
+++ b/sdk/storage_queues/src/operations/put_message.rs
@@ -52,7 +52,7 @@ impl PutMessageBuilder {
                 self.body
             );
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Post,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/set_queue_acl.rs
+++ b/sdk/storage_queues/src/operations/set_queue_acl.rs
@@ -45,7 +45,7 @@ impl SetQueueACLBuilder {
                 qapl.to_xml()
             };
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Put,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/set_queue_acl.rs
+++ b/sdk/storage_queues/src/operations/set_queue_acl.rs
@@ -1,5 +1,5 @@
 use crate::{clients::QueueClient, QueueStoredAccessPolicy};
-use azure_core::{error::Error, prelude::*, Method, Response as AzureResponse};
+use azure_core::{error::Error, headers::Headers, prelude::*, Method, Response as AzureResponse};
 use azure_storage::{core::headers::CommonStorageResponseHeaders, StoredAccessPolicyList};
 use std::convert::TryInto;
 
@@ -48,6 +48,7 @@ impl SetQueueACLBuilder {
             let mut request = self.queue_client.storage_client().prepare_request(
                 url,
                 Method::Put,
+                Headers::new(),
                 Some(xml_body.into()),
             )?;
 

--- a/sdk/storage_queues/src/operations/set_queue_metadata.rs
+++ b/sdk/storage_queues/src/operations/set_queue_metadata.rs
@@ -35,7 +35,7 @@ impl SetQueueMetadataBuilder {
             url.query_pairs_mut().append_pair("comp", "metadata");
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request = self.queue_client.storage_client().prepare_request(
+            let mut request = self.queue_client.storage_client().finalize_request(
                 url,
                 Method::Put,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/set_queue_metadata.rs
+++ b/sdk/storage_queues/src/operations/set_queue_metadata.rs
@@ -1,5 +1,7 @@
 use crate::clients::QueueClient;
-use azure_core::{error::Error, prelude::*, Context, Method, Response as AzureResponse};
+use azure_core::{
+    error::Error, headers::Headers, prelude::*, Context, Method, Response as AzureResponse,
+};
 use azure_storage::core::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
@@ -33,10 +35,12 @@ impl SetQueueMetadataBuilder {
             url.query_pairs_mut().append_pair("comp", "metadata");
             self.timeout.append_to_url_query(&mut url);
 
-            let mut request =
-                self.queue_client
-                    .storage_client()
-                    .prepare_request(url, Method::Put, None)?;
+            let mut request = self.queue_client.storage_client().prepare_request(
+                url,
+                Method::Put,
+                Headers::new(),
+                None,
+            )?;
             for m in self.metadata.iter() {
                 request.add_mandatory_header(&m);
             }

--- a/sdk/storage_queues/src/operations/set_queue_service_properties.rs
+++ b/sdk/storage_queues/src/operations/set_queue_service_properties.rs
@@ -50,7 +50,7 @@ impl SetQueueServicePropertiesBuilder {
             let xml_body =
                 serde_xml_rs::to_string(&self.properties).map_kind(ErrorKind::DataConversion)?;
 
-            let mut request = self.service_client.storage_client.prepare_request(
+            let mut request = self.service_client.storage_client.finalize_request(
                 url,
                 Method::Put,
                 Headers::new(),

--- a/sdk/storage_queues/src/operations/set_queue_service_properties.rs
+++ b/sdk/storage_queues/src/operations/set_queue_service_properties.rs
@@ -1,6 +1,7 @@
 use crate::{QueueServiceClient, QueueServiceProperties};
 use azure_core::{
     error::{Error, ErrorKind, ResultExt},
+    headers::Headers,
     prelude::*,
     Context, Method, Response as AzureResponse,
 };
@@ -52,6 +53,7 @@ impl SetQueueServicePropertiesBuilder {
             let mut request = self.service_client.storage_client.prepare_request(
                 url,
                 Method::Put,
+                Headers::new(),
                 Some(xml_body.into()),
             )?;
 

--- a/sdk/storage_queues/src/operations/update_message.rs
+++ b/sdk/storage_queues/src/operations/update_message.rs
@@ -1,6 +1,7 @@
 use crate::{clients::PopReceiptClient, prelude::*};
 use azure_core::{
     error::Error,
+    headers::Headers,
     headers::{rfc2822_from_headers_mandatory, HeaderName},
     prelude::*,
     Context, Method, Response as AzureResponse,
@@ -56,6 +57,7 @@ impl UpdateMessageBuilder {
             let mut request = self.pop_receipt_client.storage_client().prepare_request(
                 url,
                 Method::Put,
+                Headers::new(),
                 Some(message.into()),
             )?;
 

--- a/sdk/storage_queues/src/operations/update_message.rs
+++ b/sdk/storage_queues/src/operations/update_message.rs
@@ -54,7 +54,7 @@ impl UpdateMessageBuilder {
                 self.body
             );
 
-            let mut request = self.pop_receipt_client.storage_client().prepare_request(
+            let mut request = self.pop_receipt_client.storage_client().finalize_request(
                 url,
                 Method::Put,
                 Headers::new(),


### PR DESCRIPTION
`prepare_request` adds the authentication related headers.  When using Access Key methods, both Blob Storage and Data Tables uses data from the headers as part of canonicalized data that gets signed, which is checked at the server side.

As such, the headers must be part of what is sent to `prepare_request`.

See #871 for a walk through for Data Tables.