### PR TITLE
revamp SAS builders to model operations

### DIFF
--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -1,6 +1,8 @@
 use crate::authorization_policy::AuthorizationPolicy;
 use crate::operations::*;
-use crate::shared_access_signature::account_sas::AccountSharedAccessSignatureBuilder;
+use crate::shared_access_signature::account_sas::{
+    AccountSasPermissions, AccountSasResource, AccountSasResourceType, AccountSharedAccessSignature,
+};
 use crate::ConnectionString;
 use azure_core::Method;
 use azure_core::{
@@ -10,6 +12,7 @@ use azure_core::{
     ClientOptions, Context, Pipeline, Request, Response,
 };
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use std::sync::Arc;
 use url::Url;
 
@@ -413,10 +416,14 @@ impl StorageClient {
 
     pub fn shared_access_signature(
         &self,
-    ) -> azure_core::Result<AccountSharedAccessSignatureBuilder> {
+        resource: AccountSasResource,
+        resource_type: AccountSasResourceType,
+        expiry: DateTime<Utc>,
+        permissions: AccountSasPermissions,
+    ) -> azure_core::Result<AccountSharedAccessSignature> {
         match &self.storage_credentials {
             StorageCredentials::Key(account, key) => {
-                Ok(AccountSharedAccessSignatureBuilder::new(account.clone(), key.clone()))
+                Ok(AccountSharedAccessSignature::new(account.clone(), key.clone(), resource, resource_type, expiry, permissions))
             }
             _ => Err(Error::message(ErrorKind::Other, "failed shared access signature generation. SAS can be generated only from key and account clients")),
         }

--- a/sdk/storage/src/core/shared_access_signature/account_sas.rs
+++ b/sdk/storage/src/core/shared_access_signature/account_sas.rs
@@ -134,9 +134,9 @@ pub struct AccountSharedAccessSignature {
     version: AccountSasVersion,
     resource: AccountSasResource,
     resource_type: AccountSasResourceType,
-    start: Option<DateTime<Utc>>,
     expiry: DateTime<Utc>,
     permissions: AccountSasPermissions,
+    start: Option<DateTime<Utc>>,
     ip: Option<String>,
     protocol: Option<SasProtocol>,
 }
@@ -156,15 +156,16 @@ impl AccountSharedAccessSignature {
             version: AccountSasVersion::V20181109,
             resource,
             resource_type,
-            start: None,
             expiry,
             permissions,
+            start: None,
             ip: None,
             protocol: None,
         }
     }
 
     setters! {
+        version: AccountSasVersion => version,
         start: DateTime<Utc> => Some(start),
         ip: String => Some(ip),
         protocol: SasProtocol => Some(protocol),

--- a/sdk/storage/src/core/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/core/shared_access_signature/service_sas.rs
@@ -93,13 +93,13 @@ impl fmt::Display for BlobSasPermissions {
 pub struct BlobSharedAccessSignature {
     key: String,
     canonicalized_resource: String,
+    resource: BlobSignedResource,
     permissions: BlobSasPermissions, // sp
-    start: Option<DateTime<Utc>>,    // st
     expiry: DateTime<Utc>,           // se
+    start: Option<DateTime<Utc>>,    // st
     identifier: Option<String>,
     ip: Option<String>,
     protocol: Option<SasProtocol>,
-    resource: BlobSignedResource,
 }
 
 impl BlobSharedAccessSignature {
@@ -113,13 +113,13 @@ impl BlobSharedAccessSignature {
         Self {
             key,
             canonicalized_resource,
+            resource,
             permissions,
-            start: None,
             expiry,
+            start: None,
             identifier: None,
             ip: None,
             protocol: None,
-            resource,
         }
     }
 

--- a/sdk/storage/src/core/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/core/shared_access_signature/service_sas.rs
@@ -3,7 +3,7 @@ use crate::{
     hmac,
 };
 use chrono::{DateTime, Utc};
-use std::{fmt, marker::PhantomData};
+use std::fmt;
 
 const SERVICE_SAS_VERSION: &str = "2020-06-12";
 
@@ -92,37 +92,60 @@ impl fmt::Display for BlobSasPermissions {
 
 pub struct BlobSharedAccessSignature {
     key: String,
-
     canonicalized_resource: String,
-    signed_permissions: BlobSasPermissions, // sp
-    signed_start: Option<DateTime<Utc>>,    // st
-    signed_expiry: DateTime<Utc>,           // se
-    signed_identifier: Option<String>,
-    signed_ip: Option<String>,
-    signed_protocol: Option<SasProtocol>,
-    signed_resource: BlobSignedResource,
+    permissions: BlobSasPermissions, // sp
+    start: Option<DateTime<Utc>>,    // st
+    expiry: DateTime<Utc>,           // se
+    identifier: Option<String>,
+    ip: Option<String>,
+    protocol: Option<SasProtocol>,
+    resource: BlobSignedResource,
 }
 
 impl BlobSharedAccessSignature {
+    pub fn new(
+        key: String,
+        canonicalized_resource: String,
+        permissions: BlobSasPermissions,
+        expiry: DateTime<Utc>,
+        resource: BlobSignedResource,
+    ) -> Self {
+        Self {
+            key,
+            canonicalized_resource,
+            permissions,
+            start: None,
+            expiry,
+            identifier: None,
+            ip: None,
+            protocol: None,
+            resource,
+        }
+    }
+
+    setters! {
+        start: DateTime<Utc> => Some(start),
+        identifier: String => Some(identifier),
+        ip: String => Some(ip),
+        protocol: SasProtocol => Some(protocol),
+    }
+
     fn sign(&self) -> String {
         let content = vec![
-            self.signed_permissions.to_string(),
-            self.signed_start.map_or("".to_string(), format_date),
-            format_date(self.signed_expiry),
+            self.permissions.to_string(),
+            self.start.map_or("".to_string(), format_date),
+            format_date(self.expiry),
             self.canonicalized_resource.clone(),
-            self.signed_identifier
+            self.identifier
                 .as_ref()
                 .unwrap_or(&"".to_string())
                 .to_string(),
-            self.signed_ip
-                .as_ref()
-                .unwrap_or(&"".to_string())
-                .to_string(),
-            self.signed_protocol
+            self.ip.as_ref().unwrap_or(&"".to_string()).to_string(),
+            self.protocol
                 .map(|x| x.to_string())
                 .unwrap_or_else(|| "".to_string()),
             SERVICE_SAS_VERSION.to_string(),
-            self.signed_resource.to_string(),
+            self.resource.to_string(),
             "".to_string(), // snapshot time
             "".to_string(), // rscd
             "".to_string(), // rscc
@@ -131,7 +154,7 @@ impl BlobSharedAccessSignature {
             "".to_string(), // rsct
         ];
 
-        hmac::sign(&content.join("\n"), &self.key).unwrap()
+        hmac::sign(&content.join("\n"), &self.key).expect("HMAC signing failed")
     }
 }
 
@@ -139,20 +162,20 @@ impl SasToken for BlobSharedAccessSignature {
     fn token(&self) -> String {
         let mut elements: Vec<String> = vec![
             format!("sv={}", SERVICE_SAS_VERSION),
-            format!("sp={}", self.signed_permissions),
-            format!("sr={}", self.signed_resource),
-            format!("se={}", format_form(format_date(self.signed_expiry))),
+            format!("sp={}", self.permissions),
+            format!("sr={}", self.resource),
+            format!("se={}", format_form(format_date(self.expiry))),
         ];
 
-        if let Some(start) = &self.signed_start {
+        if let Some(start) = &self.start {
             elements.push(format!("st={}", format_form(format_date(*start))))
         }
 
-        if let Some(ip) = &self.signed_ip {
+        if let Some(ip) = &self.ip {
             elements.push(format!("sip={}", ip))
         }
 
-        if let Some(protocol) = &self.signed_protocol {
+        if let Some(protocol) = &self.protocol {
             elements.push(format!("spr={}", protocol))
         }
 
@@ -160,191 +183,5 @@ impl SasToken for BlobSharedAccessSignature {
         elements.push(format!("sig={}", format_form(sig)));
 
         elements.join("&")
-    }
-}
-
-pub struct SetPerms {}
-pub struct SetResources {}
-pub struct SetExpiry {}
-
-#[derive(Default)]
-pub struct BlobSharedAccessSignatureBuilder<T1, T2, T3> {
-    _phantom: PhantomData<(T1, T2, T3)>,
-    key: String,
-    canonicalized_resource: String,
-
-    // required
-    signed_permissions: Option<BlobSasPermissions>,
-    signed_expiry: Option<DateTime<Utc>>,
-    signed_resource: Option<BlobSignedResource>,
-
-    // optional
-    signed_start: Option<DateTime<Utc>>,
-    signed_identifier: Option<String>,
-    signed_ip: Option<String>,
-    signed_protocol: Option<SasProtocol>,
-}
-
-impl BlobSharedAccessSignatureBuilder<(), (), ()> {
-    pub fn new(
-        key: String,
-        canonicalized_resource: String,
-    ) -> BlobSharedAccessSignatureBuilder<(), (), ()> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key,
-            canonicalized_resource,
-            signed_permissions: None,
-            signed_expiry: None,
-            signed_resource: None,
-            signed_start: None,
-            signed_identifier: None,
-            signed_ip: None,
-            signed_protocol: None,
-        }
-    }
-}
-
-impl<T1, T2, T3> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
-    pub fn with_start(
-        self,
-        signed_start: DateTime<Utc>,
-    ) -> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key: self.key,
-            canonicalized_resource: self.canonicalized_resource,
-            signed_permissions: self.signed_permissions,
-            signed_resource: self.signed_resource,
-            signed_expiry: self.signed_expiry,
-            signed_start: Some(signed_start),
-            signed_identifier: self.signed_identifier,
-            signed_protocol: self.signed_protocol,
-            signed_ip: self.signed_ip,
-        }
-    }
-    pub fn with_ip(self, signed_ip: String) -> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key: self.key,
-            canonicalized_resource: self.canonicalized_resource,
-            signed_permissions: self.signed_permissions,
-            signed_resource: self.signed_resource,
-            signed_expiry: self.signed_expiry,
-            signed_start: self.signed_start,
-            signed_identifier: self.signed_identifier,
-            signed_protocol: self.signed_protocol,
-            signed_ip: Some(signed_ip),
-        }
-    }
-    pub fn with_identifier(
-        self,
-        signed_identifier: String,
-    ) -> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key: self.key,
-            canonicalized_resource: self.canonicalized_resource,
-            signed_permissions: self.signed_permissions,
-            signed_resource: self.signed_resource,
-            signed_expiry: self.signed_expiry,
-            signed_start: self.signed_start,
-            signed_identifier: Some(signed_identifier),
-            signed_protocol: self.signed_protocol,
-            signed_ip: self.signed_ip,
-        }
-    }
-    pub fn with_protocol(
-        self,
-        signed_protocol: SasProtocol,
-    ) -> BlobSharedAccessSignatureBuilder<T1, T2, T3> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key: self.key,
-            canonicalized_resource: self.canonicalized_resource,
-            signed_permissions: self.signed_permissions,
-            signed_resource: self.signed_resource,
-            signed_expiry: self.signed_expiry,
-            signed_start: self.signed_start,
-            signed_identifier: self.signed_identifier,
-            signed_protocol: Some(signed_protocol),
-            signed_ip: self.signed_ip,
-        }
-    }
-}
-
-impl BlobSharedAccessSignatureBuilder<SetPerms, SetResources, SetExpiry> {
-    pub fn finalize(self) -> BlobSharedAccessSignature {
-        BlobSharedAccessSignature {
-            key: self.key.clone(),
-            canonicalized_resource: self.canonicalized_resource.clone(),
-            signed_permissions: self.signed_permissions.unwrap(),
-            signed_resource: self.signed_resource.unwrap(),
-            signed_expiry: self.signed_expiry.unwrap(),
-            signed_start: self.signed_start,
-            signed_identifier: self.signed_identifier,
-            signed_protocol: self.signed_protocol,
-            signed_ip: self.signed_ip,
-        }
-    }
-}
-
-impl<T1, T2> BlobSharedAccessSignatureBuilder<(), T1, T2> {
-    pub fn with_permissions(
-        self,
-        permissions: BlobSasPermissions,
-    ) -> BlobSharedAccessSignatureBuilder<SetPerms, T1, T2> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key: self.key,
-            canonicalized_resource: self.canonicalized_resource,
-            signed_permissions: Some(permissions),
-            signed_resource: self.signed_resource,
-            signed_expiry: self.signed_expiry,
-            signed_start: self.signed_start,
-            signed_identifier: self.signed_identifier,
-            signed_protocol: self.signed_protocol,
-            signed_ip: self.signed_ip,
-        }
-    }
-}
-
-impl<T1, T2> BlobSharedAccessSignatureBuilder<T1, (), T2> {
-    pub fn with_resources(
-        self,
-        signed_resource: BlobSignedResource,
-    ) -> BlobSharedAccessSignatureBuilder<T1, SetResources, T2> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key: self.key,
-            canonicalized_resource: self.canonicalized_resource,
-            signed_permissions: self.signed_permissions,
-            signed_resource: Some(signed_resource),
-            signed_expiry: self.signed_expiry,
-            signed_start: self.signed_start,
-            signed_identifier: self.signed_identifier,
-            signed_protocol: self.signed_protocol,
-            signed_ip: self.signed_ip,
-        }
-    }
-}
-
-impl<T1, T2> BlobSharedAccessSignatureBuilder<T1, T2, ()> {
-    pub fn with_expiry(
-        self,
-        signed_expiry: DateTime<Utc>,
-    ) -> BlobSharedAccessSignatureBuilder<T1, T2, SetExpiry> {
-        BlobSharedAccessSignatureBuilder {
-            _phantom: PhantomData,
-            key: self.key,
-            canonicalized_resource: self.canonicalized_resource,
-            signed_permissions: self.signed_permissions,
-            signed_resource: self.signed_resource,
-            signed_expiry: Some(signed_expiry),
-            signed_start: self.signed_start,
-            signed_identifier: self.signed_identifier,
-            signed_protocol: self.signed_protocol,
-            signed_ip: self.signed_ip,
-        }
     }
 }

