### PR TITLE
use `clap` parser in cosmos examples

### DIFF
--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -33,11 +33,12 @@ sha2 = "0.10"
 
 [dev-dependencies]
 env_logger = "0.9"
-tokio = { version = "1", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 hyper = "0.14"
 hyper-rustls = "0.23"
 reqwest = "0.11.0"
 stop-token = { version = "0.7.0", features = ["tokio"] }
+clap = { version = "3.2.7", features = ["derive", "env"] }
 
 [features]
 test_e2e = []

--- a/sdk/data_cosmos/examples/attachments_00.rs
+++ b/sdk/data_cosmos/examples/attachments_00.rs
@@ -1,4 +1,5 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
@@ -19,27 +20,31 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
     }
 }
 
+#[derive(Debug, Parser)]
+struct Args {
+    /// Name of the database.
+    database_name: String,
+    /// Name of the collection in the database
+    collection_name: String,
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+}
+
 // This example expects you to have created a collection
 // with partitionKey on "id".
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let database_name = std::env::args()
-        .nth(1)
-        .expect("please specify database name as first command line parameter");
-    let collection_name = std::env::args()
-        .nth(2)
-        .expect("please specify collection name as second command line parameter");
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
-
-    let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
+    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
     let client = client
-        .database_client(database_name)
-        .collection_client(collection_name);
+        .database_client(args.database_name)
+        .collection_client(args.collection_name);
 
     let id = format!("unique_id{}", 100);
 

--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -1,21 +1,30 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use stop_token::prelude::*;
 use stop_token::StopSource;
 use tokio::time::{Duration, Instant};
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     env_logger::init();
     // First we retrieve the account name and access key from environment variables, and
     // create an authorization token.
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Create a new Cosmos client.
     let options = CosmosOptions::default();
-    let client = CosmosClient::new(account.clone(), authorization_token.clone(), options);
+    let client = CosmosClient::new(args.account.clone(), authorization_token.clone(), options);
 
     // Create a new database, and time out if it takes more than 1 second.
     let future = client.create_database("my_database").into_future();

--- a/sdk/data_cosmos/examples/collection.rs
+++ b/sdk/data_cosmos/examples/collection.rs
@@ -1,13 +1,22 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::stream::StreamExt;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
+    let args = Args::parse();
 
     // This is how you construct an authorization token.
     // Remember to pick the correct token type.
