### PR TITLE
Make `Continuation` an associated type

### DIFF
--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::error::{Error, ErrorKind};
+use crate::prelude::Continuation;
 use crate::request_options::LeaseId;
 use crate::{RequestId, SessionToken};
 use chrono::{DateTime, FixedOffset, Utc};
@@ -68,8 +69,10 @@ pub fn utc_date_from_rfc2822(date: &str) -> crate::Result<DateTime<Utc>> {
 
 pub fn continuation_token_from_headers_optional(
     headers: &Headers,
-) -> crate::Result<Option<String>> {
-    Ok(headers.get_optional_string(&CONTINUATION))
+) -> crate::Result<Option<Continuation>> {
+    Ok(headers
+        .get_optional_string(&CONTINUATION)
+        .map(Continuation::from))
 }
 
 pub fn sku_name_from_headers(headers: &Headers) -> crate::Result<String> {

--- a/sdk/core/src/request_options/continuation.rs
+++ b/sdk/core/src/request_options/continuation.rs
@@ -1,50 +1,11 @@
-use crate::{headers, request_options::NextMarker, request_options::Range, Header};
-use std::ops::Range as StdRange;
+use crate::{headers, Header};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Continuation {
-    String(String),
-    Range(StdRange<u64>),
-}
-
-impl From<NextMarker> for Continuation {
-    fn from(next_marker: NextMarker) -> Self {
-        Continuation::String(next_marker.as_str().to_string())
-    }
-}
-
-impl From<&str> for Continuation {
-    fn from(value: &str) -> Self {
-        Continuation::String(value.to_string())
-    }
-}
+#[derive(Clone, Debug)]
+pub struct Continuation(String);
 
 impl From<String> for Continuation {
-    fn from(value: String) -> Self {
-        Continuation::String(value)
-    }
-}
-
-impl From<StdRange<u64>> for Continuation {
-    fn from(value: StdRange<u64>) -> Self {
-        Continuation::Range(value)
-    }
-}
-
-impl From<Range> for Continuation {
-    fn from(value: Range) -> Self {
-        Continuation::Range(value.start..value.end)
-    }
-}
-
-impl Continuation {
-    pub fn as_string(&self) -> String {
-        match self {
-            Self::String(c) => c.clone(),
-            Self::Range(_) => {
-                panic!("unable to convert Continuation::Range to string")
-            }
-        }
+    fn from(s: String) -> Self {
+        Self(s)
     }
 }
 
@@ -54,6 +15,6 @@ impl Header for Continuation {
     }
 
     fn value(&self) -> headers::HeaderValue {
-        self.as_string().into()
+        self.0.clone().into()
     }
 }

--- a/sdk/core/src/request_options/next_marker.rs
+++ b/sdk/core/src/request_options/next_marker.rs
@@ -1,4 +1,3 @@
-use super::Continuation;
 use crate::headers::{self, Headers};
 use crate::AppendToUrlQuery;
 use serde::{Deserialize, Serialize};
@@ -43,12 +42,6 @@ impl NextMarker {
 impl AppendToUrlQuery for NextMarker {
     fn append_to_url_query(&self, url: &mut url::Url) {
         url.query_pairs_mut().append_pair("marker", &self.0);
-    }
-}
-
-impl From<Continuation> for NextMarker {
-    fn from(next_marker: Continuation) -> Self {
-        Self::new(next_marker.as_string())
     }
 }
 

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -95,7 +95,7 @@ struct JsonListAttachmentResponse {
     pub attachments: Vec<Attachment>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ListAttachmentsResponse {
     pub rid: String,
     pub count: u64,
@@ -120,7 +120,7 @@ pub struct ListAttachmentsResponse {
     pub activity_id: uuid::Uuid,
     pub gateway_version: String,
     pub date: DateTime<Utc>,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl ListAttachmentsResponse {
@@ -160,7 +160,8 @@ impl ListAttachmentsResponse {
 }
 
 impl Continuable for ListAttachmentsResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -60,7 +60,7 @@ impl ListCollectionsBuilder {
 
 pub type ListCollections = Pageable<ListCollectionsResponse, azure_core::error::Error>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ListCollectionsResponse {
     pub rid: String,
     pub collections: Vec<Collection>,
@@ -76,7 +76,7 @@ pub struct ListCollectionsResponse {
     pub activity_id: uuid::Uuid,
     pub session_token: String,
     pub gateway_version: String,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl ListCollectionsResponse {
@@ -116,7 +116,8 @@ impl ListCollectionsResponse {
 }
 
 impl Continuable for ListCollectionsResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -59,7 +59,7 @@ impl ListDatabasesBuilder {
 
 pub type ListDatabases = Pageable<ListDatabasesResponse, azure_core::error::Error>;
 
-#[derive(Clone, PartialEq, PartialOrd, Debug)]
+#[derive(Clone, Debug)]
 pub struct ListDatabasesResponse {
     pub rid: String,
     pub databases: Vec<Database>,
@@ -72,7 +72,7 @@ pub struct ListDatabasesResponse {
     pub resource_usage: Vec<ResourceQuota>,
     pub schema_version: String,
     pub service_version: String,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
     pub gateway_version: String,
 }
 
@@ -112,8 +112,9 @@ impl ListDatabasesResponse {
 }
 
 impl Continuable for ListDatabasesResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }
 

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -121,7 +121,7 @@ pub struct ListDocumentsResponse<T> {
     pub activity_id: uuid::Uuid,
     pub gateway_version: String,
     pub date: DateTime<Utc>,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -192,8 +192,9 @@ where
 }
 
 impl<T> Continuable for ListDocumentsResponse<T> {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }
 

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -67,7 +67,7 @@ impl ListPermissionsBuilder {
 
 pub type ListPermissions = Pageable<ListPermissionsResponse, azure_core::error::Error>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ListPermissionsResponse {
     pub permissions: Vec<Permission>,
     pub charge: f64,
@@ -75,7 +75,7 @@ pub struct ListPermissionsResponse {
     pub session_token: String,
     pub content_path: String,
     pub alt_content_path: String,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl ListPermissionsResponse {
@@ -107,7 +107,8 @@ impl ListPermissionsResponse {
 }
 
 impl Continuable for ListPermissionsResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -72,7 +72,7 @@ impl ListStoredProceduresBuilder {
 
 pub type ListStoredProcedures = Pageable<ListStoredProceduresResponse, azure_core::error::Error>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ListStoredProceduresResponse {
     pub stored_procedures: Vec<StoredProcedure>,
     pub charge: f64,
@@ -82,7 +82,7 @@ pub struct ListStoredProceduresResponse {
     pub resource_quota: Vec<ResourceQuota>,
     pub resource_usage: Vec<ResourceQuota>,
     pub gateway_version: String,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl ListStoredProceduresResponse {
@@ -113,7 +113,8 @@ impl ListStoredProceduresResponse {
 }
 
 impl Continuable for ListStoredProceduresResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -74,14 +74,14 @@ impl ListTriggersBuilder {
 /// The future returned by calling `into_future` on the builder.
 pub type ListTriggers = Pageable<ListTriggersResponse, azure_core::error::Error>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ListTriggersResponse {
     pub rid: String,
     pub triggers: Vec<Trigger>,
     pub content_location: String,
     pub server: String,
     pub last_state_change: DateTime<Utc>,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
     pub resource_quota: Vec<ResourceQuota>,
     pub resource_usage: Vec<ResourceQuota>,
     pub lsn: u64,
@@ -149,7 +149,8 @@ impl ListTriggersResponse {
 }
 
 impl Continuable for ListTriggersResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -78,14 +78,14 @@ impl ListUserDefinedFunctionsBuilder {
 pub type ListUserDefinedFunctions =
     Pageable<ListUserDefinedFunctionsResponse, azure_core::error::Error>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ListUserDefinedFunctionsResponse {
     pub rid: String,
     pub user_defined_functions: Vec<UserDefinedFunction>,
     pub content_location: String,
     pub server: String,
     pub last_state_change: DateTime<Utc>,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
     pub resource_quota: Vec<ResourceQuota>,
     pub resource_usage: Vec<ResourceQuota>,
     pub lsn: u64,
@@ -153,7 +153,8 @@ impl ListUserDefinedFunctionsResponse {
 }
 
 impl Continuable for ListUserDefinedFunctionsResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -68,7 +68,7 @@ impl ListUsersBuilder {
 
 pub type ListUsers = Pageable<ListUsersResponse, azure_core::error::Error>;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct ListUsersResponse {
     pub users: Vec<User>,
     pub rid: String,
@@ -76,7 +76,7 @@ pub struct ListUsersResponse {
     pub charge: f64,
     pub activity_id: uuid::Uuid,
     pub session_token: SessionToken,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl ListUsersResponse {
@@ -119,7 +119,8 @@ impl IntoIterator for ListUsersResponse {
 }
 
 impl Continuable for ListUsersResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -174,7 +174,7 @@ pub enum QueryResult<T> {
     Raw(T),
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct QueryDocumentsResponse<T> {
     pub query_response_meta: QueryResponseMeta,
     pub results: Vec<QueryResult<T>>,
@@ -201,7 +201,7 @@ pub struct QueryDocumentsResponse<T> {
     pub activity_id: uuid::Uuid,
     pub gateway_version: String,
     pub date: DateTime<Utc>,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl<T> QueryDocumentsResponse<T> {
@@ -280,7 +280,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct QueryDocumentsResponseRaw<T> {
     pub query_response_meta: QueryResponseMeta,
     pub results: Vec<T>,
@@ -308,7 +308,7 @@ pub struct QueryDocumentsResponseRaw<T> {
     pub activity_id: uuid::Uuid,
     pub gateway_version: String,
     pub date: DateTime<Utc>,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl<T> std::convert::From<QueryDocumentsResponse<T>> for QueryDocumentsResponseRaw<T> {
@@ -352,7 +352,7 @@ impl<T> std::convert::From<QueryDocumentsResponse<T>> for QueryDocumentsResponse
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct QueryDocumentsResponseDocuments<T> {
     pub query_response_meta: QueryResponseMeta,
     pub results: Vec<DocumentQueryResult<T>>,
@@ -380,7 +380,7 @@ pub struct QueryDocumentsResponseDocuments<T> {
     pub activity_id: uuid::Uuid,
     pub gateway_version: String,
     pub date: DateTime<Utc>,
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
 }
 
 impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsResponseDocuments<T> {
@@ -430,8 +430,10 @@ impl<T> std::convert::TryFrom<QueryDocumentsResponse<T>> for QueryDocumentsRespo
         })
     }
 }
+
 impl<T> Continuable for QueryDocumentsResponse<T> {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation_token.clone().map(Continuation::from)
+    type Continuation = Continuation;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }

--- a/sdk/iot_hub/examples/query_iothub.rs
+++ b/sdk/iot_hub/examples/query_iothub.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let response = service_client
         .query()
         .max_item_count(1)
-        .continuation(token.as_str())
+        .continuation(token)
         .execute(query)
         .await?;
 

--- a/sdk/iot_hub/src/service/requests/query_builder.rs
+++ b/sdk/iot_hub/src/service/requests/query_builder.rs
@@ -31,8 +31,8 @@ impl<'a> QueryBuilder<'a> {
     }
 
     azure_core::setters! {
-        continuation: String => Some(Continuation::String(continuation)),
         max_item_count: i32 => MaxItemCount::new(max_item_count),
+        continuation: Continuation => Some(continuation),
     }
 
     /// Invoke a qiven query on the IoT Hub

--- a/sdk/iot_hub/src/service/responses/query_response.rs
+++ b/sdk/iot_hub/src/service/responses/query_response.rs
@@ -1,5 +1,6 @@
 use azure_core::error::Error;
 use azure_core::headers::{self, continuation_token_from_headers_optional};
+use azure_core::prelude::Continuation;
 use serde_json::Value;
 
 /// The response for a query invocation
@@ -7,7 +8,7 @@ pub struct QueryResponse {
     /// The result of the query
     pub result: Value,
     /// The continuation token for the next result of the query
-    pub continuation_token: Option<String>,
+    pub continuation_token: Option<Continuation>,
     /// The type of the item in the result
     pub item_type: String,
 }

--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -41,17 +41,14 @@ impl GetBlobBuilder {
     }
 
     pub fn into_stream(self) -> Pageable<GetBlobResponse, Error> {
-        let make_request = move |continuation: Option<Continuation>| {
+        let make_request = move |continuation: Option<Range>| {
             let this = self.clone();
             let mut ctx = self.context.clone();
             async move {
                 let mut url = this.blob_client.url_with_segments(None)?;
 
                 let range = match continuation {
-                    Some(Continuation::String(_)) => {
-                        panic!("unexpected contination type")
-                    }
-                    Some(Continuation::Range(range)) => range.into(),
+                    Some(range) => range,
                     None => initial_range(this.chunk_size, this.range),
                 };
 
@@ -112,8 +109,9 @@ impl GetBlobResponse {
 }
 
 impl Continuable for GetBlobResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.remaining_range.map(Continuation::from)
+    type Continuation = Range;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.remaining_range
     }
 }
 

--- a/sdk/storage_blobs/src/container/operations/list_containers.rs
+++ b/sdk/storage_blobs/src/container/operations/list_containers.rs
@@ -42,7 +42,7 @@ impl ListContainersBuilder {
     }
 
     pub fn into_stream(self) -> Pageable<ListContainersResponse, Error> {
-        let make_request = move |continuation: Option<Continuation>| {
+        let make_request = move |continuation: Option<NextMarker>| {
             let this = self.clone();
             let mut ctx = self.context.clone();
             async move {
@@ -57,9 +57,8 @@ impl ListContainersBuilder {
 
                 this.prefix.append_to_url_query(&mut url);
 
-                if let Some(continuation) = continuation {
-                    url.query_pairs_mut()
-                        .append_pair("marker", &continuation.as_string());
+                if let Some(next_marker) = continuation {
+                    next_marker.append_to_url_query(&mut url);
                 }
 
                 if let Some(include) = match (this.include_metadata, this.include_deleted) {
@@ -119,7 +118,8 @@ impl ListContainersResponse {
 }
 
 impl Continuable for ListContainersResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.next_marker.clone().map(Continuation::from)
+    type Continuation = NextMarker;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.next_marker.clone().map(NextMarker::from)
     }
 }

--- a/sdk/storage_datalake/src/operations/file_systems_list.rs
+++ b/sdk/storage_datalake/src/operations/file_systems_list.rs
@@ -41,7 +41,7 @@ impl ListFileSystemsBuilder {
     }
 
     pub fn into_stream(self) -> ListFileSystems {
-        let make_request = move |continuation: Option<Continuation>| {
+        let make_request = move |continuation: Option<NextMarker>| {
             let this = self.clone();
             let ctx = self.context.clone().unwrap_or_default();
 
@@ -53,8 +53,7 @@ impl ListFileSystemsBuilder {
                 this.timeout.append_to_url_query(&mut url);
 
                 if let Some(c) = continuation {
-                    let nm: NextMarker = c.into();
-                    nm.append_to_url_query_as_continuation(&mut url);
+                    c.append_to_url_query_as_continuation(&mut url);
                 } else {
                     this.next_marker.append_to_url_query(&mut url);
                 };
@@ -99,8 +98,9 @@ impl ListFileSystemsResponse {
 }
 
 impl Continuable for ListFileSystemsResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.next_marker.clone().map(Continuation::from)
+    type Continuation = NextMarker;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.next_marker.clone()
     }
 }
 

--- a/sdk/storage_datalake/src/operations/path_list.rs
+++ b/sdk/storage_datalake/src/operations/path_list.rs
@@ -52,7 +52,7 @@ impl ListPathsBuilder {
     }
 
     pub fn into_stream(self) -> ListPaths {
-        let make_request = move |continuation: Option<Continuation>| {
+        let make_request = move |continuation: Option<NextMarker>| {
             let this = self.clone();
             let ctx = self.context.clone();
 
@@ -112,8 +112,9 @@ impl ListPathsResponse {
 }
 
 impl Continuable for ListPathsResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.continuation.clone().map(Continuation::from)
+    type Continuation = NextMarker;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation.clone()
     }
 }
 

--- a/sdk/storage_queues/src/operations/list_queues.rs
+++ b/sdk/storage_queues/src/operations/list_queues.rs
@@ -37,7 +37,7 @@ impl ListQueuesBuilder {
     }
 
     pub fn into_stream(self) -> Pageable<ListQueuesResponse, Error> {
-        let make_request = move |continuation: Option<Continuation>| {
+        let make_request = move |continuation: Option<NextMarker>| {
             let mut this = self.clone();
             async move {
                 let mut url = this
@@ -51,9 +51,8 @@ impl ListQueuesBuilder {
 
                 this.prefix.append_to_url_query(&mut url);
 
-                if let Some(continuation) = continuation {
-                    url.query_pairs_mut()
-                        .append_pair("marker", &continuation.as_string());
+                if let Some(next_marker) = continuation {
+                    next_marker.append_to_url_query(&mut url);
                 }
 
                 this.max_results.append_to_url_query(&mut url);
@@ -96,8 +95,9 @@ pub struct ListQueuesResponse {
 }
 
 impl Continuable for ListQueuesResponse {
-    fn continuation(&self) -> Option<Continuation> {
-        self.next_marker.clone().map(Continuation::from)
+    type Continuation = NextMarker;
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.next_marker.clone()
     }
 }
 


### PR DESCRIPTION
This adds an associated type to `Continuable` called `Continuation`. This means that implementors of `Continuable` are in charge of specifying which type is used to indicate how they continue. This removes a bunch of run time checks that the right type of `Continuation` was used.