### PR TITLE
Shared auth among cosmos examples

### DIFF
--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -1,30 +1,14 @@
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use stop_token::prelude::*;
 use stop_token::StopSource;
 use tokio::time::{Duration, Instant};
 
-#[derive(Debug, Parser)]
-struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
-}
+mod util;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     env_logger::init();
-    // First we retrieve the account name and access key from environment variables, and
-    // create an authorization token.
-    let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    // Create a new Cosmos client.
-    let options = CosmosOptions::default();
-    let client = CosmosClient::new(args.account.clone(), authorization_token.clone(), options);
+    let client = util::Auth::parse().into_client()?;
 
     // Create a new database, and time out if it takes more than 1 second.
     let future = client.create_database("my_database").into_future();

--- a/sdk/data_cosmos/examples/create_delete_database.rs
+++ b/sdk/data_cosmos/examples/create_delete_database.rs
@@ -1,87 +1,60 @@
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::stream::StreamExt;
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
     /// The name of the database
     database_name: String,
+    #[clap(flatten)]
+    auth: util::Auth,
 }
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // First we retrieve the account name and access key from environment variables.
-    // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
+    let database_name = args.database_name;
+    let client = args.auth.into_client()?;
 
-    // This is how you construct an authorization token.
-    // Remember to pick the correct token type.
-    // Here we assume master.
-    // Most methods return a ```Result<_, azure_data_cosmos::Error>```.
-    // ```azure_data_cosmos::Error``` is an enum union of all the possible underlying
-    // errors, plus Azure specific ones. For example if a REST call returns the
-    // unexpected result (ie NotFound instead of Ok) we return an Err telling
-    // you that.
-    let authorization_token =
-        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    // Once we have an authorization token you can create a client instance. You can change the
-    // authorization token at later time if you need, for example, to escalate the privileges for a
-    // single operation.
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
-
-    // The Cosmos' client exposes a lot of methods. This one lists the databases in the specified
-    // account. Database do not implement Display but deref to &str so you can pass it to methods
-    // both as struct or id.
-
+    // The Cosmos' client exposes a lot of methods. This one lists the databases in the specified account.
     let mut list_databases_stream = client.list_databases().into_stream();
     while let Some(list_databases_response) = list_databases_stream.next().await {
         println!("list_databases_response = {:#?}", list_databases_response?);
     }
     drop(list_databases_stream);
 
-    let db = client
-        .create_database(&args.database_name)
-        .into_future()
-        .await?;
+    let db = client.create_database(&database_name).into_future().await?;
     println!("created database = {:#?}", db);
 
     // create collection!
-    {
-        let database = client.database_client(args.database_name.clone());
-        let create_collection_response = database
-            .create_collection("panzadoro", "/id")
-            .into_future()
-            .await?;
+    let database = client.database_client(database_name.clone());
+    let create_collection_response = database
+        .create_collection("panzadoro", "/id")
+        .into_future()
+        .await?;
 
-        println!(
-            "create_collection_response == {:#?}",
-            create_collection_response
-        );
+    println!(
+        "create_collection_response == {:#?}",
+        create_collection_response
+    );
 
-        let db_collection = database.collection_client("panzadoro");
+    let db_collection = database.collection_client("panzadoro");
 
-        let get_collection_response = db_collection.get_collection().into_future().await?;
-        println!("get_collection_response == {:#?}", get_collection_response);
+    let get_collection_response = db_collection.get_collection().into_future().await?;
+    println!("get_collection_response == {:#?}", get_collection_response);
 
-        let mut stream = database.list_collections().into_stream();
-        while let Some(res) = stream.next().await {
-            let res = res?;
-            println!("res == {:#?}", res);
-        }
-
-        let delete_response = db_collection.delete_collection().into_future().await?;
-        println!("collection deleted: {:#?}", delete_response);
+    let mut stream = database.list_collections().into_stream();
+    while let Some(res) = stream.next().await {
+        let res = res?;
+        println!("res == {:#?}", res);
     }
 
+    let delete_response = db_collection.delete_collection().into_future().await?;
+    println!("collection deleted: {:#?}", delete_response);
+
     let resp = client
-        .database_client(args.database_name)
+        .database_client(database_name)
         .delete_database()
         .into_future()
         .await?;

--- a/sdk/data_cosmos/examples/database_00.rs
+++ b/sdk/data_cosmos/examples/database_00.rs
@@ -1,29 +1,12 @@
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::stream::StreamExt;
 use serde_json::Value;
 
-#[derive(Debug, Parser)]
-struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
-}
+mod util;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // First we retrieve the account name and access key from environment variables.
-    // We expect access keys (ie, not resource constrained)
-
-    let args = Args::parse();
-
-    let authorization_token =
-        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
+    let client = util::Auth::parse().into_client()?;
 
     let dbs = client
         .list_databases()