--- a/sdk/storage_blobs/examples/copy_blob.rs
+++ b/sdk/storage_blobs/examples/copy_blob.rs
@@ -43,17 +43,17 @@ async fn main() -> azure_core::Result<()> {
         let now = Utc::now();
         let later = now + Duration::hours(1);
         let sas = source_storage_client
-            .shared_access_signature()?
-            .with_resource(AccountSasResource::Blob)
-            .with_resource_type(AccountSasResourceType::Object)
-            .with_start(now)
-            .with_expiry(later)
-            .with_permissions(AccountSasPermissions {
-                read: true,
-                ..Default::default()
-            })
-            .with_protocol(SasProtocol::HttpHttps)
-            .finalize();
+            .shared_access_signature(
+                AccountSasResource::Blob,
+                AccountSasResourceType::Object,
+                later,
+                AccountSasPermissions {
+                    read: true,
+                    ..Default::default()
+                },
+            )?
+            .start(now)
+            .protocol(SasProtocol::HttpHttps);
         println!("token: '{}'", sas.token());
 
         source_blob.generate_signed_blob_url(&sas)?

--- a/sdk/storage_blobs/examples/shared_access_signature.rs
+++ b/sdk/storage_blobs/examples/shared_access_signature.rs
@@ -30,47 +30,47 @@ fn code() -> azure_core::Result<()> {
     let blob_client = container_client.blob_client(&blob_name);
 
     let sas = storage_client
-        .shared_access_signature()?
-        .with_resource(AccountSasResource::Blob)
-        .with_resource_type(AccountSasResourceType::Object)
-        .with_start(now)
-        .with_expiry(later)
-        .with_permissions(AccountSasPermissions {
-            read: true,
-            ..Default::default()
-        })
-        .with_protocol(SasProtocol::Https)
-        .finalize();
+        .shared_access_signature(
+            AccountSasResource::Blob,
+            AccountSasResourceType::Object,
+            later,
+            AccountSasPermissions {
+                read: true,
+                ..Default::default()
+            },
+        )?
+        .start(now)
+        .protocol(SasProtocol::Https);
 
     println!("blob account level token: '{}'", sas.token());
     let url = blob_client.generate_signed_blob_url(&sas)?;
     println!("blob account level url: '{}'", url);
 
     let sas = blob_client
-        .shared_access_signature()?
-        .with_expiry(later)
-        .with_start(now)
-        .with_permissions(BlobSasPermissions {
-            write: true,
-            ..Default::default()
-        })
-        .finalize();
+        .shared_access_signature(
+            BlobSasPermissions {
+                write: true,
+                ..Default::default()
+            },
+            later,
+        )?
+        .start(now);
     println!("blob service token: {}", sas.token());
     let url = blob_client.generate_signed_blob_url(&sas)?;
     println!("blob service level url: '{}'", url);
 
     let sas = container_client
-        .shared_access_signature()?
-        .with_expiry(later)
-        .with_start(now)
-        .with_permissions(BlobSasPermissions {
-            read: true,
-            list: true,
-            write: true,
-            ..Default::default()
-        })
-        .with_protocol(SasProtocol::HttpHttps)
-        .finalize();
+        .shared_access_signature(
+            BlobSasPermissions {
+                read: true,
+                list: true,
+                write: true,
+                ..Default::default()
+            },
+            later,
+        )?
+        .start(now)
+        .protocol(SasProtocol::HttpHttps);
 
     println!("container sas token: {}", sas.token());
     let url = container_client.generate_signed_container_url(&sas)?;

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -8,12 +8,14 @@ use azure_core::{
 use azure_core::{Method, Url};
 use azure_storage::{
     core::clients::{ServiceType, StorageClient, StorageCredentials},
+    prelude::BlobSasPermissions,
     shared_access_signature::{
-        service_sas::{BlobSharedAccessSignatureBuilder, BlobSignedResource, SetResources},
+        service_sas::{BlobSharedAccessSignature, BlobSignedResource},
         SasToken,
     },
 };
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 
 pub trait AsContainerClient<CN: Into<String>> {
     fn container_client(&self, container_name: CN) -> ContainerClient;
@@ -124,7 +126,9 @@ impl ContainerClient {
 
     pub fn shared_access_signature(
         &self,
-    ) -> azure_core::Result<BlobSharedAccessSignatureBuilder<(), SetResources, ()>> {
+        permissions: BlobSasPermissions,
+        expiry: DateTime<Utc>,
+    ) -> azure_core::Result<BlobSharedAccessSignature> {
         let canonicalized_resource = format!(
             "/blob/{}/{}",
             self.storage_client().account(),
@@ -133,8 +137,7 @@ impl ContainerClient {
 
         match self.storage_client().storage_credentials() {
             StorageCredentials::Key(ref _account, ref key) => Ok(
-                BlobSharedAccessSignatureBuilder::new(key.to_string(), canonicalized_resource)
-                    .with_resources(BlobSignedResource::Container),
+                BlobSharedAccessSignature::new(key.to_string(), canonicalized_resource, permissions, expiry, BlobSignedResource::Container),
             ),
             _ => Err(Error::message(ErrorKind::Credential,
                 "Shared access signature generation - SAS can be generated only from key and account clients",

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -1,7 +1,4 @@
 #![cfg_attr(feature = "into_future", feature(into_future))]
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
-#![deny(clippy::panic_used)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -1,4 +1,7 @@
 #![cfg_attr(feature = "into_future", feature(into_future))]
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::panic_used)]
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
Moved to using the same Builder pattern implemented by Operations, such that required params are provided by the creator, with setters for optional fields.