### PR TITLE
Simplify cosmos client construction

### DIFF
--- a/sdk/data_cosmos/README.md
+++ b/sdk/data_cosmos/README.md
@@ -56,7 +56,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
 
     // Next we will create a Cosmos client.
-    let client = CosmosClient::new(account.clone(), authorization_token, CosmosOptions::default());
+    let client = CosmosClient::new(account.clone(), authorization_token);
 
     // We know the database so we can obtain a database client.
     let database = client.database_client(database_name);

--- a/sdk/data_cosmos/examples/attachments_00.rs
+++ b/sdk/data_cosmos/examples/attachments_00.rs
@@ -41,7 +41,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default())
+    let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)
         .collection_client(args.collection_name);
 

--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -23,7 +23,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Create a new Cosmos client.
-    let client = CosmosClient::new(args.account.clone(), authorization_token.clone());
+    let client = CosmosClient::new(args.account, authorization_token);
 
     // Create a new database, and time out if it takes more than 1 second.
     let future = client.create_database("my_database").into_future();

--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -23,8 +23,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Create a new Cosmos client.
-    let options = CosmosOptions::default();
-    let client = CosmosClient::new(args.account.clone(), authorization_token.clone(), options);
+    let client = CosmosClient::new(args.account.clone(), authorization_token.clone());
 
     // Create a new database, and time out if it takes more than 1 second.
     let future = client.create_database("my_database").into_future();

--- a/sdk/data_cosmos/examples/collection.rs
+++ b/sdk/data_cosmos/examples/collection.rs
@@ -32,11 +32,7 @@ async fn main() -> azure_core::Result<()> {
     // authorization token at later time if you need, for example, to escalate the privileges for a
     // single operation.
     // Here we are using reqwest but other clients are supported (check the documentation).
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
 
     // The Cosmos' client exposes a lot of methods. This one lists the databases in the specified account.
     let databases = client

--- a/sdk/data_cosmos/examples/collection.rs
+++ b/sdk/data_cosmos/examples/collection.rs
@@ -32,7 +32,7 @@ async fn main() -> azure_core::Result<()> {
     // authorization token at later time if you need, for example, to escalate the privileges for a
     // single operation.
     // Here we are using reqwest but other clients are supported (check the documentation).
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(&args.account, authorization_token);
 
     // The Cosmos' client exposes a lot of methods. This one lists the databases in the specified account.
     let databases = client

--- a/sdk/data_cosmos/examples/create_delete_database.rs
+++ b/sdk/data_cosmos/examples/create_delete_database.rs
@@ -34,7 +34,7 @@ async fn main() -> azure_core::Result<()> {
     // Once we have an authorization token you can create a client instance. You can change the
     // authorization token at later time if you need, for example, to escalate the privileges for a
     // single operation.
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
+    let client = CosmosClient::new(args.account, authorization_token);
 
     // The Cosmos' client exposes a lot of methods. This one lists the databases in the specified
     // account. Database do not implement Display but deref to &str so you can pass it to methods

--- a/sdk/data_cosmos/examples/database_00.rs
+++ b/sdk/data_cosmos/examples/database_00.rs
@@ -23,7 +23,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token =
         permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
+    let client = CosmosClient::new(args.account, authorization_token);
 
     let dbs = client
         .list_databases()

--- a/sdk/data_cosmos/examples/database_01.rs
+++ b/sdk/data_cosmos/examples/database_01.rs
@@ -19,8 +19,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
-
+    let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client("pollo");
     println!("database_name == {}", database.database_name());
 

--- a/sdk/data_cosmos/examples/document_00.rs
+++ b/sdk/data_cosmos/examples/document_00.rs
@@ -54,11 +54,7 @@ async fn main() -> azure_core::Result<()> {
 
     // Next we will create a Cosmos client. You need an authorization_token but you can later
     // change it if needed.
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token.clone(),
-        CosmosOptions::default(),
-    );
+    let client = CosmosClient::new(args.account.clone(), authorization_token.clone());
 
     // list_databases will give us the databases available in our account. If there is
     // an error (for example, the given key is not valid) you will receive a

--- a/sdk/data_cosmos/examples/document_00.rs
+++ b/sdk/data_cosmos/examples/document_00.rs
@@ -54,7 +54,7 @@ async fn main() -> azure_core::Result<()> {
 
     // Next we will create a Cosmos client. You need an authorization_token but you can later
     // change it if needed.
-    let client = CosmosClient::new(args.account.clone(), authorization_token.clone());
+    let client = CosmosClient::new(args.account, authorization_token);
 
     // list_databases will give us the databases available in our account. If there is
     // an error (for example, the given key is not valid) you will receive a

--- a/sdk/data_cosmos/examples/document_entries_00.rs
+++ b/sdk/data_cosmos/examples/document_entries_00.rs
@@ -44,7 +44,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token =
         permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default())
+    let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)
         .collection_client(args.collection_name);
 

--- a/sdk/data_cosmos/examples/document_entries_01.rs
+++ b/sdk/data_cosmos/examples/document_entries_01.rs
@@ -40,7 +40,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default())
+    let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)
         .collection_client(args.collection_name);
 

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -24,7 +24,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name.clone());
 
     let mut context = Context::new();

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -24,12 +24,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
-
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
     let database = client.database_client(args.database_name.clone());
 
     let mut context = Context::new();