--- a/sdk/data_cosmos/examples/database_01.rs
+++ b/sdk/data_cosmos/examples/database_01.rs
@@ -1,25 +1,11 @@
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::stream::StreamExt;
 
-#[derive(Debug, Parser)]
-struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
-}
+mod util;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // First we retrieve the account name and access key from environment variables.
-    // We expect access keys (ie, not resource constrained)
-    let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default());
+    let client = util::Auth::parse().into_client()?;
 
     let database = client.database_client("pollo");
     println!("database_name == {}", database.database_name());

--- a/sdk/data_cosmos/examples/document_00.rs
+++ b/sdk/data_cosmos/examples/document_00.rs
@@ -4,17 +4,9 @@ use serde::{Deserialize, Serialize};
 // Using the prelude module of the Cosmos crate makes easier to use the Rust Azure SDK for Cosmos DB.
 use azure_core::prelude::*;
 
-use azure_data_cosmos::prelude::*;
+mod util;
 
-#[derive(Debug, Parser)]
-struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
-}
+use azure_data_cosmos::prelude::*;
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
 struct MySampleStruct {
@@ -43,22 +35,7 @@ const COLLECTION: &str = "azuresdktc";
 // 4. Delete everything.
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // Let's get Cosmos account and access key from env variables.
-    // This helps automated testing.
-    let args = Args::parse();
-
-    // First, we create an authorization token. There are two types of tokens, master and resource
-    // constrained. Please check the Azure documentation for details. You can change tokens
-    // at will and it's a good practice to raise your privileges only when needed.
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    // Next we will create a Cosmos client. You need an authorization_token but you can later
-    // change it if needed.
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token.clone(),
-        CosmosOptions::default(),
-    );
+    let client = util::Auth::parse().into_client()?;
 
     // list_databases will give us the databases available in our account. If there is
     // an error (for example, the given key is not valid) you will receive a

--- a/sdk/data_cosmos/examples/document_entries_00.rs
+++ b/sdk/data_cosmos/examples/document_entries_00.rs
@@ -5,18 +5,16 @@ use clap::Parser;
 use futures::stream::StreamExt;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
     /// The name of the database
     database_name: String,
     /// The name of the collection
     collection_name: String,
+    #[clap(flatten)]
+    auth: util::Auth,
 }
 
 // Now we create a sample struct.
@@ -41,12 +39,14 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token =
-        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let database_name = args.database_name;
+    let collection_name = args.collection_name;
 
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default())
-        .database_client(args.database_name)
-        .collection_client(args.collection_name);
+    let client = args
+        .auth
+        .into_client()?
+        .database_client(database_name)
+        .collection_client(collection_name);
 
     let mut response = None;
     for i in 0u64..5 {

--- a/sdk/data_cosmos/examples/document_entries_01.rs
+++ b/sdk/data_cosmos/examples/document_entries_01.rs
@@ -1,16 +1,13 @@
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
+    #[clap(flatten)]
+    auth: util::Auth,
     /// The name of the database
     database_name: String,
     /// The name of the collection
@@ -38,9 +35,9 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(args.account, authorization_token, CosmosOptions::default())
+    let client = args
+        .auth
+        .into_client()?
         .database_client(args.database_name)
         .collection_client(args.collection_name);
 

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -1,45 +1,31 @@
-use azure_core::headers::{HeaderName, HeaderValue, Headers};
+use azure_core::headers::Headers;
 use azure_core::prelude::*;
 use azure_core::CustomHeaders;
 use clap::Parser;
 
-use azure_data_cosmos::prelude::*;
+mod util;
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
+    #[clap(flatten)]
+    auth: util::Auth,
     /// The name of the database
     database_name: String,
 }
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // First we retrieve the account name and access key from environment variables.
-    // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
-
+    let client = args.auth.into_client()?;
     let database = client.database_client(args.database_name.clone());
 
     let mut context = Context::new();
 
     // Next we create a CustomHeaders type and insert it into the context allowing us to insert custom headers.
     let custom_headers: CustomHeaders = {
-        let mut custom_headers = std::collections::HashMap::<HeaderName, HeaderValue>::new();
-        custom_headers.insert("MyCoolHeader".into(), "CORS maybe?".into());
-        let hs: Headers = custom_headers.into();
-        hs.into()
+        let mut custom_headers = Headers::new();
+        custom_headers.insert("MyCoolHeader", "CORS maybe?");
+        custom_headers.into()
     };
 
     context.insert(custom_headers);

--- a/sdk/data_cosmos/examples/permission_00.rs
+++ b/sdk/data_cosmos/examples/permission_00.rs
@@ -2,14 +2,12 @@ use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::StreamExt;
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
+    #[clap(flatten)]
+    auth: util::Auth,
     /// The name of the database
     database_name: String,
     /// The name of the collection
@@ -22,16 +20,8 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // First we retrieve the account name and access key from environment variables.
-    // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = args.auth.into_client()?;
 
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);