@@ -17,14 +26,14 @@ async fn main() -> azure_core::Result<()> {
     // errors, plus Azure specific ones. For example if a REST call returns the
     // unexpected result (ie NotFound instead of Ok) we return an Err telling
     // you that.
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Once we have an authorization token you can create a client instance. You can change the
     // authorization token at later time if you need, for example, to escalate the privileges for a
     // single operation.
     // Here we are using reqwest but other clients are supported (check the documentation).
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
@@ -39,7 +48,7 @@ async fn main() -> azure_core::Result<()> {
 
     println!(
         "Account {} has {} database(s)",
-        account,
+        args.account,
         databases.databases.len()
     );
 

--- a/sdk/data_cosmos/examples/database_00.rs
+++ b/sdk/data_cosmos/examples/database_00.rs
@@ -1,18 +1,29 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::stream::StreamExt;
 use serde_json::Value;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
 
-    let authorization_token = permission::AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
 
-    let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
+    let authorization_token =
+        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
+
+    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
 
     let dbs = client
         .list_databases()

--- a/sdk/data_cosmos/examples/database_01.rs
+++ b/sdk/data_cosmos/examples/database_01.rs
@@ -1,17 +1,25 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::stream::StreamExt;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
-
-    let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
+    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
 
     let database = client.database_client("pollo");
     println!("database_name == {}", database.database_name());

--- a/sdk/data_cosmos/examples/document_00.rs
+++ b/sdk/data_cosmos/examples/document_00.rs
@@ -1,9 +1,20 @@
+use clap::Parser;
 use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos DB.
 use azure_core::prelude::*;
 
 use azure_data_cosmos::prelude::*;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+}
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct MySampleStruct {
@@ -34,19 +45,17 @@ const COLLECTION: &str = "azuresdktc";
 async fn main() -> azure_core::Result<()> {
     // Let's get Cosmos account and access key from env variables.
     // This helps automated testing.
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
+    let args = Args::parse();
 
     // First, we create an authorization token. There are two types of tokens, master and resource
     // constrained. Please check the Azure documentation for details. You can change tokens
     // at will and it's a good practice to raise your privileges only when needed.
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Next we will create a Cosmos client. You need an authorization_token but you can later
     // change it if needed.
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token.clone(),
         CosmosOptions::default(),
     );

--- a/sdk/data_cosmos/examples/document_entries_00.rs
+++ b/sdk/data_cosmos/examples/document_entries_00.rs
@@ -1,8 +1,23 @@
 use azure_core::prelude::*;
 
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the collection
+    collection_name: String,
+}
 
 // Now we create a sample struct.
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -25,22 +40,13 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // with partitionKey on "id".
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let database_name = std::env::args()
-        .nth(1)
-        .expect("please specify database name as first command line parameter");
-    let collection_name = std::env::args()
-        .nth(2)
-        .expect("please specify collection name as second command line parameter");
+    let args = Args::parse();
+    let authorization_token =
+        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-
-    let authorization_token = permission::AuthorizationToken::primary_from_base64(&primary_key)?;
-
-    let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
-    let client = client.database_client(database_name);
-    let client = client.collection_client(collection_name);
+    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
+    let client = client.database_client(args.database_name);
+    let client = client.collection_client(args.collection_name);
 
     let mut response = None;
     for i in 0u64..5 {

--- a/sdk/data_cosmos/examples/document_entries_01.rs
+++ b/sdk/data_cosmos/examples/document_entries_01.rs
@@ -1,6 +1,21 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the collection
+    collection_name: String,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct MySampleStruct {
@@ -22,22 +37,12 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // with partitionKey on "id".
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let database_name = std::env::args()
-        .nth(1)
-        .expect("please specify database name as first command line parameter");
-    let collection_name = std::env::args()
-        .nth(2)
-        .expect("please specify collection name as second command line parameter");
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
-
-    let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
-    let client = client.database_client(database_name);
-    let client = client.collection_client(collection_name);
+    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
+    let client = client.database_client(args.database_name);
+    let client = client.collection_client(args.collection_name);
 
     let mut doc = MySampleStruct {
         id: format!("unique_id{}", 500),

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -1,30 +1,36 @@
 use azure_core::headers::{HeaderName, HeaderValue, Headers};
 use azure_core::prelude::*;
 use azure_core::CustomHeaders;
+use clap::Parser;
 
 use azure_data_cosmos::prelude::*;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-
-    let database_name = std::env::args()
-        .nth(1)
-        .expect("Please provide the database name as first parameter");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
 
-    let database = client.database_client(database_name.clone());
+    let database = client.database_client(args.database_name.clone());
 
     let mut context = Context::new();
 

--- a/sdk/data_cosmos/examples/key_ranges_00.rs
+++ b/sdk/data_cosmos/examples/key_ranges_00.rs
@@ -1,29 +1,34 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the collection
+    collection_name: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let database = std::env::args()
-        .nth(1)
-        .expect("please specify database name as first command line parameter");
-    let collection = std::env::args()
-        .nth(2)
-        .expect("please specify collection name as second command line parameter");
-
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
 
     let client = client
-        .database_client(database)
-        .collection_client(collection);
+        .database_client(args.database_name)
+        .collection_client(args.collection_name);
 
     let resp = client.get_partition_key_ranges().into_future().await?;
     println!("resp == {:#?}", resp);

--- a/sdk/data_cosmos/examples/permission_00.rs
+++ b/sdk/data_cosmos/examples/permission_00.rs
@@ -1,39 +1,42 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::StreamExt;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the collection
+    collection_name: String,
+    /// The name of the second collection
+    collection_name2: String,
+    /// The name of the user
+    user_name: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-
-    let database_name = std::env::args()
-        .nth(1)
-        .expect("please specify the database name as first command line parameter");
-    let collection_name = std::env::args()
-        .nth(2)
-        .expect("please specify the collection name as second command line parameter");
-    let collection_name2 = std::env::args()
-        .nth(3)
-        .expect("please specify the collection name as third command line parameter");
-    let user_name = std::env::args()
-        .nth(4)
-        .expect("please specify the user name as fourth command line parameter");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
 
-    let database = client.database_client(database_name);
-    let collection = database.collection_client(collection_name);
-    let collection2 = database.collection_client(collection_name2);
-    let user = database.user_client(user_name);
+    let database = client.database_client(args.database_name);
+    let collection = database.collection_client(args.collection_name);
+    let collection2 = database.collection_client(args.collection_name2);
+    let user = database.user_client(args.user_name);
 
     let get_database_response = database.get_database().into_future().await?;
     println!("get_database_response == {:#?}", get_database_response);

--- a/sdk/data_cosmos/examples/stored_proc_00.rs
+++ b/sdk/data_cosmos/examples/stored_proc_00.rs
@@ -6,31 +6,36 @@
 ///     response.setBody("Hello, " + personToGreet);
 /// }
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the collection
+    collection_name: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let database = std::env::args()
-        .nth(1)
-        .expect("please specify database name as first command line parameter");
-    let collection = std::env::args()
-        .nth(2)
-        .expect("please specify collection name as second command line parameter");
-
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
 
     let ret = client
-        .database_client(database)
-        .collection_client(collection)
+        .database_client(args.database_name)
+        .collection_client(args.collection_name)
         .stored_procedure_client("test_proc")
         .execute_stored_procedure::<serde_json::Value>()
         .parameters(["Robert"])

--- a/sdk/data_cosmos/examples/stored_proc_01.rs
+++ b/sdk/data_cosmos/examples/stored_proc_01.rs
@@ -6,43 +6,47 @@
 ///     response.setBody("Hello, " + personToGreet);
 /// }
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::StreamExt;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the collection
+    collection_name: String,
+    /// The name of the stored procedure
+    stored_procedure_name: String,
+}
+
+const FUNCTION_BODY: &str = r#"
+    function f(personToGreet) {
+        var context = getContext();
+        var response = context.getResponse();
+        response.setBody("Hello, " + personToGreet);
+    }
+"#;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let function_body: &str = r#"
-        function f(personToGreet) {
-            var context = getContext();
-            var response = context.getResponse();
-            response.setBody("Hello, " + personToGreet);
-        }
-        "#;
-
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-
-    let database_name = std::env::args()
-        .nth(1)
-        .expect("please specify the database name as first command line parameter");
-    let collection_name = std::env::args()
-        .nth(2)
-        .expect("please specify the collection name as second command line parameter");
-    let stored_procedure_name = std::env::args()
-        .nth(3)
-        .expect("please specify the stored procedure name as third command line parameter");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
 
-    let database = client.database_client(database_name);
-    let collection = database.collection_client(collection_name);
-    let stored_procedure = collection.stored_procedure_client(stored_procedure_name);
+    let database = client.database_client(args.database_name);
+    let collection = database.collection_client(args.collection_name);
+    let stored_procedure = collection.stored_procedure_client(args.stored_procedure_name);
 
     let list_stored_procedures_response = collection
         .list_stored_procedures()
@@ -56,7 +60,7 @@ async fn main() -> azure_core::Result<()> {
     );
 
     let create_stored_procedure_response = stored_procedure
-        .create_stored_procedure(function_body)
+        .create_stored_procedure(FUNCTION_BODY)
         .into_future()
         .await?;
     println!(

--- a/sdk/data_cosmos/examples/user_00.rs
+++ b/sdk/data_cosmos/examples/user_00.rs
@@ -1,31 +1,36 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::StreamExt;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the user
+    user_name: String,
+}
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-
-    let database_name = std::env::args()
-        .nth(1)
-        .expect("please specify the database name as first command line parameter");
-    let user_name = std::env::args()
-        .nth(2)
-        .expect("please specify the user name as first command line parameter");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
 
-    let database = client.database_client(database_name);
-    let user = database.user_client(user_name.clone());
+    let database = client.database_client(args.database_name);
+    let user = database.user_client(args.user_name.clone());
 
     let create_user_response = user.create_user().into_future().await?;
     println!("create_user_response == {:#?}", create_user_response);
@@ -37,7 +42,7 @@ async fn main() -> azure_core::Result<()> {
     let get_user_response = user.get_user().into_future().await?;
     println!("get_user_response == {:#?}", get_user_response);
 
-    let new_user = format!("{}replaced", user_name);
+    let new_user = format!("{}replaced", args.user_name);
 
     let replace_user_response = user.replace_user(new_user.clone()).into_future().await?;
     println!("replace_user_response == {:#?}", replace_user_response);

--- a/sdk/data_cosmos/examples/user_defined_function_00.rs
+++ b/sdk/data_cosmos/examples/user_defined_function_00.rs
@@ -1,5 +1,20 @@
 use azure_data_cosmos::prelude::*;
+use clap::Parser;
 use futures::stream::StreamExt;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+    /// The name of the collection
+    collection_name: String,
+}
 
 const FN_BODY: &str = r#"
 function tax(income) {
@@ -15,27 +30,17 @@ function tax(income) {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let database = std::env::args()
-        .nth(1)
-        .expect("please specify database name as first command line parameter");
-    let collection = std::env::args()
-        .nth(2)
-        .expect("please specify collection name as second command line parameter");
-
-    let account = std::env::var("COSMOS_ACCOUNT").expect("Set env variable COSMOS_ACCOUNT first!");
-    let primary_key =
-        std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
-
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     let client = CosmosClient::new(
-        account.clone(),
+        args.account.clone(),
         authorization_token,
         CosmosOptions::default(),
     );
 
-    let database = client.database_client(database);
-    let collection = database.collection_client(collection);
+    let database = client.database_client(args.database_name);
+    let collection = database.collection_client(args.collection_name);
     let user_defined_function = collection.user_defined_function_client("test15");
 
     let ret = user_defined_function


### PR DESCRIPTION
This is a relatively small change, but it moves the cosmos examples from our custom parsing code to the commonly-used [`clap`](https://docs.rs/clap) command line parser crate. The benefit of doing this is that it removes bespoke parsing code from inside `fn main` to a declarative struct at the top of the file. The focus of the examples should be on how to use the Azure APIs, and not having several lines of command line parsing code at the start of each `fn main` should make it a lot easier to skip to the core of the examples.

I was reading over some examples, and found myself distracted by the initial parsing code in each file. Taken as a whole I think this should make the examples a lot easier to follow. Thanks!