--- a/sdk/data_cosmos/examples/key_ranges_00.rs
+++ b/sdk/data_cosmos/examples/key_ranges_00.rs
@@ -20,13 +20,9 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    )
-    .database_client(args.database_name)
-    .collection_client(args.collection_name);
+    let client = CosmosClient::new(args.account.clone(), authorization_token)
+        .database_client(args.database_name)
+        .collection_client(args.collection_name);
 
     let resp = client.get_partition_key_ranges().into_future().await?;
     println!("resp == {:#?}", resp);

--- a/sdk/data_cosmos/examples/key_ranges_00.rs
+++ b/sdk/data_cosmos/examples/key_ranges_00.rs
@@ -20,7 +20,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token)
+    let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)
         .collection_client(args.collection_name);
 

--- a/sdk/data_cosmos/examples/permission_00.rs
+++ b/sdk/data_cosmos/examples/permission_00.rs
@@ -27,7 +27,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
 
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);

--- a/sdk/data_cosmos/examples/permission_00.rs
+++ b/sdk/data_cosmos/examples/permission_00.rs
@@ -27,11 +27,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
 
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);

--- a/sdk/data_cosmos/examples/query_document_00.rs
+++ b/sdk/data_cosmos/examples/query_document_00.rs
@@ -40,7 +40,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token)
+    let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)
         .collection_client(args.collection_name);
 

--- a/sdk/data_cosmos/examples/query_document_00.rs
+++ b/sdk/data_cosmos/examples/query_document_00.rs
@@ -40,13 +40,9 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    )
-    .database_client(args.database_name)
-    .collection_client(args.collection_name);
+    let client = CosmosClient::new(args.account.clone(), authorization_token)
+        .database_client(args.database_name)
+        .collection_client(args.collection_name);
 
     let query_obj = Query::new(args.query);
 

--- a/sdk/data_cosmos/examples/readme.rs
+++ b/sdk/data_cosmos/examples/readme.rs
@@ -57,11 +57,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Next we will create a Cosmos client.
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
 
     // We know the database so we can obtain a database client.
     let database = client.database_client(args.database_name);

--- a/sdk/data_cosmos/examples/readme.rs
+++ b/sdk/data_cosmos/examples/readme.rs
@@ -57,7 +57,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Next we will create a Cosmos client.
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
 
     // We know the database so we can obtain a database client.
     let database = client.database_client(args.database_name);

--- a/sdk/data_cosmos/examples/remove_all_documents.rs
+++ b/sdk/data_cosmos/examples/remove_all_documents.rs
@@ -27,11 +27,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Next we will create a Cosmos client.
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
     let collection = client
         .database_client(args.database_name)
         .collection_client(args.collection_name);

--- a/sdk/data_cosmos/examples/remove_all_documents.rs
+++ b/sdk/data_cosmos/examples/remove_all_documents.rs
@@ -27,7 +27,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Next we will create a Cosmos client.
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
     let collection = client
         .database_client(args.database_name)
         .collection_client(args.collection_name);

--- a/sdk/data_cosmos/examples/stored_proc_00.rs
+++ b/sdk/data_cosmos/examples/stored_proc_00.rs
@@ -27,7 +27,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
 
     let ret = client
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/stored_proc_00.rs
+++ b/sdk/data_cosmos/examples/stored_proc_00.rs
@@ -27,11 +27,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
 
     let ret = client
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/stored_proc_01.rs
+++ b/sdk/data_cosmos/examples/stored_proc_01.rs
@@ -38,7 +38,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let collection = CosmosClient::new(args.account.clone(), authorization_token)
+    let collection = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)
         .collection_client(args.collection_name);
     let stored_procedure = collection.stored_procedure_client(args.stored_procedure_name);