--- a/sdk/data_cosmos/examples/readme.rs
+++ b/sdk/data_cosmos/examples/readme.rs
@@ -5,7 +5,7 @@ use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::stream::StreamExt;
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 struct Args {
     /// Cosmos primary key name
     #[clap(env = "COSMOS_PRIMARY_KEY")]
@@ -47,13 +47,9 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 // 5. Check the remaining documents.
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // Let's get Cosmos account and access key from env variables.
-    // This helps automated testing.
+    // Let's get a Cosmos account name and access key from env variables.
     let args = Args::parse();
-    // First, we create an authorization token. There are two types of tokens, master and resource
-    // constrained. This SDK supports both.
-    // Please check the Azure documentation for details or the examples folder
-    // on how to create and use token-based permissions.
+    // First, we create an authorization token. There are two types of tokens: primary and resource constrained.
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
     // Next we will create a Cosmos client.

--- a/sdk/data_cosmos/examples/stored_proc_00.rs
+++ b/sdk/data_cosmos/examples/stored_proc_00.rs
@@ -5,17 +5,14 @@
 ///     var response = context.getResponse();
 ///     response.setBody("Hello, " + personToGreet);
 /// }
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
+    #[clap(flatten)]
+    auth: util::Auth,
     /// The name of the database
     database_name: String,
     /// The name of the collection
@@ -25,13 +22,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = args.auth.into_client()?;
 
     let ret = client
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/trigger_00.rs
+++ b/sdk/data_cosmos/examples/trigger_00.rs
@@ -3,14 +3,12 @@ use azure_data_cosmos::resources::trigger::{TriggerOperation, TriggerType};
 use clap::Parser;
 use futures::stream::StreamExt;
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
+    #[clap(flatten)]
+    auth: util::Auth,
     /// The name of the database
     database_name: String,
     /// The name of the collection
@@ -52,13 +50,7 @@ function updateMetadata() {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = args.auth.into_client()?;
 
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);

--- a/sdk/data_cosmos/examples/user_00.rs
+++ b/sdk/data_cosmos/examples/user_00.rs
@@ -1,15 +1,12 @@
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::StreamExt;
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
+    #[clap(flatten)]
+    auth: util::Auth,
     /// The name of the database
     database_name: String,
     /// The name of the user
@@ -18,16 +15,8 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    // First we retrieve the account name and access key from environment variables.
-    // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = args.auth.into_client()?;
 
     let database = client.database_client(args.database_name);
     let user = database.user_client(args.user_name.clone());

--- a/sdk/data_cosmos/examples/user_defined_function_00.rs
+++ b/sdk/data_cosmos/examples/user_defined_function_00.rs
@@ -1,15 +1,12 @@
-use azure_data_cosmos::prelude::*;
 use clap::Parser;
 use futures::stream::StreamExt;
 
-#[derive(Debug, Parser)]
+mod util;
+
+#[derive(Debug, clap::Parser)]
 struct Args {
-    /// Cosmos primary key name
-    #[clap(env = "COSMOS_PRIMARY_KEY")]
-    primary_key: String,
-    /// The cosmos account your're using
-    #[clap(env = "COSMOS_ACCOUNT")]
-    account: String,
+    #[clap(flatten)]
+    auth: util::Auth,
     /// The name of the database
     database_name: String,
     /// The name of the collection
@@ -31,13 +28,7 @@ function tax(income) {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
-
-    let client = CosmosClient::new(
-        args.account.clone(),
-        authorization_token,
-        CosmosOptions::default(),
-    );
+    let client = args.auth.into_client()?;
 
     let database = client.database_client(args.database_name);
     let collection = database.collection_client(args.collection_name);

--- a/sdk/data_cosmos/examples/util/mod.rs
+++ b/sdk/data_cosmos/examples/util/mod.rs
@@ -1,0 +1,35 @@
+use azure_data_cosmos::{
+    clients::{CosmosClient, CosmosOptions},
+    prelude::AuthorizationToken,
+};
+
+/// Help for getting authorization information for use in examples.
+///
+/// This gathers the primary key and cosmos account from environment variables.
+/// It can then create a Cosmos client from that. To see how this is done manually,
+/// see the `readme` example.
+#[derive(clap::Parser, Debug)]
+pub struct Auth {
+    /// Cosmos primary key
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+}
+
+impl Auth {
+    pub fn into_client(self) -> azure_core::Result<CosmosClient> {
+        let token = AuthorizationToken::primary_from_base64(&self.primary_key)?;
+        Ok(CosmosClient::new(
+            self.account,
+            token,
+            CosmosOptions::default(),
+        ))
+    }
+
+    #[allow(unused)]
+    pub fn account(&self) -> &String {
+        &self.account
+    }
+}


### PR DESCRIPTION
This makes the Cosmos examples even more focused on their core objectives by moving authentication to a `util` module. 