### PR TITLE
Use `Response::is_success` for retry policy

### DIFF
--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -48,13 +48,12 @@ where
 
         loop {
             let error = match next[0].send(ctx, request, &next[1..]).await {
-                Ok(response) if (200..400).contains(&u16::from(response.status())) => {
+                Ok(response) if response.status().is_success() => {
                     log::trace!(
                         "Succesful response. Request={:?} response={:?}",
                         request,
                         response
                     );
-                    // Successful status code
                     return Ok(response);
                 }
                 Ok(response) => {


### PR DESCRIPTION
Fixes #836 