--- a/sdk/data_cosmos/examples/stored_proc_01.rs
+++ b/sdk/data_cosmos/examples/stored_proc_01.rs
@@ -38,13 +38,9 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let collection = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    )
-    .database_client(args.database_name)
-    .collection_client(args.collection_name);
+    let collection = CosmosClient::new(args.account.clone(), authorization_token)
+        .database_client(args.database_name)
+        .collection_client(args.collection_name);
     let stored_procedure = collection.stored_procedure_client(args.stored_procedure_name);
 
     let list_stored_procedures_response = collection

--- a/sdk/data_cosmos/examples/trigger_00.rs
+++ b/sdk/data_cosmos/examples/trigger_00.rs
@@ -54,12 +54,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
-
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);
     let trigger = collection.clone().trigger_client(args.trigger_name);

--- a/sdk/data_cosmos/examples/trigger_00.rs
+++ b/sdk/data_cosmos/examples/trigger_00.rs
@@ -54,7 +54,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);
     let trigger = collection.clone().trigger_client(args.trigger_name);

--- a/sdk/data_cosmos/examples/user_00.rs
+++ b/sdk/data_cosmos/examples/user_00.rs
@@ -23,12 +23,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
-
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
     let database = client.database_client(args.database_name);
     let user = database.user_client(args.user_name.clone());
 

--- a/sdk/data_cosmos/examples/user_00.rs
+++ b/sdk/data_cosmos/examples/user_00.rs
@@ -23,7 +23,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name);
     let user = database.user_client(args.user_name.clone());
 

--- a/sdk/data_cosmos/examples/user_defined_function_00.rs
+++ b/sdk/data_cosmos/examples/user_defined_function_00.rs
@@ -33,12 +33,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
-
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);
     let user_defined_function = collection.user_defined_function_client("test15");

--- a/sdk/data_cosmos/examples/user_defined_function_00.rs
+++ b/sdk/data_cosmos/examples/user_defined_function_00.rs
@@ -33,7 +33,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);
     let user_defined_function = collection.user_defined_function_client("test15");

--- a/sdk/data_cosmos/examples/user_permission_token.rs
+++ b/sdk/data_cosmos/examples/user_permission_token.rs
@@ -26,7 +26,7 @@ async fn main() -> azure_core::Result<()> {
 
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(args.account.clone(), authorization_token);
+    let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name.clone());
     let collection = database.collection_client(args.collection_name.clone());
     let user = database.user_client(args.user_name);

