### PR TITLE
Try out an operation macro

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0"
 url = "2.2"
 uuid = { version = "1.0" }
 pin-project = "1.0.10"
+paste = "1.0"
 
 # Add dependency to getrandom to enable WASM support
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -89,3 +89,9 @@ where
         }
     }
 }
+
+#[doc(hidden)]
+/// Used by macros as an implementation detail
+pub mod __private {
+    pub use paste::paste;
+}

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -121,8 +121,8 @@ macro_rules! setters {
 ///     futures::future::BoxFuture<'static, azure_core::Result<CreateCollectionResponse>>;
 /// ```
 ///
-/// Additionally, `@list` can be used before the operation name to generate code appropriate for list operations
-/// and `??` can be used at the end of the list of options for options where we should not generate a setter.
+/// Additionally, `#[stream]` can be used before the operation name to generate code appropriate for list operations
+/// and `#[skip]` can be used at the end of the list of options for options where we should not generate a setter.
 #[macro_export]
 macro_rules! operation {
     // Construct the builder.
@@ -222,8 +222,8 @@ macro_rules! operation {
                 @nosetter
             }
     };
-    // `operation! { @list ListUsers, client: UserClient, ?consistency_level: ConsistencyLevel }`
-    (@list $name:ident,
+    // `operation! { #[stream] ListUsers, client: UserClient, ?consistency_level: ConsistencyLevel }`
+    (#[stream] $name:ident,
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty),*) => {
@@ -238,7 +238,7 @@ macro_rules! operation {
                 @nosetter
             }
     };
-    (@list $name:ident,
+    (#[stream] $name:ident,
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty,)*

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -242,7 +242,7 @@ macro_rules! operation {
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty,)*
-        $(??$nosetter:ident: $nstype:ty),*
+        $(#[skip]$nosetter:ident: $nstype:ty),*
     ) => {
             operation!{
                 @builder
@@ -261,7 +261,7 @@ macro_rules! operation {
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty,)*
-        $(??$nosetter:ident: $nstype:ty),*) => {
+        $(#[skip] $nosetter:ident: $nstype:ty),*) => {
             operation!{
                 $name<$($generic: $first_constraint $(+ $constraint)*),*>,
                 client: $client,

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -41,15 +41,15 @@ macro_rules! setters {
     (@recurse) => {};
     // Recurse without transform
     (@recurse $name:ident : $typ:ty, $($tokens:tt)*) => {
-        setters! { @recurse $name: $typ => $name, $($tokens)* }
+        $crate::setters! { @recurse $name: $typ => $name, $($tokens)* }
     };
     // Recurse with transform
     (@recurse $name:ident : $typ:ty => $transform:expr, $($tokens:tt)*) => {
-        setters! { @single $name : $typ => $transform }
-        setters! { @recurse $($tokens)* }
+        $crate::setters! { @single $name : $typ => $transform }
+        $crate::setters! { @recurse $($tokens)* }
     };
     ($($tokens:tt)*) => {
-        setters! { @recurse $($tokens)* }
+        $crate::setters! { @recurse $($tokens)* }
     }
 }
 
@@ -57,28 +57,30 @@ macro_rules! setters {
 ///
 /// For the following code:
 /// ```
-/// operation! {
+/// # #[derive(Clone, Debug)]
+/// # struct DatabaseClient;
+/// # struct CreateCollectionResponse;
+/// azure_core::operation! {
 ///    CreateCollection,
 ///    client: DatabaseClient,
 ///    collection_name: String,
-///    partition_key: PartitionKey,
-///    ?consistency_level: ConsistencyLevel,
-///    ?indexing_policy: IndexingPolicy,
-///    ?offer: Offer
-///}
+///    ?consistency_level: u32
+/// }
 /// ```
 ///
 /// The following code will be generated
 ///
 /// ```
+/// # use azure_core::setters;
+/// # use azure_core::Context;
+/// # #[derive(Clone, Debug)]
+/// # struct DatabaseClient;
+/// # struct CreateCollectionResponse;
 /// #[derive(Debug, Clone)]
 /// pub struct CreateCollectionBuilder {
 ///     client: DatabaseClient,
 ///     collection_name: String,
-///     partition_key: PartitionKey,
-///     consistency_level: Option<ConsistencyLevel>,
-///     indexing_policy: Option<IndexingPolicy>,
-///     offer: Option<Offer>,
+///     consistency_level: Option<u32>,
 ///     context: Context,
 /// }
 ///
@@ -86,23 +88,17 @@ macro_rules! setters {
 ///     pub(crate) fn new(
 ///         client: DatabaseClient,
 ///         collection_name: String,
-///         partition_key: PartitionKey,
 ///     ) -> Self {
 ///         Self {
 ///             client,
 ///             collection_name,
-///             partition_key,
 ///             consistency_level: None,
-///             indexing_policy: None,
-///             offer: None,
 ///             context: Context::new(),
 ///         }
 ///     }
 ///
 ///     setters! {
-///         consistency_level: ConsistencyLevel => Some(consistency_level),
-///         indexing_policy: IndexingPolicy => Some(indexing_policy),
-///         offer: Offer => Some(offer),
+///         consistency_level: u32 => Some(consistency_level),
 ///         context: Context => context,
 ///     }
 /// }
@@ -166,7 +162,7 @@ macro_rules! operation {
                 }
             }
 
-            setters! {
+            $crate::setters! {
                 $($optional: $otype => Some($optional),)*
                 context: azure_core::Context => context,
             }
@@ -183,7 +179,7 @@ macro_rules! operation {
         @nosetter
         $($nosetter:ident: $nstype:ty),*
         ) => {
-        operation! {
+        $crate::operation! {
             @builder $name<$($generic: $first_constraint $(+ $constraint)*),*>,
             client: $client,
             @required
@@ -212,7 +208,7 @@ macro_rules! operation {
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty),*) => {
-            operation!{
+            $crate::operation!{
                 $name<>,
                 client: $client,
                 @required
@@ -227,7 +223,7 @@ macro_rules! operation {
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty),*) => {
-            operation!{
+            $crate::operation!{
                 @builder
                 $name<>,
                 client: $client,
@@ -244,7 +240,7 @@ macro_rules! operation {
         $(?$optional:ident: $otype:ty,)*
         $(#[skip]$nosetter:ident: $nstype:ty),*
     ) => {
-            operation!{
+            $crate::operation!{
                 @builder
                 $name<>,
                 client: $client,
@@ -262,7 +258,7 @@ macro_rules! operation {
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty,)*
         $(#[skip] $nosetter:ident: $nstype:ty),*) => {
-            operation!{
+            $crate::operation!{
                 $name<$($generic: $first_constraint $(+ $constraint)*),*>,
                 client: $client,
                 @required

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -128,7 +128,7 @@ macro_rules! operation {
     // Construct the builder.
     (@builder
         // The name of the operation and any generic params along with their constraints
-        $name:ident<$($generic:ident: $($constraint:ident +)*),*>,
+        $name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)* ),*>,
         // The client
         client: $client:ty,
         // The required fields that will be used in the constructor
@@ -152,7 +152,7 @@ macro_rules! operation {
         }
 
         /// Setters for the various options for this builder
-        impl <$($generic: $($constraint +)*)*>[<$name Builder>]<$($generic),*> {
+        impl <$($generic: $first_constraint $(+ $constraint)* )*>[<$name Builder>]<$($generic),*> {
             pub(crate) fn new(
                 client: $client,
                 $($required: $rtype,)*
@@ -174,7 +174,7 @@ macro_rules! operation {
         }
     };
     // Construct a builder and the `Future` related code
-    ($name:ident<$($generic:ident: $($constraint:ident +)*),*>,
+    ($name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)* ),*>,
         client: $client:ty,
         @required
         $($required:ident: $rtype:ty,)*
@@ -184,7 +184,7 @@ macro_rules! operation {
         $($nosetter:ident: $nstype:ty),*
         ) => {
         operation! {
-            @builder $name<$($generic: $($constraint +)*),*>,
+            @builder $name<$($generic: $first_constraint $(+ $constraint)*),*>,
             client: $client,
             @required
             $($required: $rtype,)*
@@ -257,13 +257,13 @@ macro_rules! operation {
             }
     };
     // `operation! { CreateDocument<D: Serialize>, client: UserClient, ?consistency_level: ConsistencyLevel, ??other_field: bool }`
-    ($name:ident<$($generic:ident: $($constraint:ident +)*),*>,
+    ($name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)*),*>,
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty,)*
         $(??$nosetter:ident: $nstype:ty),*) => {
             operation!{
-                $name<$($generic: $($constraint +)*),*>,
+                $name<$($generic: $first_constraint $(+ $constraint)*),*>,
                 client: $client,
                 @required
                 $($required: $rtype,)*

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -238,6 +238,24 @@ macro_rules! operation {
                 @nosetter
             }
     };
+    (@list $name:ident,
+        client: $client:ty,
+        $($required:ident: $rtype:ty,)*
+        $(?$optional:ident: $otype:ty,)*
+        $(??$nosetter:ident: $nstype:ty),*
+    ) => {
+            operation!{
+                @builder
+                $name<>,
+                client: $client,
+                @required
+                $($required: $rtype,)*
+                @optional
+                $($optional: $otype,)*
+                @nosetter
+                $($nosetter: $nstype),*
+            }
+    };
     // `operation! { CreateDocument<D: Serialize>, client: UserClient, ?consistency_level: ConsistencyLevel, ??other_field: bool }`
     ($name:ident<$($generic:ident: $($constraint:ident +)*),*>,
         client: $client:ty,

--- a/sdk/core/src/request_options/if_modified_since.rs
+++ b/sdk/core/src/request_options/if_modified_since.rs
@@ -19,3 +19,9 @@ impl Header for IfModifiedSince {
         self.0.to_rfc2822().into()
     }
 }
+
+impl From<DateTime<Utc>> for IfModifiedSince {
+    fn from(time: DateTime<Utc>) -> Self {
+        Self::new(time)
+    }
+}

--- a/sdk/core/src/request_options/max_item_count.rs
+++ b/sdk/core/src/request_options/max_item_count.rs
@@ -27,3 +27,9 @@ impl From<i32> for MaxItemCount {
         Self::new(count)
     }
 }
+
+impl Default for MaxItemCount {
+    fn default() -> Self {
+        MaxItemCount::new(-1)
+    }
+}

--- a/sdk/core/src/request_options/max_item_count.rs
+++ b/sdk/core/src/request_options/max_item_count.rs
@@ -21,3 +21,9 @@ impl Header for MaxItemCount {
         format!("{}", count).into()
     }
 }
+
+impl From<i32> for MaxItemCount {
+    fn from(count: i32) -> Self {
+        Self::new(count)
+    }
+}

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 use azure_core::{collect_pinned_stream, Response as HttpResponse};
 
 operation! {
-    CreateDocument<D: Serialize + CosmosEntity + Send +>,
+    CreateDocument<D: Serialize + CosmosEntity + Send>,
     client: CollectionClient,
     document: D,
     ?is_upsert: bool,

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -21,7 +21,8 @@ operation! {
     ?if_modified_since: IfModifiedSince,
     ?consistency_level: ConsistencyLevel,
     ?allow_tentative_writes: TentativeWritesAllowance,
-    ??partition_key: String
+    #[skip]
+    partition_key: String
 }
 
 impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -4,42 +4,20 @@ use crate::resources::Attachment;
 use crate::ResourceQuota;
 
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::prelude::*;
 use azure_core::SessionToken;
 use azure_core::{collect_pinned_stream, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct CreateOrReplaceAttachmentBuilder {
+operation! {
+    CreateOrReplaceAttachment,
     client: AttachmentClient,
     is_create: bool,
     media: String,
     content_type: String,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl CreateOrReplaceAttachmentBuilder {
-    pub(crate) fn new(
-        client: AttachmentClient,
-        is_create: bool,
-        media: String,
-        content_type: String,
-    ) -> Self {
-        Self {
-            client,
-            is_create,
-            media,
-            content_type,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> CreateOrReplaceAttachment {
         Box::pin(async move {
             let mut req = if self.is_create {
@@ -82,19 +60,6 @@ impl CreateOrReplaceAttachmentBuilder {
                 .await?;
             CreateOrReplaceAttachmentResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type CreateOrReplaceAttachment =
-    futures::future::BoxFuture<'static, azure_core::Result<CreateOrReplaceAttachmentResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for CreateOrReplaceAttachmentBuilder {
-    type IntoFuture = CreateOrReplaceAttachment;
-    type Output = <CreateOrReplaceAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -13,39 +13,17 @@ use azure_core::{content_type, prelude::*};
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct CreateOrReplaceSlugAttachmentBuilder {
+operation! {
+    CreateOrReplaceSlugAttachment,
     client: AttachmentClient,
     is_create: bool,
     body: Bytes,
-    if_match_condition: Option<IfMatchCondition>,
-    consistency_level: Option<ConsistencyLevel>,
-    content_type: Option<String>,
-    context: Context,
+    ?if_match_condition: IfMatchCondition,
+    ?consistency_level: ConsistencyLevel,
+    ?content_type: String
 }
 
 impl CreateOrReplaceSlugAttachmentBuilder {
-    pub(crate) fn new(client: AttachmentClient, is_create: bool, body: Bytes) -> Self {
-        Self {
-            client,
-            is_create,
-            body,
-            if_match_condition: None,
-            consistency_level: None,
-            content_type: None,
-            context: Context::new(),
-        }
-    }
-}
-
-impl CreateOrReplaceSlugAttachmentBuilder {
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        content_type: String => Some(content_type),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> CreateOrReplaceSlugAttachment {
         Box::pin(async move {
             let mut request = if self.is_create {
@@ -93,18 +71,6 @@ impl CreateOrReplaceSlugAttachmentBuilder {
 
             CreateOrReplaceSlugAttachmentResponse::try_from(response).await
         })
-    }
-}
-/// The future returned by calling `into_future` on the builder.
-pub type CreateOrReplaceSlugAttachment =
-    futures::future::BoxFuture<'static, azure_core::Result<CreateOrReplaceSlugAttachmentResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for CreateOrReplaceSlugAttachmentBuilder {
-    type IntoFuture = CreateOrReplaceSlugAttachment;
-    type Output = <CreateOrReplaceSlugAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -5,45 +5,20 @@ use crate::resources::Trigger;
 use crate::ResourceQuota;
 use azure_core::collect_pinned_stream;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::prelude::*;
 use azure_core::Response as HttpResponse;
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct CreateOrReplaceTriggerBuilder {
+operation! {
+    CreateOrReplaceTrigger,
     client: TriggerClient,
     is_create: bool,
     body: String,
     trigger_type: TriggerType,
     trigger_operation: TriggerOperation,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl CreateOrReplaceTriggerBuilder {
-    pub(crate) fn new(
-        client: TriggerClient,
-        is_create: bool,
-        body: String,
-        trigger_type: TriggerType,
-        trigger_operation: TriggerOperation,
-    ) -> Self {
-        Self {
-            client,
-            is_create,
-            body,
-            trigger_operation,
-            trigger_type,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> CreateOrReplaceTrigger {
         Box::pin(async move {
             let mut request = if self.is_create {
@@ -85,18 +60,6 @@ impl CreateOrReplaceTriggerBuilder {
 
             CreateOrReplaceTriggerResponse::try_from(response).await
         })
-    }
-}
-/// The future returned by calling `into_future` on the builder.
-pub type CreateOrReplaceTrigger =
-    futures::future::BoxFuture<'static, azure_core::Result<CreateOrReplaceTriggerResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for CreateOrReplaceTriggerBuilder {
-    type IntoFuture = CreateOrReplaceTrigger;
-    type Output = <CreateOrReplaceTrigger as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -4,35 +4,18 @@ use crate::resources::UserDefinedFunction;
 use crate::ResourceQuota;
 
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::prelude::*;
 use azure_core::{collect_pinned_stream, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct CreateOrReplaceUserDefinedFunctionBuilder {
+operation! {
+    CreateOrReplaceUserDefinedFunction,
     client: UserDefinedFunctionClient,
     is_create: bool,
     body: String,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl CreateOrReplaceUserDefinedFunctionBuilder {
-    pub(crate) fn new(client: UserDefinedFunctionClient, is_create: bool, body: String) -> Self {
-        Self {
-            client,
-            is_create,
-            body,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> CreateOrReplaceUserDefinedFunction {
         Box::pin(async move {
             let mut request = match self.is_create {
@@ -65,21 +48,6 @@ impl CreateOrReplaceUserDefinedFunctionBuilder {
 
             CreateOrReplaceUserDefinedFunctionResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type CreateOrReplaceUserDefinedFunction = futures::future::BoxFuture<
-    'static,
-    azure_core::Result<CreateOrReplaceUserDefinedFunctionResponse>,
->;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for CreateOrReplaceUserDefinedFunctionBuilder {
-    type IntoFuture = CreateOrReplaceUserDefinedFunction;
-    type Output = <CreateOrReplaceUserDefinedFunction as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -3,32 +3,17 @@ use crate::prelude::*;
 use crate::resources::StoredProcedure;
 use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::{collect_pinned_stream, Context, Response as HttpResponse};
+use azure_core::{collect_pinned_stream, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct CreateStoredProcedureBuilder {
+operation! {
+    CreateStoredProcedure,
     client: StoredProcedureClient,
     function_body: String,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl CreateStoredProcedureBuilder {
-    pub(crate) fn new(client: StoredProcedureClient, body: String) -> Self {
-        Self {
-            client,
-            function_body: body,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> CreateStoredProcedure {
         Box::pin(async move {
             let mut req = self
@@ -63,19 +48,6 @@ impl CreateStoredProcedureBuilder {
         })
     }
 }
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for CreateStoredProcedureBuilder {
-    type IntoFuture = CreateStoredProcedure;
-    type Output = <CreateStoredProcedure as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type CreateStoredProcedure =
-    futures::future::BoxFuture<'static, azure_core::Result<CreateStoredProcedureResponse>>;
 
 /// A stored procedure response
 #[derive(Debug, Clone, PartialEq)]

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -1,27 +1,12 @@
-use crate::{prelude::*, resources::user::UserResponse};
-use azure_core::Context;
+use crate::{prelude::*, resources::user::UserResponse as CreateUserResponse};
 
-#[derive(Debug, Clone)]
-pub struct CreateUserBuilder {
+operation! {
+    CreateUser,
     client: UserClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl CreateUserBuilder {
-    pub(crate) fn new(client: UserClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> CreateUser {
         Box::pin(async move {
             let mut request = self.client.cosmos_client().request(
@@ -48,20 +33,8 @@ impl CreateUserBuilder {
                 )
                 .await?;
 
-            UserResponse::try_from(response).await
+            CreateUserResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type CreateUser = futures::future::BoxFuture<'static, azure_core::Result<UserResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for CreateUserBuilder {
-    type IntoFuture = CreateUser;
-    type Output = <CreateUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -8,30 +8,14 @@ use azure_core::Response as HttpResponse;
 use azure_core::SessionToken;
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct DeleteAttachmentBuilder {
+operation! {
+    DeleteAttachment,
     client: AttachmentClient,
-    if_match_condition: Option<IfMatchCondition>,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?if_match_condition: IfMatchCondition,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeleteAttachmentBuilder {
-    pub(crate) fn new(client: AttachmentClient) -> Self {
-        Self {
-            client,
-            if_match_condition: None,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> DeleteAttachment {
         Box::pin(async move {
             let mut request = self.client.attachment_request(azure_core::Method::Delete);
@@ -56,19 +40,6 @@ impl DeleteAttachmentBuilder {
 
             DeleteAttachmentResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeleteAttachment =
-    futures::future::BoxFuture<'static, azure_core::Result<DeleteAttachmentResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeleteAttachmentBuilder {
-    type IntoFuture = DeleteAttachment;
-    type Output = <DeleteAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use crate::{headers::from_headers::*, ResourceQuota};
 use azure_core::headers::{content_type_from_headers, session_token_from_headers};
-use azure_core::{Response as HttpResponse};
+use azure_core::Response as HttpResponse;
 use chrono::{DateTime, Utc};
 
 operation! {

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -1,30 +1,16 @@
 use crate::prelude::*;
 use crate::{headers::from_headers::*, ResourceQuota};
 use azure_core::headers::{content_type_from_headers, session_token_from_headers};
-use azure_core::{Context, Response as HttpResponse};
+use azure_core::{Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct DeleteCollectionBuilder {
+operation! {
+    DeleteCollection,
     client: CollectionClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeleteCollectionBuilder {
-    pub fn new(client: CollectionClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> DeleteCollection {
         Box::pin(async move {
             let mut request = self.client.collection_request(azure_core::Method::Delete);
@@ -44,19 +30,6 @@ impl DeleteCollectionBuilder {
 
             DeleteCollectionResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeleteCollection =
-    futures::future::BoxFuture<'static, azure_core::Result<DeleteCollectionResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeleteCollectionBuilder {
-    type IntoFuture = DeleteCollection;
-    type Output = <DeleteCollection as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -2,30 +2,15 @@ use crate::headers::from_headers::*;
 use crate::prelude::*;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
-use azure_core::Context;
 use azure_core::Response as HttpResponse;
 
-#[derive(Debug, Clone)]
-pub struct DeleteDatabaseBuilder {
+operation! {
+    DeleteDatabase,
     client: DatabaseClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeleteDatabaseBuilder {
-    pub(crate) fn new(client: DatabaseClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> DeleteDatabase {
         Box::pin(async move {
             let mut request = self.client.database_request(azure_core::Method::Delete);
@@ -40,19 +25,6 @@ impl DeleteDatabaseBuilder {
                 .await?;
             DeleteDatabaseResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeleteDatabase =
-    futures::future::BoxFuture<'static, azure_core::Result<DeleteDatabaseResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeleteDatabaseBuilder {
-    type IntoFuture = DeleteDatabase;
-    type Output = <DeleteDatabase as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -2,30 +2,15 @@ use crate::headers::from_headers::*;
 use crate::prelude::*;
 
 use azure_core::headers::session_token_from_headers;
-use azure_core::Context;
 use azure_core::Response as HttpResponse;
 
-#[derive(Debug, Clone)]
-pub struct DeletePermissionBuilder {
+operation! {
+    DeletePermission,
     client: PermissionClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeletePermissionBuilder {
-    pub(crate) fn new(client: PermissionClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> DeletePermission {
         Box::pin(async move {
             let mut request = self.client.permission_request(azure_core::Method::Delete);
@@ -45,19 +30,6 @@ impl DeletePermissionBuilder {
 
             DeletePermissionResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeletePermission =
-    futures::future::BoxFuture<'static, azure_core::Result<DeletePermissionResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeletePermissionBuilder {
-    type IntoFuture = DeletePermission;
-    type Output = <DeletePermission as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -2,30 +2,16 @@ use crate::headers::from_headers::*;
 use crate::prelude::*;
 use crate::ResourceQuota;
 use azure_core::headers::session_token_from_headers;
-use azure_core::prelude::*;
 use azure_core::Response as HttpResponse;
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct DeleteStoredProcedureBuilder {
+operation! {
+    DeleteStoredProcedure,
     client: StoredProcedureClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeleteStoredProcedureBuilder {
-    pub(crate) fn new(client: StoredProcedureClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-    }
-
     pub fn into_future(self) -> DeleteStoredProcedure {
         Box::pin(async move {
             let mut request = self
@@ -47,19 +33,6 @@ impl DeleteStoredProcedureBuilder {
 
             DeleteStoredProcedureResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeleteStoredProcedure =
-    futures::future::BoxFuture<'static, azure_core::Result<DeleteStoredProcedureResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeleteStoredProcedureBuilder {
-    type IntoFuture = DeleteStoredProcedure;
-    type Output = <DeleteStoredProcedure as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -3,31 +3,16 @@ use crate::prelude::*;
 use crate::ResourceQuota;
 
 use azure_core::headers::session_token_from_headers;
-use azure_core::prelude::*;
 use azure_core::Response as HttpResponse;
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct DeleteTriggerBuilder {
+operation! {
+    DeleteTrigger,
     client: TriggerClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeleteTriggerBuilder {
-    pub(crate) fn new(client: TriggerClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> DeleteTrigger {
         Box::pin(async move {
             let mut request = self.client.trigger_request(azure_core::Method::Delete);
@@ -47,19 +32,6 @@ impl DeleteTriggerBuilder {
 
             DeleteTriggerResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeleteTrigger =
-    futures::future::BoxFuture<'static, azure_core::Result<DeleteTriggerResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeleteTriggerBuilder {
-    type IntoFuture = DeleteTrigger;
-    type Output = <DeleteTrigger as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -1,28 +1,14 @@
 use crate::headers::from_headers::*;
 use crate::prelude::*;
-use azure_core::{headers::session_token_from_headers, Context, Response as HttpResponse};
+use azure_core::{headers::session_token_from_headers, Response as HttpResponse};
 
-#[derive(Debug, Clone)]
-pub struct DeleteUserBuilder {
+operation! {
+    DeleteUser,
     client: UserClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeleteUserBuilder {
-    pub(crate) fn new(client: UserClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> DeleteUser {
         Box::pin(async move {
             let mut request = self.client.user_request(azure_core::Method::Delete);
@@ -41,18 +27,6 @@ impl DeleteUserBuilder {
 
             DeleteUserResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeleteUser = futures::future::BoxFuture<'static, azure_core::Result<DeleteUserResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeleteUserBuilder {
-    type IntoFuture = DeleteUser;
-    type Output = <DeleteUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -3,31 +3,16 @@ use crate::prelude::*;
 use crate::ResourceQuota;
 
 use azure_core::headers::session_token_from_headers;
-use azure_core::prelude::*;
 use azure_core::Response as HttpResponse;
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct DeleteUserDefinedFunctionBuilder {
+operation! {
+    DeleteUserDefinedFunction,
     client: UserDefinedFunctionClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl DeleteUserDefinedFunctionBuilder {
-    pub(crate) fn new(client: UserDefinedFunctionClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> DeleteUserDefinedFunction {
         Box::pin(async move {
             let mut request = self.client.udf_request(azure_core::Method::Delete);
@@ -51,19 +36,6 @@ impl DeleteUserDefinedFunctionBuilder {
         })
     }
 }
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for DeleteUserDefinedFunctionBuilder {
-    type IntoFuture = DeleteUserDefinedFunction;
-    type Output = <DeleteUserDefinedFunction as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type DeleteUserDefinedFunction =
-    futures::future::BoxFuture<'static, azure_core::Result<DeleteUserDefinedFunctionResponse>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteUserDefinedFunctionResponse {

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -10,30 +10,14 @@ use azure_core::SessionToken;
 use azure_core::{collect_pinned_stream, prelude::*, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct GetAttachmentBuilder {
+operation! {
+    GetAttachment,
     client: AttachmentClient,
-    if_match_condition: Option<IfMatchCondition>,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?if_match_condition: IfMatchCondition,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl GetAttachmentBuilder {
-    pub(crate) fn new(client: AttachmentClient) -> Self {
-        Self {
-            client,
-            if_match_condition: None,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> GetAttachment {
         Box::pin(async move {
             let mut request = self.client.attachment_request(azure_core::Method::Get);
@@ -60,19 +44,6 @@ impl GetAttachmentBuilder {
         })
     }
 }
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for GetAttachmentBuilder {
-    type IntoFuture = GetAttachment;
-    type Output = <GetAttachment as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type GetAttachment =
-    futures::future::BoxFuture<'static, azure_core::Result<GetAttachmentResponse>>;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct GetAttachmentResponse {

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -4,30 +4,16 @@ use crate::headers::from_headers::*;
 use azure_core::headers::{
     content_type_from_headers, etag_from_headers, session_token_from_headers,
 };
-use azure_core::{collect_pinned_stream, Context, Response as HttpResponse};
+use azure_core::{collect_pinned_stream, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct GetCollectionBuilder {
+operation! {
+    GetCollection,
     client: CollectionClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl GetCollectionBuilder {
-    pub(crate) fn new(client: CollectionClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> GetCollection {
         Box::pin(async move {
             let mut request = self.client.collection_request(azure_core::Method::Get);
@@ -47,19 +33,6 @@ impl GetCollectionBuilder {
 
             GetCollectionResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type GetCollection =
-    futures::future::BoxFuture<'static, azure_core::Result<GetCollectionResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for GetCollectionBuilder {
-    type IntoFuture = GetCollection;
-    type Output = <GetCollection as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -3,31 +3,16 @@ use crate::prelude::*;
 use crate::ResourceQuota;
 
 use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Context;
 use azure_core::{collect_pinned_stream, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct GetDatabaseBuilder {
+operation! {
+    GetDatabase,
     client: DatabaseClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl GetDatabaseBuilder {
-    pub(crate) fn new(client: DatabaseClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> GetDatabase {
         Box::pin(async move {
             let mut request = self.client.database_request(azure_core::Method::Get);
@@ -42,18 +27,6 @@ impl GetDatabaseBuilder {
                 .await?;
             GetDatabaseResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type GetDatabase = futures::future::BoxFuture<'static, azure_core::Result<GetDatabaseResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for GetDatabaseBuilder {
-    type IntoFuture = GetDatabase;
-    type Output = <GetDatabase as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -5,33 +5,15 @@ use azure_core::headers::{item_count_from_headers, session_token_from_headers};
 use azure_core::{collect_pinned_stream, prelude::*, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct GetPartitionKeyRangesBuilder {
+operation! {
+    GetPartitionKeyRanges,
     client: CollectionClient,
-    if_match_condition: Option<IfMatchCondition>,
-    if_modified_since: Option<IfModifiedSince>,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?if_match_condition: IfMatchCondition,
+    ?if_modified_since: IfModifiedSince,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl GetPartitionKeyRangesBuilder {
-    pub(crate) fn new(client: CollectionClient) -> Self {
-        Self {
-            client,
-            if_match_condition: None,
-            if_modified_since: None,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        if_modified_since: DateTime<Utc> => Some(IfModifiedSince::new(if_modified_since)),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> GetPartitionKeyRanges {
         Box::pin(async move {
             let mut request = self.client.cosmos_client().request(
@@ -62,19 +44,6 @@ impl GetPartitionKeyRangesBuilder {
 
             GetPartitionKeyRangesResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type GetPartitionKeyRanges =
-    futures::future::BoxFuture<'static, azure_core::Result<GetPartitionKeyRangesResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for GetPartitionKeyRangesBuilder {
-    type IntoFuture = GetPartitionKeyRanges;
-    type Output = <GetPartitionKeyRanges as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/get_permission.rs
+++ b/sdk/data_cosmos/src/operations/get_permission.rs
@@ -1,28 +1,12 @@
-use crate::{prelude::*, resources::permission::PermissionResponse};
+use crate::{prelude::*, resources::permission::PermissionResponse as GetPermissionResponse};
 
-use azure_core::Context;
-
-#[derive(Debug, Clone)]
-pub struct GetPermissionBuilder {
+operation! {
+    GetPermission,
     client: PermissionClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl GetPermissionBuilder {
-    pub fn new(client: PermissionClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> GetPermission {
         Box::pin(async move {
             let mut request = self.client.permission_request(azure_core::Method::Get);
@@ -40,20 +24,7 @@ impl GetPermissionBuilder {
                 )
                 .await?;
 
-            PermissionResponse::try_from(response).await
+            GetPermissionResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type GetPermission =
-    futures::future::BoxFuture<'static, azure_core::Result<PermissionResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for GetPermissionBuilder {
-    type IntoFuture = GetPermission;
-    type Output = <GetPermission as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/get_user.rs
+++ b/sdk/data_cosmos/src/operations/get_user.rs
@@ -1,27 +1,12 @@
-use crate::{prelude::*, resources::user::UserResponse};
-use azure_core::Context;
+use crate::{prelude::*, resources::user::UserResponse as GetUserResponse};
 
-#[derive(Debug, Clone)]
-pub struct GetUserBuilder {
+operation! {
+    GetUser,
     client: UserClient,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl GetUserBuilder {
-    pub fn new(client: UserClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> GetUser {
         Box::pin(async move {
             let mut request = self.client.user_request(azure_core::Method::Get);
@@ -39,19 +24,7 @@ impl GetUserBuilder {
                 )
                 .await?;
 
-            UserResponse::try_from(response).await
+            GetUserResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type GetUser = futures::future::BoxFuture<'static, azure_core::Result<UserResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for GetUserBuilder {
-    type IntoFuture = GetUser;
-    type Output = <GetUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -12,7 +12,7 @@ use azure_core::{Pageable, Response as HttpResponse, SessionToken};
 use chrono::{DateTime, Utc};
 
 operation! {
-    @list
+    #[stream]
     ListAttachments,
     client: DocumentClient,
     ?max_item_count: MaxItemCount,

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -41,9 +41,8 @@ impl ListAttachmentsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request
-                    .insert_headers(&this.max_item_count.unwrap_or_else(|| MaxItemCount::new(-1)));
-                request.insert_headers(&this.a_im.unwrap_or(ChangeFeed::None));
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
+                request.insert_headers(&this.a_im.unwrap_or_default());
                 crate::cosmos_entity::add_as_partition_key_header_serialized(
                     this.client.partition_key_serialized(),
                     &mut request,

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -11,36 +11,17 @@ use azure_core::prelude::*;
 use azure_core::{Pageable, Response as HttpResponse, SessionToken};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct ListAttachmentsBuilder {
+operation! {
+    @list
+    ListAttachments,
     client: DocumentClient,
-    if_match_condition: Option<IfMatchCondition>,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    a_im: ChangeFeed,
-    context: Context,
+    ?max_item_count: MaxItemCount,
+    ?a_im: ChangeFeed,
+    ?if_match_condition: IfMatchCondition,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListAttachmentsBuilder {
-    pub(crate) fn new(client: DocumentClient) -> Self {
-        Self {
-            client,
-            if_match_condition: None,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            a_im: ChangeFeed::None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        a_im: ChangeFeed,
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListAttachments {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
@@ -60,8 +41,9 @@ impl ListAttachmentsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
-                request.insert_headers(&this.a_im);
+                request
+                    .insert_headers(&this.max_item_count.unwrap_or_else(|| MaxItemCount::new(-1)));
+                request.insert_headers(&this.a_im.unwrap_or(ChangeFeed::None));
                 crate::cosmos_entity::add_as_partition_key_header_serialized(
                     this.client.partition_key_serialized(),
                     &mut request,

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -9,7 +9,7 @@ use azure_core::{collect_pinned_stream, Pageable};
 use chrono::{DateTime, Utc};
 
 operation! {
-    @list
+    #[stream]
     ListCollections,
     client: DatabaseClient,
     ?max_item_count: MaxItemCount,

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -8,30 +8,15 @@ use azure_core::Response as HttpResponse;
 use azure_core::{collect_pinned_stream, Pageable};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct ListCollectionsBuilder {
+operation! {
+    @list
+    ListCollections,
     client: DatabaseClient,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    context: Context,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListCollectionsBuilder {
-    pub(crate) fn new(client: DatabaseClient) -> Self {
-        Self {
-            client,
-            max_item_count: MaxItemCount::new(-1),
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListCollections {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
@@ -41,7 +26,7 @@ impl ListCollectionsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -8,7 +8,7 @@ use azure_core::{collect_pinned_stream, prelude::*, Pageable, Response};
 use chrono::{DateTime, Utc};
 
 operation! {
-    @list
+    #[stream]
     ListDatabases,
     client: CosmosClient,
     ?max_item_count: MaxItemCount,

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -7,30 +7,15 @@ use azure_core::headers::{continuation_token_from_headers_optional, session_toke
 use azure_core::{collect_pinned_stream, prelude::*, Pageable, Response};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct ListDatabasesBuilder {
+operation! {
+    @list
+    ListDatabases,
     client: CosmosClient,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    context: Context,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListDatabasesBuilder {
-    pub(crate) fn new(client: CosmosClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListDatabases {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
@@ -40,7 +25,7 @@ impl ListDatabasesBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
                 request.insert_headers(&continuation);
 
                 let response = this

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -11,38 +11,18 @@ use azure_core::{prelude::*, Pageable};
 use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 
-#[derive(Debug, Clone)]
-pub struct ListDocumentsBuilder {
+operation! {
+    @list
+    ListDocuments,
     client: CollectionClient,
-    if_match_condition: Option<IfMatchCondition>,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    a_im: ChangeFeed,
-    partition_range_id: Option<PartitionRangeId>,
-    context: Context,
+    ?max_item_count: MaxItemCount,
+    ?a_im: ChangeFeed,
+    ?if_match_condition: IfMatchCondition,
+    ?consistency_level: ConsistencyLevel,
+    ?partition_range_id: PartitionRangeId
 }
 
 impl ListDocumentsBuilder {
-    pub(crate) fn new(client: CollectionClient) -> Self {
-        Self {
-            client,
-            if_match_condition: None,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            a_im: ChangeFeed::None,
-            partition_range_id: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        a_im: ChangeFeed,
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        partition_range_id: String => Some(PartitionRangeId::new(partition_range_id)),
-    }
-
     pub fn into_stream<T>(self) -> ListDocuments<T>
     where
         T: DeserializeOwned + Send + Sync,
@@ -64,8 +44,8 @@ impl ListDocumentsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     req.insert_headers(cl);
                 }
-                req.insert_headers(&this.max_item_count);
-                req.insert_headers(&this.a_im);
+                req.insert_headers(&this.max_item_count.unwrap_or_default());
+                req.insert_headers(&this.a_im.unwrap_or_default());
                 req.insert_headers(&this.partition_range_id);
                 req.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use serde::de::DeserializeOwned;
 
 operation! {
-    @list
+    #[stream]
     ListDocuments,
     client: CollectionClient,
     ?max_item_count: MaxItemCount,

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -7,30 +7,15 @@ use azure_core::headers::{continuation_token_from_headers_optional, session_toke
 use azure_core::prelude::*;
 use azure_core::{Pageable, Response as HttpResponse};
 
-#[derive(Debug, Clone)]
-pub struct ListPermissionsBuilder {
+operation! {
+    @list
+    ListPermissions,
     client: UserClient,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    context: Context,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListPermissionsBuilder {
-    pub(crate) fn new(client: UserClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListPermissions {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
@@ -48,7 +33,7 @@ impl ListPermissionsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -8,7 +8,7 @@ use azure_core::prelude::*;
 use azure_core::{Pageable, Response as HttpResponse};
 
 operation! {
-    @list
+    #[stream]
     ListPermissions,
     client: UserClient,
     ?max_item_count: MaxItemCount,

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -10,7 +10,7 @@ use azure_core::{Pageable, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
 operation! {
-    @list
+    #[stream]
     ListStoredProcedures,
     client: CollectionClient,
     ?max_item_count: MaxItemCount,

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -9,30 +9,15 @@ use azure_core::prelude::*;
 use azure_core::{Pageable, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct ListStoredProceduresBuilder {
+operation! {
+    @list
+    ListStoredProcedures,
     client: CollectionClient,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    context: Context,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListStoredProceduresBuilder {
-    pub(crate) fn new(client: CollectionClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListStoredProcedures {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
@@ -50,7 +35,7 @@ impl ListStoredProceduresBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -10,7 +10,7 @@ use azure_core::{Pageable, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
 operation! {
-    @list
+    #[stream]
     ListTriggers,
     client: CollectionClient,
     ?if_match_condition: IfMatchCondition,

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -9,33 +9,16 @@ use azure_core::prelude::*;
 use azure_core::{Pageable, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct ListTriggersBuilder {
+operation! {
+    @list
+    ListTriggers,
     client: CollectionClient,
-    if_match_condition: Option<IfMatchCondition>,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    context: Context,
+    ?if_match_condition: IfMatchCondition,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListTriggersBuilder {
-    pub(crate) fn new(client: CollectionClient) -> Self {
-        Self {
-            client,
-            if_match_condition: None,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListTriggers {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
@@ -54,7 +37,7 @@ impl ListTriggersBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -10,33 +10,16 @@ use azure_core::headers::{
 use azure_core::{prelude::*, Pageable, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct ListUserDefinedFunctionsBuilder {
+operation! {
+    @list
+    ListUserDefinedFunctions,
     client: CollectionClient,
-    if_match_condition: Option<IfMatchCondition>,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    context: Context,
+    ?if_match_condition: IfMatchCondition,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListUserDefinedFunctionsBuilder {
-    pub(crate) fn new(client: CollectionClient) -> Self {
-        Self {
-            client,
-            if_match_condition: None,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListUserDefinedFunctions {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();
@@ -55,7 +38,7 @@ impl ListUserDefinedFunctionsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
 
                 request.insert_headers(&continuation);
 

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -11,7 +11,7 @@ use azure_core::{prelude::*, Pageable, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
 operation! {
-    @list
+    #[stream]
     ListUserDefinedFunctions,
     client: CollectionClient,
     ?if_match_condition: IfMatchCondition,

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -8,32 +8,17 @@ use azure_core::{
     prelude::MaxItemCount,
     Response as HttpResponse, SessionToken,
 };
-use azure_core::{Context, Continuable, Pageable};
+use azure_core::{Continuable, Pageable};
 
-#[derive(Debug, Clone)]
-pub struct ListUsersBuilder {
+operation! {
+    @list
+    ListUsers,
     client: DatabaseClient,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    context: Context,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ListUsersBuilder {
-    pub(crate) fn new(client: DatabaseClient) -> Self {
-        Self {
-            client,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        context: Context => context,
-    }
-
     pub fn into_stream(self) -> ListUsers {
         let make_request = move |continuation: Option<Continuation>| {
             let this = self.clone();

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -32,7 +32,7 @@ impl ListUsersBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
 
                 if let Some(ref c) = continuation {
                     request.insert_headers(c);

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -11,7 +11,7 @@ use azure_core::{
 use azure_core::{Continuable, Pageable};
 
 operation! {
-    @list
+    #[stream]
     ListUsers,
     client: DatabaseClient,
     ?max_item_count: MaxItemCount,

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -32,7 +32,8 @@ operation! {
     ?consistency_level: ConsistencyLevel,
     ?parallelize_cross_partition_query: ParallelizeCrossPartition,
     ?query_cross_partition: QueryCrossPartition,
-    ??partition_key_serialized: String
+    #[skip]
+    partition_key_serialized: String
 }
 
 impl QueryDocumentsBuilder {

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use std::convert::TryInto;
 
 operation! {
-    @list
+    #[stream]
     QueryDocuments,
     client: CollectionClient,
     query: Query,

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -21,48 +21,21 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 use std::convert::TryInto;
 
-#[derive(Debug, Clone)]
-pub struct QueryDocumentsBuilder {
+operation! {
+    @list
+    QueryDocuments,
     client: CollectionClient,
     query: Query,
-    if_match_condition: Option<IfMatchCondition>,
-    if_modified_since: Option<IfModifiedSince>,
-    consistency_level: Option<ConsistencyLevel>,
-    max_item_count: MaxItemCount,
-    partition_key_serialized: Option<String>,
-    query_cross_partition: QueryCrossPartition,
-    #[allow(unused)]
-    parallelize_cross_partition_query: ParallelizeCrossPartition,
-    context: Context,
+    ?if_match_condition: IfMatchCondition,
+    ?if_modified_since: IfModifiedSince,
+    ?max_item_count: MaxItemCount,
+    ?consistency_level: ConsistencyLevel,
+    ?parallelize_cross_partition_query: ParallelizeCrossPartition,
+    ?query_cross_partition: QueryCrossPartition,
+    ??partition_key_serialized: String
 }
 
 impl QueryDocumentsBuilder {
-    pub(crate) fn new(client: CollectionClient, query: Query) -> Self {
-        Self {
-            client,
-            query,
-            if_match_condition: None,
-            if_modified_since: None,
-            consistency_level: None,
-            max_item_count: MaxItemCount::new(-1),
-            partition_key_serialized: None,
-            query_cross_partition: QueryCrossPartition::No,
-            // TODO: use this in request
-            parallelize_cross_partition_query: ParallelizeCrossPartition::No,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        max_item_count: i32 => MaxItemCount::new(max_item_count),
-        if_modified_since: DateTime<Utc> => Some(IfModifiedSince::new(if_modified_since)),
-        query_cross_partition: bool => if query_cross_partition { QueryCrossPartition::Yes } else { QueryCrossPartition::No },
-        parallelize_cross_partition_query: bool => if parallelize_cross_partition_query { ParallelizeCrossPartition::Yes } else { ParallelizeCrossPartition::No },
-        context: Context => context,
-    }
-
     pub fn partition_key<PK: serde::Serialize>(self, pk: &PK) -> azure_core::Result<Self> {
         Ok(Self {
             partition_key_serialized: Some(crate::cosmos_entity::serialize_partition_key(pk)?),
@@ -102,8 +75,8 @@ impl QueryDocumentsBuilder {
                 if let Some(cl) = &this.consistency_level {
                     request.insert_headers(cl);
                 }
-                request.insert_headers(&this.max_item_count);
-                request.insert_headers(&this.query_cross_partition);
+                request.insert_headers(&this.max_item_count.unwrap_or_default());
+                request.insert_headers(&this.query_cross_partition.unwrap_or_default());
 
                 request.set_body(serde_json::to_vec(&this.query)?);
                 if let Some(partition_key_serialized) = this.partition_key_serialized.as_ref() {

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -4,35 +4,18 @@ use crate::resources::collection::{IndexingPolicy, PartitionKey};
 use azure_core::headers::{
     content_type_from_headers, etag_from_headers, session_token_from_headers,
 };
-use azure_core::{collect_pinned_stream, Context, Response as HttpResponse};
+use azure_core::{collect_pinned_stream, Response as HttpResponse};
 use chrono::{DateTime, Utc};
 
-#[derive(Debug, Clone)]
-pub struct ReplaceCollectionBuilder {
+operation! {
+    ReplaceCollection,
     client: CollectionClient,
     partition_key: PartitionKey,
-    consistency_level: Option<ConsistencyLevel>,
-    indexing_policy: Option<IndexingPolicy>,
-    context: Context,
+    ?indexing_policy: IndexingPolicy,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ReplaceCollectionBuilder {
-    pub(crate) fn new(client: CollectionClient, partition_key: PartitionKey) -> Self {
-        Self {
-            client,
-            partition_key,
-            consistency_level: None,
-            indexing_policy: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        indexing_policy: IndexingPolicy => Some(indexing_policy),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> ReplaceCollection {
         Box::pin(async move {
             let mut request = self.client.collection_request(azure_core::Method::Put);
@@ -60,19 +43,6 @@ impl ReplaceCollectionBuilder {
 
             ReplaceCollectionResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type ReplaceCollection =
-    futures::future::BoxFuture<'static, azure_core::Result<ReplaceCollectionResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for ReplaceCollectionBuilder {
-    type IntoFuture = ReplaceCollection;
-    type Output = <ReplaceCollection as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }
 

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 operation! {
-    ReplaceDocument<D: Serialize + Send +>,
+    ReplaceDocument<D: Serialize + Send>,
     client: DocumentClient,
     document: D,
     ?indexing_directive: IndexingDirective,

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -20,7 +20,8 @@ operation! {
     ?if_modified_since: IfModifiedSince,
     ?allow_tentative_writes: TentativeWritesAllowance,
     ?consistency_level: ConsistencyLevel,
-    ??partition_key: String
+    #[skip]
+    partition_key: String
 }
 
 impl<D: Serialize + Send + 'static> ReplaceDocumentBuilder<D> {

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -1,34 +1,17 @@
 use crate::prelude::*;
-use crate::resources::permission::{ExpirySeconds, PermissionMode, PermissionResponse};
+use crate::resources::permission::{
+    ExpirySeconds, PermissionMode, PermissionResponse as ReplacePermissionResponse,
+};
 
-use azure_core::Context;
-
-#[derive(Debug, Clone)]
-pub struct ReplacePermissionBuilder {
+operation! {
+    ReplacePermission,
     client: PermissionClient,
     permission_mode: PermissionMode,
-    expiry_seconds: Option<ExpirySeconds>,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?expiry_seconds: ExpirySeconds,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ReplacePermissionBuilder {
-    pub(crate) fn new(client: PermissionClient, permission_mode: PermissionMode) -> Self {
-        Self {
-            client,
-            permission_mode,
-            expiry_seconds: Some(ExpirySeconds::new(3600)),
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        expiry_seconds: u64 => Some(ExpirySeconds::new(expiry_seconds)),
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> ReplacePermission {
         Box::pin(async move {
             let mut request = self.client.permission_request(azure_core::Method::Put);
@@ -62,20 +45,7 @@ impl ReplacePermissionBuilder {
                 )
                 .await?;
 
-            PermissionResponse::try_from(response).await
+            ReplacePermissionResponse::try_from(response).await
         })
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type ReplacePermission =
-    futures::future::BoxFuture<'static, azure_core::Result<PermissionResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for ReplacePermissionBuilder {
-    type IntoFuture = ReplacePermission;
-    type Output = <ReplacePermission as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
     }
 }

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -1,31 +1,14 @@
 use super::CreateStoredProcedureResponse;
 use crate::prelude::*;
-use azure_core::prelude::*;
 
-#[derive(Debug, Clone)]
-pub struct ReplaceStoredProcedureBuilder {
+operation! {
+    ReplaceStoredProcedure,
     client: StoredProcedureClient,
     function_body: String,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ReplaceStoredProcedureBuilder {
-    pub(crate) fn new(client: StoredProcedureClient, function_body: String) -> Self {
-        Self {
-            client,
-            function_body,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-}
-
-impl ReplaceStoredProcedureBuilder {
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-    }
-
     pub fn into_future(self) -> ReplaceStoredProcedure {
         Box::pin(async move {
             let mut req = self
@@ -60,18 +43,5 @@ impl ReplaceStoredProcedureBuilder {
         })
     }
 }
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for ReplaceStoredProcedureBuilder {
-    type IntoFuture = ReplaceStoredProcedure;
-    type Output = <ReplaceStoredProcedure as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
-    }
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type ReplaceStoredProcedure =
-    futures::future::BoxFuture<'static, azure_core::Result<ReplaceStoredProcedureResponse>>;
 
 pub type ReplaceStoredProcedureResponse = CreateStoredProcedureResponse;

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -1,29 +1,13 @@
-use crate::{prelude::*, resources::user::UserResponse};
-use azure_core::Context;
+use crate::{prelude::*, resources::user::UserResponse as ReplaceUserResponse};
 
-#[derive(Debug, Clone)]
-pub struct ReplaceUserBuilder {
+operation! {
+    ReplaceUser,
     client: UserClient,
     user_name: String,
-    consistency_level: Option<ConsistencyLevel>,
-    context: Context,
+    ?consistency_level: ConsistencyLevel
 }
 
 impl ReplaceUserBuilder {
-    pub(crate) fn new(client: UserClient, user_name: String) -> Self {
-        Self {
-            client,
-            user_name,
-            consistency_level: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        consistency_level: ConsistencyLevel => Some(consistency_level),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> ReplaceUser {
         Box::pin(async move {
             let mut request = self.client.user_request(azure_core::Method::Put);
@@ -44,7 +28,7 @@ impl ReplaceUserBuilder {
                 )
                 .await?;
 
-            UserResponse::try_from(response).await
+            ReplaceUserResponse::try_from(response).await
         })
     }
 }
@@ -52,16 +36,4 @@ impl ReplaceUserBuilder {
 #[derive(Serialize)]
 struct ReplaceUserBody<'a> {
     id: &'a str,
-}
-
-/// The future returned by calling `into_future` on the builder.
-pub type ReplaceUser = futures::future::BoxFuture<'static, azure_core::Result<UserResponse>>;
-
-#[cfg(feature = "into_future")]
-impl std::future::IntoFuture for ReplaceUserBuilder {
-    type IntoFuture = ReplaceUser;
-    type Output = <ReplaceUser as std::future::Future>::Output;
-    fn into_future(self) -> Self::IntoFuture {
-        Self::into_future(self)
-    }
 }

--- a/sdk/data_cosmos/src/resources/document/indexing_directive.rs
+++ b/sdk/data_cosmos/src/resources/document/indexing_directive.rs
@@ -13,6 +13,12 @@ pub enum IndexingDirective {
     Exclude,
 }
 
+impl Default for IndexingDirective {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
 impl<'a> From<&'a IndexingDirective> for &'a str {
     fn from(s: &'a IndexingDirective) -> &'a str {
         match s {

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -78,6 +78,22 @@ pub enum QueryCrossPartition {
     No,
 }
 
+impl Default for QueryCrossPartition {
+    fn default() -> Self {
+        Self::No
+    }
+}
+
+impl From<bool> for QueryCrossPartition {
+    fn from(b: bool) -> Self {
+        if b {
+            Self::Yes
+        } else {
+            Self::No
+        }
+    }
+}
+
 impl QueryCrossPartition {
     fn as_bool_str(&self) -> &str {
         match self {
@@ -110,6 +126,16 @@ impl ParallelizeCrossPartition {
         match self {
             Self::Yes => "true",
             Self::No => "false",
+        }
+    }
+}
+
+impl From<bool> for ParallelizeCrossPartition {
+    fn from(b: bool) -> Self {
+        if b {
+            Self::Yes
+        } else {
+            Self::No
         }
     }
 }
@@ -159,6 +185,12 @@ pub enum ChangeFeed {
     None,
 }
 
+impl Default for ChangeFeed {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
 impl AsHeaders for ChangeFeed {
     type Iter = std::option::IntoIter<(HeaderName, HeaderValue)>;
     fn as_headers(&self) -> Self::Iter {
@@ -185,6 +217,12 @@ impl TentativeWritesAllowance {
             Self::Allow => "true",
             Self::Deny => "false",
         }
+    }
+}
+
+impl Default for TentativeWritesAllowance {
+    fn default() -> Self {
+        Self::Deny
     }
 }
 

--- a/sdk/data_cosmos/src/resources/permission/mod.rs
+++ b/sdk/data_cosmos/src/resources/permission/mod.rs
@@ -35,3 +35,9 @@ impl Header for ExpirySeconds {
         self.0.to_string().into()
     }
 }
+
+impl From<u64> for ExpirySeconds {
+    fn from(s: u64) -> Self {
+        Self::new(s)
+    }
+}

--- a/sdk/iot_hub/src/service/requests/query_builder.rs
+++ b/sdk/iot_hub/src/service/requests/query_builder.rs
@@ -2,7 +2,6 @@
 
 use crate::service::{responses::QueryResponse, ServiceClient, API_VERSION};
 use azure_core::prelude::*;
-use azure_core::setters;
 use azure_core::Method;
 use serde::Serialize;
 use std::convert::TryInto;


### PR DESCRIPTION
This introduces an `operation!` macro which reduces the amount of boiler plate around declaring operations considerably.

This is how it looks when called:

```rust
operation! {
    CreateCollection,
    client: DatabaseClient,
    collection_name: String,
    partition_key: PartitionKey,
    ?consistency_level: ConsistencyLevel,
    ?indexing_policy: IndexingPolicy,
    ?offer: Offer
}
```

And it expands to:

```rust
#[derive(Debug, Clone)]
pub struct CreateCollectionBuilder {
    client: DatabaseClient,
    collection_name: String,
    partition_key: PartitionKey,
    consistency_level: Option<ConsistencyLevel>,
    indexing_policy: Option<IndexingPolicy>,
    offer: Option<Offer>,
    context: Context,
}

impl CreateCollectionBuilder {
    pub(crate) fn new(
        client: DatabaseClient,
        collection_name: String,
        partition_key: PartitionKey,
    ) -> Self {
        Self {
            client,
            collection_name,
            partition_key,
            consistency_level: None,
            indexing_policy: None,
            offer: None,
            context: Context::new(),
        }
    }

    setters! {
        consistency_level: ConsistencyLevel => Some(consistency_level),
        indexing_policy: IndexingPolicy => Some(indexing_policy),
        offer: Offer => Some(offer),
        context: Context => context,
    }
}

#[cfg(feature = "into_future")]
impl std::future::IntoFuture for CreateCollectionBuilder {
    type IntoFuture = CreateCollection;
    type Output = <CreateCollection as std::future::Future>::Output;
    fn into_future(self) -> Self::IntoFuture {
        Self::into_future(self)
    }
}

/// The future returned by calling `into_future` on the builder.
pub type CreateCollection =
    futures::future::BoxFuture<'static, azure_core::Result<CreateCollectionResponse>>;
```

This would ensure all of our operation builders follow the same pattern.

Some current limitations:
* Does not work for pageable operations
* Does not work for operations that require a generic param

I believe both of these limitations are pretty easy to overcome, but I wanted to see what folks thought.

Thoughts?