### PR TITLE
add missing restype=container query param for container get_props

### DIFF
--- a/sdk/storage_blobs/src/container/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/container/operations/get_properties.rs
@@ -36,6 +36,9 @@ impl GetPropertiesBuilder {
     pub fn into_future(mut self) -> Response {
         Box::pin(async move {
             let mut url = self.container_client.url_with_segments(None)?;
+
+            url.query_pairs_mut().append_pair("restype", "container");
+
             self.timeout.append_to_url_query(&mut url);
 
             let mut headers = Headers::new();


### PR DESCRIPTION
Without it get_properties returns a 404.

I also noticed that list_containers should be a storage account operation and not a container operation: https://docs.microsoft.com/en-us/rest/api/storageservices/list-containers2
Should it be moved?