--- a/sdk/data_cosmos/examples/user_permission_token.rs
+++ b/sdk/data_cosmos/examples/user_permission_token.rs
@@ -26,12 +26,7 @@ async fn main() -> azure_core::Result<()> {
 
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
-
+    let client = CosmosClient::new(args.account.clone(), authorization_token);
     let database = client.database_client(args.database_name.clone());
     let collection = database.collection_client(args.collection_name.clone());
     let user = database.user_client(args.user_name);

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -23,10 +23,10 @@ pub struct CosmosClient {
 
 impl CosmosClient {
     /// Create a new `CosmosClient` which connects to the account's instance in the public Azure cloud.
-    pub fn new(account: String, auth_token: AuthorizationToken) -> Self {
+    pub fn new(account: impl Into<String>, auth_token: AuthorizationToken) -> Self {
         Self {
             pipeline: new_pipeline_from_options(ClientOptions::default(), auth_token),
-            cloud_location: CloudLocation::Public(account),
+            cloud_location: CloudLocation::Public(account.into()),
         }
     }
 
@@ -45,15 +45,20 @@ impl CosmosClient {
     }
 
     /// Create a new `CosmosClient` which connects to the account's instance in the Chinese Azure cloud.
-    pub fn new_china(account: String, auth_token: AuthorizationToken) -> Self {
+    pub fn new_china(account: impl Into<String>, auth_token: AuthorizationToken) -> Self {
         Self {
             pipeline: new_pipeline_from_options(ClientOptions::default(), auth_token),
-            cloud_location: CloudLocation::China(account),
+            cloud_location: CloudLocation::China(account.into()),
         }
     }
 
     /// Create a new `CosmosClient` which connects to the account's instance in custom Azure cloud.
-    pub fn new_custom(account: String, auth_token: AuthorizationToken, uri: String) -> Self {
+    pub fn new_custom(
+        account: impl Into<String>,
+        auth_token: AuthorizationToken,
+        uri: String,
+    ) -> Self {
+        let account = account.into();
         Self {
             pipeline: new_pipeline_from_options(ClientOptions::default(), auth_token),
             cloud_location: CloudLocation::Custom { account, uri },
@@ -61,13 +66,13 @@ impl CosmosClient {
     }
 
     /// Create a new `CosmosClient` which connects to the account's instance in Azure emulator
-    pub fn new_emulator(address: &str, port: u16) -> Self {
+    pub fn new_emulator(address: impl AsRef<str>, port: u16) -> Self {
         let auth_token = AuthorizationToken::primary_from_base64(EMULATOR_ACCOUNT_KEY).unwrap();
         Self {
             pipeline: new_pipeline_from_options(ClientOptions::default(), auth_token),
             cloud_location: CloudLocation::Custom {
                 account: String::from("Custom"),
-                uri: format!("https://{}:{}", address, port),
+                uri: format!("https://{}:{}", address.as_ref(), port),
             },
         }
     }

--- a/sdk/data_cosmos/src/clients/mod.rs
+++ b/sdk/data_cosmos/src/clients/mod.rs
@@ -34,7 +34,7 @@ mod user_defined_function;
 
 pub use attachment::AttachmentClient;
 pub use collection::CollectionClient;
-pub use cosmos::{CosmosClient, CosmosOptions};
+pub use cosmos::CosmosClient;
 pub use database::DatabaseClient;
 pub use document::DocumentClient;
 pub use permission::PermissionClient;

--- a/sdk/data_cosmos/src/clients/mod.rs
+++ b/sdk/data_cosmos/src/clients/mod.rs
@@ -11,13 +11,13 @@
 //! ```no_run
 //! use azure_data_cosmos::prelude::*;
 //!
-//! let account = todo!("Get Cosmos account name from the Azure Portal");
+//! let account: String = todo!("Get Cosmos account name from the Azure Portal");
 //! let primary_key: String = todo!("Get Cosmos primary key from the Azure Portal");
 //! let authorization_token = AuthorizationToken::primary_from_base64(&primary_key).unwrap();
 //! let database_name: String = todo!("Think of some database name");
 //!
 //! // Create an http client, then a `CosmosClient`, and then a `DatabaseClient`
-//! let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
+//! let client = CosmosClient::new(account, authorization_token);
 //! let client = client.database_client(database_name);
 //! ```
 

--- a/sdk/data_cosmos/src/lib.rs
+++ b/sdk/data_cosmos/src/lib.rs
@@ -55,7 +55,7 @@ async fn main() -> azure_core::Result<()> {
     let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
 
     // Next we will create a Cosmos client.
-    let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
+    let client = CosmosClient::new(account, authorization_token);
 
     // We know the database so we can obtain a database client.
     let database = client.database_client(database_name);

--- a/sdk/data_cosmos/tests/setup.rs
+++ b/sdk/data_cosmos/tests/setup.rs
@@ -5,7 +5,7 @@ pub fn initialize() -> azure_core::Result<CosmosClient> {
     let account = get_account();
     let authorization_token = get_authorization_token()?;
 
-    let client = CosmosClient::new(account, authorization_token, CosmosOptions::default());
+    let client = CosmosClient::new(account, authorization_token);
 
     Ok(client)
 }


### PR DESCRIPTION
This PR builds on https://github.com/Azure/azure-sdk-for-rust/pull/884 to slim down the instantiation of the cosmos client. It does away with `CosmosOptions` and adds more lenient bounds on the constructor. This PR is best reviewed on a per-commit basis. Thanks!

## Example

```rust
// before
let client = CosmosClient::new(
    account.clone(),
    authorization_token,
    CosmosOptions::default(),
);
```

```rust
// after
let client = CosmosClient::new(&account, authorization_token);
```

## Details

The `CosmosOptions` struct is a thin wrapper around the `azure_core::ClientOptions` struct. It doesn't expose any custom fields, and forwards all calls directly to the internal `ClientOptions` struct.

`CosmosOptions` has two constructors: the empty `new` method /`Default` implementation, and the `new_with_transaction_name` method. The latter which is only used inside the `CosmosClient::new_with_transaction` method, so removing it hasn't removed any existing functionality.

We know that we want to expose the ability to add custom pipeline plugins (middleware) to the clients. But this can be done by exposing builder methods on the client, and we don't need an `Options` struct to achieve this. On the contrary: the work in this PR is intended as prep work to enable the implementation of a builder structure.

So to summarize: no existing functionality is lost, and this sets us up to implement pipeline extensions using builder methods on the client.