### PR TITLE
Only add params if they don't already exist

### DIFF
--- a/sdk/storage/src/core/clients/storage_account_client.rs
+++ b/sdk/storage/src/core/clients/storage_account_client.rs
@@ -429,7 +429,15 @@ impl StorageAccountClient {
         // if we have a SAS token (in form of query pairs), let's add it to the url here
         if let StorageCredentials::SASToken(query_pairs) = &self.storage_credentials {
             for (k, v) in query_pairs {
-                request.url_mut().query_pairs_mut().append_pair(k, v);
+                // TODO: this is a temporary fix so that we don't double add SAS tokens
+                // This can be removed when all Storage SDKs have been moved to the pipeline architecture
+                if !request
+                    .url()
+                    .query_pairs()
+                    .any(|(existing, _)| &*existing == k)
+                {
+                    request.url_mut().query_pairs_mut().append_pair(k, v);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #867 

Once we move all of the SDKs that use the `StorageAccountClient` to the pipeline architecture, this workaround can be removed. 