### PR TITLE
finish moving to StatusCode rather than u16 for HTTP status code

### DIFF
--- a/sdk/core/src/http_client/mod.rs
+++ b/sdk/core/src/http_client/mod.rs
@@ -37,11 +37,12 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
         let rsp = self.execute_request(request).await?;
         let (status, headers, body) = rsp.deconstruct();
         let body = crate::collect_pinned_stream(body).await?;
-        let status_u16 = status as u16;
-        if !(200..400).contains(&status_u16) {
-            return Err(ErrorKind::http_response_from_body(status_u16, &body).into_error());
+
+        if status.is_success() {
+            Ok(crate::CollectedResponse::new(status, headers, body))
+        } else {
+            return Err(ErrorKind::http_response_from_body(status, &body).into_error());
         }
-        Ok(crate::CollectedResponse::new(status, headers, body))
     }
 }
 

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -59,19 +59,14 @@ where
                 }
                 Ok(response) => {
                     // Error status code
-                    let code = response.status() as u16;
+                    let status = response.status();
 
                     let http_error = HttpError::new(response).await;
                     // status code should already be parsed as valid from the underlying HTTP
                     // implementations.
-                    let status = StatusCode::try_from(code).map_err(|_| {
-                        Error::with_message(ErrorKind::DataConversion, || {
-                            format!("invalid status code '{code}'")
-                        })
-                    })?;
                     let error = Error::full(
                         ErrorKind::http_response(
-                            code,
+                            status,
                             http_error.error_code().map(|s| s.to_owned()),
                         ),
                         http_error,

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -84,7 +84,7 @@ pub async fn perform(
     let rsp_status = rsp.status();
     let rsp_body = rsp.into_body().await;
     if !rsp_status.is_success() {
-        return Err(ErrorKind::http_response_from_body(rsp_status as u16, &rsp_body).into_error());
+        return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
     }
     serde_json::from_slice(&rsp_body).map_kind(ErrorKind::DataConversion)
 }

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -45,7 +45,7 @@ where
     let rsp_status = rsp.status();
     let rsp_body = rsp.into_body().await;
     if !rsp_status.is_success() {
-        return Err(ErrorKind::http_response_from_body(rsp_status as u16, &rsp_body).into_error());
+        return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
     }
     let device_code_response: DeviceCodePhaseOneResponse = serde_json::from_slice(&rsp_body)?;
 

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -55,9 +55,7 @@ pub async fn exchange(
         if let Ok(token_error) = serde_json::from_slice::<RefreshTokenError>(&rsp_body) {
             return Err(Error::new(ErrorKind::Credential, token_error));
         } else {
-            return Err(
-                ErrorKind::http_response_from_body(rsp_status as u16, &rsp_body).into_error(),
-            );
+            return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
         }
     }
 

--- a/sdk/storage_blobs/examples/missing_blob.rs
+++ b/sdk/storage_blobs/examples/missing_blob.rs
@@ -1,0 +1,41 @@
+use azure_core::{error::ErrorKind, StatusCode};
+use azure_storage::core::prelude::*;
+use azure_storage_blobs::prelude::*;
+use uuid::Uuid;
+
+#[tokio::main]
+async fn main() -> azure_core::Result<()> {
+    // First we retrieve the account name and access key from environment variables.
+    let account =
+        std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
+    let access_key =
+        std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
+
+    let container_name = format!("example-{}", Uuid::new_v4());
+    let blob_name = format!("missing-{}.txt", Uuid::new_v4());
+
+    let storage_client = StorageClient::new_access_key(&account, &access_key);
+    let container_client = storage_client.container_client(&container_name);
+    println!("creating container {}", container_name);
+    container_client.create().into_future().await?;
+
+    let blob_client = container_client.blob_client(&blob_name);
+
+    println!("getting properties for {}/{}", container_name, blob_name);
+    let result = blob_client.get_properties().into_future().await;
+    let error = result.expect_err("get_properties on missing blob should fail");
+    if let ErrorKind::HttpResponse {
+        status: StatusCode::NotFound,
+        ..
+    } = error.kind()
+    {
+        println!("{}/{} does not exist", container_name, blob_name);
+    } else {
+        panic!("unexpected error: {}", error);
+    }
+
+    // cleanup
+    container_client.delete().into_future().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
While trying to address #883, I found that multiple other places were
using u16 instead of StatusCode.  This updates the other areas and adds
the requested example.