### PR TITLE
add _client suffix for accessing clients

### DIFF
--- a/services/autorust/codegen/src/codegen_operations.rs
+++ b/services/autorust/codegen/src/codegen_operations.rs
@@ -43,9 +43,10 @@ fn error_fqn(operation: &WebOperationGen) -> Result<TokenStream> {
 pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<TokenStream> {
     let mut clients = TokenStream::new();
     for md in modules {
+        let client = format!("{md}_client").to_snake_case_ident()?;
         let md = md.to_snake_case_ident()?;
         clients.extend(quote! {
-            pub fn #md(&self) -> #md::Client {
+            pub fn #client(&self) -> #md::Client {
                 #md::Client(self.clone())
             }
         });

--- a/services/mgmt/activedirectory/src/package_2017_04_01/operations.rs
+++ b/services/mgmt/activedirectory/src/package_2017_04_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn diagnostic_settings_category(&self) -> diagnostic_settings_category::Client {
+    pub fn diagnostic_settings_category_client(&self) -> diagnostic_settings_category::Client {
         diagnostic_settings_category::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/activedirectory/src/package_2020_03/operations.rs
+++ b/services/mgmt/activedirectory/src/package_2020_03/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_for_azure_ad(&self) -> private_link_for_azure_ad::Client {
+    pub fn private_link_for_azure_ad_client(&self) -> private_link_for_azure_ad::Client {
         private_link_for_azure_ad::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/activedirectory/src/package_preview_2017_04/operations.rs
+++ b/services/mgmt/activedirectory/src/package_preview_2017_04/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn diagnostic_settings_category(&self) -> diagnostic_settings_category::Client {
+    pub fn diagnostic_settings_category_client(&self) -> diagnostic_settings_category::Client {
         diagnostic_settings_category::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/activedirectory/src/package_preview_2020_03/operations.rs
+++ b/services/mgmt/activedirectory/src/package_preview_2020_03/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn private_link_for_azure_ad(&self) -> private_link_for_azure_ad::Client {
+    pub fn private_link_for_azure_ad_client(&self) -> private_link_for_azure_ad::Client {
         private_link_for_azure_ad::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/activedirectory/src/package_preview_2020_07/operations.rs
+++ b/services/mgmt/activedirectory/src/package_preview_2020_07/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_ad_metrics(&self) -> azure_ad_metrics::Client {
+    pub fn azure_ad_metrics_client(&self) -> azure_ad_metrics::Client {
         azure_ad_metrics::Client(self.clone())
     }
 }

--- a/services/mgmt/addons/src/package_2017_05/operations.rs
+++ b/services/mgmt/addons/src/package_2017_05/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn canonical_support_plan_types(&self) -> canonical_support_plan_types::Client {
+    pub fn canonical_support_plan_types_client(&self) -> canonical_support_plan_types::Client {
         canonical_support_plan_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn support_plan_types(&self) -> support_plan_types::Client {
+    pub fn support_plan_types_client(&self) -> support_plan_types::Client {
         support_plan_types::Client(self.clone())
     }
 }

--- a/services/mgmt/addons/src/package_2018_03/operations.rs
+++ b/services/mgmt/addons/src/package_2018_03/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn support_plan_types(&self) -> support_plan_types::Client {
+    pub fn support_plan_types_client(&self) -> support_plan_types::Client {
         support_plan_types::Client(self.clone())
     }
 }

--- a/services/mgmt/adhybridhealthservice/src/package_2014_01/operations.rs
+++ b/services/mgmt/adhybridhealthservice/src/package_2014_01/operations.rs
@@ -74,55 +74,55 @@ impl Client {
             pipeline,
         }
     }
-    pub fn ad_domain_service_members(&self) -> ad_domain_service_members::Client {
+    pub fn ad_domain_service_members_client(&self) -> ad_domain_service_members::Client {
         ad_domain_service_members::Client(self.clone())
     }
-    pub fn adds_service(&self) -> adds_service::Client {
+    pub fn adds_service_client(&self) -> adds_service::Client {
         adds_service::Client(self.clone())
     }
-    pub fn adds_service_members(&self) -> adds_service_members::Client {
+    pub fn adds_service_members_client(&self) -> adds_service_members::Client {
         adds_service_members::Client(self.clone())
     }
-    pub fn adds_services(&self) -> adds_services::Client {
+    pub fn adds_services_client(&self) -> adds_services::Client {
         adds_services::Client(self.clone())
     }
-    pub fn adds_services_replication_status(&self) -> adds_services_replication_status::Client {
+    pub fn adds_services_replication_status_client(&self) -> adds_services_replication_status::Client {
         adds_services_replication_status::Client(self.clone())
     }
-    pub fn adds_services_service_members(&self) -> adds_services_service_members::Client {
+    pub fn adds_services_service_members_client(&self) -> adds_services_service_members::Client {
         adds_services_service_members::Client(self.clone())
     }
-    pub fn adds_services_user_preference(&self) -> adds_services_user_preference::Client {
+    pub fn adds_services_user_preference_client(&self) -> adds_services_user_preference::Client {
         adds_services_user_preference::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn configuration(&self) -> configuration::Client {
+    pub fn configuration_client(&self) -> configuration::Client {
         configuration::Client(self.clone())
     }
-    pub fn dimensions(&self) -> dimensions::Client {
+    pub fn dimensions_client(&self) -> dimensions::Client {
         dimensions::Client(self.clone())
     }
-    pub fn list(&self) -> list::Client {
+    pub fn list_client(&self) -> list::Client {
         list::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn service_members(&self) -> service_members::Client {
+    pub fn service_members_client(&self) -> service_members::Client {
         service_members::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn update(&self) -> update::Client {
+    pub fn update_client(&self) -> update::Client {
         update::Client(self.clone())
     }
 }

--- a/services/mgmt/adp/src/package_2020_07_01_preview/operations.rs
+++ b/services/mgmt/adp/src/package_2020_07_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn data_pools(&self) -> data_pools::Client {
+    pub fn data_pools_client(&self) -> data_pools::Client {
         data_pools::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/adp/src/package_2021_02_01_preview/operations.rs
+++ b/services/mgmt/adp/src/package_2021_02_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn data_pools(&self) -> data_pools::Client {
+    pub fn data_pools_client(&self) -> data_pools::Client {
         data_pools::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/adp/src/package_2021_11_01_preview/operations.rs
+++ b/services/mgmt/adp/src/package_2021_11_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn data_pools(&self) -> data_pools::Client {
+    pub fn data_pools_client(&self) -> data_pools::Client {
         data_pools::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/advisor/src/package_2017_03/operations.rs
+++ b/services/mgmt/advisor/src/package_2017_03/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn suppressions(&self) -> suppressions::Client {
+    pub fn suppressions_client(&self) -> suppressions::Client {
         suppressions::Client(self.clone())
     }
 }

--- a/services/mgmt/advisor/src/package_2017_04/operations.rs
+++ b/services/mgmt/advisor/src/package_2017_04/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recommendation_metadata(&self) -> recommendation_metadata::Client {
+    pub fn recommendation_metadata_client(&self) -> recommendation_metadata::Client {
         recommendation_metadata::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn suppressions(&self) -> suppressions::Client {
+    pub fn suppressions_client(&self) -> suppressions::Client {
         suppressions::Client(self.clone())
     }
 }

--- a/services/mgmt/advisor/src/package_2020_01/operations.rs
+++ b/services/mgmt/advisor/src/package_2020_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recommendation_metadata(&self) -> recommendation_metadata::Client {
+    pub fn recommendation_metadata_client(&self) -> recommendation_metadata::Client {
         recommendation_metadata::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn suppressions(&self) -> suppressions::Client {
+    pub fn suppressions_client(&self) -> suppressions::Client {
         suppressions::Client(self.clone())
     }
 }

--- a/services/mgmt/advisor/src/package_2020_07_preview/operations.rs
+++ b/services/mgmt/advisor/src/package_2020_07_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn advisor_scores(&self) -> advisor_scores::Client {
+    pub fn advisor_scores_client(&self) -> advisor_scores::Client {
         advisor_scores::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/advisor/src/package_2022_02_preview/operations.rs
+++ b/services/mgmt/advisor/src/package_2022_02_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/agrifood/src/package_2020_05_12_preview/operations.rs
+++ b/services/mgmt/agrifood/src/package_2020_05_12_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn farm_beats_extensions(&self) -> farm_beats_extensions::Client {
+    pub fn farm_beats_extensions_client(&self) -> farm_beats_extensions::Client {
         farm_beats_extensions::Client(self.clone())
     }
-    pub fn farm_beats_models(&self) -> farm_beats_models::Client {
+    pub fn farm_beats_models_client(&self) -> farm_beats_models::Client {
         farm_beats_models::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/alertsmanagement/src/package_2019_06_preview/operations.rs
+++ b/services/mgmt/alertsmanagement/src/package_2019_06_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn action_rules(&self) -> action_rules::Client {
+    pub fn action_rules_client(&self) -> action_rules::Client {
         action_rules::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn smart_detector_alert_rules(&self) -> smart_detector_alert_rules::Client {
+    pub fn smart_detector_alert_rules_client(&self) -> smart_detector_alert_rules::Client {
         smart_detector_alert_rules::Client(self.clone())
     }
-    pub fn smart_groups(&self) -> smart_groups::Client {
+    pub fn smart_groups_client(&self) -> smart_groups::Client {
         smart_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/alertsmanagement/src/package_2021_08/operations.rs
+++ b/services/mgmt/alertsmanagement/src/package_2021_08/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn alert_processing_rules(&self) -> alert_processing_rules::Client {
+    pub fn alert_processing_rules_client(&self) -> alert_processing_rules::Client {
         alert_processing_rules::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn smart_groups(&self) -> smart_groups::Client {
+    pub fn smart_groups_client(&self) -> smart_groups::Client {
         smart_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/alertsmanagement/src/package_preview_2019_05/operations.rs
+++ b/services/mgmt/alertsmanagement/src/package_preview_2019_05/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn action_rules(&self) -> action_rules::Client {
+    pub fn action_rules_client(&self) -> action_rules::Client {
         action_rules::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn smart_groups(&self) -> smart_groups::Client {
+    pub fn smart_groups_client(&self) -> smart_groups::Client {
         smart_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/alertsmanagement/src/package_preview_2021_01/operations.rs
+++ b/services/mgmt/alertsmanagement/src/package_preview_2021_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn migrate_from_smart_detection(&self) -> migrate_from_smart_detection::Client {
+    pub fn migrate_from_smart_detection_client(&self) -> migrate_from_smart_detection::Client {
         migrate_from_smart_detection::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/alertsmanagement/src/package_preview_2021_08/operations.rs
+++ b/services/mgmt/alertsmanagement/src/package_preview_2021_08/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn alert_processing_rules(&self) -> alert_processing_rules::Client {
+    pub fn alert_processing_rules_client(&self) -> alert_processing_rules::Client {
         alert_processing_rules::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn smart_groups(&self) -> smart_groups::Client {
+    pub fn smart_groups_client(&self) -> smart_groups::Client {
         smart_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/analysisservices/src/package_2016_05/operations.rs
+++ b/services/mgmt/analysisservices/src/package_2016_05/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/analysisservices/src/package_2017_07/operations.rs
+++ b/services/mgmt/analysisservices/src/package_2017_07/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/analysisservices/src/package_2017_08_beta/operations.rs
+++ b/services/mgmt/analysisservices/src/package_2017_08_beta/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/apimanagement/src/package_preview_2019_12/operations.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2019_12/operations.rs
@@ -74,196 +74,196 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api(&self) -> api::Client {
+    pub fn api_client(&self) -> api::Client {
         api::Client(self.clone())
     }
-    pub fn api_diagnostic(&self) -> api_diagnostic::Client {
+    pub fn api_diagnostic_client(&self) -> api_diagnostic::Client {
         api_diagnostic::Client(self.clone())
     }
-    pub fn api_export(&self) -> api_export::Client {
+    pub fn api_export_client(&self) -> api_export::Client {
         api_export::Client(self.clone())
     }
-    pub fn api_issue(&self) -> api_issue::Client {
+    pub fn api_issue_client(&self) -> api_issue::Client {
         api_issue::Client(self.clone())
     }
-    pub fn api_issue_attachment(&self) -> api_issue_attachment::Client {
+    pub fn api_issue_attachment_client(&self) -> api_issue_attachment::Client {
         api_issue_attachment::Client(self.clone())
     }
-    pub fn api_issue_comment(&self) -> api_issue_comment::Client {
+    pub fn api_issue_comment_client(&self) -> api_issue_comment::Client {
         api_issue_comment::Client(self.clone())
     }
-    pub fn api_management_operations(&self) -> api_management_operations::Client {
+    pub fn api_management_operations_client(&self) -> api_management_operations::Client {
         api_management_operations::Client(self.clone())
     }
-    pub fn api_management_service(&self) -> api_management_service::Client {
+    pub fn api_management_service_client(&self) -> api_management_service::Client {
         api_management_service::Client(self.clone())
     }
-    pub fn api_management_service_skus(&self) -> api_management_service_skus::Client {
+    pub fn api_management_service_skus_client(&self) -> api_management_service_skus::Client {
         api_management_service_skus::Client(self.clone())
     }
-    pub fn api_operation(&self) -> api_operation::Client {
+    pub fn api_operation_client(&self) -> api_operation::Client {
         api_operation::Client(self.clone())
     }
-    pub fn api_operation_policy(&self) -> api_operation_policy::Client {
+    pub fn api_operation_policy_client(&self) -> api_operation_policy::Client {
         api_operation_policy::Client(self.clone())
     }
-    pub fn api_policy(&self) -> api_policy::Client {
+    pub fn api_policy_client(&self) -> api_policy::Client {
         api_policy::Client(self.clone())
     }
-    pub fn api_product(&self) -> api_product::Client {
+    pub fn api_product_client(&self) -> api_product::Client {
         api_product::Client(self.clone())
     }
-    pub fn api_release(&self) -> api_release::Client {
+    pub fn api_release_client(&self) -> api_release::Client {
         api_release::Client(self.clone())
     }
-    pub fn api_revision(&self) -> api_revision::Client {
+    pub fn api_revision_client(&self) -> api_revision::Client {
         api_revision::Client(self.clone())
     }
-    pub fn api_schema(&self) -> api_schema::Client {
+    pub fn api_schema_client(&self) -> api_schema::Client {
         api_schema::Client(self.clone())
     }
-    pub fn api_tag_description(&self) -> api_tag_description::Client {
+    pub fn api_tag_description_client(&self) -> api_tag_description::Client {
         api_tag_description::Client(self.clone())
     }
-    pub fn api_version_set(&self) -> api_version_set::Client {
+    pub fn api_version_set_client(&self) -> api_version_set::Client {
         api_version_set::Client(self.clone())
     }
-    pub fn authorization_server(&self) -> authorization_server::Client {
+    pub fn authorization_server_client(&self) -> authorization_server::Client {
         authorization_server::Client(self.clone())
     }
-    pub fn backend(&self) -> backend::Client {
+    pub fn backend_client(&self) -> backend::Client {
         backend::Client(self.clone())
     }
-    pub fn cache(&self) -> cache::Client {
+    pub fn cache_client(&self) -> cache::Client {
         cache::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn delegation_settings(&self) -> delegation_settings::Client {
+    pub fn delegation_settings_client(&self) -> delegation_settings::Client {
         delegation_settings::Client(self.clone())
     }
-    pub fn diagnostic(&self) -> diagnostic::Client {
+    pub fn diagnostic_client(&self) -> diagnostic::Client {
         diagnostic::Client(self.clone())
     }
-    pub fn email_template(&self) -> email_template::Client {
+    pub fn email_template_client(&self) -> email_template::Client {
         email_template::Client(self.clone())
     }
-    pub fn gateway(&self) -> gateway::Client {
+    pub fn gateway_client(&self) -> gateway::Client {
         gateway::Client(self.clone())
     }
-    pub fn gateway_api(&self) -> gateway_api::Client {
+    pub fn gateway_api_client(&self) -> gateway_api::Client {
         gateway_api::Client(self.clone())
     }
-    pub fn gateway_hostname_configuration(&self) -> gateway_hostname_configuration::Client {
+    pub fn gateway_hostname_configuration_client(&self) -> gateway_hostname_configuration::Client {
         gateway_hostname_configuration::Client(self.clone())
     }
-    pub fn group(&self) -> group::Client {
+    pub fn group_client(&self) -> group::Client {
         group::Client(self.clone())
     }
-    pub fn group_user(&self) -> group_user::Client {
+    pub fn group_user_client(&self) -> group_user::Client {
         group_user::Client(self.clone())
     }
-    pub fn identity_provider(&self) -> identity_provider::Client {
+    pub fn identity_provider_client(&self) -> identity_provider::Client {
         identity_provider::Client(self.clone())
     }
-    pub fn issue(&self) -> issue::Client {
+    pub fn issue_client(&self) -> issue::Client {
         issue::Client(self.clone())
     }
-    pub fn logger(&self) -> logger::Client {
+    pub fn logger_client(&self) -> logger::Client {
         logger::Client(self.clone())
     }
-    pub fn named_value(&self) -> named_value::Client {
+    pub fn named_value_client(&self) -> named_value::Client {
         named_value::Client(self.clone())
     }
-    pub fn network_status(&self) -> network_status::Client {
+    pub fn network_status_client(&self) -> network_status::Client {
         network_status::Client(self.clone())
     }
-    pub fn notification(&self) -> notification::Client {
+    pub fn notification_client(&self) -> notification::Client {
         notification::Client(self.clone())
     }
-    pub fn notification_recipient_email(&self) -> notification_recipient_email::Client {
+    pub fn notification_recipient_email_client(&self) -> notification_recipient_email::Client {
         notification_recipient_email::Client(self.clone())
     }
-    pub fn notification_recipient_user(&self) -> notification_recipient_user::Client {
+    pub fn notification_recipient_user_client(&self) -> notification_recipient_user::Client {
         notification_recipient_user::Client(self.clone())
     }
-    pub fn open_id_connect_provider(&self) -> open_id_connect_provider::Client {
+    pub fn open_id_connect_provider_client(&self) -> open_id_connect_provider::Client {
         open_id_connect_provider::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_description(&self) -> policy_description::Client {
+    pub fn policy_description_client(&self) -> policy_description::Client {
         policy_description::Client(self.clone())
     }
-    pub fn product(&self) -> product::Client {
+    pub fn product_client(&self) -> product::Client {
         product::Client(self.clone())
     }
-    pub fn product_api(&self) -> product_api::Client {
+    pub fn product_api_client(&self) -> product_api::Client {
         product_api::Client(self.clone())
     }
-    pub fn product_group(&self) -> product_group::Client {
+    pub fn product_group_client(&self) -> product_group::Client {
         product_group::Client(self.clone())
     }
-    pub fn product_policy(&self) -> product_policy::Client {
+    pub fn product_policy_client(&self) -> product_policy::Client {
         product_policy::Client(self.clone())
     }
-    pub fn product_subscriptions(&self) -> product_subscriptions::Client {
+    pub fn product_subscriptions_client(&self) -> product_subscriptions::Client {
         product_subscriptions::Client(self.clone())
     }
-    pub fn quota_by_counter_keys(&self) -> quota_by_counter_keys::Client {
+    pub fn quota_by_counter_keys_client(&self) -> quota_by_counter_keys::Client {
         quota_by_counter_keys::Client(self.clone())
     }
-    pub fn quota_by_period_keys(&self) -> quota_by_period_keys::Client {
+    pub fn quota_by_period_keys_client(&self) -> quota_by_period_keys::Client {
         quota_by_period_keys::Client(self.clone())
     }
-    pub fn region(&self) -> region::Client {
+    pub fn region_client(&self) -> region::Client {
         region::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn sign_in_settings(&self) -> sign_in_settings::Client {
+    pub fn sign_in_settings_client(&self) -> sign_in_settings::Client {
         sign_in_settings::Client(self.clone())
     }
-    pub fn sign_up_settings(&self) -> sign_up_settings::Client {
+    pub fn sign_up_settings_client(&self) -> sign_up_settings::Client {
         sign_up_settings::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn tag(&self) -> tag::Client {
+    pub fn tag_client(&self) -> tag::Client {
         tag::Client(self.clone())
     }
-    pub fn tag_resource(&self) -> tag_resource::Client {
+    pub fn tag_resource_client(&self) -> tag_resource::Client {
         tag_resource::Client(self.clone())
     }
-    pub fn tenant_access(&self) -> tenant_access::Client {
+    pub fn tenant_access_client(&self) -> tenant_access::Client {
         tenant_access::Client(self.clone())
     }
-    pub fn tenant_access_git(&self) -> tenant_access_git::Client {
+    pub fn tenant_access_git_client(&self) -> tenant_access_git::Client {
         tenant_access_git::Client(self.clone())
     }
-    pub fn tenant_configuration(&self) -> tenant_configuration::Client {
+    pub fn tenant_configuration_client(&self) -> tenant_configuration::Client {
         tenant_configuration::Client(self.clone())
     }
-    pub fn user(&self) -> user::Client {
+    pub fn user_client(&self) -> user::Client {
         user::Client(self.clone())
     }
-    pub fn user_confirmation_password(&self) -> user_confirmation_password::Client {
+    pub fn user_confirmation_password_client(&self) -> user_confirmation_password::Client {
         user_confirmation_password::Client(self.clone())
     }
-    pub fn user_group(&self) -> user_group::Client {
+    pub fn user_group_client(&self) -> user_group::Client {
         user_group::Client(self.clone())
     }
-    pub fn user_identities(&self) -> user_identities::Client {
+    pub fn user_identities_client(&self) -> user_identities::Client {
         user_identities::Client(self.clone())
     }
-    pub fn user_subscription(&self) -> user_subscription::Client {
+    pub fn user_subscription_client(&self) -> user_subscription::Client {
         user_subscription::Client(self.clone())
     }
 }

--- a/services/mgmt/apimanagement/src/package_preview_2020_06/operations.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2020_06/operations.rs
@@ -74,220 +74,220 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api(&self) -> api::Client {
+    pub fn api_client(&self) -> api::Client {
         api::Client(self.clone())
     }
-    pub fn api_diagnostic(&self) -> api_diagnostic::Client {
+    pub fn api_diagnostic_client(&self) -> api_diagnostic::Client {
         api_diagnostic::Client(self.clone())
     }
-    pub fn api_export(&self) -> api_export::Client {
+    pub fn api_export_client(&self) -> api_export::Client {
         api_export::Client(self.clone())
     }
-    pub fn api_issue(&self) -> api_issue::Client {
+    pub fn api_issue_client(&self) -> api_issue::Client {
         api_issue::Client(self.clone())
     }
-    pub fn api_issue_attachment(&self) -> api_issue_attachment::Client {
+    pub fn api_issue_attachment_client(&self) -> api_issue_attachment::Client {
         api_issue_attachment::Client(self.clone())
     }
-    pub fn api_issue_comment(&self) -> api_issue_comment::Client {
+    pub fn api_issue_comment_client(&self) -> api_issue_comment::Client {
         api_issue_comment::Client(self.clone())
     }
-    pub fn api_management_operations(&self) -> api_management_operations::Client {
+    pub fn api_management_operations_client(&self) -> api_management_operations::Client {
         api_management_operations::Client(self.clone())
     }
-    pub fn api_management_service(&self) -> api_management_service::Client {
+    pub fn api_management_service_client(&self) -> api_management_service::Client {
         api_management_service::Client(self.clone())
     }
-    pub fn api_management_service_skus(&self) -> api_management_service_skus::Client {
+    pub fn api_management_service_skus_client(&self) -> api_management_service_skus::Client {
         api_management_service_skus::Client(self.clone())
     }
-    pub fn api_management_skus(&self) -> api_management_skus::Client {
+    pub fn api_management_skus_client(&self) -> api_management_skus::Client {
         api_management_skus::Client(self.clone())
     }
-    pub fn api_operation(&self) -> api_operation::Client {
+    pub fn api_operation_client(&self) -> api_operation::Client {
         api_operation::Client(self.clone())
     }
-    pub fn api_operation_policy(&self) -> api_operation_policy::Client {
+    pub fn api_operation_policy_client(&self) -> api_operation_policy::Client {
         api_operation_policy::Client(self.clone())
     }
-    pub fn api_policy(&self) -> api_policy::Client {
+    pub fn api_policy_client(&self) -> api_policy::Client {
         api_policy::Client(self.clone())
     }
-    pub fn api_product(&self) -> api_product::Client {
+    pub fn api_product_client(&self) -> api_product::Client {
         api_product::Client(self.clone())
     }
-    pub fn api_release(&self) -> api_release::Client {
+    pub fn api_release_client(&self) -> api_release::Client {
         api_release::Client(self.clone())
     }
-    pub fn api_revision(&self) -> api_revision::Client {
+    pub fn api_revision_client(&self) -> api_revision::Client {
         api_revision::Client(self.clone())
     }
-    pub fn api_schema(&self) -> api_schema::Client {
+    pub fn api_schema_client(&self) -> api_schema::Client {
         api_schema::Client(self.clone())
     }
-    pub fn api_tag_description(&self) -> api_tag_description::Client {
+    pub fn api_tag_description_client(&self) -> api_tag_description::Client {
         api_tag_description::Client(self.clone())
     }
-    pub fn api_version_set(&self) -> api_version_set::Client {
+    pub fn api_version_set_client(&self) -> api_version_set::Client {
         api_version_set::Client(self.clone())
     }
-    pub fn authorization_server(&self) -> authorization_server::Client {
+    pub fn authorization_server_client(&self) -> authorization_server::Client {
         authorization_server::Client(self.clone())
     }
-    pub fn backend(&self) -> backend::Client {
+    pub fn backend_client(&self) -> backend::Client {
         backend::Client(self.clone())
     }
-    pub fn cache(&self) -> cache::Client {
+    pub fn cache_client(&self) -> cache::Client {
         cache::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn content_item(&self) -> content_item::Client {
+    pub fn content_item_client(&self) -> content_item::Client {
         content_item::Client(self.clone())
     }
-    pub fn content_type(&self) -> content_type::Client {
+    pub fn content_type_client(&self) -> content_type::Client {
         content_type::Client(self.clone())
     }
-    pub fn delegation_settings(&self) -> delegation_settings::Client {
+    pub fn delegation_settings_client(&self) -> delegation_settings::Client {
         delegation_settings::Client(self.clone())
     }
-    pub fn deleted_services(&self) -> deleted_services::Client {
+    pub fn deleted_services_client(&self) -> deleted_services::Client {
         deleted_services::Client(self.clone())
     }
-    pub fn diagnostic(&self) -> diagnostic::Client {
+    pub fn diagnostic_client(&self) -> diagnostic::Client {
         diagnostic::Client(self.clone())
     }
-    pub fn email_template(&self) -> email_template::Client {
+    pub fn email_template_client(&self) -> email_template::Client {
         email_template::Client(self.clone())
     }
-    pub fn gateway(&self) -> gateway::Client {
+    pub fn gateway_client(&self) -> gateway::Client {
         gateway::Client(self.clone())
     }
-    pub fn gateway_api(&self) -> gateway_api::Client {
+    pub fn gateway_api_client(&self) -> gateway_api::Client {
         gateway_api::Client(self.clone())
     }
-    pub fn gateway_certificate_authority(&self) -> gateway_certificate_authority::Client {
+    pub fn gateway_certificate_authority_client(&self) -> gateway_certificate_authority::Client {
         gateway_certificate_authority::Client(self.clone())
     }
-    pub fn gateway_hostname_configuration(&self) -> gateway_hostname_configuration::Client {
+    pub fn gateway_hostname_configuration_client(&self) -> gateway_hostname_configuration::Client {
         gateway_hostname_configuration::Client(self.clone())
     }
-    pub fn group(&self) -> group::Client {
+    pub fn group_client(&self) -> group::Client {
         group::Client(self.clone())
     }
-    pub fn group_user(&self) -> group_user::Client {
+    pub fn group_user_client(&self) -> group_user::Client {
         group_user::Client(self.clone())
     }
-    pub fn identity_provider(&self) -> identity_provider::Client {
+    pub fn identity_provider_client(&self) -> identity_provider::Client {
         identity_provider::Client(self.clone())
     }
-    pub fn issue(&self) -> issue::Client {
+    pub fn issue_client(&self) -> issue::Client {
         issue::Client(self.clone())
     }
-    pub fn logger(&self) -> logger::Client {
+    pub fn logger_client(&self) -> logger::Client {
         logger::Client(self.clone())
     }
-    pub fn named_value(&self) -> named_value::Client {
+    pub fn named_value_client(&self) -> named_value::Client {
         named_value::Client(self.clone())
     }
-    pub fn network_status(&self) -> network_status::Client {
+    pub fn network_status_client(&self) -> network_status::Client {
         network_status::Client(self.clone())
     }
-    pub fn notification(&self) -> notification::Client {
+    pub fn notification_client(&self) -> notification::Client {
         notification::Client(self.clone())
     }
-    pub fn notification_recipient_email(&self) -> notification_recipient_email::Client {
+    pub fn notification_recipient_email_client(&self) -> notification_recipient_email::Client {
         notification_recipient_email::Client(self.clone())
     }
-    pub fn notification_recipient_user(&self) -> notification_recipient_user::Client {
+    pub fn notification_recipient_user_client(&self) -> notification_recipient_user::Client {
         notification_recipient_user::Client(self.clone())
     }
-    pub fn open_id_connect_provider(&self) -> open_id_connect_provider::Client {
+    pub fn open_id_connect_provider_client(&self) -> open_id_connect_provider::Client {
         open_id_connect_provider::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_description(&self) -> policy_description::Client {
+    pub fn policy_description_client(&self) -> policy_description::Client {
         policy_description::Client(self.clone())
     }
-    pub fn portal_revision(&self) -> portal_revision::Client {
+    pub fn portal_revision_client(&self) -> portal_revision::Client {
         portal_revision::Client(self.clone())
     }
-    pub fn portal_settings(&self) -> portal_settings::Client {
+    pub fn portal_settings_client(&self) -> portal_settings::Client {
         portal_settings::Client(self.clone())
     }
-    pub fn product(&self) -> product::Client {
+    pub fn product_client(&self) -> product::Client {
         product::Client(self.clone())
     }
-    pub fn product_api(&self) -> product_api::Client {
+    pub fn product_api_client(&self) -> product_api::Client {
         product_api::Client(self.clone())
     }
-    pub fn product_group(&self) -> product_group::Client {
+    pub fn product_group_client(&self) -> product_group::Client {
         product_group::Client(self.clone())
     }
-    pub fn product_policy(&self) -> product_policy::Client {
+    pub fn product_policy_client(&self) -> product_policy::Client {
         product_policy::Client(self.clone())
     }
-    pub fn product_subscriptions(&self) -> product_subscriptions::Client {
+    pub fn product_subscriptions_client(&self) -> product_subscriptions::Client {
         product_subscriptions::Client(self.clone())
     }
-    pub fn quota_by_counter_keys(&self) -> quota_by_counter_keys::Client {
+    pub fn quota_by_counter_keys_client(&self) -> quota_by_counter_keys::Client {
         quota_by_counter_keys::Client(self.clone())
     }
-    pub fn quota_by_period_keys(&self) -> quota_by_period_keys::Client {
+    pub fn quota_by_period_keys_client(&self) -> quota_by_period_keys::Client {
         quota_by_period_keys::Client(self.clone())
     }
-    pub fn region(&self) -> region::Client {
+    pub fn region_client(&self) -> region::Client {
         region::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn sign_in_settings(&self) -> sign_in_settings::Client {
+    pub fn sign_in_settings_client(&self) -> sign_in_settings::Client {
         sign_in_settings::Client(self.clone())
     }
-    pub fn sign_up_settings(&self) -> sign_up_settings::Client {
+    pub fn sign_up_settings_client(&self) -> sign_up_settings::Client {
         sign_up_settings::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn tag(&self) -> tag::Client {
+    pub fn tag_client(&self) -> tag::Client {
         tag::Client(self.clone())
     }
-    pub fn tag_resource(&self) -> tag_resource::Client {
+    pub fn tag_resource_client(&self) -> tag_resource::Client {
         tag_resource::Client(self.clone())
     }
-    pub fn tenant_access(&self) -> tenant_access::Client {
+    pub fn tenant_access_client(&self) -> tenant_access::Client {
         tenant_access::Client(self.clone())
     }
-    pub fn tenant_access_git(&self) -> tenant_access_git::Client {
+    pub fn tenant_access_git_client(&self) -> tenant_access_git::Client {
         tenant_access_git::Client(self.clone())
     }
-    pub fn tenant_configuration(&self) -> tenant_configuration::Client {
+    pub fn tenant_configuration_client(&self) -> tenant_configuration::Client {
         tenant_configuration::Client(self.clone())
     }
-    pub fn tenant_settings(&self) -> tenant_settings::Client {
+    pub fn tenant_settings_client(&self) -> tenant_settings::Client {
         tenant_settings::Client(self.clone())
     }
-    pub fn user(&self) -> user::Client {
+    pub fn user_client(&self) -> user::Client {
         user::Client(self.clone())
     }
-    pub fn user_confirmation_password(&self) -> user_confirmation_password::Client {
+    pub fn user_confirmation_password_client(&self) -> user_confirmation_password::Client {
         user_confirmation_password::Client(self.clone())
     }
-    pub fn user_group(&self) -> user_group::Client {
+    pub fn user_group_client(&self) -> user_group::Client {
         user_group::Client(self.clone())
     }
-    pub fn user_identities(&self) -> user_identities::Client {
+    pub fn user_identities_client(&self) -> user_identities::Client {
         user_identities::Client(self.clone())
     }
-    pub fn user_subscription(&self) -> user_subscription::Client {
+    pub fn user_subscription_client(&self) -> user_subscription::Client {
         user_subscription::Client(self.clone())
     }
 }

--- a/services/mgmt/apimanagement/src/package_preview_2021_01/operations.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2021_01/operations.rs
@@ -74,220 +74,220 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api(&self) -> api::Client {
+    pub fn api_client(&self) -> api::Client {
         api::Client(self.clone())
     }
-    pub fn api_diagnostic(&self) -> api_diagnostic::Client {
+    pub fn api_diagnostic_client(&self) -> api_diagnostic::Client {
         api_diagnostic::Client(self.clone())
     }
-    pub fn api_export(&self) -> api_export::Client {
+    pub fn api_export_client(&self) -> api_export::Client {
         api_export::Client(self.clone())
     }
-    pub fn api_issue(&self) -> api_issue::Client {
+    pub fn api_issue_client(&self) -> api_issue::Client {
         api_issue::Client(self.clone())
     }
-    pub fn api_issue_attachment(&self) -> api_issue_attachment::Client {
+    pub fn api_issue_attachment_client(&self) -> api_issue_attachment::Client {
         api_issue_attachment::Client(self.clone())
     }
-    pub fn api_issue_comment(&self) -> api_issue_comment::Client {
+    pub fn api_issue_comment_client(&self) -> api_issue_comment::Client {
         api_issue_comment::Client(self.clone())
     }
-    pub fn api_management_operations(&self) -> api_management_operations::Client {
+    pub fn api_management_operations_client(&self) -> api_management_operations::Client {
         api_management_operations::Client(self.clone())
     }
-    pub fn api_management_service(&self) -> api_management_service::Client {
+    pub fn api_management_service_client(&self) -> api_management_service::Client {
         api_management_service::Client(self.clone())
     }
-    pub fn api_management_service_skus(&self) -> api_management_service_skus::Client {
+    pub fn api_management_service_skus_client(&self) -> api_management_service_skus::Client {
         api_management_service_skus::Client(self.clone())
     }
-    pub fn api_management_skus(&self) -> api_management_skus::Client {
+    pub fn api_management_skus_client(&self) -> api_management_skus::Client {
         api_management_skus::Client(self.clone())
     }
-    pub fn api_operation(&self) -> api_operation::Client {
+    pub fn api_operation_client(&self) -> api_operation::Client {
         api_operation::Client(self.clone())
     }
-    pub fn api_operation_policy(&self) -> api_operation_policy::Client {
+    pub fn api_operation_policy_client(&self) -> api_operation_policy::Client {
         api_operation_policy::Client(self.clone())
     }
-    pub fn api_policy(&self) -> api_policy::Client {
+    pub fn api_policy_client(&self) -> api_policy::Client {
         api_policy::Client(self.clone())
     }
-    pub fn api_product(&self) -> api_product::Client {
+    pub fn api_product_client(&self) -> api_product::Client {
         api_product::Client(self.clone())
     }
-    pub fn api_release(&self) -> api_release::Client {
+    pub fn api_release_client(&self) -> api_release::Client {
         api_release::Client(self.clone())
     }
-    pub fn api_revision(&self) -> api_revision::Client {
+    pub fn api_revision_client(&self) -> api_revision::Client {
         api_revision::Client(self.clone())
     }
-    pub fn api_schema(&self) -> api_schema::Client {
+    pub fn api_schema_client(&self) -> api_schema::Client {
         api_schema::Client(self.clone())
     }
-    pub fn api_tag_description(&self) -> api_tag_description::Client {
+    pub fn api_tag_description_client(&self) -> api_tag_description::Client {
         api_tag_description::Client(self.clone())
     }
-    pub fn api_version_set(&self) -> api_version_set::Client {
+    pub fn api_version_set_client(&self) -> api_version_set::Client {
         api_version_set::Client(self.clone())
     }
-    pub fn authorization_server(&self) -> authorization_server::Client {
+    pub fn authorization_server_client(&self) -> authorization_server::Client {
         authorization_server::Client(self.clone())
     }
-    pub fn backend(&self) -> backend::Client {
+    pub fn backend_client(&self) -> backend::Client {
         backend::Client(self.clone())
     }
-    pub fn cache(&self) -> cache::Client {
+    pub fn cache_client(&self) -> cache::Client {
         cache::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn content_item(&self) -> content_item::Client {
+    pub fn content_item_client(&self) -> content_item::Client {
         content_item::Client(self.clone())
     }
-    pub fn content_type(&self) -> content_type::Client {
+    pub fn content_type_client(&self) -> content_type::Client {
         content_type::Client(self.clone())
     }
-    pub fn delegation_settings(&self) -> delegation_settings::Client {
+    pub fn delegation_settings_client(&self) -> delegation_settings::Client {
         delegation_settings::Client(self.clone())
     }
-    pub fn deleted_services(&self) -> deleted_services::Client {
+    pub fn deleted_services_client(&self) -> deleted_services::Client {
         deleted_services::Client(self.clone())
     }
-    pub fn diagnostic(&self) -> diagnostic::Client {
+    pub fn diagnostic_client(&self) -> diagnostic::Client {
         diagnostic::Client(self.clone())
     }
-    pub fn email_template(&self) -> email_template::Client {
+    pub fn email_template_client(&self) -> email_template::Client {
         email_template::Client(self.clone())
     }
-    pub fn gateway(&self) -> gateway::Client {
+    pub fn gateway_client(&self) -> gateway::Client {
         gateway::Client(self.clone())
     }
-    pub fn gateway_api(&self) -> gateway_api::Client {
+    pub fn gateway_api_client(&self) -> gateway_api::Client {
         gateway_api::Client(self.clone())
     }
-    pub fn gateway_certificate_authority(&self) -> gateway_certificate_authority::Client {
+    pub fn gateway_certificate_authority_client(&self) -> gateway_certificate_authority::Client {
         gateway_certificate_authority::Client(self.clone())
     }
-    pub fn gateway_hostname_configuration(&self) -> gateway_hostname_configuration::Client {
+    pub fn gateway_hostname_configuration_client(&self) -> gateway_hostname_configuration::Client {
         gateway_hostname_configuration::Client(self.clone())
     }
-    pub fn group(&self) -> group::Client {
+    pub fn group_client(&self) -> group::Client {
         group::Client(self.clone())
     }
-    pub fn group_user(&self) -> group_user::Client {
+    pub fn group_user_client(&self) -> group_user::Client {
         group_user::Client(self.clone())
     }
-    pub fn identity_provider(&self) -> identity_provider::Client {
+    pub fn identity_provider_client(&self) -> identity_provider::Client {
         identity_provider::Client(self.clone())
     }
-    pub fn issue(&self) -> issue::Client {
+    pub fn issue_client(&self) -> issue::Client {
         issue::Client(self.clone())
     }
-    pub fn logger(&self) -> logger::Client {
+    pub fn logger_client(&self) -> logger::Client {
         logger::Client(self.clone())
     }
-    pub fn named_value(&self) -> named_value::Client {
+    pub fn named_value_client(&self) -> named_value::Client {
         named_value::Client(self.clone())
     }
-    pub fn network_status(&self) -> network_status::Client {
+    pub fn network_status_client(&self) -> network_status::Client {
         network_status::Client(self.clone())
     }
-    pub fn notification(&self) -> notification::Client {
+    pub fn notification_client(&self) -> notification::Client {
         notification::Client(self.clone())
     }
-    pub fn notification_recipient_email(&self) -> notification_recipient_email::Client {
+    pub fn notification_recipient_email_client(&self) -> notification_recipient_email::Client {
         notification_recipient_email::Client(self.clone())
     }
-    pub fn notification_recipient_user(&self) -> notification_recipient_user::Client {
+    pub fn notification_recipient_user_client(&self) -> notification_recipient_user::Client {
         notification_recipient_user::Client(self.clone())
     }
-    pub fn open_id_connect_provider(&self) -> open_id_connect_provider::Client {
+    pub fn open_id_connect_provider_client(&self) -> open_id_connect_provider::Client {
         open_id_connect_provider::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_description(&self) -> policy_description::Client {
+    pub fn policy_description_client(&self) -> policy_description::Client {
         policy_description::Client(self.clone())
     }
-    pub fn portal_revision(&self) -> portal_revision::Client {
+    pub fn portal_revision_client(&self) -> portal_revision::Client {
         portal_revision::Client(self.clone())
     }
-    pub fn portal_settings(&self) -> portal_settings::Client {
+    pub fn portal_settings_client(&self) -> portal_settings::Client {
         portal_settings::Client(self.clone())
     }
-    pub fn product(&self) -> product::Client {
+    pub fn product_client(&self) -> product::Client {
         product::Client(self.clone())
     }
-    pub fn product_api(&self) -> product_api::Client {
+    pub fn product_api_client(&self) -> product_api::Client {
         product_api::Client(self.clone())
     }
-    pub fn product_group(&self) -> product_group::Client {
+    pub fn product_group_client(&self) -> product_group::Client {
         product_group::Client(self.clone())
     }
-    pub fn product_policy(&self) -> product_policy::Client {
+    pub fn product_policy_client(&self) -> product_policy::Client {
         product_policy::Client(self.clone())
     }
-    pub fn product_subscriptions(&self) -> product_subscriptions::Client {
+    pub fn product_subscriptions_client(&self) -> product_subscriptions::Client {
         product_subscriptions::Client(self.clone())
     }
-    pub fn quota_by_counter_keys(&self) -> quota_by_counter_keys::Client {
+    pub fn quota_by_counter_keys_client(&self) -> quota_by_counter_keys::Client {
         quota_by_counter_keys::Client(self.clone())
     }
-    pub fn quota_by_period_keys(&self) -> quota_by_period_keys::Client {
+    pub fn quota_by_period_keys_client(&self) -> quota_by_period_keys::Client {
         quota_by_period_keys::Client(self.clone())
     }
-    pub fn region(&self) -> region::Client {
+    pub fn region_client(&self) -> region::Client {
         region::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn sign_in_settings(&self) -> sign_in_settings::Client {
+    pub fn sign_in_settings_client(&self) -> sign_in_settings::Client {
         sign_in_settings::Client(self.clone())
     }
-    pub fn sign_up_settings(&self) -> sign_up_settings::Client {
+    pub fn sign_up_settings_client(&self) -> sign_up_settings::Client {
         sign_up_settings::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn tag(&self) -> tag::Client {
+    pub fn tag_client(&self) -> tag::Client {
         tag::Client(self.clone())
     }
-    pub fn tag_resource(&self) -> tag_resource::Client {
+    pub fn tag_resource_client(&self) -> tag_resource::Client {
         tag_resource::Client(self.clone())
     }
-    pub fn tenant_access(&self) -> tenant_access::Client {
+    pub fn tenant_access_client(&self) -> tenant_access::Client {
         tenant_access::Client(self.clone())
     }
-    pub fn tenant_access_git(&self) -> tenant_access_git::Client {
+    pub fn tenant_access_git_client(&self) -> tenant_access_git::Client {
         tenant_access_git::Client(self.clone())
     }
-    pub fn tenant_configuration(&self) -> tenant_configuration::Client {
+    pub fn tenant_configuration_client(&self) -> tenant_configuration::Client {
         tenant_configuration::Client(self.clone())
     }
-    pub fn tenant_settings(&self) -> tenant_settings::Client {
+    pub fn tenant_settings_client(&self) -> tenant_settings::Client {
         tenant_settings::Client(self.clone())
     }
-    pub fn user(&self) -> user::Client {
+    pub fn user_client(&self) -> user::Client {
         user::Client(self.clone())
     }
-    pub fn user_confirmation_password(&self) -> user_confirmation_password::Client {
+    pub fn user_confirmation_password_client(&self) -> user_confirmation_password::Client {
         user_confirmation_password::Client(self.clone())
     }
-    pub fn user_group(&self) -> user_group::Client {
+    pub fn user_group_client(&self) -> user_group::Client {
         user_group::Client(self.clone())
     }
-    pub fn user_identities(&self) -> user_identities::Client {
+    pub fn user_identities_client(&self) -> user_identities::Client {
         user_identities::Client(self.clone())
     }
-    pub fn user_subscription(&self) -> user_subscription::Client {
+    pub fn user_subscription_client(&self) -> user_subscription::Client {
         user_subscription::Client(self.clone())
     }
 }

--- a/services/mgmt/apimanagement/src/package_preview_2021_04/operations.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2021_04/operations.rs
@@ -74,229 +74,229 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api(&self) -> api::Client {
+    pub fn api_client(&self) -> api::Client {
         api::Client(self.clone())
     }
-    pub fn api_diagnostic(&self) -> api_diagnostic::Client {
+    pub fn api_diagnostic_client(&self) -> api_diagnostic::Client {
         api_diagnostic::Client(self.clone())
     }
-    pub fn api_export(&self) -> api_export::Client {
+    pub fn api_export_client(&self) -> api_export::Client {
         api_export::Client(self.clone())
     }
-    pub fn api_issue(&self) -> api_issue::Client {
+    pub fn api_issue_client(&self) -> api_issue::Client {
         api_issue::Client(self.clone())
     }
-    pub fn api_issue_attachment(&self) -> api_issue_attachment::Client {
+    pub fn api_issue_attachment_client(&self) -> api_issue_attachment::Client {
         api_issue_attachment::Client(self.clone())
     }
-    pub fn api_issue_comment(&self) -> api_issue_comment::Client {
+    pub fn api_issue_comment_client(&self) -> api_issue_comment::Client {
         api_issue_comment::Client(self.clone())
     }
-    pub fn api_management_operations(&self) -> api_management_operations::Client {
+    pub fn api_management_operations_client(&self) -> api_management_operations::Client {
         api_management_operations::Client(self.clone())
     }
-    pub fn api_management_service(&self) -> api_management_service::Client {
+    pub fn api_management_service_client(&self) -> api_management_service::Client {
         api_management_service::Client(self.clone())
     }
-    pub fn api_management_service_skus(&self) -> api_management_service_skus::Client {
+    pub fn api_management_service_skus_client(&self) -> api_management_service_skus::Client {
         api_management_service_skus::Client(self.clone())
     }
-    pub fn api_management_skus(&self) -> api_management_skus::Client {
+    pub fn api_management_skus_client(&self) -> api_management_skus::Client {
         api_management_skus::Client(self.clone())
     }
-    pub fn api_operation(&self) -> api_operation::Client {
+    pub fn api_operation_client(&self) -> api_operation::Client {
         api_operation::Client(self.clone())
     }
-    pub fn api_operation_policy(&self) -> api_operation_policy::Client {
+    pub fn api_operation_policy_client(&self) -> api_operation_policy::Client {
         api_operation_policy::Client(self.clone())
     }
-    pub fn api_policy(&self) -> api_policy::Client {
+    pub fn api_policy_client(&self) -> api_policy::Client {
         api_policy::Client(self.clone())
     }
-    pub fn api_product(&self) -> api_product::Client {
+    pub fn api_product_client(&self) -> api_product::Client {
         api_product::Client(self.clone())
     }
-    pub fn api_release(&self) -> api_release::Client {
+    pub fn api_release_client(&self) -> api_release::Client {
         api_release::Client(self.clone())
     }
-    pub fn api_revision(&self) -> api_revision::Client {
+    pub fn api_revision_client(&self) -> api_revision::Client {
         api_revision::Client(self.clone())
     }
-    pub fn api_schema(&self) -> api_schema::Client {
+    pub fn api_schema_client(&self) -> api_schema::Client {
         api_schema::Client(self.clone())
     }
-    pub fn api_tag_description(&self) -> api_tag_description::Client {
+    pub fn api_tag_description_client(&self) -> api_tag_description::Client {
         api_tag_description::Client(self.clone())
     }
-    pub fn api_version_set(&self) -> api_version_set::Client {
+    pub fn api_version_set_client(&self) -> api_version_set::Client {
         api_version_set::Client(self.clone())
     }
-    pub fn authorization_server(&self) -> authorization_server::Client {
+    pub fn authorization_server_client(&self) -> authorization_server::Client {
         authorization_server::Client(self.clone())
     }
-    pub fn backend(&self) -> backend::Client {
+    pub fn backend_client(&self) -> backend::Client {
         backend::Client(self.clone())
     }
-    pub fn cache(&self) -> cache::Client {
+    pub fn cache_client(&self) -> cache::Client {
         cache::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn content_item(&self) -> content_item::Client {
+    pub fn content_item_client(&self) -> content_item::Client {
         content_item::Client(self.clone())
     }
-    pub fn content_type(&self) -> content_type::Client {
+    pub fn content_type_client(&self) -> content_type::Client {
         content_type::Client(self.clone())
     }
-    pub fn delegation_settings(&self) -> delegation_settings::Client {
+    pub fn delegation_settings_client(&self) -> delegation_settings::Client {
         delegation_settings::Client(self.clone())
     }
-    pub fn deleted_services(&self) -> deleted_services::Client {
+    pub fn deleted_services_client(&self) -> deleted_services::Client {
         deleted_services::Client(self.clone())
     }
-    pub fn diagnostic(&self) -> diagnostic::Client {
+    pub fn diagnostic_client(&self) -> diagnostic::Client {
         diagnostic::Client(self.clone())
     }
-    pub fn email_template(&self) -> email_template::Client {
+    pub fn email_template_client(&self) -> email_template::Client {
         email_template::Client(self.clone())
     }
-    pub fn gateway(&self) -> gateway::Client {
+    pub fn gateway_client(&self) -> gateway::Client {
         gateway::Client(self.clone())
     }
-    pub fn gateway_api(&self) -> gateway_api::Client {
+    pub fn gateway_api_client(&self) -> gateway_api::Client {
         gateway_api::Client(self.clone())
     }
-    pub fn gateway_certificate_authority(&self) -> gateway_certificate_authority::Client {
+    pub fn gateway_certificate_authority_client(&self) -> gateway_certificate_authority::Client {
         gateway_certificate_authority::Client(self.clone())
     }
-    pub fn gateway_hostname_configuration(&self) -> gateway_hostname_configuration::Client {
+    pub fn gateway_hostname_configuration_client(&self) -> gateway_hostname_configuration::Client {
         gateway_hostname_configuration::Client(self.clone())
     }
-    pub fn group(&self) -> group::Client {
+    pub fn group_client(&self) -> group::Client {
         group::Client(self.clone())
     }
-    pub fn group_user(&self) -> group_user::Client {
+    pub fn group_user_client(&self) -> group_user::Client {
         group_user::Client(self.clone())
     }
-    pub fn identity_provider(&self) -> identity_provider::Client {
+    pub fn identity_provider_client(&self) -> identity_provider::Client {
         identity_provider::Client(self.clone())
     }
-    pub fn issue(&self) -> issue::Client {
+    pub fn issue_client(&self) -> issue::Client {
         issue::Client(self.clone())
     }
-    pub fn logger(&self) -> logger::Client {
+    pub fn logger_client(&self) -> logger::Client {
         logger::Client(self.clone())
     }
-    pub fn named_value(&self) -> named_value::Client {
+    pub fn named_value_client(&self) -> named_value::Client {
         named_value::Client(self.clone())
     }
-    pub fn network_status(&self) -> network_status::Client {
+    pub fn network_status_client(&self) -> network_status::Client {
         network_status::Client(self.clone())
     }
-    pub fn notification(&self) -> notification::Client {
+    pub fn notification_client(&self) -> notification::Client {
         notification::Client(self.clone())
     }
-    pub fn notification_recipient_email(&self) -> notification_recipient_email::Client {
+    pub fn notification_recipient_email_client(&self) -> notification_recipient_email::Client {
         notification_recipient_email::Client(self.clone())
     }
-    pub fn notification_recipient_user(&self) -> notification_recipient_user::Client {
+    pub fn notification_recipient_user_client(&self) -> notification_recipient_user::Client {
         notification_recipient_user::Client(self.clone())
     }
-    pub fn open_id_connect_provider(&self) -> open_id_connect_provider::Client {
+    pub fn open_id_connect_provider_client(&self) -> open_id_connect_provider::Client {
         open_id_connect_provider::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn outbound_network_dependencies_endpoints(&self) -> outbound_network_dependencies_endpoints::Client {
+    pub fn outbound_network_dependencies_endpoints_client(&self) -> outbound_network_dependencies_endpoints::Client {
         outbound_network_dependencies_endpoints::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_description(&self) -> policy_description::Client {
+    pub fn policy_description_client(&self) -> policy_description::Client {
         policy_description::Client(self.clone())
     }
-    pub fn portal_revision(&self) -> portal_revision::Client {
+    pub fn portal_revision_client(&self) -> portal_revision::Client {
         portal_revision::Client(self.clone())
     }
-    pub fn portal_settings(&self) -> portal_settings::Client {
+    pub fn portal_settings_client(&self) -> portal_settings::Client {
         portal_settings::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn product(&self) -> product::Client {
+    pub fn product_client(&self) -> product::Client {
         product::Client(self.clone())
     }
-    pub fn product_api(&self) -> product_api::Client {
+    pub fn product_api_client(&self) -> product_api::Client {
         product_api::Client(self.clone())
     }
-    pub fn product_group(&self) -> product_group::Client {
+    pub fn product_group_client(&self) -> product_group::Client {
         product_group::Client(self.clone())
     }
-    pub fn product_policy(&self) -> product_policy::Client {
+    pub fn product_policy_client(&self) -> product_policy::Client {
         product_policy::Client(self.clone())
     }
-    pub fn product_subscriptions(&self) -> product_subscriptions::Client {
+    pub fn product_subscriptions_client(&self) -> product_subscriptions::Client {
         product_subscriptions::Client(self.clone())
     }
-    pub fn quota_by_counter_keys(&self) -> quota_by_counter_keys::Client {
+    pub fn quota_by_counter_keys_client(&self) -> quota_by_counter_keys::Client {
         quota_by_counter_keys::Client(self.clone())
     }
-    pub fn quota_by_period_keys(&self) -> quota_by_period_keys::Client {
+    pub fn quota_by_period_keys_client(&self) -> quota_by_period_keys::Client {
         quota_by_period_keys::Client(self.clone())
     }
-    pub fn region(&self) -> region::Client {
+    pub fn region_client(&self) -> region::Client {
         region::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn schema(&self) -> schema::Client {
+    pub fn schema_client(&self) -> schema::Client {
         schema::Client(self.clone())
     }
-    pub fn sign_in_settings(&self) -> sign_in_settings::Client {
+    pub fn sign_in_settings_client(&self) -> sign_in_settings::Client {
         sign_in_settings::Client(self.clone())
     }
-    pub fn sign_up_settings(&self) -> sign_up_settings::Client {
+    pub fn sign_up_settings_client(&self) -> sign_up_settings::Client {
         sign_up_settings::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn tag(&self) -> tag::Client {
+    pub fn tag_client(&self) -> tag::Client {
         tag::Client(self.clone())
     }
-    pub fn tag_resource(&self) -> tag_resource::Client {
+    pub fn tag_resource_client(&self) -> tag_resource::Client {
         tag_resource::Client(self.clone())
     }
-    pub fn tenant_access(&self) -> tenant_access::Client {
+    pub fn tenant_access_client(&self) -> tenant_access::Client {
         tenant_access::Client(self.clone())
     }
-    pub fn tenant_access_git(&self) -> tenant_access_git::Client {
+    pub fn tenant_access_git_client(&self) -> tenant_access_git::Client {
         tenant_access_git::Client(self.clone())
     }
-    pub fn tenant_configuration(&self) -> tenant_configuration::Client {
+    pub fn tenant_configuration_client(&self) -> tenant_configuration::Client {
         tenant_configuration::Client(self.clone())
     }
-    pub fn tenant_settings(&self) -> tenant_settings::Client {
+    pub fn tenant_settings_client(&self) -> tenant_settings::Client {
         tenant_settings::Client(self.clone())
     }
-    pub fn user(&self) -> user::Client {
+    pub fn user_client(&self) -> user::Client {
         user::Client(self.clone())
     }
-    pub fn user_confirmation_password(&self) -> user_confirmation_password::Client {
+    pub fn user_confirmation_password_client(&self) -> user_confirmation_password::Client {
         user_confirmation_password::Client(self.clone())
     }
-    pub fn user_group(&self) -> user_group::Client {
+    pub fn user_group_client(&self) -> user_group::Client {
         user_group::Client(self.clone())
     }
-    pub fn user_identities(&self) -> user_identities::Client {
+    pub fn user_identities_client(&self) -> user_identities::Client {
         user_identities::Client(self.clone())
     }
-    pub fn user_subscription(&self) -> user_subscription::Client {
+    pub fn user_subscription_client(&self) -> user_subscription::Client {
         user_subscription::Client(self.clone())
     }
 }

--- a/services/mgmt/apimanagement/src/package_preview_2021_12/operations.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2021_12/operations.rs
@@ -74,235 +74,235 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api(&self) -> api::Client {
+    pub fn api_client(&self) -> api::Client {
         api::Client(self.clone())
     }
-    pub fn api_diagnostic(&self) -> api_diagnostic::Client {
+    pub fn api_diagnostic_client(&self) -> api_diagnostic::Client {
         api_diagnostic::Client(self.clone())
     }
-    pub fn api_export(&self) -> api_export::Client {
+    pub fn api_export_client(&self) -> api_export::Client {
         api_export::Client(self.clone())
     }
-    pub fn api_issue(&self) -> api_issue::Client {
+    pub fn api_issue_client(&self) -> api_issue::Client {
         api_issue::Client(self.clone())
     }
-    pub fn api_issue_attachment(&self) -> api_issue_attachment::Client {
+    pub fn api_issue_attachment_client(&self) -> api_issue_attachment::Client {
         api_issue_attachment::Client(self.clone())
     }
-    pub fn api_issue_comment(&self) -> api_issue_comment::Client {
+    pub fn api_issue_comment_client(&self) -> api_issue_comment::Client {
         api_issue_comment::Client(self.clone())
     }
-    pub fn api_management_operations(&self) -> api_management_operations::Client {
+    pub fn api_management_operations_client(&self) -> api_management_operations::Client {
         api_management_operations::Client(self.clone())
     }
-    pub fn api_management_service(&self) -> api_management_service::Client {
+    pub fn api_management_service_client(&self) -> api_management_service::Client {
         api_management_service::Client(self.clone())
     }
-    pub fn api_management_service_skus(&self) -> api_management_service_skus::Client {
+    pub fn api_management_service_skus_client(&self) -> api_management_service_skus::Client {
         api_management_service_skus::Client(self.clone())
     }
-    pub fn api_management_skus(&self) -> api_management_skus::Client {
+    pub fn api_management_skus_client(&self) -> api_management_skus::Client {
         api_management_skus::Client(self.clone())
     }
-    pub fn api_operation(&self) -> api_operation::Client {
+    pub fn api_operation_client(&self) -> api_operation::Client {
         api_operation::Client(self.clone())
     }
-    pub fn api_operation_policy(&self) -> api_operation_policy::Client {
+    pub fn api_operation_policy_client(&self) -> api_operation_policy::Client {
         api_operation_policy::Client(self.clone())
     }
-    pub fn api_policy(&self) -> api_policy::Client {
+    pub fn api_policy_client(&self) -> api_policy::Client {
         api_policy::Client(self.clone())
     }
-    pub fn api_product(&self) -> api_product::Client {
+    pub fn api_product_client(&self) -> api_product::Client {
         api_product::Client(self.clone())
     }
-    pub fn api_release(&self) -> api_release::Client {
+    pub fn api_release_client(&self) -> api_release::Client {
         api_release::Client(self.clone())
     }
-    pub fn api_revision(&self) -> api_revision::Client {
+    pub fn api_revision_client(&self) -> api_revision::Client {
         api_revision::Client(self.clone())
     }
-    pub fn api_schema(&self) -> api_schema::Client {
+    pub fn api_schema_client(&self) -> api_schema::Client {
         api_schema::Client(self.clone())
     }
-    pub fn api_tag_description(&self) -> api_tag_description::Client {
+    pub fn api_tag_description_client(&self) -> api_tag_description::Client {
         api_tag_description::Client(self.clone())
     }
-    pub fn api_version_set(&self) -> api_version_set::Client {
+    pub fn api_version_set_client(&self) -> api_version_set::Client {
         api_version_set::Client(self.clone())
     }
-    pub fn authorization_server(&self) -> authorization_server::Client {
+    pub fn authorization_server_client(&self) -> authorization_server::Client {
         authorization_server::Client(self.clone())
     }
-    pub fn backend(&self) -> backend::Client {
+    pub fn backend_client(&self) -> backend::Client {
         backend::Client(self.clone())
     }
-    pub fn cache(&self) -> cache::Client {
+    pub fn cache_client(&self) -> cache::Client {
         cache::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn content_item(&self) -> content_item::Client {
+    pub fn content_item_client(&self) -> content_item::Client {
         content_item::Client(self.clone())
     }
-    pub fn content_type(&self) -> content_type::Client {
+    pub fn content_type_client(&self) -> content_type::Client {
         content_type::Client(self.clone())
     }
-    pub fn delegation_settings(&self) -> delegation_settings::Client {
+    pub fn delegation_settings_client(&self) -> delegation_settings::Client {
         delegation_settings::Client(self.clone())
     }
-    pub fn deleted_services(&self) -> deleted_services::Client {
+    pub fn deleted_services_client(&self) -> deleted_services::Client {
         deleted_services::Client(self.clone())
     }
-    pub fn diagnostic(&self) -> diagnostic::Client {
+    pub fn diagnostic_client(&self) -> diagnostic::Client {
         diagnostic::Client(self.clone())
     }
-    pub fn email_template(&self) -> email_template::Client {
+    pub fn email_template_client(&self) -> email_template::Client {
         email_template::Client(self.clone())
     }
-    pub fn gateway(&self) -> gateway::Client {
+    pub fn gateway_client(&self) -> gateway::Client {
         gateway::Client(self.clone())
     }
-    pub fn gateway_api(&self) -> gateway_api::Client {
+    pub fn gateway_api_client(&self) -> gateway_api::Client {
         gateway_api::Client(self.clone())
     }
-    pub fn gateway_certificate_authority(&self) -> gateway_certificate_authority::Client {
+    pub fn gateway_certificate_authority_client(&self) -> gateway_certificate_authority::Client {
         gateway_certificate_authority::Client(self.clone())
     }
-    pub fn gateway_hostname_configuration(&self) -> gateway_hostname_configuration::Client {
+    pub fn gateway_hostname_configuration_client(&self) -> gateway_hostname_configuration::Client {
         gateway_hostname_configuration::Client(self.clone())
     }
-    pub fn global_schema(&self) -> global_schema::Client {
+    pub fn global_schema_client(&self) -> global_schema::Client {
         global_schema::Client(self.clone())
     }
-    pub fn group(&self) -> group::Client {
+    pub fn group_client(&self) -> group::Client {
         group::Client(self.clone())
     }
-    pub fn group_user(&self) -> group_user::Client {
+    pub fn group_user_client(&self) -> group_user::Client {
         group_user::Client(self.clone())
     }
-    pub fn identity_provider(&self) -> identity_provider::Client {
+    pub fn identity_provider_client(&self) -> identity_provider::Client {
         identity_provider::Client(self.clone())
     }
-    pub fn issue(&self) -> issue::Client {
+    pub fn issue_client(&self) -> issue::Client {
         issue::Client(self.clone())
     }
-    pub fn logger(&self) -> logger::Client {
+    pub fn logger_client(&self) -> logger::Client {
         logger::Client(self.clone())
     }
-    pub fn named_value(&self) -> named_value::Client {
+    pub fn named_value_client(&self) -> named_value::Client {
         named_value::Client(self.clone())
     }
-    pub fn network_status(&self) -> network_status::Client {
+    pub fn network_status_client(&self) -> network_status::Client {
         network_status::Client(self.clone())
     }
-    pub fn notification(&self) -> notification::Client {
+    pub fn notification_client(&self) -> notification::Client {
         notification::Client(self.clone())
     }
-    pub fn notification_recipient_email(&self) -> notification_recipient_email::Client {
+    pub fn notification_recipient_email_client(&self) -> notification_recipient_email::Client {
         notification_recipient_email::Client(self.clone())
     }
-    pub fn notification_recipient_user(&self) -> notification_recipient_user::Client {
+    pub fn notification_recipient_user_client(&self) -> notification_recipient_user::Client {
         notification_recipient_user::Client(self.clone())
     }
-    pub fn open_id_connect_provider(&self) -> open_id_connect_provider::Client {
+    pub fn open_id_connect_provider_client(&self) -> open_id_connect_provider::Client {
         open_id_connect_provider::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn outbound_network_dependencies_endpoints(&self) -> outbound_network_dependencies_endpoints::Client {
+    pub fn outbound_network_dependencies_endpoints_client(&self) -> outbound_network_dependencies_endpoints::Client {
         outbound_network_dependencies_endpoints::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_description(&self) -> policy_description::Client {
+    pub fn policy_description_client(&self) -> policy_description::Client {
         policy_description::Client(self.clone())
     }
-    pub fn policy_fragment(&self) -> policy_fragment::Client {
+    pub fn policy_fragment_client(&self) -> policy_fragment::Client {
         policy_fragment::Client(self.clone())
     }
-    pub fn portal_config(&self) -> portal_config::Client {
+    pub fn portal_config_client(&self) -> portal_config::Client {
         portal_config::Client(self.clone())
     }
-    pub fn portal_revision(&self) -> portal_revision::Client {
+    pub fn portal_revision_client(&self) -> portal_revision::Client {
         portal_revision::Client(self.clone())
     }
-    pub fn portal_settings(&self) -> portal_settings::Client {
+    pub fn portal_settings_client(&self) -> portal_settings::Client {
         portal_settings::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn product(&self) -> product::Client {
+    pub fn product_client(&self) -> product::Client {
         product::Client(self.clone())
     }
-    pub fn product_api(&self) -> product_api::Client {
+    pub fn product_api_client(&self) -> product_api::Client {
         product_api::Client(self.clone())
     }
-    pub fn product_group(&self) -> product_group::Client {
+    pub fn product_group_client(&self) -> product_group::Client {
         product_group::Client(self.clone())
     }
-    pub fn product_policy(&self) -> product_policy::Client {
+    pub fn product_policy_client(&self) -> product_policy::Client {
         product_policy::Client(self.clone())
     }
-    pub fn product_subscriptions(&self) -> product_subscriptions::Client {
+    pub fn product_subscriptions_client(&self) -> product_subscriptions::Client {
         product_subscriptions::Client(self.clone())
     }
-    pub fn quota_by_counter_keys(&self) -> quota_by_counter_keys::Client {
+    pub fn quota_by_counter_keys_client(&self) -> quota_by_counter_keys::Client {
         quota_by_counter_keys::Client(self.clone())
     }
-    pub fn quota_by_period_keys(&self) -> quota_by_period_keys::Client {
+    pub fn quota_by_period_keys_client(&self) -> quota_by_period_keys::Client {
         quota_by_period_keys::Client(self.clone())
     }
-    pub fn region(&self) -> region::Client {
+    pub fn region_client(&self) -> region::Client {
         region::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn sign_in_settings(&self) -> sign_in_settings::Client {
+    pub fn sign_in_settings_client(&self) -> sign_in_settings::Client {
         sign_in_settings::Client(self.clone())
     }
-    pub fn sign_up_settings(&self) -> sign_up_settings::Client {
+    pub fn sign_up_settings_client(&self) -> sign_up_settings::Client {
         sign_up_settings::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn tag(&self) -> tag::Client {
+    pub fn tag_client(&self) -> tag::Client {
         tag::Client(self.clone())
     }
-    pub fn tag_resource(&self) -> tag_resource::Client {
+    pub fn tag_resource_client(&self) -> tag_resource::Client {
         tag_resource::Client(self.clone())
     }
-    pub fn tenant_access(&self) -> tenant_access::Client {
+    pub fn tenant_access_client(&self) -> tenant_access::Client {
         tenant_access::Client(self.clone())
     }
-    pub fn tenant_access_git(&self) -> tenant_access_git::Client {
+    pub fn tenant_access_git_client(&self) -> tenant_access_git::Client {
         tenant_access_git::Client(self.clone())
     }
-    pub fn tenant_configuration(&self) -> tenant_configuration::Client {
+    pub fn tenant_configuration_client(&self) -> tenant_configuration::Client {
         tenant_configuration::Client(self.clone())
     }
-    pub fn tenant_settings(&self) -> tenant_settings::Client {
+    pub fn tenant_settings_client(&self) -> tenant_settings::Client {
         tenant_settings::Client(self.clone())
     }
-    pub fn user(&self) -> user::Client {
+    pub fn user_client(&self) -> user::Client {
         user::Client(self.clone())
     }
-    pub fn user_confirmation_password(&self) -> user_confirmation_password::Client {
+    pub fn user_confirmation_password_client(&self) -> user_confirmation_password::Client {
         user_confirmation_password::Client(self.clone())
     }
-    pub fn user_group(&self) -> user_group::Client {
+    pub fn user_group_client(&self) -> user_group::Client {
         user_group::Client(self.clone())
     }
-    pub fn user_identities(&self) -> user_identities::Client {
+    pub fn user_identities_client(&self) -> user_identities::Client {
         user_identities::Client(self.clone())
     }
-    pub fn user_subscription(&self) -> user_subscription::Client {
+    pub fn user_subscription_client(&self) -> user_subscription::Client {
         user_subscription::Client(self.clone())
     }
 }

--- a/services/mgmt/app/src/package_2022_01_01_preview/operations.rs
+++ b/services/mgmt/app/src/package_2022_01_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn container_apps(&self) -> container_apps::Client {
+    pub fn container_apps_client(&self) -> container_apps::Client {
         container_apps::Client(self.clone())
     }
-    pub fn container_apps_auth_configs(&self) -> container_apps_auth_configs::Client {
+    pub fn container_apps_auth_configs_client(&self) -> container_apps_auth_configs::Client {
         container_apps_auth_configs::Client(self.clone())
     }
-    pub fn container_apps_revision_replicas(&self) -> container_apps_revision_replicas::Client {
+    pub fn container_apps_revision_replicas_client(&self) -> container_apps_revision_replicas::Client {
         container_apps_revision_replicas::Client(self.clone())
     }
-    pub fn container_apps_revisions(&self) -> container_apps_revisions::Client {
+    pub fn container_apps_revisions_client(&self) -> container_apps_revisions::Client {
         container_apps_revisions::Client(self.clone())
     }
-    pub fn container_apps_source_controls(&self) -> container_apps_source_controls::Client {
+    pub fn container_apps_source_controls_client(&self) -> container_apps_source_controls::Client {
         container_apps_source_controls::Client(self.clone())
     }
-    pub fn dapr_components(&self) -> dapr_components::Client {
+    pub fn dapr_components_client(&self) -> dapr_components::Client {
         dapr_components::Client(self.clone())
     }
-    pub fn managed_environments(&self) -> managed_environments::Client {
+    pub fn managed_environments_client(&self) -> managed_environments::Client {
         managed_environments::Client(self.clone())
     }
-    pub fn managed_environments_storages(&self) -> managed_environments_storages::Client {
+    pub fn managed_environments_storages_client(&self) -> managed_environments_storages::Client {
         managed_environments_storages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/app/src/package_2022_03/operations.rs
+++ b/services/mgmt/app/src/package_2022_03/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn container_apps(&self) -> container_apps::Client {
+    pub fn container_apps_client(&self) -> container_apps::Client {
         container_apps::Client(self.clone())
     }
-    pub fn container_apps_auth_configs(&self) -> container_apps_auth_configs::Client {
+    pub fn container_apps_auth_configs_client(&self) -> container_apps_auth_configs::Client {
         container_apps_auth_configs::Client(self.clone())
     }
-    pub fn container_apps_revision_replicas(&self) -> container_apps_revision_replicas::Client {
+    pub fn container_apps_revision_replicas_client(&self) -> container_apps_revision_replicas::Client {
         container_apps_revision_replicas::Client(self.clone())
     }
-    pub fn container_apps_revisions(&self) -> container_apps_revisions::Client {
+    pub fn container_apps_revisions_client(&self) -> container_apps_revisions::Client {
         container_apps_revisions::Client(self.clone())
     }
-    pub fn container_apps_source_controls(&self) -> container_apps_source_controls::Client {
+    pub fn container_apps_source_controls_client(&self) -> container_apps_source_controls::Client {
         container_apps_source_controls::Client(self.clone())
     }
-    pub fn dapr_components(&self) -> dapr_components::Client {
+    pub fn dapr_components_client(&self) -> dapr_components::Client {
         dapr_components::Client(self.clone())
     }
-    pub fn managed_environments(&self) -> managed_environments::Client {
+    pub fn managed_environments_client(&self) -> managed_environments::Client {
         managed_environments::Client(self.clone())
     }
-    pub fn managed_environments_storages(&self) -> managed_environments_storages::Client {
+    pub fn managed_environments_storages_client(&self) -> managed_environments_storages::Client {
         managed_environments_storages::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/appconfiguration/src/package_2020_06_01/operations.rs
+++ b/services/mgmt/appconfiguration/src/package_2020_06_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configuration_stores(&self) -> configuration_stores::Client {
+    pub fn configuration_stores_client(&self) -> configuration_stores::Client {
         configuration_stores::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/appconfiguration/src/package_2020_07_01_preview/operations.rs
+++ b/services/mgmt/appconfiguration/src/package_2020_07_01_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configuration_stores(&self) -> configuration_stores::Client {
+    pub fn configuration_stores_client(&self) -> configuration_stores::Client {
         configuration_stores::Client(self.clone())
     }
-    pub fn key_values(&self) -> key_values::Client {
+    pub fn key_values_client(&self) -> key_values::Client {
         key_values::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/appconfiguration/src/package_2021_03_01_preview/operations.rs
+++ b/services/mgmt/appconfiguration/src/package_2021_03_01_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configuration_stores(&self) -> configuration_stores::Client {
+    pub fn configuration_stores_client(&self) -> configuration_stores::Client {
         configuration_stores::Client(self.clone())
     }
-    pub fn key_values(&self) -> key_values::Client {
+    pub fn key_values_client(&self) -> key_values::Client {
         key_values::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/appconfiguration/src/package_2021_10_01_preview/operations.rs
+++ b/services/mgmt/appconfiguration/src/package_2021_10_01_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configuration_stores(&self) -> configuration_stores::Client {
+    pub fn configuration_stores_client(&self) -> configuration_stores::Client {
         configuration_stores::Client(self.clone())
     }
-    pub fn key_values(&self) -> key_values::Client {
+    pub fn key_values_client(&self) -> key_values::Client {
         key_values::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/appconfiguration/src/package_2022_05_01/operations.rs
+++ b/services/mgmt/appconfiguration/src/package_2022_05_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configuration_stores(&self) -> configuration_stores::Client {
+    pub fn configuration_stores_client(&self) -> configuration_stores::Client {
         configuration_stores::Client(self.clone())
     }
-    pub fn key_values(&self) -> key_values::Client {
+    pub fn key_values_client(&self) -> key_values::Client {
         key_values::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/applicationinsights/src/package_2021_10/operations.rs
+++ b/services/mgmt/applicationinsights/src/package_2021_10/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn live_token(&self) -> live_token::Client {
+    pub fn live_token_client(&self) -> live_token::Client {
         live_token::Client(self.clone())
     }
 }

--- a/services/mgmt/applicationinsights/src/package_2022_01_11/operations.rs
+++ b/services/mgmt/applicationinsights/src/package_2022_01_11/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn analytics_items(&self) -> analytics_items::Client {
+    pub fn analytics_items_client(&self) -> analytics_items::Client {
         analytics_items::Client(self.clone())
     }
-    pub fn annotations(&self) -> annotations::Client {
+    pub fn annotations_client(&self) -> annotations::Client {
         annotations::Client(self.clone())
     }
-    pub fn api_keys(&self) -> api_keys::Client {
+    pub fn api_keys_client(&self) -> api_keys::Client {
         api_keys::Client(self.clone())
     }
-    pub fn component_available_features(&self) -> component_available_features::Client {
+    pub fn component_available_features_client(&self) -> component_available_features::Client {
         component_available_features::Client(self.clone())
     }
-    pub fn component_current_billing_features(&self) -> component_current_billing_features::Client {
+    pub fn component_current_billing_features_client(&self) -> component_current_billing_features::Client {
         component_current_billing_features::Client(self.clone())
     }
-    pub fn component_feature_capabilities(&self) -> component_feature_capabilities::Client {
+    pub fn component_feature_capabilities_client(&self) -> component_feature_capabilities::Client {
         component_feature_capabilities::Client(self.clone())
     }
-    pub fn component_linked_storage_accounts(&self) -> component_linked_storage_accounts::Client {
+    pub fn component_linked_storage_accounts_client(&self) -> component_linked_storage_accounts::Client {
         component_linked_storage_accounts::Client(self.clone())
     }
-    pub fn component_quota_status(&self) -> component_quota_status::Client {
+    pub fn component_quota_status_client(&self) -> component_quota_status::Client {
         component_quota_status::Client(self.clone())
     }
-    pub fn components(&self) -> components::Client {
+    pub fn components_client(&self) -> components::Client {
         components::Client(self.clone())
     }
-    pub fn export_configurations(&self) -> export_configurations::Client {
+    pub fn export_configurations_client(&self) -> export_configurations::Client {
         export_configurations::Client(self.clone())
     }
-    pub fn favorites(&self) -> favorites::Client {
+    pub fn favorites_client(&self) -> favorites::Client {
         favorites::Client(self.clone())
     }
-    pub fn live_token(&self) -> live_token::Client {
+    pub fn live_token_client(&self) -> live_token::Client {
         live_token::Client(self.clone())
     }
-    pub fn my_workbooks(&self) -> my_workbooks::Client {
+    pub fn my_workbooks_client(&self) -> my_workbooks::Client {
         my_workbooks::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proactive_detection_configurations(&self) -> proactive_detection_configurations::Client {
+    pub fn proactive_detection_configurations_client(&self) -> proactive_detection_configurations::Client {
         proactive_detection_configurations::Client(self.clone())
     }
-    pub fn web_test_locations(&self) -> web_test_locations::Client {
+    pub fn web_test_locations_client(&self) -> web_test_locations::Client {
         web_test_locations::Client(self.clone())
     }
-    pub fn web_tests(&self) -> web_tests::Client {
+    pub fn web_tests_client(&self) -> web_tests::Client {
         web_tests::Client(self.clone())
     }
-    pub fn work_item_configurations(&self) -> work_item_configurations::Client {
+    pub fn work_item_configurations_client(&self) -> work_item_configurations::Client {
         work_item_configurations::Client(self.clone())
     }
-    pub fn workbook_templates(&self) -> workbook_templates::Client {
+    pub fn workbook_templates_client(&self) -> workbook_templates::Client {
         workbook_templates::Client(self.clone())
     }
-    pub fn workbooks(&self) -> workbooks::Client {
+    pub fn workbooks_client(&self) -> workbooks::Client {
         workbooks::Client(self.clone())
     }
 }

--- a/services/mgmt/applicationinsights/src/package_2022_02_01/operations.rs
+++ b/services/mgmt/applicationinsights/src/package_2022_02_01/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn analytics_items(&self) -> analytics_items::Client {
+    pub fn analytics_items_client(&self) -> analytics_items::Client {
         analytics_items::Client(self.clone())
     }
-    pub fn annotations(&self) -> annotations::Client {
+    pub fn annotations_client(&self) -> annotations::Client {
         annotations::Client(self.clone())
     }
-    pub fn api_keys(&self) -> api_keys::Client {
+    pub fn api_keys_client(&self) -> api_keys::Client {
         api_keys::Client(self.clone())
     }
-    pub fn component_available_features(&self) -> component_available_features::Client {
+    pub fn component_available_features_client(&self) -> component_available_features::Client {
         component_available_features::Client(self.clone())
     }
-    pub fn component_current_billing_features(&self) -> component_current_billing_features::Client {
+    pub fn component_current_billing_features_client(&self) -> component_current_billing_features::Client {
         component_current_billing_features::Client(self.clone())
     }
-    pub fn component_feature_capabilities(&self) -> component_feature_capabilities::Client {
+    pub fn component_feature_capabilities_client(&self) -> component_feature_capabilities::Client {
         component_feature_capabilities::Client(self.clone())
     }
-    pub fn component_linked_storage_accounts(&self) -> component_linked_storage_accounts::Client {
+    pub fn component_linked_storage_accounts_client(&self) -> component_linked_storage_accounts::Client {
         component_linked_storage_accounts::Client(self.clone())
     }
-    pub fn component_quota_status(&self) -> component_quota_status::Client {
+    pub fn component_quota_status_client(&self) -> component_quota_status::Client {
         component_quota_status::Client(self.clone())
     }
-    pub fn components(&self) -> components::Client {
+    pub fn components_client(&self) -> components::Client {
         components::Client(self.clone())
     }
-    pub fn export_configurations(&self) -> export_configurations::Client {
+    pub fn export_configurations_client(&self) -> export_configurations::Client {
         export_configurations::Client(self.clone())
     }
-    pub fn favorites(&self) -> favorites::Client {
+    pub fn favorites_client(&self) -> favorites::Client {
         favorites::Client(self.clone())
     }
-    pub fn live_token(&self) -> live_token::Client {
+    pub fn live_token_client(&self) -> live_token::Client {
         live_token::Client(self.clone())
     }
-    pub fn my_workbooks(&self) -> my_workbooks::Client {
+    pub fn my_workbooks_client(&self) -> my_workbooks::Client {
         my_workbooks::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proactive_detection_configurations(&self) -> proactive_detection_configurations::Client {
+    pub fn proactive_detection_configurations_client(&self) -> proactive_detection_configurations::Client {
         proactive_detection_configurations::Client(self.clone())
     }
-    pub fn web_test_locations(&self) -> web_test_locations::Client {
+    pub fn web_test_locations_client(&self) -> web_test_locations::Client {
         web_test_locations::Client(self.clone())
     }
-    pub fn web_tests(&self) -> web_tests::Client {
+    pub fn web_tests_client(&self) -> web_tests::Client {
         web_tests::Client(self.clone())
     }
-    pub fn work_item_configurations(&self) -> work_item_configurations::Client {
+    pub fn work_item_configurations_client(&self) -> work_item_configurations::Client {
         work_item_configurations::Client(self.clone())
     }
-    pub fn workbook_templates(&self) -> workbook_templates::Client {
+    pub fn workbook_templates_client(&self) -> workbook_templates::Client {
         workbook_templates::Client(self.clone())
     }
-    pub fn workbooks(&self) -> workbooks::Client {
+    pub fn workbooks_client(&self) -> workbooks::Client {
         workbooks::Client(self.clone())
     }
 }

--- a/services/mgmt/applicationinsights/src/package_2022_04_01/operations.rs
+++ b/services/mgmt/applicationinsights/src/package_2022_04_01/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn analytics_items(&self) -> analytics_items::Client {
+    pub fn analytics_items_client(&self) -> analytics_items::Client {
         analytics_items::Client(self.clone())
     }
-    pub fn annotations(&self) -> annotations::Client {
+    pub fn annotations_client(&self) -> annotations::Client {
         annotations::Client(self.clone())
     }
-    pub fn api_keys(&self) -> api_keys::Client {
+    pub fn api_keys_client(&self) -> api_keys::Client {
         api_keys::Client(self.clone())
     }
-    pub fn component_available_features(&self) -> component_available_features::Client {
+    pub fn component_available_features_client(&self) -> component_available_features::Client {
         component_available_features::Client(self.clone())
     }
-    pub fn component_current_billing_features(&self) -> component_current_billing_features::Client {
+    pub fn component_current_billing_features_client(&self) -> component_current_billing_features::Client {
         component_current_billing_features::Client(self.clone())
     }
-    pub fn component_feature_capabilities(&self) -> component_feature_capabilities::Client {
+    pub fn component_feature_capabilities_client(&self) -> component_feature_capabilities::Client {
         component_feature_capabilities::Client(self.clone())
     }
-    pub fn component_linked_storage_accounts(&self) -> component_linked_storage_accounts::Client {
+    pub fn component_linked_storage_accounts_client(&self) -> component_linked_storage_accounts::Client {
         component_linked_storage_accounts::Client(self.clone())
     }
-    pub fn component_quota_status(&self) -> component_quota_status::Client {
+    pub fn component_quota_status_client(&self) -> component_quota_status::Client {
         component_quota_status::Client(self.clone())
     }
-    pub fn components(&self) -> components::Client {
+    pub fn components_client(&self) -> components::Client {
         components::Client(self.clone())
     }
-    pub fn export_configurations(&self) -> export_configurations::Client {
+    pub fn export_configurations_client(&self) -> export_configurations::Client {
         export_configurations::Client(self.clone())
     }
-    pub fn favorites(&self) -> favorites::Client {
+    pub fn favorites_client(&self) -> favorites::Client {
         favorites::Client(self.clone())
     }
-    pub fn live_token(&self) -> live_token::Client {
+    pub fn live_token_client(&self) -> live_token::Client {
         live_token::Client(self.clone())
     }
-    pub fn my_workbooks(&self) -> my_workbooks::Client {
+    pub fn my_workbooks_client(&self) -> my_workbooks::Client {
         my_workbooks::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proactive_detection_configurations(&self) -> proactive_detection_configurations::Client {
+    pub fn proactive_detection_configurations_client(&self) -> proactive_detection_configurations::Client {
         proactive_detection_configurations::Client(self.clone())
     }
-    pub fn web_test_locations(&self) -> web_test_locations::Client {
+    pub fn web_test_locations_client(&self) -> web_test_locations::Client {
         web_test_locations::Client(self.clone())
     }
-    pub fn web_tests(&self) -> web_tests::Client {
+    pub fn web_tests_client(&self) -> web_tests::Client {
         web_tests::Client(self.clone())
     }
-    pub fn work_item_configurations(&self) -> work_item_configurations::Client {
+    pub fn work_item_configurations_client(&self) -> work_item_configurations::Client {
         work_item_configurations::Client(self.clone())
     }
-    pub fn workbook_templates(&self) -> workbook_templates::Client {
+    pub fn workbook_templates_client(&self) -> workbook_templates::Client {
         workbook_templates::Client(self.clone())
     }
-    pub fn workbooks(&self) -> workbooks::Client {
+    pub fn workbooks_client(&self) -> workbooks::Client {
         workbooks::Client(self.clone())
     }
 }

--- a/services/mgmt/applicationinsights/src/package_preview_2020_02/operations.rs
+++ b/services/mgmt/applicationinsights/src/package_preview_2020_02/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/appplatform/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/appplatform/src/package_preview_2021_06/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn bindings(&self) -> bindings::Client {
+    pub fn bindings_client(&self) -> bindings::Client {
         bindings::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn config_servers(&self) -> config_servers::Client {
+    pub fn config_servers_client(&self) -> config_servers::Client {
         config_servers::Client(self.clone())
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn monitoring_settings(&self) -> monitoring_settings::Client {
+    pub fn monitoring_settings_client(&self) -> monitoring_settings::Client {
         monitoring_settings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn runtime_versions(&self) -> runtime_versions::Client {
+    pub fn runtime_versions_client(&self) -> runtime_versions::Client {
         runtime_versions::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
 }

--- a/services/mgmt/appplatform/src/package_preview_2021_09/operations.rs
+++ b/services/mgmt/appplatform/src/package_preview_2021_09/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn bindings(&self) -> bindings::Client {
+    pub fn bindings_client(&self) -> bindings::Client {
         bindings::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn config_servers(&self) -> config_servers::Client {
+    pub fn config_servers_client(&self) -> config_servers::Client {
         config_servers::Client(self.clone())
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn monitoring_settings(&self) -> monitoring_settings::Client {
+    pub fn monitoring_settings_client(&self) -> monitoring_settings::Client {
         monitoring_settings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn runtime_versions(&self) -> runtime_versions::Client {
+    pub fn runtime_versions_client(&self) -> runtime_versions::Client {
         runtime_versions::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storages(&self) -> storages::Client {
+    pub fn storages_client(&self) -> storages::Client {
         storages::Client(self.clone())
     }
 }

--- a/services/mgmt/appplatform/src/package_preview_2022_01/operations.rs
+++ b/services/mgmt/appplatform/src/package_preview_2022_01/operations.rs
@@ -74,73 +74,73 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_portal_custom_domains(&self) -> api_portal_custom_domains::Client {
+    pub fn api_portal_custom_domains_client(&self) -> api_portal_custom_domains::Client {
         api_portal_custom_domains::Client(self.clone())
     }
-    pub fn api_portals(&self) -> api_portals::Client {
+    pub fn api_portals_client(&self) -> api_portals::Client {
         api_portals::Client(self.clone())
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn bindings(&self) -> bindings::Client {
+    pub fn bindings_client(&self) -> bindings::Client {
         bindings::Client(self.clone())
     }
-    pub fn build_service(&self) -> build_service::Client {
+    pub fn build_service_client(&self) -> build_service::Client {
         build_service::Client(self.clone())
     }
-    pub fn build_service_agent_pool(&self) -> build_service_agent_pool::Client {
+    pub fn build_service_agent_pool_client(&self) -> build_service_agent_pool::Client {
         build_service_agent_pool::Client(self.clone())
     }
-    pub fn build_service_builder(&self) -> build_service_builder::Client {
+    pub fn build_service_builder_client(&self) -> build_service_builder::Client {
         build_service_builder::Client(self.clone())
     }
-    pub fn buildpack_binding(&self) -> buildpack_binding::Client {
+    pub fn buildpack_binding_client(&self) -> buildpack_binding::Client {
         buildpack_binding::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn config_servers(&self) -> config_servers::Client {
+    pub fn config_servers_client(&self) -> config_servers::Client {
         config_servers::Client(self.clone())
     }
-    pub fn configuration_services(&self) -> configuration_services::Client {
+    pub fn configuration_services_client(&self) -> configuration_services::Client {
         configuration_services::Client(self.clone())
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn gateway_custom_domains(&self) -> gateway_custom_domains::Client {
+    pub fn gateway_custom_domains_client(&self) -> gateway_custom_domains::Client {
         gateway_custom_domains::Client(self.clone())
     }
-    pub fn gateway_route_configs(&self) -> gateway_route_configs::Client {
+    pub fn gateway_route_configs_client(&self) -> gateway_route_configs::Client {
         gateway_route_configs::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn monitoring_settings(&self) -> monitoring_settings::Client {
+    pub fn monitoring_settings_client(&self) -> monitoring_settings::Client {
         monitoring_settings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn runtime_versions(&self) -> runtime_versions::Client {
+    pub fn runtime_versions_client(&self) -> runtime_versions::Client {
         runtime_versions::Client(self.clone())
     }
-    pub fn service_registries(&self) -> service_registries::Client {
+    pub fn service_registries_client(&self) -> service_registries::Client {
         service_registries::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storages(&self) -> storages::Client {
+    pub fn storages_client(&self) -> storages::Client {
         storages::Client(self.clone())
     }
 }

--- a/services/mgmt/appplatform/src/package_preview_2022_03/operations.rs
+++ b/services/mgmt/appplatform/src/package_preview_2022_03/operations.rs
@@ -74,73 +74,73 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_portal_custom_domains(&self) -> api_portal_custom_domains::Client {
+    pub fn api_portal_custom_domains_client(&self) -> api_portal_custom_domains::Client {
         api_portal_custom_domains::Client(self.clone())
     }
-    pub fn api_portals(&self) -> api_portals::Client {
+    pub fn api_portals_client(&self) -> api_portals::Client {
         api_portals::Client(self.clone())
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn bindings(&self) -> bindings::Client {
+    pub fn bindings_client(&self) -> bindings::Client {
         bindings::Client(self.clone())
     }
-    pub fn build_service(&self) -> build_service::Client {
+    pub fn build_service_client(&self) -> build_service::Client {
         build_service::Client(self.clone())
     }
-    pub fn build_service_agent_pool(&self) -> build_service_agent_pool::Client {
+    pub fn build_service_agent_pool_client(&self) -> build_service_agent_pool::Client {
         build_service_agent_pool::Client(self.clone())
     }
-    pub fn build_service_builder(&self) -> build_service_builder::Client {
+    pub fn build_service_builder_client(&self) -> build_service_builder::Client {
         build_service_builder::Client(self.clone())
     }
-    pub fn buildpack_binding(&self) -> buildpack_binding::Client {
+    pub fn buildpack_binding_client(&self) -> buildpack_binding::Client {
         buildpack_binding::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn config_servers(&self) -> config_servers::Client {
+    pub fn config_servers_client(&self) -> config_servers::Client {
         config_servers::Client(self.clone())
     }
-    pub fn configuration_services(&self) -> configuration_services::Client {
+    pub fn configuration_services_client(&self) -> configuration_services::Client {
         configuration_services::Client(self.clone())
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn gateway_custom_domains(&self) -> gateway_custom_domains::Client {
+    pub fn gateway_custom_domains_client(&self) -> gateway_custom_domains::Client {
         gateway_custom_domains::Client(self.clone())
     }
-    pub fn gateway_route_configs(&self) -> gateway_route_configs::Client {
+    pub fn gateway_route_configs_client(&self) -> gateway_route_configs::Client {
         gateway_route_configs::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn monitoring_settings(&self) -> monitoring_settings::Client {
+    pub fn monitoring_settings_client(&self) -> monitoring_settings::Client {
         monitoring_settings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn runtime_versions(&self) -> runtime_versions::Client {
+    pub fn runtime_versions_client(&self) -> runtime_versions::Client {
         runtime_versions::Client(self.clone())
     }
-    pub fn service_registries(&self) -> service_registries::Client {
+    pub fn service_registries_client(&self) -> service_registries::Client {
         service_registries::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storages(&self) -> storages::Client {
+    pub fn storages_client(&self) -> storages::Client {
         storages::Client(self.clone())
     }
 }

--- a/services/mgmt/appplatform/src/package_preview_2022_05/operations.rs
+++ b/services/mgmt/appplatform/src/package_preview_2022_05/operations.rs
@@ -74,73 +74,73 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_portal_custom_domains(&self) -> api_portal_custom_domains::Client {
+    pub fn api_portal_custom_domains_client(&self) -> api_portal_custom_domains::Client {
         api_portal_custom_domains::Client(self.clone())
     }
-    pub fn api_portals(&self) -> api_portals::Client {
+    pub fn api_portals_client(&self) -> api_portals::Client {
         api_portals::Client(self.clone())
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn bindings(&self) -> bindings::Client {
+    pub fn bindings_client(&self) -> bindings::Client {
         bindings::Client(self.clone())
     }
-    pub fn build_service(&self) -> build_service::Client {
+    pub fn build_service_client(&self) -> build_service::Client {
         build_service::Client(self.clone())
     }
-    pub fn build_service_agent_pool(&self) -> build_service_agent_pool::Client {
+    pub fn build_service_agent_pool_client(&self) -> build_service_agent_pool::Client {
         build_service_agent_pool::Client(self.clone())
     }
-    pub fn build_service_builder(&self) -> build_service_builder::Client {
+    pub fn build_service_builder_client(&self) -> build_service_builder::Client {
         build_service_builder::Client(self.clone())
     }
-    pub fn buildpack_binding(&self) -> buildpack_binding::Client {
+    pub fn buildpack_binding_client(&self) -> buildpack_binding::Client {
         buildpack_binding::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn config_servers(&self) -> config_servers::Client {
+    pub fn config_servers_client(&self) -> config_servers::Client {
         config_servers::Client(self.clone())
     }
-    pub fn configuration_services(&self) -> configuration_services::Client {
+    pub fn configuration_services_client(&self) -> configuration_services::Client {
         configuration_services::Client(self.clone())
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn gateway_custom_domains(&self) -> gateway_custom_domains::Client {
+    pub fn gateway_custom_domains_client(&self) -> gateway_custom_domains::Client {
         gateway_custom_domains::Client(self.clone())
     }
-    pub fn gateway_route_configs(&self) -> gateway_route_configs::Client {
+    pub fn gateway_route_configs_client(&self) -> gateway_route_configs::Client {
         gateway_route_configs::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn monitoring_settings(&self) -> monitoring_settings::Client {
+    pub fn monitoring_settings_client(&self) -> monitoring_settings::Client {
         monitoring_settings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn runtime_versions(&self) -> runtime_versions::Client {
+    pub fn runtime_versions_client(&self) -> runtime_versions::Client {
         runtime_versions::Client(self.clone())
     }
-    pub fn service_registries(&self) -> service_registries::Client {
+    pub fn service_registries_client(&self) -> service_registries::Client {
         service_registries::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storages(&self) -> storages::Client {
+    pub fn storages_client(&self) -> storages::Client {
         storages::Client(self.clone())
     }
 }

--- a/services/mgmt/arcdata/src/package_2021_08_01/operations.rs
+++ b/services/mgmt/arcdata/src/package_2021_08_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_controllers(&self) -> data_controllers::Client {
+    pub fn data_controllers_client(&self) -> data_controllers::Client {
         data_controllers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn sql_managed_instances(&self) -> sql_managed_instances::Client {
+    pub fn sql_managed_instances_client(&self) -> sql_managed_instances::Client {
         sql_managed_instances::Client(self.clone())
     }
-    pub fn sql_server_instances(&self) -> sql_server_instances::Client {
+    pub fn sql_server_instances_client(&self) -> sql_server_instances::Client {
         sql_server_instances::Client(self.clone())
     }
 }

--- a/services/mgmt/arcdata/src/package_2021_11_01/operations.rs
+++ b/services/mgmt/arcdata/src/package_2021_11_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_controllers(&self) -> data_controllers::Client {
+    pub fn data_controllers_client(&self) -> data_controllers::Client {
         data_controllers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn sql_managed_instances(&self) -> sql_managed_instances::Client {
+    pub fn sql_managed_instances_client(&self) -> sql_managed_instances::Client {
         sql_managed_instances::Client(self.clone())
     }
-    pub fn sql_server_instances(&self) -> sql_server_instances::Client {
+    pub fn sql_server_instances_client(&self) -> sql_server_instances::Client {
         sql_server_instances::Client(self.clone())
     }
 }

--- a/services/mgmt/arcdata/src/package_preview_2021_06_01/operations.rs
+++ b/services/mgmt/arcdata/src/package_preview_2021_06_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_controllers(&self) -> data_controllers::Client {
+    pub fn data_controllers_client(&self) -> data_controllers::Client {
         data_controllers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn postgres_instances(&self) -> postgres_instances::Client {
+    pub fn postgres_instances_client(&self) -> postgres_instances::Client {
         postgres_instances::Client(self.clone())
     }
-    pub fn sql_managed_instances(&self) -> sql_managed_instances::Client {
+    pub fn sql_managed_instances_client(&self) -> sql_managed_instances::Client {
         sql_managed_instances::Client(self.clone())
     }
-    pub fn sql_server_instances(&self) -> sql_server_instances::Client {
+    pub fn sql_server_instances_client(&self) -> sql_server_instances::Client {
         sql_server_instances::Client(self.clone())
     }
 }

--- a/services/mgmt/arcdata/src/package_preview_2021_07_01/operations.rs
+++ b/services/mgmt/arcdata/src/package_preview_2021_07_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_controllers(&self) -> data_controllers::Client {
+    pub fn data_controllers_client(&self) -> data_controllers::Client {
         data_controllers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn postgres_instances(&self) -> postgres_instances::Client {
+    pub fn postgres_instances_client(&self) -> postgres_instances::Client {
         postgres_instances::Client(self.clone())
     }
-    pub fn sql_managed_instances(&self) -> sql_managed_instances::Client {
+    pub fn sql_managed_instances_client(&self) -> sql_managed_instances::Client {
         sql_managed_instances::Client(self.clone())
     }
-    pub fn sql_server_instances(&self) -> sql_server_instances::Client {
+    pub fn sql_server_instances_client(&self) -> sql_server_instances::Client {
         sql_server_instances::Client(self.clone())
     }
 }

--- a/services/mgmt/arcdata/src/package_preview_2022_03/operations.rs
+++ b/services/mgmt/arcdata/src/package_preview_2022_03/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn active_directory_connectors(&self) -> active_directory_connectors::Client {
+    pub fn active_directory_connectors_client(&self) -> active_directory_connectors::Client {
         active_directory_connectors::Client(self.clone())
     }
-    pub fn data_controllers(&self) -> data_controllers::Client {
+    pub fn data_controllers_client(&self) -> data_controllers::Client {
         data_controllers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn postgres_instances(&self) -> postgres_instances::Client {
+    pub fn postgres_instances_client(&self) -> postgres_instances::Client {
         postgres_instances::Client(self.clone())
     }
-    pub fn sql_managed_instances(&self) -> sql_managed_instances::Client {
+    pub fn sql_managed_instances_client(&self) -> sql_managed_instances::Client {
         sql_managed_instances::Client(self.clone())
     }
-    pub fn sql_server_instances(&self) -> sql_server_instances::Client {
+    pub fn sql_server_instances_client(&self) -> sql_server_instances::Client {
         sql_server_instances::Client(self.clone())
     }
 }

--- a/services/mgmt/attestation/src/package_2018_09_01/operations.rs
+++ b/services/mgmt/attestation/src/package_2018_09_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attestation_providers(&self) -> attestation_providers::Client {
+    pub fn attestation_providers_client(&self) -> attestation_providers::Client {
         attestation_providers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/attestation/src/package_2020_10_01/operations.rs
+++ b/services/mgmt/attestation/src/package_2020_10_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attestation_providers(&self) -> attestation_providers::Client {
+    pub fn attestation_providers_client(&self) -> attestation_providers::Client {
         attestation_providers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
 }

--- a/services/mgmt/attestation/src/package_2021_06_01/operations.rs
+++ b/services/mgmt/attestation/src/package_2021_06_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attestation_providers(&self) -> attestation_providers::Client {
+    pub fn attestation_providers_client(&self) -> attestation_providers::Client {
         attestation_providers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/authorization/src/package_2020_10_01/operations.rs
+++ b/services/mgmt/authorization/src/package_2020_10_01/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn classic_administrators(&self) -> classic_administrators::Client {
+    pub fn classic_administrators_client(&self) -> classic_administrators::Client {
         classic_administrators::Client(self.clone())
     }
-    pub fn eligible_child_resources(&self) -> eligible_child_resources::Client {
+    pub fn eligible_child_resources_client(&self) -> eligible_child_resources::Client {
         eligible_child_resources::Client(self.clone())
     }
-    pub fn global_administrator(&self) -> global_administrator::Client {
+    pub fn global_administrator_client(&self) -> global_administrator::Client {
         global_administrator::Client(self.clone())
     }
-    pub fn permissions(&self) -> permissions::Client {
+    pub fn permissions_client(&self) -> permissions::Client {
         permissions::Client(self.clone())
     }
-    pub fn provider_operations_metadata(&self) -> provider_operations_metadata::Client {
+    pub fn provider_operations_metadata_client(&self) -> provider_operations_metadata::Client {
         provider_operations_metadata::Client(self.clone())
     }
-    pub fn role_assignment_schedule_instances(&self) -> role_assignment_schedule_instances::Client {
+    pub fn role_assignment_schedule_instances_client(&self) -> role_assignment_schedule_instances::Client {
         role_assignment_schedule_instances::Client(self.clone())
     }
-    pub fn role_assignment_schedule_requests(&self) -> role_assignment_schedule_requests::Client {
+    pub fn role_assignment_schedule_requests_client(&self) -> role_assignment_schedule_requests::Client {
         role_assignment_schedule_requests::Client(self.clone())
     }
-    pub fn role_assignment_schedules(&self) -> role_assignment_schedules::Client {
+    pub fn role_assignment_schedules_client(&self) -> role_assignment_schedules::Client {
         role_assignment_schedules::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
-    pub fn role_eligibility_schedule_instances(&self) -> role_eligibility_schedule_instances::Client {
+    pub fn role_eligibility_schedule_instances_client(&self) -> role_eligibility_schedule_instances::Client {
         role_eligibility_schedule_instances::Client(self.clone())
     }
-    pub fn role_eligibility_schedule_requests(&self) -> role_eligibility_schedule_requests::Client {
+    pub fn role_eligibility_schedule_requests_client(&self) -> role_eligibility_schedule_requests::Client {
         role_eligibility_schedule_requests::Client(self.clone())
     }
-    pub fn role_eligibility_schedules(&self) -> role_eligibility_schedules::Client {
+    pub fn role_eligibility_schedules_client(&self) -> role_eligibility_schedules::Client {
         role_eligibility_schedules::Client(self.clone())
     }
-    pub fn role_management_policies(&self) -> role_management_policies::Client {
+    pub fn role_management_policies_client(&self) -> role_management_policies::Client {
         role_management_policies::Client(self.clone())
     }
-    pub fn role_management_policy_assignments(&self) -> role_management_policy_assignments::Client {
+    pub fn role_management_policy_assignments_client(&self) -> role_management_policy_assignments::Client {
         role_management_policy_assignments::Client(self.clone())
     }
 }

--- a/services/mgmt/authorization/src/package_2020_10_01_preview/operations.rs
+++ b/services/mgmt/authorization/src/package_2020_10_01_preview/operations.rs
@@ -74,78 +74,78 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_review_default_settings(&self) -> access_review_default_settings::Client {
+    pub fn access_review_default_settings_client(&self) -> access_review_default_settings::Client {
         access_review_default_settings::Client(self.clone())
     }
-    pub fn access_review_instance(&self) -> access_review_instance::Client {
+    pub fn access_review_instance_client(&self) -> access_review_instance::Client {
         access_review_instance::Client(self.clone())
     }
-    pub fn access_review_instance_decisions(&self) -> access_review_instance_decisions::Client {
+    pub fn access_review_instance_decisions_client(&self) -> access_review_instance_decisions::Client {
         access_review_instance_decisions::Client(self.clone())
     }
-    pub fn access_review_instance_my_decisions(&self) -> access_review_instance_my_decisions::Client {
+    pub fn access_review_instance_my_decisions_client(&self) -> access_review_instance_my_decisions::Client {
         access_review_instance_my_decisions::Client(self.clone())
     }
-    pub fn access_review_instances(&self) -> access_review_instances::Client {
+    pub fn access_review_instances_client(&self) -> access_review_instances::Client {
         access_review_instances::Client(self.clone())
     }
-    pub fn access_review_instances_assigned_for_my_approval(&self) -> access_review_instances_assigned_for_my_approval::Client {
+    pub fn access_review_instances_assigned_for_my_approval_client(&self) -> access_review_instances_assigned_for_my_approval::Client {
         access_review_instances_assigned_for_my_approval::Client(self.clone())
     }
-    pub fn access_review_schedule_definitions(&self) -> access_review_schedule_definitions::Client {
+    pub fn access_review_schedule_definitions_client(&self) -> access_review_schedule_definitions::Client {
         access_review_schedule_definitions::Client(self.clone())
     }
-    pub fn access_review_schedule_definitions_assigned_for_my_approval(
+    pub fn access_review_schedule_definitions_assigned_for_my_approval_client(
         &self,
     ) -> access_review_schedule_definitions_assigned_for_my_approval::Client {
         access_review_schedule_definitions_assigned_for_my_approval::Client(self.clone())
     }
-    pub fn deny_assignments(&self) -> deny_assignments::Client {
+    pub fn deny_assignments_client(&self) -> deny_assignments::Client {
         deny_assignments::Client(self.clone())
     }
-    pub fn eligible_child_resources(&self) -> eligible_child_resources::Client {
+    pub fn eligible_child_resources_client(&self) -> eligible_child_resources::Client {
         eligible_child_resources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn permissions(&self) -> permissions::Client {
+    pub fn permissions_client(&self) -> permissions::Client {
         permissions::Client(self.clone())
     }
-    pub fn provider_operations_metadata(&self) -> provider_operations_metadata::Client {
+    pub fn provider_operations_metadata_client(&self) -> provider_operations_metadata::Client {
         provider_operations_metadata::Client(self.clone())
     }
-    pub fn role_assignment_metrics(&self) -> role_assignment_metrics::Client {
+    pub fn role_assignment_metrics_client(&self) -> role_assignment_metrics::Client {
         role_assignment_metrics::Client(self.clone())
     }
-    pub fn role_assignment_schedule_instances(&self) -> role_assignment_schedule_instances::Client {
+    pub fn role_assignment_schedule_instances_client(&self) -> role_assignment_schedule_instances::Client {
         role_assignment_schedule_instances::Client(self.clone())
     }
-    pub fn role_assignment_schedule_requests(&self) -> role_assignment_schedule_requests::Client {
+    pub fn role_assignment_schedule_requests_client(&self) -> role_assignment_schedule_requests::Client {
         role_assignment_schedule_requests::Client(self.clone())
     }
-    pub fn role_assignment_schedules(&self) -> role_assignment_schedules::Client {
+    pub fn role_assignment_schedules_client(&self) -> role_assignment_schedules::Client {
         role_assignment_schedules::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
-    pub fn role_eligibility_schedule_instances(&self) -> role_eligibility_schedule_instances::Client {
+    pub fn role_eligibility_schedule_instances_client(&self) -> role_eligibility_schedule_instances::Client {
         role_eligibility_schedule_instances::Client(self.clone())
     }
-    pub fn role_eligibility_schedule_requests(&self) -> role_eligibility_schedule_requests::Client {
+    pub fn role_eligibility_schedule_requests_client(&self) -> role_eligibility_schedule_requests::Client {
         role_eligibility_schedule_requests::Client(self.clone())
     }
-    pub fn role_eligibility_schedules(&self) -> role_eligibility_schedules::Client {
+    pub fn role_eligibility_schedules_client(&self) -> role_eligibility_schedules::Client {
         role_eligibility_schedules::Client(self.clone())
     }
-    pub fn role_management_policies(&self) -> role_management_policies::Client {
+    pub fn role_management_policies_client(&self) -> role_management_policies::Client {
         role_management_policies::Client(self.clone())
     }
-    pub fn role_management_policy_assignments(&self) -> role_management_policy_assignments::Client {
+    pub fn role_management_policy_assignments_client(&self) -> role_management_policy_assignments::Client {
         role_management_policy_assignments::Client(self.clone())
     }
 }

--- a/services/mgmt/authorization/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/authorization/src/package_preview_2021_11/operations.rs
@@ -74,51 +74,51 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_review_default_settings(&self) -> access_review_default_settings::Client {
+    pub fn access_review_default_settings_client(&self) -> access_review_default_settings::Client {
         access_review_default_settings::Client(self.clone())
     }
-    pub fn access_review_history_definition(&self) -> access_review_history_definition::Client {
+    pub fn access_review_history_definition_client(&self) -> access_review_history_definition::Client {
         access_review_history_definition::Client(self.clone())
     }
-    pub fn access_review_history_definition_instance(&self) -> access_review_history_definition_instance::Client {
+    pub fn access_review_history_definition_instance_client(&self) -> access_review_history_definition_instance::Client {
         access_review_history_definition_instance::Client(self.clone())
     }
-    pub fn access_review_history_definition_instances(&self) -> access_review_history_definition_instances::Client {
+    pub fn access_review_history_definition_instances_client(&self) -> access_review_history_definition_instances::Client {
         access_review_history_definition_instances::Client(self.clone())
     }
-    pub fn access_review_history_definitions(&self) -> access_review_history_definitions::Client {
+    pub fn access_review_history_definitions_client(&self) -> access_review_history_definitions::Client {
         access_review_history_definitions::Client(self.clone())
     }
-    pub fn access_review_instance(&self) -> access_review_instance::Client {
+    pub fn access_review_instance_client(&self) -> access_review_instance::Client {
         access_review_instance::Client(self.clone())
     }
-    pub fn access_review_instance_contacted_reviewers(&self) -> access_review_instance_contacted_reviewers::Client {
+    pub fn access_review_instance_contacted_reviewers_client(&self) -> access_review_instance_contacted_reviewers::Client {
         access_review_instance_contacted_reviewers::Client(self.clone())
     }
-    pub fn access_review_instance_decisions(&self) -> access_review_instance_decisions::Client {
+    pub fn access_review_instance_decisions_client(&self) -> access_review_instance_decisions::Client {
         access_review_instance_decisions::Client(self.clone())
     }
-    pub fn access_review_instance_my_decisions(&self) -> access_review_instance_my_decisions::Client {
+    pub fn access_review_instance_my_decisions_client(&self) -> access_review_instance_my_decisions::Client {
         access_review_instance_my_decisions::Client(self.clone())
     }
-    pub fn access_review_instances(&self) -> access_review_instances::Client {
+    pub fn access_review_instances_client(&self) -> access_review_instances::Client {
         access_review_instances::Client(self.clone())
     }
-    pub fn access_review_instances_assigned_for_my_approval(&self) -> access_review_instances_assigned_for_my_approval::Client {
+    pub fn access_review_instances_assigned_for_my_approval_client(&self) -> access_review_instances_assigned_for_my_approval::Client {
         access_review_instances_assigned_for_my_approval::Client(self.clone())
     }
-    pub fn access_review_schedule_definitions(&self) -> access_review_schedule_definitions::Client {
+    pub fn access_review_schedule_definitions_client(&self) -> access_review_schedule_definitions::Client {
         access_review_schedule_definitions::Client(self.clone())
     }
-    pub fn access_review_schedule_definitions_assigned_for_my_approval(
+    pub fn access_review_schedule_definitions_assigned_for_my_approval_client(
         &self,
     ) -> access_review_schedule_definitions_assigned_for_my_approval::Client {
         access_review_schedule_definitions_assigned_for_my_approval::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn tenant_level_access_review_instance_contacted_reviewers(
+    pub fn tenant_level_access_review_instance_contacted_reviewers_client(
         &self,
     ) -> tenant_level_access_review_instance_contacted_reviewers::Client {
         tenant_level_access_review_instance_contacted_reviewers::Client(self.clone())

--- a/services/mgmt/authorization/src/profile_hybrid_2019_03_01/operations.rs
+++ b/services/mgmt/authorization/src/profile_hybrid_2019_03_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn global_administrator(&self) -> global_administrator::Client {
+    pub fn global_administrator_client(&self) -> global_administrator::Client {
         global_administrator::Client(self.clone())
     }
-    pub fn permissions(&self) -> permissions::Client {
+    pub fn permissions_client(&self) -> permissions::Client {
         permissions::Client(self.clone())
     }
-    pub fn provider_operations_metadata(&self) -> provider_operations_metadata::Client {
+    pub fn provider_operations_metadata_client(&self) -> provider_operations_metadata::Client {
         provider_operations_metadata::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/authorization/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/authorization/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn global_administrator(&self) -> global_administrator::Client {
+    pub fn global_administrator_client(&self) -> global_administrator::Client {
         global_administrator::Client(self.clone())
     }
-    pub fn permissions(&self) -> permissions::Client {
+    pub fn permissions_client(&self) -> permissions::Client {
         permissions::Client(self.clone())
     }
-    pub fn provider_operations_metadata(&self) -> provider_operations_metadata::Client {
+    pub fn provider_operations_metadata_client(&self) -> provider_operations_metadata::Client {
         provider_operations_metadata::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/automanage/src/package_2020_06_30_preview/operations.rs
+++ b/services/mgmt/automanage/src/package_2020_06_30_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn configuration_profile_assignments(&self) -> configuration_profile_assignments::Client {
+    pub fn configuration_profile_assignments_client(&self) -> configuration_profile_assignments::Client {
         configuration_profile_assignments::Client(self.clone())
     }
-    pub fn configuration_profile_preferences(&self) -> configuration_profile_preferences::Client {
+    pub fn configuration_profile_preferences_client(&self) -> configuration_profile_preferences::Client {
         configuration_profile_preferences::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/automanage/src/package_2021_04_30_preview/operations.rs
+++ b/services/mgmt/automanage/src/package_2021_04_30_preview/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn best_practices(&self) -> best_practices::Client {
+    pub fn best_practices_client(&self) -> best_practices::Client {
         best_practices::Client(self.clone())
     }
-    pub fn best_practices_versions(&self) -> best_practices_versions::Client {
+    pub fn best_practices_versions_client(&self) -> best_practices_versions::Client {
         best_practices_versions::Client(self.clone())
     }
-    pub fn configuration_profile_assignments(&self) -> configuration_profile_assignments::Client {
+    pub fn configuration_profile_assignments_client(&self) -> configuration_profile_assignments::Client {
         configuration_profile_assignments::Client(self.clone())
     }
-    pub fn configuration_profile_hci_assignments(&self) -> configuration_profile_hci_assignments::Client {
+    pub fn configuration_profile_hci_assignments_client(&self) -> configuration_profile_hci_assignments::Client {
         configuration_profile_hci_assignments::Client(self.clone())
     }
-    pub fn configuration_profile_hcrp_assignments(&self) -> configuration_profile_hcrp_assignments::Client {
+    pub fn configuration_profile_hcrp_assignments_client(&self) -> configuration_profile_hcrp_assignments::Client {
         configuration_profile_hcrp_assignments::Client(self.clone())
     }
-    pub fn configuration_profiles(&self) -> configuration_profiles::Client {
+    pub fn configuration_profiles_client(&self) -> configuration_profiles::Client {
         configuration_profiles::Client(self.clone())
     }
-    pub fn configuration_profiles_versions(&self) -> configuration_profiles_versions::Client {
+    pub fn configuration_profiles_versions_client(&self) -> configuration_profiles_versions::Client {
         configuration_profiles_versions::Client(self.clone())
     }
-    pub fn hci_reports(&self) -> hci_reports::Client {
+    pub fn hci_reports_client(&self) -> hci_reports::Client {
         hci_reports::Client(self.clone())
     }
-    pub fn hcrp_reports(&self) -> hcrp_reports::Client {
+    pub fn hcrp_reports_client(&self) -> hcrp_reports::Client {
         hcrp_reports::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn service_principals(&self) -> service_principals::Client {
+    pub fn service_principals_client(&self) -> service_principals::Client {
         service_principals::Client(self.clone())
     }
 }

--- a/services/mgmt/automanage/src/package_2022_05/operations.rs
+++ b/services/mgmt/automanage/src/package_2022_05/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn best_practices(&self) -> best_practices::Client {
+    pub fn best_practices_client(&self) -> best_practices::Client {
         best_practices::Client(self.clone())
     }
-    pub fn best_practices_versions(&self) -> best_practices_versions::Client {
+    pub fn best_practices_versions_client(&self) -> best_practices_versions::Client {
         best_practices_versions::Client(self.clone())
     }
-    pub fn configuration_profile_assignments(&self) -> configuration_profile_assignments::Client {
+    pub fn configuration_profile_assignments_client(&self) -> configuration_profile_assignments::Client {
         configuration_profile_assignments::Client(self.clone())
     }
-    pub fn configuration_profile_hci_assignments(&self) -> configuration_profile_hci_assignments::Client {
+    pub fn configuration_profile_hci_assignments_client(&self) -> configuration_profile_hci_assignments::Client {
         configuration_profile_hci_assignments::Client(self.clone())
     }
-    pub fn configuration_profile_hcrp_assignments(&self) -> configuration_profile_hcrp_assignments::Client {
+    pub fn configuration_profile_hcrp_assignments_client(&self) -> configuration_profile_hcrp_assignments::Client {
         configuration_profile_hcrp_assignments::Client(self.clone())
     }
-    pub fn configuration_profiles(&self) -> configuration_profiles::Client {
+    pub fn configuration_profiles_client(&self) -> configuration_profiles::Client {
         configuration_profiles::Client(self.clone())
     }
-    pub fn configuration_profiles_versions(&self) -> configuration_profiles_versions::Client {
+    pub fn configuration_profiles_versions_client(&self) -> configuration_profiles_versions::Client {
         configuration_profiles_versions::Client(self.clone())
     }
-    pub fn hci_reports(&self) -> hci_reports::Client {
+    pub fn hci_reports_client(&self) -> hci_reports::Client {
         hci_reports::Client(self.clone())
     }
-    pub fn hcrp_reports(&self) -> hcrp_reports::Client {
+    pub fn hcrp_reports_client(&self) -> hcrp_reports::Client {
         hcrp_reports::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn service_principals(&self) -> service_principals::Client {
+    pub fn service_principals_client(&self) -> service_principals::Client {
         service_principals::Client(self.clone())
     }
 }

--- a/services/mgmt/automation/src/package_2018_06_preview/operations.rs
+++ b/services/mgmt/automation/src/package_2018_06_preview/operations.rs
@@ -74,127 +74,127 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activity(&self) -> activity::Client {
+    pub fn activity_client(&self) -> activity::Client {
         activity::Client(self.clone())
     }
-    pub fn agent_registration_information(&self) -> agent_registration_information::Client {
+    pub fn agent_registration_information_client(&self) -> agent_registration_information::Client {
         agent_registration_information::Client(self.clone())
     }
-    pub fn automation_account(&self) -> automation_account::Client {
+    pub fn automation_account_client(&self) -> automation_account::Client {
         automation_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn connection(&self) -> connection::Client {
+    pub fn connection_client(&self) -> connection::Client {
         connection::Client(self.clone())
     }
-    pub fn connection_type(&self) -> connection_type::Client {
+    pub fn connection_type_client(&self) -> connection_type::Client {
         connection_type::Client(self.clone())
     }
-    pub fn credential(&self) -> credential::Client {
+    pub fn credential_client(&self) -> credential::Client {
         credential::Client(self.clone())
     }
-    pub fn dsc_compilation_job(&self) -> dsc_compilation_job::Client {
+    pub fn dsc_compilation_job_client(&self) -> dsc_compilation_job::Client {
         dsc_compilation_job::Client(self.clone())
     }
-    pub fn dsc_compilation_job_stream(&self) -> dsc_compilation_job_stream::Client {
+    pub fn dsc_compilation_job_stream_client(&self) -> dsc_compilation_job_stream::Client {
         dsc_compilation_job_stream::Client(self.clone())
     }
-    pub fn dsc_configuration(&self) -> dsc_configuration::Client {
+    pub fn dsc_configuration_client(&self) -> dsc_configuration::Client {
         dsc_configuration::Client(self.clone())
     }
-    pub fn dsc_node(&self) -> dsc_node::Client {
+    pub fn dsc_node_client(&self) -> dsc_node::Client {
         dsc_node::Client(self.clone())
     }
-    pub fn dsc_node_configuration(&self) -> dsc_node_configuration::Client {
+    pub fn dsc_node_configuration_client(&self) -> dsc_node_configuration::Client {
         dsc_node_configuration::Client(self.clone())
     }
-    pub fn fields(&self) -> fields::Client {
+    pub fn fields_client(&self) -> fields::Client {
         fields::Client(self.clone())
     }
-    pub fn hybrid_runbook_worker_group(&self) -> hybrid_runbook_worker_group::Client {
+    pub fn hybrid_runbook_worker_group_client(&self) -> hybrid_runbook_worker_group::Client {
         hybrid_runbook_worker_group::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn job_stream(&self) -> job_stream::Client {
+    pub fn job_stream_client(&self) -> job_stream::Client {
         job_stream::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn linked_workspace(&self) -> linked_workspace::Client {
+    pub fn linked_workspace_client(&self) -> linked_workspace::Client {
         linked_workspace::Client(self.clone())
     }
-    pub fn module(&self) -> module::Client {
+    pub fn module_client(&self) -> module::Client {
         module::Client(self.clone())
     }
-    pub fn node_count_information(&self) -> node_count_information::Client {
+    pub fn node_count_information_client(&self) -> node_count_information::Client {
         node_count_information::Client(self.clone())
     }
-    pub fn node_reports(&self) -> node_reports::Client {
+    pub fn node_reports_client(&self) -> node_reports::Client {
         node_reports::Client(self.clone())
     }
-    pub fn object_data_types(&self) -> object_data_types::Client {
+    pub fn object_data_types_client(&self) -> object_data_types::Client {
         object_data_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn python2_package(&self) -> python2_package::Client {
+    pub fn python2_package_client(&self) -> python2_package::Client {
         python2_package::Client(self.clone())
     }
-    pub fn runbook(&self) -> runbook::Client {
+    pub fn runbook_client(&self) -> runbook::Client {
         runbook::Client(self.clone())
     }
-    pub fn runbook_draft(&self) -> runbook_draft::Client {
+    pub fn runbook_draft_client(&self) -> runbook_draft::Client {
         runbook_draft::Client(self.clone())
     }
-    pub fn schedule(&self) -> schedule::Client {
+    pub fn schedule_client(&self) -> schedule::Client {
         schedule::Client(self.clone())
     }
-    pub fn software_update_configuration_machine_runs(&self) -> software_update_configuration_machine_runs::Client {
+    pub fn software_update_configuration_machine_runs_client(&self) -> software_update_configuration_machine_runs::Client {
         software_update_configuration_machine_runs::Client(self.clone())
     }
-    pub fn software_update_configuration_runs(&self) -> software_update_configuration_runs::Client {
+    pub fn software_update_configuration_runs_client(&self) -> software_update_configuration_runs::Client {
         software_update_configuration_runs::Client(self.clone())
     }
-    pub fn software_update_configurations(&self) -> software_update_configurations::Client {
+    pub fn software_update_configurations_client(&self) -> software_update_configurations::Client {
         software_update_configurations::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_control_sync_job(&self) -> source_control_sync_job::Client {
+    pub fn source_control_sync_job_client(&self) -> source_control_sync_job::Client {
         source_control_sync_job::Client(self.clone())
     }
-    pub fn source_control_sync_job_streams(&self) -> source_control_sync_job_streams::Client {
+    pub fn source_control_sync_job_streams_client(&self) -> source_control_sync_job_streams::Client {
         source_control_sync_job_streams::Client(self.clone())
     }
-    pub fn statistics(&self) -> statistics::Client {
+    pub fn statistics_client(&self) -> statistics::Client {
         statistics::Client(self.clone())
     }
-    pub fn test_job(&self) -> test_job::Client {
+    pub fn test_job_client(&self) -> test_job::Client {
         test_job::Client(self.clone())
     }
-    pub fn test_job_streams(&self) -> test_job_streams::Client {
+    pub fn test_job_streams_client(&self) -> test_job_streams::Client {
         test_job_streams::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn variable(&self) -> variable::Client {
+    pub fn variable_client(&self) -> variable::Client {
         variable::Client(self.clone())
     }
-    pub fn watcher(&self) -> watcher::Client {
+    pub fn watcher_client(&self) -> watcher::Client {
         watcher::Client(self.clone())
     }
-    pub fn webhook(&self) -> webhook::Client {
+    pub fn webhook_client(&self) -> webhook::Client {
         webhook::Client(self.clone())
     }
 }

--- a/services/mgmt/automation/src/package_2019_06/operations.rs
+++ b/services/mgmt/automation/src/package_2019_06/operations.rs
@@ -74,127 +74,127 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activity(&self) -> activity::Client {
+    pub fn activity_client(&self) -> activity::Client {
         activity::Client(self.clone())
     }
-    pub fn agent_registration_information(&self) -> agent_registration_information::Client {
+    pub fn agent_registration_information_client(&self) -> agent_registration_information::Client {
         agent_registration_information::Client(self.clone())
     }
-    pub fn automation_account(&self) -> automation_account::Client {
+    pub fn automation_account_client(&self) -> automation_account::Client {
         automation_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn connection(&self) -> connection::Client {
+    pub fn connection_client(&self) -> connection::Client {
         connection::Client(self.clone())
     }
-    pub fn connection_type(&self) -> connection_type::Client {
+    pub fn connection_type_client(&self) -> connection_type::Client {
         connection_type::Client(self.clone())
     }
-    pub fn credential(&self) -> credential::Client {
+    pub fn credential_client(&self) -> credential::Client {
         credential::Client(self.clone())
     }
-    pub fn dsc_compilation_job(&self) -> dsc_compilation_job::Client {
+    pub fn dsc_compilation_job_client(&self) -> dsc_compilation_job::Client {
         dsc_compilation_job::Client(self.clone())
     }
-    pub fn dsc_compilation_job_stream(&self) -> dsc_compilation_job_stream::Client {
+    pub fn dsc_compilation_job_stream_client(&self) -> dsc_compilation_job_stream::Client {
         dsc_compilation_job_stream::Client(self.clone())
     }
-    pub fn dsc_configuration(&self) -> dsc_configuration::Client {
+    pub fn dsc_configuration_client(&self) -> dsc_configuration::Client {
         dsc_configuration::Client(self.clone())
     }
-    pub fn dsc_node(&self) -> dsc_node::Client {
+    pub fn dsc_node_client(&self) -> dsc_node::Client {
         dsc_node::Client(self.clone())
     }
-    pub fn dsc_node_configuration(&self) -> dsc_node_configuration::Client {
+    pub fn dsc_node_configuration_client(&self) -> dsc_node_configuration::Client {
         dsc_node_configuration::Client(self.clone())
     }
-    pub fn fields(&self) -> fields::Client {
+    pub fn fields_client(&self) -> fields::Client {
         fields::Client(self.clone())
     }
-    pub fn hybrid_runbook_worker_group(&self) -> hybrid_runbook_worker_group::Client {
+    pub fn hybrid_runbook_worker_group_client(&self) -> hybrid_runbook_worker_group::Client {
         hybrid_runbook_worker_group::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn job_stream(&self) -> job_stream::Client {
+    pub fn job_stream_client(&self) -> job_stream::Client {
         job_stream::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn linked_workspace(&self) -> linked_workspace::Client {
+    pub fn linked_workspace_client(&self) -> linked_workspace::Client {
         linked_workspace::Client(self.clone())
     }
-    pub fn module(&self) -> module::Client {
+    pub fn module_client(&self) -> module::Client {
         module::Client(self.clone())
     }
-    pub fn node_count_information(&self) -> node_count_information::Client {
+    pub fn node_count_information_client(&self) -> node_count_information::Client {
         node_count_information::Client(self.clone())
     }
-    pub fn node_reports(&self) -> node_reports::Client {
+    pub fn node_reports_client(&self) -> node_reports::Client {
         node_reports::Client(self.clone())
     }
-    pub fn object_data_types(&self) -> object_data_types::Client {
+    pub fn object_data_types_client(&self) -> object_data_types::Client {
         object_data_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn python2_package(&self) -> python2_package::Client {
+    pub fn python2_package_client(&self) -> python2_package::Client {
         python2_package::Client(self.clone())
     }
-    pub fn runbook(&self) -> runbook::Client {
+    pub fn runbook_client(&self) -> runbook::Client {
         runbook::Client(self.clone())
     }
-    pub fn runbook_draft(&self) -> runbook_draft::Client {
+    pub fn runbook_draft_client(&self) -> runbook_draft::Client {
         runbook_draft::Client(self.clone())
     }
-    pub fn schedule(&self) -> schedule::Client {
+    pub fn schedule_client(&self) -> schedule::Client {
         schedule::Client(self.clone())
     }
-    pub fn software_update_configuration_machine_runs(&self) -> software_update_configuration_machine_runs::Client {
+    pub fn software_update_configuration_machine_runs_client(&self) -> software_update_configuration_machine_runs::Client {
         software_update_configuration_machine_runs::Client(self.clone())
     }
-    pub fn software_update_configuration_runs(&self) -> software_update_configuration_runs::Client {
+    pub fn software_update_configuration_runs_client(&self) -> software_update_configuration_runs::Client {
         software_update_configuration_runs::Client(self.clone())
     }
-    pub fn software_update_configurations(&self) -> software_update_configurations::Client {
+    pub fn software_update_configurations_client(&self) -> software_update_configurations::Client {
         software_update_configurations::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_control_sync_job(&self) -> source_control_sync_job::Client {
+    pub fn source_control_sync_job_client(&self) -> source_control_sync_job::Client {
         source_control_sync_job::Client(self.clone())
     }
-    pub fn source_control_sync_job_streams(&self) -> source_control_sync_job_streams::Client {
+    pub fn source_control_sync_job_streams_client(&self) -> source_control_sync_job_streams::Client {
         source_control_sync_job_streams::Client(self.clone())
     }
-    pub fn statistics(&self) -> statistics::Client {
+    pub fn statistics_client(&self) -> statistics::Client {
         statistics::Client(self.clone())
     }
-    pub fn test_job(&self) -> test_job::Client {
+    pub fn test_job_client(&self) -> test_job::Client {
         test_job::Client(self.clone())
     }
-    pub fn test_job_streams(&self) -> test_job_streams::Client {
+    pub fn test_job_streams_client(&self) -> test_job_streams::Client {
         test_job_streams::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn variable(&self) -> variable::Client {
+    pub fn variable_client(&self) -> variable::Client {
         variable::Client(self.clone())
     }
-    pub fn watcher(&self) -> watcher::Client {
+    pub fn watcher_client(&self) -> watcher::Client {
         watcher::Client(self.clone())
     }
-    pub fn webhook(&self) -> webhook::Client {
+    pub fn webhook_client(&self) -> webhook::Client {
         webhook::Client(self.clone())
     }
 }

--- a/services/mgmt/automation/src/package_2020_01_13_preview/operations.rs
+++ b/services/mgmt/automation/src/package_2020_01_13_preview/operations.rs
@@ -74,133 +74,133 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activity(&self) -> activity::Client {
+    pub fn activity_client(&self) -> activity::Client {
         activity::Client(self.clone())
     }
-    pub fn agent_registration_information(&self) -> agent_registration_information::Client {
+    pub fn agent_registration_information_client(&self) -> agent_registration_information::Client {
         agent_registration_information::Client(self.clone())
     }
-    pub fn automation_account(&self) -> automation_account::Client {
+    pub fn automation_account_client(&self) -> automation_account::Client {
         automation_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn connection(&self) -> connection::Client {
+    pub fn connection_client(&self) -> connection::Client {
         connection::Client(self.clone())
     }
-    pub fn connection_type(&self) -> connection_type::Client {
+    pub fn connection_type_client(&self) -> connection_type::Client {
         connection_type::Client(self.clone())
     }
-    pub fn credential(&self) -> credential::Client {
+    pub fn credential_client(&self) -> credential::Client {
         credential::Client(self.clone())
     }
-    pub fn dsc_compilation_job(&self) -> dsc_compilation_job::Client {
+    pub fn dsc_compilation_job_client(&self) -> dsc_compilation_job::Client {
         dsc_compilation_job::Client(self.clone())
     }
-    pub fn dsc_compilation_job_stream(&self) -> dsc_compilation_job_stream::Client {
+    pub fn dsc_compilation_job_stream_client(&self) -> dsc_compilation_job_stream::Client {
         dsc_compilation_job_stream::Client(self.clone())
     }
-    pub fn dsc_configuration(&self) -> dsc_configuration::Client {
+    pub fn dsc_configuration_client(&self) -> dsc_configuration::Client {
         dsc_configuration::Client(self.clone())
     }
-    pub fn dsc_node(&self) -> dsc_node::Client {
+    pub fn dsc_node_client(&self) -> dsc_node::Client {
         dsc_node::Client(self.clone())
     }
-    pub fn dsc_node_configuration(&self) -> dsc_node_configuration::Client {
+    pub fn dsc_node_configuration_client(&self) -> dsc_node_configuration::Client {
         dsc_node_configuration::Client(self.clone())
     }
-    pub fn fields(&self) -> fields::Client {
+    pub fn fields_client(&self) -> fields::Client {
         fields::Client(self.clone())
     }
-    pub fn hybrid_runbook_worker_group(&self) -> hybrid_runbook_worker_group::Client {
+    pub fn hybrid_runbook_worker_group_client(&self) -> hybrid_runbook_worker_group::Client {
         hybrid_runbook_worker_group::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn job_stream(&self) -> job_stream::Client {
+    pub fn job_stream_client(&self) -> job_stream::Client {
         job_stream::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn linked_workspace(&self) -> linked_workspace::Client {
+    pub fn linked_workspace_client(&self) -> linked_workspace::Client {
         linked_workspace::Client(self.clone())
     }
-    pub fn module(&self) -> module::Client {
+    pub fn module_client(&self) -> module::Client {
         module::Client(self.clone())
     }
-    pub fn node_count_information(&self) -> node_count_information::Client {
+    pub fn node_count_information_client(&self) -> node_count_information::Client {
         node_count_information::Client(self.clone())
     }
-    pub fn node_reports(&self) -> node_reports::Client {
+    pub fn node_reports_client(&self) -> node_reports::Client {
         node_reports::Client(self.clone())
     }
-    pub fn object_data_types(&self) -> object_data_types::Client {
+    pub fn object_data_types_client(&self) -> object_data_types::Client {
         object_data_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn python2_package(&self) -> python2_package::Client {
+    pub fn python2_package_client(&self) -> python2_package::Client {
         python2_package::Client(self.clone())
     }
-    pub fn runbook(&self) -> runbook::Client {
+    pub fn runbook_client(&self) -> runbook::Client {
         runbook::Client(self.clone())
     }
-    pub fn runbook_draft(&self) -> runbook_draft::Client {
+    pub fn runbook_draft_client(&self) -> runbook_draft::Client {
         runbook_draft::Client(self.clone())
     }
-    pub fn schedule(&self) -> schedule::Client {
+    pub fn schedule_client(&self) -> schedule::Client {
         schedule::Client(self.clone())
     }
-    pub fn software_update_configuration_machine_runs(&self) -> software_update_configuration_machine_runs::Client {
+    pub fn software_update_configuration_machine_runs_client(&self) -> software_update_configuration_machine_runs::Client {
         software_update_configuration_machine_runs::Client(self.clone())
     }
-    pub fn software_update_configuration_runs(&self) -> software_update_configuration_runs::Client {
+    pub fn software_update_configuration_runs_client(&self) -> software_update_configuration_runs::Client {
         software_update_configuration_runs::Client(self.clone())
     }
-    pub fn software_update_configurations(&self) -> software_update_configurations::Client {
+    pub fn software_update_configurations_client(&self) -> software_update_configurations::Client {
         software_update_configurations::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_control_sync_job(&self) -> source_control_sync_job::Client {
+    pub fn source_control_sync_job_client(&self) -> source_control_sync_job::Client {
         source_control_sync_job::Client(self.clone())
     }
-    pub fn source_control_sync_job_streams(&self) -> source_control_sync_job_streams::Client {
+    pub fn source_control_sync_job_streams_client(&self) -> source_control_sync_job_streams::Client {
         source_control_sync_job_streams::Client(self.clone())
     }
-    pub fn statistics(&self) -> statistics::Client {
+    pub fn statistics_client(&self) -> statistics::Client {
         statistics::Client(self.clone())
     }
-    pub fn test_job(&self) -> test_job::Client {
+    pub fn test_job_client(&self) -> test_job::Client {
         test_job::Client(self.clone())
     }
-    pub fn test_job_streams(&self) -> test_job_streams::Client {
+    pub fn test_job_streams_client(&self) -> test_job_streams::Client {
         test_job_streams::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn variable(&self) -> variable::Client {
+    pub fn variable_client(&self) -> variable::Client {
         variable::Client(self.clone())
     }
-    pub fn watcher(&self) -> watcher::Client {
+    pub fn watcher_client(&self) -> watcher::Client {
         watcher::Client(self.clone())
     }
-    pub fn webhook(&self) -> webhook::Client {
+    pub fn webhook_client(&self) -> webhook::Client {
         webhook::Client(self.clone())
     }
 }

--- a/services/mgmt/automation/src/package_2021_06_22/operations.rs
+++ b/services/mgmt/automation/src/package_2021_06_22/operations.rs
@@ -74,136 +74,136 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activity(&self) -> activity::Client {
+    pub fn activity_client(&self) -> activity::Client {
         activity::Client(self.clone())
     }
-    pub fn agent_registration_information(&self) -> agent_registration_information::Client {
+    pub fn agent_registration_information_client(&self) -> agent_registration_information::Client {
         agent_registration_information::Client(self.clone())
     }
-    pub fn automation_account(&self) -> automation_account::Client {
+    pub fn automation_account_client(&self) -> automation_account::Client {
         automation_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn connection(&self) -> connection::Client {
+    pub fn connection_client(&self) -> connection::Client {
         connection::Client(self.clone())
     }
-    pub fn connection_type(&self) -> connection_type::Client {
+    pub fn connection_type_client(&self) -> connection_type::Client {
         connection_type::Client(self.clone())
     }
-    pub fn credential(&self) -> credential::Client {
+    pub fn credential_client(&self) -> credential::Client {
         credential::Client(self.clone())
     }
-    pub fn dsc_compilation_job(&self) -> dsc_compilation_job::Client {
+    pub fn dsc_compilation_job_client(&self) -> dsc_compilation_job::Client {
         dsc_compilation_job::Client(self.clone())
     }
-    pub fn dsc_compilation_job_stream(&self) -> dsc_compilation_job_stream::Client {
+    pub fn dsc_compilation_job_stream_client(&self) -> dsc_compilation_job_stream::Client {
         dsc_compilation_job_stream::Client(self.clone())
     }
-    pub fn dsc_configuration(&self) -> dsc_configuration::Client {
+    pub fn dsc_configuration_client(&self) -> dsc_configuration::Client {
         dsc_configuration::Client(self.clone())
     }
-    pub fn dsc_node(&self) -> dsc_node::Client {
+    pub fn dsc_node_client(&self) -> dsc_node::Client {
         dsc_node::Client(self.clone())
     }
-    pub fn dsc_node_configuration(&self) -> dsc_node_configuration::Client {
+    pub fn dsc_node_configuration_client(&self) -> dsc_node_configuration::Client {
         dsc_node_configuration::Client(self.clone())
     }
-    pub fn fields(&self) -> fields::Client {
+    pub fn fields_client(&self) -> fields::Client {
         fields::Client(self.clone())
     }
-    pub fn hybrid_runbook_worker_group(&self) -> hybrid_runbook_worker_group::Client {
+    pub fn hybrid_runbook_worker_group_client(&self) -> hybrid_runbook_worker_group::Client {
         hybrid_runbook_worker_group::Client(self.clone())
     }
-    pub fn hybrid_runbook_workers(&self) -> hybrid_runbook_workers::Client {
+    pub fn hybrid_runbook_workers_client(&self) -> hybrid_runbook_workers::Client {
         hybrid_runbook_workers::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn job_stream(&self) -> job_stream::Client {
+    pub fn job_stream_client(&self) -> job_stream::Client {
         job_stream::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn linked_workspace(&self) -> linked_workspace::Client {
+    pub fn linked_workspace_client(&self) -> linked_workspace::Client {
         linked_workspace::Client(self.clone())
     }
-    pub fn module(&self) -> module::Client {
+    pub fn module_client(&self) -> module::Client {
         module::Client(self.clone())
     }
-    pub fn node_count_information(&self) -> node_count_information::Client {
+    pub fn node_count_information_client(&self) -> node_count_information::Client {
         node_count_information::Client(self.clone())
     }
-    pub fn node_reports(&self) -> node_reports::Client {
+    pub fn node_reports_client(&self) -> node_reports::Client {
         node_reports::Client(self.clone())
     }
-    pub fn object_data_types(&self) -> object_data_types::Client {
+    pub fn object_data_types_client(&self) -> object_data_types::Client {
         object_data_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn python2_package(&self) -> python2_package::Client {
+    pub fn python2_package_client(&self) -> python2_package::Client {
         python2_package::Client(self.clone())
     }
-    pub fn runbook(&self) -> runbook::Client {
+    pub fn runbook_client(&self) -> runbook::Client {
         runbook::Client(self.clone())
     }
-    pub fn runbook_draft(&self) -> runbook_draft::Client {
+    pub fn runbook_draft_client(&self) -> runbook_draft::Client {
         runbook_draft::Client(self.clone())
     }
-    pub fn schedule(&self) -> schedule::Client {
+    pub fn schedule_client(&self) -> schedule::Client {
         schedule::Client(self.clone())
     }
-    pub fn software_update_configuration_machine_runs(&self) -> software_update_configuration_machine_runs::Client {
+    pub fn software_update_configuration_machine_runs_client(&self) -> software_update_configuration_machine_runs::Client {
         software_update_configuration_machine_runs::Client(self.clone())
     }
-    pub fn software_update_configuration_runs(&self) -> software_update_configuration_runs::Client {
+    pub fn software_update_configuration_runs_client(&self) -> software_update_configuration_runs::Client {
         software_update_configuration_runs::Client(self.clone())
     }
-    pub fn software_update_configurations(&self) -> software_update_configurations::Client {
+    pub fn software_update_configurations_client(&self) -> software_update_configurations::Client {
         software_update_configurations::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_control_sync_job(&self) -> source_control_sync_job::Client {
+    pub fn source_control_sync_job_client(&self) -> source_control_sync_job::Client {
         source_control_sync_job::Client(self.clone())
     }
-    pub fn source_control_sync_job_streams(&self) -> source_control_sync_job_streams::Client {
+    pub fn source_control_sync_job_streams_client(&self) -> source_control_sync_job_streams::Client {
         source_control_sync_job_streams::Client(self.clone())
     }
-    pub fn statistics(&self) -> statistics::Client {
+    pub fn statistics_client(&self) -> statistics::Client {
         statistics::Client(self.clone())
     }
-    pub fn test_job(&self) -> test_job::Client {
+    pub fn test_job_client(&self) -> test_job::Client {
         test_job::Client(self.clone())
     }
-    pub fn test_job_streams(&self) -> test_job_streams::Client {
+    pub fn test_job_streams_client(&self) -> test_job_streams::Client {
         test_job_streams::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn variable(&self) -> variable::Client {
+    pub fn variable_client(&self) -> variable::Client {
         variable::Client(self.clone())
     }
-    pub fn watcher(&self) -> watcher::Client {
+    pub fn watcher_client(&self) -> watcher::Client {
         watcher::Client(self.clone())
     }
-    pub fn webhook(&self) -> webhook::Client {
+    pub fn webhook_client(&self) -> webhook::Client {
         webhook::Client(self.clone())
     }
 }

--- a/services/mgmt/automation/src/package_2022_01_31/operations.rs
+++ b/services/mgmt/automation/src/package_2022_01_31/operations.rs
@@ -74,139 +74,139 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activity(&self) -> activity::Client {
+    pub fn activity_client(&self) -> activity::Client {
         activity::Client(self.clone())
     }
-    pub fn agent_registration_information(&self) -> agent_registration_information::Client {
+    pub fn agent_registration_information_client(&self) -> agent_registration_information::Client {
         agent_registration_information::Client(self.clone())
     }
-    pub fn automation_account(&self) -> automation_account::Client {
+    pub fn automation_account_client(&self) -> automation_account::Client {
         automation_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn connection(&self) -> connection::Client {
+    pub fn connection_client(&self) -> connection::Client {
         connection::Client(self.clone())
     }
-    pub fn connection_type(&self) -> connection_type::Client {
+    pub fn connection_type_client(&self) -> connection_type::Client {
         connection_type::Client(self.clone())
     }
-    pub fn credential(&self) -> credential::Client {
+    pub fn credential_client(&self) -> credential::Client {
         credential::Client(self.clone())
     }
-    pub fn deleted_automation_accounts(&self) -> deleted_automation_accounts::Client {
+    pub fn deleted_automation_accounts_client(&self) -> deleted_automation_accounts::Client {
         deleted_automation_accounts::Client(self.clone())
     }
-    pub fn dsc_compilation_job(&self) -> dsc_compilation_job::Client {
+    pub fn dsc_compilation_job_client(&self) -> dsc_compilation_job::Client {
         dsc_compilation_job::Client(self.clone())
     }
-    pub fn dsc_compilation_job_stream(&self) -> dsc_compilation_job_stream::Client {
+    pub fn dsc_compilation_job_stream_client(&self) -> dsc_compilation_job_stream::Client {
         dsc_compilation_job_stream::Client(self.clone())
     }
-    pub fn dsc_configuration(&self) -> dsc_configuration::Client {
+    pub fn dsc_configuration_client(&self) -> dsc_configuration::Client {
         dsc_configuration::Client(self.clone())
     }
-    pub fn dsc_node(&self) -> dsc_node::Client {
+    pub fn dsc_node_client(&self) -> dsc_node::Client {
         dsc_node::Client(self.clone())
     }
-    pub fn dsc_node_configuration(&self) -> dsc_node_configuration::Client {
+    pub fn dsc_node_configuration_client(&self) -> dsc_node_configuration::Client {
         dsc_node_configuration::Client(self.clone())
     }
-    pub fn fields(&self) -> fields::Client {
+    pub fn fields_client(&self) -> fields::Client {
         fields::Client(self.clone())
     }
-    pub fn hybrid_runbook_worker_group(&self) -> hybrid_runbook_worker_group::Client {
+    pub fn hybrid_runbook_worker_group_client(&self) -> hybrid_runbook_worker_group::Client {
         hybrid_runbook_worker_group::Client(self.clone())
     }
-    pub fn hybrid_runbook_workers(&self) -> hybrid_runbook_workers::Client {
+    pub fn hybrid_runbook_workers_client(&self) -> hybrid_runbook_workers::Client {
         hybrid_runbook_workers::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn job_stream(&self) -> job_stream::Client {
+    pub fn job_stream_client(&self) -> job_stream::Client {
         job_stream::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn linked_workspace(&self) -> linked_workspace::Client {
+    pub fn linked_workspace_client(&self) -> linked_workspace::Client {
         linked_workspace::Client(self.clone())
     }
-    pub fn module(&self) -> module::Client {
+    pub fn module_client(&self) -> module::Client {
         module::Client(self.clone())
     }
-    pub fn node_count_information(&self) -> node_count_information::Client {
+    pub fn node_count_information_client(&self) -> node_count_information::Client {
         node_count_information::Client(self.clone())
     }
-    pub fn node_reports(&self) -> node_reports::Client {
+    pub fn node_reports_client(&self) -> node_reports::Client {
         node_reports::Client(self.clone())
     }
-    pub fn object_data_types(&self) -> object_data_types::Client {
+    pub fn object_data_types_client(&self) -> object_data_types::Client {
         object_data_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn python2_package(&self) -> python2_package::Client {
+    pub fn python2_package_client(&self) -> python2_package::Client {
         python2_package::Client(self.clone())
     }
-    pub fn runbook(&self) -> runbook::Client {
+    pub fn runbook_client(&self) -> runbook::Client {
         runbook::Client(self.clone())
     }
-    pub fn runbook_draft(&self) -> runbook_draft::Client {
+    pub fn runbook_draft_client(&self) -> runbook_draft::Client {
         runbook_draft::Client(self.clone())
     }
-    pub fn schedule(&self) -> schedule::Client {
+    pub fn schedule_client(&self) -> schedule::Client {
         schedule::Client(self.clone())
     }
-    pub fn software_update_configuration_machine_runs(&self) -> software_update_configuration_machine_runs::Client {
+    pub fn software_update_configuration_machine_runs_client(&self) -> software_update_configuration_machine_runs::Client {
         software_update_configuration_machine_runs::Client(self.clone())
     }
-    pub fn software_update_configuration_runs(&self) -> software_update_configuration_runs::Client {
+    pub fn software_update_configuration_runs_client(&self) -> software_update_configuration_runs::Client {
         software_update_configuration_runs::Client(self.clone())
     }
-    pub fn software_update_configurations(&self) -> software_update_configurations::Client {
+    pub fn software_update_configurations_client(&self) -> software_update_configurations::Client {
         software_update_configurations::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_control_sync_job(&self) -> source_control_sync_job::Client {
+    pub fn source_control_sync_job_client(&self) -> source_control_sync_job::Client {
         source_control_sync_job::Client(self.clone())
     }
-    pub fn source_control_sync_job_streams(&self) -> source_control_sync_job_streams::Client {
+    pub fn source_control_sync_job_streams_client(&self) -> source_control_sync_job_streams::Client {
         source_control_sync_job_streams::Client(self.clone())
     }
-    pub fn statistics(&self) -> statistics::Client {
+    pub fn statistics_client(&self) -> statistics::Client {
         statistics::Client(self.clone())
     }
-    pub fn test_job(&self) -> test_job::Client {
+    pub fn test_job_client(&self) -> test_job::Client {
         test_job::Client(self.clone())
     }
-    pub fn test_job_streams(&self) -> test_job_streams::Client {
+    pub fn test_job_streams_client(&self) -> test_job_streams::Client {
         test_job_streams::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn variable(&self) -> variable::Client {
+    pub fn variable_client(&self) -> variable::Client {
         variable::Client(self.clone())
     }
-    pub fn watcher(&self) -> watcher::Client {
+    pub fn watcher_client(&self) -> watcher::Client {
         watcher::Client(self.clone())
     }
-    pub fn webhook(&self) -> webhook::Client {
+    pub fn webhook_client(&self) -> webhook::Client {
         webhook::Client(self.clone())
     }
 }

--- a/services/mgmt/baremetalinfrastructure/src/package_2020_08_06_preview/operations.rs
+++ b/services/mgmt/baremetalinfrastructure/src/package_2020_08_06_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_bare_metal_instances(&self) -> azure_bare_metal_instances::Client {
+    pub fn azure_bare_metal_instances_client(&self) -> azure_bare_metal_instances::Client {
         azure_bare_metal_instances::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/baremetalinfrastructure/src/package_2021_08_09/operations.rs
+++ b/services/mgmt/baremetalinfrastructure/src/package_2021_08_09/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_bare_metal_instances(&self) -> azure_bare_metal_instances::Client {
+    pub fn azure_bare_metal_instances_client(&self) -> azure_bare_metal_instances::Client {
         azure_bare_metal_instances::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/batch/examples/list_accounts.rs
+++ b/services/mgmt/batch/examples/list_accounts.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subscription_id = AzureCliCredential::get_subscription()?;
     let client = azure_mgmt_batch::ClientBuilder::new(credential).build();
 
-    let mut accounts = client.batch_account().list(subscription_id).into_stream();
+    let mut accounts = client.batch_account_client().list(subscription_id).into_stream();
     while let Some(accounts) = accounts.next().await {
         let accounts = accounts?;
         for account in accounts.value {

--- a/services/mgmt/batch/examples/list_pools.rs
+++ b/services/mgmt/batch/examples/list_pools.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = azure_mgmt_batch::ClientBuilder::new(credential).build();
 
     let mut pools = client
-        .pool()
+        .pool_client()
         .list_by_batch_account(resource_group_name, account_name, subscription_id)
         .into_stream();
 

--- a/services/mgmt/batch/src/package_2020_09/operations.rs
+++ b/services/mgmt/batch/src/package_2020_09/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn application_package(&self) -> application_package::Client {
+    pub fn application_package_client(&self) -> application_package::Client {
         application_package::Client(self.clone())
     }
-    pub fn batch_account(&self) -> batch_account::Client {
+    pub fn batch_account_client(&self) -> batch_account::Client {
         batch_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resource(&self) -> private_link_resource::Client {
+    pub fn private_link_resource_client(&self) -> private_link_resource::Client {
         private_link_resource::Client(self.clone())
     }
 }

--- a/services/mgmt/batch/src/package_2021_01/operations.rs
+++ b/services/mgmt/batch/src/package_2021_01/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn application_package(&self) -> application_package::Client {
+    pub fn application_package_client(&self) -> application_package::Client {
         application_package::Client(self.clone())
     }
-    pub fn batch_account(&self) -> batch_account::Client {
+    pub fn batch_account_client(&self) -> batch_account::Client {
         batch_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resource(&self) -> private_link_resource::Client {
+    pub fn private_link_resource_client(&self) -> private_link_resource::Client {
         private_link_resource::Client(self.clone())
     }
 }

--- a/services/mgmt/batch/src/package_2021_06/operations.rs
+++ b/services/mgmt/batch/src/package_2021_06/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn application_package(&self) -> application_package::Client {
+    pub fn application_package_client(&self) -> application_package::Client {
         application_package::Client(self.clone())
     }
-    pub fn batch_account(&self) -> batch_account::Client {
+    pub fn batch_account_client(&self) -> batch_account::Client {
         batch_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resource(&self) -> private_link_resource::Client {
+    pub fn private_link_resource_client(&self) -> private_link_resource::Client {
         private_link_resource::Client(self.clone())
     }
 }

--- a/services/mgmt/batch/src/package_2022_01/operations.rs
+++ b/services/mgmt/batch/src/package_2022_01/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn application_package(&self) -> application_package::Client {
+    pub fn application_package_client(&self) -> application_package::Client {
         application_package::Client(self.clone())
     }
-    pub fn batch_account(&self) -> batch_account::Client {
+    pub fn batch_account_client(&self) -> batch_account::Client {
         batch_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resource(&self) -> private_link_resource::Client {
+    pub fn private_link_resource_client(&self) -> private_link_resource::Client {
         private_link_resource::Client(self.clone())
     }
 }

--- a/services/mgmt/batch/src/package_2022_06/operations.rs
+++ b/services/mgmt/batch/src/package_2022_06/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn application_package(&self) -> application_package::Client {
+    pub fn application_package_client(&self) -> application_package::Client {
         application_package::Client(self.clone())
     }
-    pub fn batch_account(&self) -> batch_account::Client {
+    pub fn batch_account_client(&self) -> batch_account::Client {
         batch_account::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resource(&self) -> private_link_resource::Client {
+    pub fn private_link_resource_client(&self) -> private_link_resource::Client {
         private_link_resource::Client(self.clone())
     }
 }

--- a/services/mgmt/billing/src/package_2019_10_preview/operations.rs
+++ b/services/mgmt/billing/src/package_2019_10_preview/operations.rs
@@ -74,88 +74,88 @@ impl Client {
             pipeline,
         }
     }
-    pub fn address(&self) -> address::Client {
+    pub fn address_client(&self) -> address::Client {
         address::Client(self.clone())
     }
-    pub fn agreements(&self) -> agreements::Client {
+    pub fn agreements_client(&self) -> agreements::Client {
         agreements::Client(self.clone())
     }
-    pub fn available_balances(&self) -> available_balances::Client {
+    pub fn available_balances_client(&self) -> available_balances::Client {
         available_balances::Client(self.clone())
     }
-    pub fn billing_accounts(&self) -> billing_accounts::Client {
+    pub fn billing_accounts_client(&self) -> billing_accounts::Client {
         billing_accounts::Client(self.clone())
     }
-    pub fn billing_permissions(&self) -> billing_permissions::Client {
+    pub fn billing_permissions_client(&self) -> billing_permissions::Client {
         billing_permissions::Client(self.clone())
     }
-    pub fn billing_profiles(&self) -> billing_profiles::Client {
+    pub fn billing_profiles_client(&self) -> billing_profiles::Client {
         billing_profiles::Client(self.clone())
     }
-    pub fn billing_property(&self) -> billing_property::Client {
+    pub fn billing_property_client(&self) -> billing_property::Client {
         billing_property::Client(self.clone())
     }
-    pub fn billing_role_assignments(&self) -> billing_role_assignments::Client {
+    pub fn billing_role_assignments_client(&self) -> billing_role_assignments::Client {
         billing_role_assignments::Client(self.clone())
     }
-    pub fn billing_role_definitions(&self) -> billing_role_definitions::Client {
+    pub fn billing_role_definitions_client(&self) -> billing_role_definitions::Client {
         billing_role_definitions::Client(self.clone())
     }
-    pub fn billing_subscriptions(&self) -> billing_subscriptions::Client {
+    pub fn billing_subscriptions_client(&self) -> billing_subscriptions::Client {
         billing_subscriptions::Client(self.clone())
     }
-    pub fn customers(&self) -> customers::Client {
+    pub fn customers_client(&self) -> customers::Client {
         customers::Client(self.clone())
     }
-    pub fn departments(&self) -> departments::Client {
+    pub fn departments_client(&self) -> departments::Client {
         departments::Client(self.clone())
     }
-    pub fn enrollment_account_role_assignments(&self) -> enrollment_account_role_assignments::Client {
+    pub fn enrollment_account_role_assignments_client(&self) -> enrollment_account_role_assignments::Client {
         enrollment_account_role_assignments::Client(self.clone())
     }
-    pub fn enrollment_accounts(&self) -> enrollment_accounts::Client {
+    pub fn enrollment_accounts_client(&self) -> enrollment_accounts::Client {
         enrollment_accounts::Client(self.clone())
     }
-    pub fn enrollment_department_role_assignments(&self) -> enrollment_department_role_assignments::Client {
+    pub fn enrollment_department_role_assignments_client(&self) -> enrollment_department_role_assignments::Client {
         enrollment_department_role_assignments::Client(self.clone())
     }
-    pub fn instructions(&self) -> instructions::Client {
+    pub fn instructions_client(&self) -> instructions::Client {
         instructions::Client(self.clone())
     }
-    pub fn invoice_sections(&self) -> invoice_sections::Client {
+    pub fn invoice_sections_client(&self) -> invoice_sections::Client {
         invoice_sections::Client(self.clone())
     }
-    pub fn invoices(&self) -> invoices::Client {
+    pub fn invoices_client(&self) -> invoices::Client {
         invoices::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn partner_transfers(&self) -> partner_transfers::Client {
+    pub fn partner_transfers_client(&self) -> partner_transfers::Client {
         partner_transfers::Client(self.clone())
     }
-    pub fn payment_methods(&self) -> payment_methods::Client {
+    pub fn payment_methods_client(&self) -> payment_methods::Client {
         payment_methods::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn price_sheet(&self) -> price_sheet::Client {
+    pub fn price_sheet_client(&self) -> price_sheet::Client {
         price_sheet::Client(self.clone())
     }
-    pub fn products(&self) -> products::Client {
+    pub fn products_client(&self) -> products::Client {
         products::Client(self.clone())
     }
-    pub fn recipient_transfers(&self) -> recipient_transfers::Client {
+    pub fn recipient_transfers_client(&self) -> recipient_transfers::Client {
         recipient_transfers::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn transactions(&self) -> transactions::Client {
+    pub fn transactions_client(&self) -> transactions::Client {
         transactions::Client(self.clone())
     }
-    pub fn transfers(&self) -> transfers::Client {
+    pub fn transfers_client(&self) -> transfers::Client {
         transfers::Client(self.clone())
     }
 }

--- a/services/mgmt/billing/src/package_2020_05/operations.rs
+++ b/services/mgmt/billing/src/package_2020_05/operations.rs
@@ -74,67 +74,67 @@ impl Client {
             pipeline,
         }
     }
-    pub fn address(&self) -> address::Client {
+    pub fn address_client(&self) -> address::Client {
         address::Client(self.clone())
     }
-    pub fn agreements(&self) -> agreements::Client {
+    pub fn agreements_client(&self) -> agreements::Client {
         agreements::Client(self.clone())
     }
-    pub fn available_balances(&self) -> available_balances::Client {
+    pub fn available_balances_client(&self) -> available_balances::Client {
         available_balances::Client(self.clone())
     }
-    pub fn billing_accounts(&self) -> billing_accounts::Client {
+    pub fn billing_accounts_client(&self) -> billing_accounts::Client {
         billing_accounts::Client(self.clone())
     }
-    pub fn billing_periods(&self) -> billing_periods::Client {
+    pub fn billing_periods_client(&self) -> billing_periods::Client {
         billing_periods::Client(self.clone())
     }
-    pub fn billing_permissions(&self) -> billing_permissions::Client {
+    pub fn billing_permissions_client(&self) -> billing_permissions::Client {
         billing_permissions::Client(self.clone())
     }
-    pub fn billing_profiles(&self) -> billing_profiles::Client {
+    pub fn billing_profiles_client(&self) -> billing_profiles::Client {
         billing_profiles::Client(self.clone())
     }
-    pub fn billing_property(&self) -> billing_property::Client {
+    pub fn billing_property_client(&self) -> billing_property::Client {
         billing_property::Client(self.clone())
     }
-    pub fn billing_role_assignments(&self) -> billing_role_assignments::Client {
+    pub fn billing_role_assignments_client(&self) -> billing_role_assignments::Client {
         billing_role_assignments::Client(self.clone())
     }
-    pub fn billing_role_definitions(&self) -> billing_role_definitions::Client {
+    pub fn billing_role_definitions_client(&self) -> billing_role_definitions::Client {
         billing_role_definitions::Client(self.clone())
     }
-    pub fn billing_subscriptions(&self) -> billing_subscriptions::Client {
+    pub fn billing_subscriptions_client(&self) -> billing_subscriptions::Client {
         billing_subscriptions::Client(self.clone())
     }
-    pub fn customers(&self) -> customers::Client {
+    pub fn customers_client(&self) -> customers::Client {
         customers::Client(self.clone())
     }
-    pub fn enrollment_accounts(&self) -> enrollment_accounts::Client {
+    pub fn enrollment_accounts_client(&self) -> enrollment_accounts::Client {
         enrollment_accounts::Client(self.clone())
     }
-    pub fn instructions(&self) -> instructions::Client {
+    pub fn instructions_client(&self) -> instructions::Client {
         instructions::Client(self.clone())
     }
-    pub fn invoice_sections(&self) -> invoice_sections::Client {
+    pub fn invoice_sections_client(&self) -> invoice_sections::Client {
         invoice_sections::Client(self.clone())
     }
-    pub fn invoices(&self) -> invoices::Client {
+    pub fn invoices_client(&self) -> invoices::Client {
         invoices::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn products(&self) -> products::Client {
+    pub fn products_client(&self) -> products::Client {
         products::Client(self.clone())
     }
-    pub fn reservations(&self) -> reservations::Client {
+    pub fn reservations_client(&self) -> reservations::Client {
         reservations::Client(self.clone())
     }
-    pub fn transactions(&self) -> transactions::Client {
+    pub fn transactions_client(&self) -> transactions::Client {
         transactions::Client(self.clone())
     }
 }

--- a/services/mgmt/billing/src/package_2020_09_preview/operations.rs
+++ b/services/mgmt/billing/src/package_2020_09_preview/operations.rs
@@ -74,70 +74,70 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activate(&self) -> activate::Client {
+    pub fn activate_client(&self) -> activate::Client {
         activate::Client(self.clone())
     }
-    pub fn address(&self) -> address::Client {
+    pub fn address_client(&self) -> address::Client {
         address::Client(self.clone())
     }
-    pub fn agreements(&self) -> agreements::Client {
+    pub fn agreements_client(&self) -> agreements::Client {
         agreements::Client(self.clone())
     }
-    pub fn available_balances(&self) -> available_balances::Client {
+    pub fn available_balances_client(&self) -> available_balances::Client {
         available_balances::Client(self.clone())
     }
-    pub fn billing_accounts(&self) -> billing_accounts::Client {
+    pub fn billing_accounts_client(&self) -> billing_accounts::Client {
         billing_accounts::Client(self.clone())
     }
-    pub fn billing_permissions(&self) -> billing_permissions::Client {
+    pub fn billing_permissions_client(&self) -> billing_permissions::Client {
         billing_permissions::Client(self.clone())
     }
-    pub fn billing_profiles(&self) -> billing_profiles::Client {
+    pub fn billing_profiles_client(&self) -> billing_profiles::Client {
         billing_profiles::Client(self.clone())
     }
-    pub fn billing_property(&self) -> billing_property::Client {
+    pub fn billing_property_client(&self) -> billing_property::Client {
         billing_property::Client(self.clone())
     }
-    pub fn billing_role_assignments(&self) -> billing_role_assignments::Client {
+    pub fn billing_role_assignments_client(&self) -> billing_role_assignments::Client {
         billing_role_assignments::Client(self.clone())
     }
-    pub fn billing_role_definitions(&self) -> billing_role_definitions::Client {
+    pub fn billing_role_definitions_client(&self) -> billing_role_definitions::Client {
         billing_role_definitions::Client(self.clone())
     }
-    pub fn billing_subscriptions(&self) -> billing_subscriptions::Client {
+    pub fn billing_subscriptions_client(&self) -> billing_subscriptions::Client {
         billing_subscriptions::Client(self.clone())
     }
-    pub fn customers(&self) -> customers::Client {
+    pub fn customers_client(&self) -> customers::Client {
         customers::Client(self.clone())
     }
-    pub fn instructions(&self) -> instructions::Client {
+    pub fn instructions_client(&self) -> instructions::Client {
         instructions::Client(self.clone())
     }
-    pub fn invoice_sections(&self) -> invoice_sections::Client {
+    pub fn invoice_sections_client(&self) -> invoice_sections::Client {
         invoice_sections::Client(self.clone())
     }
-    pub fn invoices(&self) -> invoices::Client {
+    pub fn invoices_client(&self) -> invoices::Client {
         invoices::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn products(&self) -> products::Client {
+    pub fn products_client(&self) -> products::Client {
         products::Client(self.clone())
     }
-    pub fn promotion(&self) -> promotion::Client {
+    pub fn promotion_client(&self) -> promotion::Client {
         promotion::Client(self.clone())
     }
-    pub fn promotions(&self) -> promotions::Client {
+    pub fn promotions_client(&self) -> promotions::Client {
         promotions::Client(self.clone())
     }
-    pub fn reservations(&self) -> reservations::Client {
+    pub fn reservations_client(&self) -> reservations::Client {
         reservations::Client(self.clone())
     }
-    pub fn transactions(&self) -> transactions::Client {
+    pub fn transactions_client(&self) -> transactions::Client {
         transactions::Client(self.clone())
     }
 }

--- a/services/mgmt/billing/src/package_2020_11_preview/operations.rs
+++ b/services/mgmt/billing/src/package_2020_11_preview/operations.rs
@@ -74,70 +74,70 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activate(&self) -> activate::Client {
+    pub fn activate_client(&self) -> activate::Client {
         activate::Client(self.clone())
     }
-    pub fn address(&self) -> address::Client {
+    pub fn address_client(&self) -> address::Client {
         address::Client(self.clone())
     }
-    pub fn agreements(&self) -> agreements::Client {
+    pub fn agreements_client(&self) -> agreements::Client {
         agreements::Client(self.clone())
     }
-    pub fn available_balances(&self) -> available_balances::Client {
+    pub fn available_balances_client(&self) -> available_balances::Client {
         available_balances::Client(self.clone())
     }
-    pub fn billing_accounts(&self) -> billing_accounts::Client {
+    pub fn billing_accounts_client(&self) -> billing_accounts::Client {
         billing_accounts::Client(self.clone())
     }
-    pub fn billing_permissions(&self) -> billing_permissions::Client {
+    pub fn billing_permissions_client(&self) -> billing_permissions::Client {
         billing_permissions::Client(self.clone())
     }
-    pub fn billing_profiles(&self) -> billing_profiles::Client {
+    pub fn billing_profiles_client(&self) -> billing_profiles::Client {
         billing_profiles::Client(self.clone())
     }
-    pub fn billing_property(&self) -> billing_property::Client {
+    pub fn billing_property_client(&self) -> billing_property::Client {
         billing_property::Client(self.clone())
     }
-    pub fn billing_role_assignments(&self) -> billing_role_assignments::Client {
+    pub fn billing_role_assignments_client(&self) -> billing_role_assignments::Client {
         billing_role_assignments::Client(self.clone())
     }
-    pub fn billing_role_definitions(&self) -> billing_role_definitions::Client {
+    pub fn billing_role_definitions_client(&self) -> billing_role_definitions::Client {
         billing_role_definitions::Client(self.clone())
     }
-    pub fn billing_subscriptions(&self) -> billing_subscriptions::Client {
+    pub fn billing_subscriptions_client(&self) -> billing_subscriptions::Client {
         billing_subscriptions::Client(self.clone())
     }
-    pub fn customers(&self) -> customers::Client {
+    pub fn customers_client(&self) -> customers::Client {
         customers::Client(self.clone())
     }
-    pub fn instructions(&self) -> instructions::Client {
+    pub fn instructions_client(&self) -> instructions::Client {
         instructions::Client(self.clone())
     }
-    pub fn invoice_sections(&self) -> invoice_sections::Client {
+    pub fn invoice_sections_client(&self) -> invoice_sections::Client {
         invoice_sections::Client(self.clone())
     }
-    pub fn invoices(&self) -> invoices::Client {
+    pub fn invoices_client(&self) -> invoices::Client {
         invoices::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn products(&self) -> products::Client {
+    pub fn products_client(&self) -> products::Client {
         products::Client(self.clone())
     }
-    pub fn promotion(&self) -> promotion::Client {
+    pub fn promotion_client(&self) -> promotion::Client {
         promotion::Client(self.clone())
     }
-    pub fn promotions(&self) -> promotions::Client {
+    pub fn promotions_client(&self) -> promotions::Client {
         promotions::Client(self.clone())
     }
-    pub fn reservations(&self) -> reservations::Client {
+    pub fn reservations_client(&self) -> reservations::Client {
         reservations::Client(self.clone())
     }
-    pub fn transactions(&self) -> transactions::Client {
+    pub fn transactions_client(&self) -> transactions::Client {
         transactions::Client(self.clone())
     }
 }

--- a/services/mgmt/billing/src/package_2021_10/operations.rs
+++ b/services/mgmt/billing/src/package_2021_10/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn billing_subscriptions(&self) -> billing_subscriptions::Client {
+    pub fn billing_subscriptions_client(&self) -> billing_subscriptions::Client {
         billing_subscriptions::Client(self.clone())
     }
-    pub fn billing_subscriptions_aliases(&self) -> billing_subscriptions_aliases::Client {
+    pub fn billing_subscriptions_aliases_client(&self) -> billing_subscriptions_aliases::Client {
         billing_subscriptions_aliases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn payment_methods(&self) -> payment_methods::Client {
+    pub fn payment_methods_client(&self) -> payment_methods::Client {
         payment_methods::Client(self.clone())
     }
 }

--- a/services/mgmt/blockchain/src/package_2018_06_01_preview/operations.rs
+++ b/services/mgmt/blockchain/src/package_2018_06_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn blockchain_member_operation_results(&self) -> blockchain_member_operation_results::Client {
+    pub fn blockchain_member_operation_results_client(&self) -> blockchain_member_operation_results::Client {
         blockchain_member_operation_results::Client(self.clone())
     }
-    pub fn blockchain_members(&self) -> blockchain_members::Client {
+    pub fn blockchain_members_client(&self) -> blockchain_members::Client {
         blockchain_members::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn transaction_nodes(&self) -> transaction_nodes::Client {
+    pub fn transaction_nodes_client(&self) -> transaction_nodes::Client {
         transaction_nodes::Client(self.clone())
     }
 }

--- a/services/mgmt/blueprint/src/package_2017_11_preview/operations.rs
+++ b/services/mgmt/blueprint/src/package_2017_11_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn artifacts(&self) -> artifacts::Client {
+    pub fn artifacts_client(&self) -> artifacts::Client {
         artifacts::Client(self.clone())
     }
-    pub fn assignments(&self) -> assignments::Client {
+    pub fn assignments_client(&self) -> assignments::Client {
         assignments::Client(self.clone())
     }
-    pub fn blueprints(&self) -> blueprints::Client {
+    pub fn blueprints_client(&self) -> blueprints::Client {
         blueprints::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn published_artifacts(&self) -> published_artifacts::Client {
+    pub fn published_artifacts_client(&self) -> published_artifacts::Client {
         published_artifacts::Client(self.clone())
     }
-    pub fn published_blueprints(&self) -> published_blueprints::Client {
+    pub fn published_blueprints_client(&self) -> published_blueprints::Client {
         published_blueprints::Client(self.clone())
     }
 }

--- a/services/mgmt/blueprint/src/package_2018_11_preview/operations.rs
+++ b/services/mgmt/blueprint/src/package_2018_11_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn artifacts(&self) -> artifacts::Client {
+    pub fn artifacts_client(&self) -> artifacts::Client {
         artifacts::Client(self.clone())
     }
-    pub fn assignment_operations(&self) -> assignment_operations::Client {
+    pub fn assignment_operations_client(&self) -> assignment_operations::Client {
         assignment_operations::Client(self.clone())
     }
-    pub fn assignments(&self) -> assignments::Client {
+    pub fn assignments_client(&self) -> assignments::Client {
         assignments::Client(self.clone())
     }
-    pub fn blueprints(&self) -> blueprints::Client {
+    pub fn blueprints_client(&self) -> blueprints::Client {
         blueprints::Client(self.clone())
     }
-    pub fn published_artifacts(&self) -> published_artifacts::Client {
+    pub fn published_artifacts_client(&self) -> published_artifacts::Client {
         published_artifacts::Client(self.clone())
     }
-    pub fn published_blueprints(&self) -> published_blueprints::Client {
+    pub fn published_blueprints_client(&self) -> published_blueprints::Client {
         published_blueprints::Client(self.clone())
     }
 }

--- a/services/mgmt/botservice/src/package_2017_12_01/operations.rs
+++ b/services/mgmt/botservice/src/package_2017_12_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bot_connection(&self) -> bot_connection::Client {
+    pub fn bot_connection_client(&self) -> bot_connection::Client {
         bot_connection::Client(self.clone())
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn channels(&self) -> channels::Client {
+    pub fn channels_client(&self) -> channels::Client {
         channels::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/botservice/src/package_2018_07_12/operations.rs
+++ b/services/mgmt/botservice/src/package_2018_07_12/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bot_connection(&self) -> bot_connection::Client {
+    pub fn bot_connection_client(&self) -> bot_connection::Client {
         bot_connection::Client(self.clone())
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn channels(&self) -> channels::Client {
+    pub fn channels_client(&self) -> channels::Client {
         channels::Client(self.clone())
     }
-    pub fn enterprise_channels(&self) -> enterprise_channels::Client {
+    pub fn enterprise_channels_client(&self) -> enterprise_channels::Client {
         enterprise_channels::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/botservice/src/package_2020_06_02/operations.rs
+++ b/services/mgmt/botservice/src/package_2020_06_02/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bot_connection(&self) -> bot_connection::Client {
+    pub fn bot_connection_client(&self) -> bot_connection::Client {
         bot_connection::Client(self.clone())
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn channels(&self) -> channels::Client {
+    pub fn channels_client(&self) -> channels::Client {
         channels::Client(self.clone())
     }
-    pub fn direct_line(&self) -> direct_line::Client {
+    pub fn direct_line_client(&self) -> direct_line::Client {
         direct_line::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/botservice/src/package_2021_03_01/operations.rs
+++ b/services/mgmt/botservice/src/package_2021_03_01/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bot_connection(&self) -> bot_connection::Client {
+    pub fn bot_connection_client(&self) -> bot_connection::Client {
         bot_connection::Client(self.clone())
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn channels(&self) -> channels::Client {
+    pub fn channels_client(&self) -> channels::Client {
         channels::Client(self.clone())
     }
-    pub fn direct_line(&self) -> direct_line::Client {
+    pub fn direct_line_client(&self) -> direct_line::Client {
         direct_line::Client(self.clone())
     }
-    pub fn host_settings(&self) -> host_settings::Client {
+    pub fn host_settings_client(&self) -> host_settings::Client {
         host_settings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/botservice/src/package_preview_2021_05/operations.rs
+++ b/services/mgmt/botservice/src/package_preview_2021_05/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bot_connection(&self) -> bot_connection::Client {
+    pub fn bot_connection_client(&self) -> bot_connection::Client {
         bot_connection::Client(self.clone())
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn channels(&self) -> channels::Client {
+    pub fn channels_client(&self) -> channels::Client {
         channels::Client(self.clone())
     }
-    pub fn direct_line(&self) -> direct_line::Client {
+    pub fn direct_line_client(&self) -> direct_line::Client {
         direct_line::Client(self.clone())
     }
-    pub fn host_settings(&self) -> host_settings::Client {
+    pub fn host_settings_client(&self) -> host_settings::Client {
         host_settings::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/cdn/src/package_2019_06_preview/operations.rs
+++ b/services/mgmt/cdn/src/package_2019_06_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn edge_nodes(&self) -> edge_nodes::Client {
+    pub fn edge_nodes_client(&self) -> edge_nodes::Client {
         edge_nodes::Client(self.clone())
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn origins(&self) -> origins::Client {
+    pub fn origins_client(&self) -> origins::Client {
         origins::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn resource_usage(&self) -> resource_usage::Client {
+    pub fn resource_usage_client(&self) -> resource_usage::Client {
         resource_usage::Client(self.clone())
     }
 }

--- a/services/mgmt/cdn/src/package_2019_12/operations.rs
+++ b/services/mgmt/cdn/src/package_2019_12/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn edge_nodes(&self) -> edge_nodes::Client {
+    pub fn edge_nodes_client(&self) -> edge_nodes::Client {
         edge_nodes::Client(self.clone())
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn origin_groups(&self) -> origin_groups::Client {
+    pub fn origin_groups_client(&self) -> origin_groups::Client {
         origin_groups::Client(self.clone())
     }
-    pub fn origins(&self) -> origins::Client {
+    pub fn origins_client(&self) -> origins::Client {
         origins::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn resource_usage(&self) -> resource_usage::Client {
+    pub fn resource_usage_client(&self) -> resource_usage::Client {
         resource_usage::Client(self.clone())
     }
 }

--- a/services/mgmt/cdn/src/package_2020_04/operations.rs
+++ b/services/mgmt/cdn/src/package_2020_04/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn edge_nodes(&self) -> edge_nodes::Client {
+    pub fn edge_nodes_client(&self) -> edge_nodes::Client {
         edge_nodes::Client(self.clone())
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn origin_groups(&self) -> origin_groups::Client {
+    pub fn origin_groups_client(&self) -> origin_groups::Client {
         origin_groups::Client(self.clone())
     }
-    pub fn origins(&self) -> origins::Client {
+    pub fn origins_client(&self) -> origins::Client {
         origins::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn resource_usage(&self) -> resource_usage::Client {
+    pub fn resource_usage_client(&self) -> resource_usage::Client {
         resource_usage::Client(self.clone())
     }
 }

--- a/services/mgmt/cdn/src/package_2020_09/operations.rs
+++ b/services/mgmt/cdn/src/package_2020_09/operations.rs
@@ -74,70 +74,70 @@ impl Client {
             pipeline,
         }
     }
-    pub fn afd_custom_domains(&self) -> afd_custom_domains::Client {
+    pub fn afd_custom_domains_client(&self) -> afd_custom_domains::Client {
         afd_custom_domains::Client(self.clone())
     }
-    pub fn afd_endpoints(&self) -> afd_endpoints::Client {
+    pub fn afd_endpoints_client(&self) -> afd_endpoints::Client {
         afd_endpoints::Client(self.clone())
     }
-    pub fn afd_origin_groups(&self) -> afd_origin_groups::Client {
+    pub fn afd_origin_groups_client(&self) -> afd_origin_groups::Client {
         afd_origin_groups::Client(self.clone())
     }
-    pub fn afd_origins(&self) -> afd_origins::Client {
+    pub fn afd_origins_client(&self) -> afd_origins::Client {
         afd_origins::Client(self.clone())
     }
-    pub fn afd_profiles(&self) -> afd_profiles::Client {
+    pub fn afd_profiles_client(&self) -> afd_profiles::Client {
         afd_profiles::Client(self.clone())
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn edge_nodes(&self) -> edge_nodes::Client {
+    pub fn edge_nodes_client(&self) -> edge_nodes::Client {
         edge_nodes::Client(self.clone())
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn log_analytics(&self) -> log_analytics::Client {
+    pub fn log_analytics_client(&self) -> log_analytics::Client {
         log_analytics::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn origin_groups(&self) -> origin_groups::Client {
+    pub fn origin_groups_client(&self) -> origin_groups::Client {
         origin_groups::Client(self.clone())
     }
-    pub fn origins(&self) -> origins::Client {
+    pub fn origins_client(&self) -> origins::Client {
         origins::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn resource_usage(&self) -> resource_usage::Client {
+    pub fn resource_usage_client(&self) -> resource_usage::Client {
         resource_usage::Client(self.clone())
     }
-    pub fn routes(&self) -> routes::Client {
+    pub fn routes_client(&self) -> routes::Client {
         routes::Client(self.clone())
     }
-    pub fn rule_sets(&self) -> rule_sets::Client {
+    pub fn rule_sets_client(&self) -> rule_sets::Client {
         rule_sets::Client(self.clone())
     }
-    pub fn rules(&self) -> rules::Client {
+    pub fn rules_client(&self) -> rules::Client {
         rules::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn security_policies(&self) -> security_policies::Client {
+    pub fn security_policies_client(&self) -> security_policies::Client {
         security_policies::Client(self.clone())
     }
-    pub fn validate(&self) -> validate::Client {
+    pub fn validate_client(&self) -> validate::Client {
         validate::Client(self.clone())
     }
 }

--- a/services/mgmt/cdn/src/package_2021_06/operations.rs
+++ b/services/mgmt/cdn/src/package_2021_06/operations.rs
@@ -74,70 +74,70 @@ impl Client {
             pipeline,
         }
     }
-    pub fn afd_custom_domains(&self) -> afd_custom_domains::Client {
+    pub fn afd_custom_domains_client(&self) -> afd_custom_domains::Client {
         afd_custom_domains::Client(self.clone())
     }
-    pub fn afd_endpoints(&self) -> afd_endpoints::Client {
+    pub fn afd_endpoints_client(&self) -> afd_endpoints::Client {
         afd_endpoints::Client(self.clone())
     }
-    pub fn afd_origin_groups(&self) -> afd_origin_groups::Client {
+    pub fn afd_origin_groups_client(&self) -> afd_origin_groups::Client {
         afd_origin_groups::Client(self.clone())
     }
-    pub fn afd_origins(&self) -> afd_origins::Client {
+    pub fn afd_origins_client(&self) -> afd_origins::Client {
         afd_origins::Client(self.clone())
     }
-    pub fn afd_profiles(&self) -> afd_profiles::Client {
+    pub fn afd_profiles_client(&self) -> afd_profiles::Client {
         afd_profiles::Client(self.clone())
     }
-    pub fn custom_domains(&self) -> custom_domains::Client {
+    pub fn custom_domains_client(&self) -> custom_domains::Client {
         custom_domains::Client(self.clone())
     }
-    pub fn edge_nodes(&self) -> edge_nodes::Client {
+    pub fn edge_nodes_client(&self) -> edge_nodes::Client {
         edge_nodes::Client(self.clone())
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn log_analytics(&self) -> log_analytics::Client {
+    pub fn log_analytics_client(&self) -> log_analytics::Client {
         log_analytics::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn origin_groups(&self) -> origin_groups::Client {
+    pub fn origin_groups_client(&self) -> origin_groups::Client {
         origin_groups::Client(self.clone())
     }
-    pub fn origins(&self) -> origins::Client {
+    pub fn origins_client(&self) -> origins::Client {
         origins::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn resource_usage(&self) -> resource_usage::Client {
+    pub fn resource_usage_client(&self) -> resource_usage::Client {
         resource_usage::Client(self.clone())
     }
-    pub fn routes(&self) -> routes::Client {
+    pub fn routes_client(&self) -> routes::Client {
         routes::Client(self.clone())
     }
-    pub fn rule_sets(&self) -> rule_sets::Client {
+    pub fn rule_sets_client(&self) -> rule_sets::Client {
         rule_sets::Client(self.clone())
     }
-    pub fn rules(&self) -> rules::Client {
+    pub fn rules_client(&self) -> rules::Client {
         rules::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn security_policies(&self) -> security_policies::Client {
+    pub fn security_policies_client(&self) -> security_policies::Client {
         security_policies::Client(self.clone())
     }
-    pub fn validate(&self) -> validate::Client {
+    pub fn validate_client(&self) -> validate::Client {
         validate::Client(self.clone())
     }
 }

--- a/services/mgmt/changeanalysis/src/package_2020_04_01_preview/operations.rs
+++ b/services/mgmt/changeanalysis/src/package_2020_04_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configuration_profile(&self) -> configuration_profile::Client {
+    pub fn configuration_profile_client(&self) -> configuration_profile::Client {
         configuration_profile::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/changeanalysis/src/package_2021_04_01/operations.rs
+++ b/services/mgmt/changeanalysis/src/package_2021_04_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn changes(&self) -> changes::Client {
+    pub fn changes_client(&self) -> changes::Client {
         changes::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn resource_changes(&self) -> resource_changes::Client {
+    pub fn resource_changes_client(&self) -> resource_changes::Client {
         resource_changes::Client(self.clone())
     }
 }

--- a/services/mgmt/changeanalysis/src/package_2021_04_01_preview/operations.rs
+++ b/services/mgmt/changeanalysis/src/package_2021_04_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn change_snapshots(&self) -> change_snapshots::Client {
+    pub fn change_snapshots_client(&self) -> change_snapshots::Client {
         change_snapshots::Client(self.clone())
     }
-    pub fn changes(&self) -> changes::Client {
+    pub fn changes_client(&self) -> changes::Client {
         changes::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn resource_changes(&self) -> resource_changes::Client {
+    pub fn resource_changes_client(&self) -> resource_changes::Client {
         resource_changes::Client(self.clone())
     }
 }

--- a/services/mgmt/chaos/src/package_2021_09_15_preview/operations.rs
+++ b/services/mgmt/chaos/src/package_2021_09_15_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn capabilities(&self) -> capabilities::Client {
+    pub fn capabilities_client(&self) -> capabilities::Client {
         capabilities::Client(self.clone())
     }
-    pub fn capability_types(&self) -> capability_types::Client {
+    pub fn capability_types_client(&self) -> capability_types::Client {
         capability_types::Client(self.clone())
     }
-    pub fn experiments(&self) -> experiments::Client {
+    pub fn experiments_client(&self) -> experiments::Client {
         experiments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn target_types(&self) -> target_types::Client {
+    pub fn target_types_client(&self) -> target_types::Client {
         target_types::Client(self.clone())
     }
-    pub fn targets(&self) -> targets::Client {
+    pub fn targets_client(&self) -> targets::Client {
         targets::Client(self.clone())
     }
 }

--- a/services/mgmt/cognitiveservices/src/package_2016_02_preview/operations.rs
+++ b/services/mgmt/cognitiveservices/src/package_2016_02_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cognitive_services_accounts(&self) -> cognitive_services_accounts::Client {
+    pub fn cognitive_services_accounts_client(&self) -> cognitive_services_accounts::Client {
         cognitive_services_accounts::Client(self.clone())
     }
 }

--- a/services/mgmt/cognitiveservices/src/package_2017_04/operations.rs
+++ b/services/mgmt/cognitiveservices/src/package_2017_04/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
 }

--- a/services/mgmt/cognitiveservices/src/package_2021_04/operations.rs
+++ b/services/mgmt/cognitiveservices/src/package_2021_04/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn deleted_accounts(&self) -> deleted_accounts::Client {
+    pub fn deleted_accounts_client(&self) -> deleted_accounts::Client {
         deleted_accounts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
 }

--- a/services/mgmt/cognitiveservices/src/package_2021_10/operations.rs
+++ b/services/mgmt/cognitiveservices/src/package_2021_10/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn commitment_plans(&self) -> commitment_plans::Client {
+    pub fn commitment_plans_client(&self) -> commitment_plans::Client {
         commitment_plans::Client(self.clone())
     }
-    pub fn commitment_tiers(&self) -> commitment_tiers::Client {
+    pub fn commitment_tiers_client(&self) -> commitment_tiers::Client {
         commitment_tiers::Client(self.clone())
     }
-    pub fn deleted_accounts(&self) -> deleted_accounts::Client {
+    pub fn deleted_accounts_client(&self) -> deleted_accounts::Client {
         deleted_accounts::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
 }

--- a/services/mgmt/cognitiveservices/src/package_2022_03/operations.rs
+++ b/services/mgmt/cognitiveservices/src/package_2022_03/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn commitment_plans(&self) -> commitment_plans::Client {
+    pub fn commitment_plans_client(&self) -> commitment_plans::Client {
         commitment_plans::Client(self.clone())
     }
-    pub fn commitment_tiers(&self) -> commitment_tiers::Client {
+    pub fn commitment_tiers_client(&self) -> commitment_tiers::Client {
         commitment_tiers::Client(self.clone())
     }
-    pub fn deleted_accounts(&self) -> deleted_accounts::Client {
+    pub fn deleted_accounts_client(&self) -> deleted_accounts::Client {
         deleted_accounts::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
 }

--- a/services/mgmt/commerce/src/package_2015_06_preview/operations.rs
+++ b/services/mgmt/commerce/src/package_2015_06_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn rate_card(&self) -> rate_card::Client {
+    pub fn rate_card_client(&self) -> rate_card::Client {
         rate_card::Client(self.clone())
     }
-    pub fn usage_aggregates(&self) -> usage_aggregates::Client {
+    pub fn usage_aggregates_client(&self) -> usage_aggregates::Client {
         usage_aggregates::Client(self.clone())
     }
 }

--- a/services/mgmt/commerce/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/commerce/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn rate_card(&self) -> rate_card::Client {
+    pub fn rate_card_client(&self) -> rate_card::Client {
         rate_card::Client(self.clone())
     }
-    pub fn usage_aggregates(&self) -> usage_aggregates::Client {
+    pub fn usage_aggregates_client(&self) -> usage_aggregates::Client {
         usage_aggregates::Client(self.clone())
     }
 }

--- a/services/mgmt/communication/src/package_2020_08_20/operations.rs
+++ b/services/mgmt/communication/src/package_2020_08_20/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn communication_service(&self) -> communication_service::Client {
+    pub fn communication_service_client(&self) -> communication_service::Client {
         communication_service::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/communication/src/package_2020_08_20_preview/operations.rs
+++ b/services/mgmt/communication/src/package_2020_08_20_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn communication_service(&self) -> communication_service::Client {
+    pub fn communication_service_client(&self) -> communication_service::Client {
         communication_service::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/communication/src/package_2021_10_01_preview/operations.rs
+++ b/services/mgmt/communication/src/package_2021_10_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn communication_services(&self) -> communication_services::Client {
+    pub fn communication_services_client(&self) -> communication_services::Client {
         communication_services::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn email_services(&self) -> email_services::Client {
+    pub fn email_services_client(&self) -> email_services::Client {
         email_services::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/compute/examples/vm_list.rs
+++ b/services/mgmt/compute/examples/vm_list.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = azure_mgmt_compute::ClientBuilder::new(credential).build();
 
     let mut count = 0;
-    let mut vms = client.virtual_machines().list_all(subscription_id).into_stream();
+    let mut vms = client.virtual_machines_client().list_all(subscription_id).into_stream();
     while let Some(vms) = vms.next().await {
         let vms = vms?;
         count += vms.value.len();

--- a/services/mgmt/compute/src/package_2021_11_01/operations.rs
+++ b/services/mgmt/compute/src/package_2021_11_01/operations.rs
@@ -74,151 +74,151 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_sets(&self) -> availability_sets::Client {
+    pub fn availability_sets_client(&self) -> availability_sets::Client {
         availability_sets::Client(self.clone())
     }
-    pub fn capacity_reservation_groups(&self) -> capacity_reservation_groups::Client {
+    pub fn capacity_reservation_groups_client(&self) -> capacity_reservation_groups::Client {
         capacity_reservation_groups::Client(self.clone())
     }
-    pub fn capacity_reservations(&self) -> capacity_reservations::Client {
+    pub fn capacity_reservations_client(&self) -> capacity_reservations::Client {
         capacity_reservations::Client(self.clone())
     }
-    pub fn cloud_service_operating_systems(&self) -> cloud_service_operating_systems::Client {
+    pub fn cloud_service_operating_systems_client(&self) -> cloud_service_operating_systems::Client {
         cloud_service_operating_systems::Client(self.clone())
     }
-    pub fn cloud_service_role_instances(&self) -> cloud_service_role_instances::Client {
+    pub fn cloud_service_role_instances_client(&self) -> cloud_service_role_instances::Client {
         cloud_service_role_instances::Client(self.clone())
     }
-    pub fn cloud_service_roles(&self) -> cloud_service_roles::Client {
+    pub fn cloud_service_roles_client(&self) -> cloud_service_roles::Client {
         cloud_service_roles::Client(self.clone())
     }
-    pub fn cloud_services(&self) -> cloud_services::Client {
+    pub fn cloud_services_client(&self) -> cloud_services::Client {
         cloud_services::Client(self.clone())
     }
-    pub fn cloud_services_update_domain(&self) -> cloud_services_update_domain::Client {
+    pub fn cloud_services_update_domain_client(&self) -> cloud_services_update_domain::Client {
         cloud_services_update_domain::Client(self.clone())
     }
-    pub fn community_galleries(&self) -> community_galleries::Client {
+    pub fn community_galleries_client(&self) -> community_galleries::Client {
         community_galleries::Client(self.clone())
     }
-    pub fn community_gallery_image_versions(&self) -> community_gallery_image_versions::Client {
+    pub fn community_gallery_image_versions_client(&self) -> community_gallery_image_versions::Client {
         community_gallery_image_versions::Client(self.clone())
     }
-    pub fn community_gallery_images(&self) -> community_gallery_images::Client {
+    pub fn community_gallery_images_client(&self) -> community_gallery_images::Client {
         community_gallery_images::Client(self.clone())
     }
-    pub fn dedicated_host_groups(&self) -> dedicated_host_groups::Client {
+    pub fn dedicated_host_groups_client(&self) -> dedicated_host_groups::Client {
         dedicated_host_groups::Client(self.clone())
     }
-    pub fn dedicated_hosts(&self) -> dedicated_hosts::Client {
+    pub fn dedicated_hosts_client(&self) -> dedicated_hosts::Client {
         dedicated_hosts::Client(self.clone())
     }
-    pub fn disk_accesses(&self) -> disk_accesses::Client {
+    pub fn disk_accesses_client(&self) -> disk_accesses::Client {
         disk_accesses::Client(self.clone())
     }
-    pub fn disk_encryption_sets(&self) -> disk_encryption_sets::Client {
+    pub fn disk_encryption_sets_client(&self) -> disk_encryption_sets::Client {
         disk_encryption_sets::Client(self.clone())
     }
-    pub fn disk_restore_point(&self) -> disk_restore_point::Client {
+    pub fn disk_restore_point_client(&self) -> disk_restore_point::Client {
         disk_restore_point::Client(self.clone())
     }
-    pub fn disks(&self) -> disks::Client {
+    pub fn disks_client(&self) -> disks::Client {
         disks::Client(self.clone())
     }
-    pub fn galleries(&self) -> galleries::Client {
+    pub fn galleries_client(&self) -> galleries::Client {
         galleries::Client(self.clone())
     }
-    pub fn gallery_application_versions(&self) -> gallery_application_versions::Client {
+    pub fn gallery_application_versions_client(&self) -> gallery_application_versions::Client {
         gallery_application_versions::Client(self.clone())
     }
-    pub fn gallery_applications(&self) -> gallery_applications::Client {
+    pub fn gallery_applications_client(&self) -> gallery_applications::Client {
         gallery_applications::Client(self.clone())
     }
-    pub fn gallery_image_versions(&self) -> gallery_image_versions::Client {
+    pub fn gallery_image_versions_client(&self) -> gallery_image_versions::Client {
         gallery_image_versions::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn gallery_sharing_profile(&self) -> gallery_sharing_profile::Client {
+    pub fn gallery_sharing_profile_client(&self) -> gallery_sharing_profile::Client {
         gallery_sharing_profile::Client(self.clone())
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn log_analytics(&self) -> log_analytics::Client {
+    pub fn log_analytics_client(&self) -> log_analytics::Client {
         log_analytics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proximity_placement_groups(&self) -> proximity_placement_groups::Client {
+    pub fn proximity_placement_groups_client(&self) -> proximity_placement_groups::Client {
         proximity_placement_groups::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn restore_point_collections(&self) -> restore_point_collections::Client {
+    pub fn restore_point_collections_client(&self) -> restore_point_collections::Client {
         restore_point_collections::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn shared_galleries(&self) -> shared_galleries::Client {
+    pub fn shared_galleries_client(&self) -> shared_galleries::Client {
         shared_galleries::Client(self.clone())
     }
-    pub fn shared_gallery_image_versions(&self) -> shared_gallery_image_versions::Client {
+    pub fn shared_gallery_image_versions_client(&self) -> shared_gallery_image_versions::Client {
         shared_gallery_image_versions::Client(self.clone())
     }
-    pub fn shared_gallery_images(&self) -> shared_gallery_images::Client {
+    pub fn shared_gallery_images_client(&self) -> shared_gallery_images::Client {
         shared_gallery_images::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn ssh_public_keys(&self) -> ssh_public_keys::Client {
+    pub fn ssh_public_keys_client(&self) -> ssh_public_keys::Client {
         ssh_public_keys::Client(self.clone())
     }
-    pub fn usage(&self) -> usage::Client {
+    pub fn usage_client(&self) -> usage::Client {
         usage::Client(self.clone())
     }
-    pub fn virtual_machine_extension_images(&self) -> virtual_machine_extension_images::Client {
+    pub fn virtual_machine_extension_images_client(&self) -> virtual_machine_extension_images::Client {
         virtual_machine_extension_images::Client(self.clone())
     }
-    pub fn virtual_machine_extensions(&self) -> virtual_machine_extensions::Client {
+    pub fn virtual_machine_extensions_client(&self) -> virtual_machine_extensions::Client {
         virtual_machine_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_images(&self) -> virtual_machine_images::Client {
+    pub fn virtual_machine_images_client(&self) -> virtual_machine_images::Client {
         virtual_machine_images::Client(self.clone())
     }
-    pub fn virtual_machine_images_edge_zone(&self) -> virtual_machine_images_edge_zone::Client {
+    pub fn virtual_machine_images_edge_zone_client(&self) -> virtual_machine_images_edge_zone::Client {
         virtual_machine_images_edge_zone::Client(self.clone())
     }
-    pub fn virtual_machine_run_commands(&self) -> virtual_machine_run_commands::Client {
+    pub fn virtual_machine_run_commands_client(&self) -> virtual_machine_run_commands::Client {
         virtual_machine_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_extensions(&self) -> virtual_machine_scale_set_extensions::Client {
+    pub fn virtual_machine_scale_set_extensions_client(&self) -> virtual_machine_scale_set_extensions::Client {
         virtual_machine_scale_set_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_rolling_upgrades(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
+    pub fn virtual_machine_scale_set_rolling_upgrades_client(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
         virtual_machine_scale_set_rolling_upgrades::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_v_ms(&self) -> virtual_machine_scale_set_v_ms::Client {
+    pub fn virtual_machine_scale_set_v_ms_client(&self) -> virtual_machine_scale_set_v_ms::Client {
         virtual_machine_scale_set_v_ms::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_extensions(&self) -> virtual_machine_scale_set_vm_extensions::Client {
+    pub fn virtual_machine_scale_set_vm_extensions_client(&self) -> virtual_machine_scale_set_vm_extensions::Client {
         virtual_machine_scale_set_vm_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_run_commands(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
+    pub fn virtual_machine_scale_set_vm_run_commands_client(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
         virtual_machine_scale_set_vm_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_sets(&self) -> virtual_machine_scale_sets::Client {
+    pub fn virtual_machine_scale_sets_client(&self) -> virtual_machine_scale_sets::Client {
         virtual_machine_scale_sets::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/compute/src/package_2021_12_01/operations.rs
+++ b/services/mgmt/compute/src/package_2021_12_01/operations.rs
@@ -74,151 +74,151 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_sets(&self) -> availability_sets::Client {
+    pub fn availability_sets_client(&self) -> availability_sets::Client {
         availability_sets::Client(self.clone())
     }
-    pub fn capacity_reservation_groups(&self) -> capacity_reservation_groups::Client {
+    pub fn capacity_reservation_groups_client(&self) -> capacity_reservation_groups::Client {
         capacity_reservation_groups::Client(self.clone())
     }
-    pub fn capacity_reservations(&self) -> capacity_reservations::Client {
+    pub fn capacity_reservations_client(&self) -> capacity_reservations::Client {
         capacity_reservations::Client(self.clone())
     }
-    pub fn cloud_service_operating_systems(&self) -> cloud_service_operating_systems::Client {
+    pub fn cloud_service_operating_systems_client(&self) -> cloud_service_operating_systems::Client {
         cloud_service_operating_systems::Client(self.clone())
     }
-    pub fn cloud_service_role_instances(&self) -> cloud_service_role_instances::Client {
+    pub fn cloud_service_role_instances_client(&self) -> cloud_service_role_instances::Client {
         cloud_service_role_instances::Client(self.clone())
     }
-    pub fn cloud_service_roles(&self) -> cloud_service_roles::Client {
+    pub fn cloud_service_roles_client(&self) -> cloud_service_roles::Client {
         cloud_service_roles::Client(self.clone())
     }
-    pub fn cloud_services(&self) -> cloud_services::Client {
+    pub fn cloud_services_client(&self) -> cloud_services::Client {
         cloud_services::Client(self.clone())
     }
-    pub fn cloud_services_update_domain(&self) -> cloud_services_update_domain::Client {
+    pub fn cloud_services_update_domain_client(&self) -> cloud_services_update_domain::Client {
         cloud_services_update_domain::Client(self.clone())
     }
-    pub fn community_galleries(&self) -> community_galleries::Client {
+    pub fn community_galleries_client(&self) -> community_galleries::Client {
         community_galleries::Client(self.clone())
     }
-    pub fn community_gallery_image_versions(&self) -> community_gallery_image_versions::Client {
+    pub fn community_gallery_image_versions_client(&self) -> community_gallery_image_versions::Client {
         community_gallery_image_versions::Client(self.clone())
     }
-    pub fn community_gallery_images(&self) -> community_gallery_images::Client {
+    pub fn community_gallery_images_client(&self) -> community_gallery_images::Client {
         community_gallery_images::Client(self.clone())
     }
-    pub fn dedicated_host_groups(&self) -> dedicated_host_groups::Client {
+    pub fn dedicated_host_groups_client(&self) -> dedicated_host_groups::Client {
         dedicated_host_groups::Client(self.clone())
     }
-    pub fn dedicated_hosts(&self) -> dedicated_hosts::Client {
+    pub fn dedicated_hosts_client(&self) -> dedicated_hosts::Client {
         dedicated_hosts::Client(self.clone())
     }
-    pub fn disk_accesses(&self) -> disk_accesses::Client {
+    pub fn disk_accesses_client(&self) -> disk_accesses::Client {
         disk_accesses::Client(self.clone())
     }
-    pub fn disk_encryption_sets(&self) -> disk_encryption_sets::Client {
+    pub fn disk_encryption_sets_client(&self) -> disk_encryption_sets::Client {
         disk_encryption_sets::Client(self.clone())
     }
-    pub fn disk_restore_point(&self) -> disk_restore_point::Client {
+    pub fn disk_restore_point_client(&self) -> disk_restore_point::Client {
         disk_restore_point::Client(self.clone())
     }
-    pub fn disks(&self) -> disks::Client {
+    pub fn disks_client(&self) -> disks::Client {
         disks::Client(self.clone())
     }
-    pub fn galleries(&self) -> galleries::Client {
+    pub fn galleries_client(&self) -> galleries::Client {
         galleries::Client(self.clone())
     }
-    pub fn gallery_application_versions(&self) -> gallery_application_versions::Client {
+    pub fn gallery_application_versions_client(&self) -> gallery_application_versions::Client {
         gallery_application_versions::Client(self.clone())
     }
-    pub fn gallery_applications(&self) -> gallery_applications::Client {
+    pub fn gallery_applications_client(&self) -> gallery_applications::Client {
         gallery_applications::Client(self.clone())
     }
-    pub fn gallery_image_versions(&self) -> gallery_image_versions::Client {
+    pub fn gallery_image_versions_client(&self) -> gallery_image_versions::Client {
         gallery_image_versions::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn gallery_sharing_profile(&self) -> gallery_sharing_profile::Client {
+    pub fn gallery_sharing_profile_client(&self) -> gallery_sharing_profile::Client {
         gallery_sharing_profile::Client(self.clone())
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn log_analytics(&self) -> log_analytics::Client {
+    pub fn log_analytics_client(&self) -> log_analytics::Client {
         log_analytics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proximity_placement_groups(&self) -> proximity_placement_groups::Client {
+    pub fn proximity_placement_groups_client(&self) -> proximity_placement_groups::Client {
         proximity_placement_groups::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn restore_point_collections(&self) -> restore_point_collections::Client {
+    pub fn restore_point_collections_client(&self) -> restore_point_collections::Client {
         restore_point_collections::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn shared_galleries(&self) -> shared_galleries::Client {
+    pub fn shared_galleries_client(&self) -> shared_galleries::Client {
         shared_galleries::Client(self.clone())
     }
-    pub fn shared_gallery_image_versions(&self) -> shared_gallery_image_versions::Client {
+    pub fn shared_gallery_image_versions_client(&self) -> shared_gallery_image_versions::Client {
         shared_gallery_image_versions::Client(self.clone())
     }
-    pub fn shared_gallery_images(&self) -> shared_gallery_images::Client {
+    pub fn shared_gallery_images_client(&self) -> shared_gallery_images::Client {
         shared_gallery_images::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn ssh_public_keys(&self) -> ssh_public_keys::Client {
+    pub fn ssh_public_keys_client(&self) -> ssh_public_keys::Client {
         ssh_public_keys::Client(self.clone())
     }
-    pub fn usage(&self) -> usage::Client {
+    pub fn usage_client(&self) -> usage::Client {
         usage::Client(self.clone())
     }
-    pub fn virtual_machine_extension_images(&self) -> virtual_machine_extension_images::Client {
+    pub fn virtual_machine_extension_images_client(&self) -> virtual_machine_extension_images::Client {
         virtual_machine_extension_images::Client(self.clone())
     }
-    pub fn virtual_machine_extensions(&self) -> virtual_machine_extensions::Client {
+    pub fn virtual_machine_extensions_client(&self) -> virtual_machine_extensions::Client {
         virtual_machine_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_images(&self) -> virtual_machine_images::Client {
+    pub fn virtual_machine_images_client(&self) -> virtual_machine_images::Client {
         virtual_machine_images::Client(self.clone())
     }
-    pub fn virtual_machine_images_edge_zone(&self) -> virtual_machine_images_edge_zone::Client {
+    pub fn virtual_machine_images_edge_zone_client(&self) -> virtual_machine_images_edge_zone::Client {
         virtual_machine_images_edge_zone::Client(self.clone())
     }
-    pub fn virtual_machine_run_commands(&self) -> virtual_machine_run_commands::Client {
+    pub fn virtual_machine_run_commands_client(&self) -> virtual_machine_run_commands::Client {
         virtual_machine_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_extensions(&self) -> virtual_machine_scale_set_extensions::Client {
+    pub fn virtual_machine_scale_set_extensions_client(&self) -> virtual_machine_scale_set_extensions::Client {
         virtual_machine_scale_set_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_rolling_upgrades(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
+    pub fn virtual_machine_scale_set_rolling_upgrades_client(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
         virtual_machine_scale_set_rolling_upgrades::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_v_ms(&self) -> virtual_machine_scale_set_v_ms::Client {
+    pub fn virtual_machine_scale_set_v_ms_client(&self) -> virtual_machine_scale_set_v_ms::Client {
         virtual_machine_scale_set_v_ms::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_extensions(&self) -> virtual_machine_scale_set_vm_extensions::Client {
+    pub fn virtual_machine_scale_set_vm_extensions_client(&self) -> virtual_machine_scale_set_vm_extensions::Client {
         virtual_machine_scale_set_vm_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_run_commands(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
+    pub fn virtual_machine_scale_set_vm_run_commands_client(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
         virtual_machine_scale_set_vm_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_sets(&self) -> virtual_machine_scale_sets::Client {
+    pub fn virtual_machine_scale_sets_client(&self) -> virtual_machine_scale_sets::Client {
         virtual_machine_scale_sets::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/compute/src/package_2022_01_03/operations.rs
+++ b/services/mgmt/compute/src/package_2022_01_03/operations.rs
@@ -74,151 +74,151 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_sets(&self) -> availability_sets::Client {
+    pub fn availability_sets_client(&self) -> availability_sets::Client {
         availability_sets::Client(self.clone())
     }
-    pub fn capacity_reservation_groups(&self) -> capacity_reservation_groups::Client {
+    pub fn capacity_reservation_groups_client(&self) -> capacity_reservation_groups::Client {
         capacity_reservation_groups::Client(self.clone())
     }
-    pub fn capacity_reservations(&self) -> capacity_reservations::Client {
+    pub fn capacity_reservations_client(&self) -> capacity_reservations::Client {
         capacity_reservations::Client(self.clone())
     }
-    pub fn cloud_service_operating_systems(&self) -> cloud_service_operating_systems::Client {
+    pub fn cloud_service_operating_systems_client(&self) -> cloud_service_operating_systems::Client {
         cloud_service_operating_systems::Client(self.clone())
     }
-    pub fn cloud_service_role_instances(&self) -> cloud_service_role_instances::Client {
+    pub fn cloud_service_role_instances_client(&self) -> cloud_service_role_instances::Client {
         cloud_service_role_instances::Client(self.clone())
     }
-    pub fn cloud_service_roles(&self) -> cloud_service_roles::Client {
+    pub fn cloud_service_roles_client(&self) -> cloud_service_roles::Client {
         cloud_service_roles::Client(self.clone())
     }
-    pub fn cloud_services(&self) -> cloud_services::Client {
+    pub fn cloud_services_client(&self) -> cloud_services::Client {
         cloud_services::Client(self.clone())
     }
-    pub fn cloud_services_update_domain(&self) -> cloud_services_update_domain::Client {
+    pub fn cloud_services_update_domain_client(&self) -> cloud_services_update_domain::Client {
         cloud_services_update_domain::Client(self.clone())
     }
-    pub fn community_galleries(&self) -> community_galleries::Client {
+    pub fn community_galleries_client(&self) -> community_galleries::Client {
         community_galleries::Client(self.clone())
     }
-    pub fn community_gallery_image_versions(&self) -> community_gallery_image_versions::Client {
+    pub fn community_gallery_image_versions_client(&self) -> community_gallery_image_versions::Client {
         community_gallery_image_versions::Client(self.clone())
     }
-    pub fn community_gallery_images(&self) -> community_gallery_images::Client {
+    pub fn community_gallery_images_client(&self) -> community_gallery_images::Client {
         community_gallery_images::Client(self.clone())
     }
-    pub fn dedicated_host_groups(&self) -> dedicated_host_groups::Client {
+    pub fn dedicated_host_groups_client(&self) -> dedicated_host_groups::Client {
         dedicated_host_groups::Client(self.clone())
     }
-    pub fn dedicated_hosts(&self) -> dedicated_hosts::Client {
+    pub fn dedicated_hosts_client(&self) -> dedicated_hosts::Client {
         dedicated_hosts::Client(self.clone())
     }
-    pub fn disk_accesses(&self) -> disk_accesses::Client {
+    pub fn disk_accesses_client(&self) -> disk_accesses::Client {
         disk_accesses::Client(self.clone())
     }
-    pub fn disk_encryption_sets(&self) -> disk_encryption_sets::Client {
+    pub fn disk_encryption_sets_client(&self) -> disk_encryption_sets::Client {
         disk_encryption_sets::Client(self.clone())
     }
-    pub fn disk_restore_point(&self) -> disk_restore_point::Client {
+    pub fn disk_restore_point_client(&self) -> disk_restore_point::Client {
         disk_restore_point::Client(self.clone())
     }
-    pub fn disks(&self) -> disks::Client {
+    pub fn disks_client(&self) -> disks::Client {
         disks::Client(self.clone())
     }
-    pub fn galleries(&self) -> galleries::Client {
+    pub fn galleries_client(&self) -> galleries::Client {
         galleries::Client(self.clone())
     }
-    pub fn gallery_application_versions(&self) -> gallery_application_versions::Client {
+    pub fn gallery_application_versions_client(&self) -> gallery_application_versions::Client {
         gallery_application_versions::Client(self.clone())
     }
-    pub fn gallery_applications(&self) -> gallery_applications::Client {
+    pub fn gallery_applications_client(&self) -> gallery_applications::Client {
         gallery_applications::Client(self.clone())
     }
-    pub fn gallery_image_versions(&self) -> gallery_image_versions::Client {
+    pub fn gallery_image_versions_client(&self) -> gallery_image_versions::Client {
         gallery_image_versions::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn gallery_sharing_profile(&self) -> gallery_sharing_profile::Client {
+    pub fn gallery_sharing_profile_client(&self) -> gallery_sharing_profile::Client {
         gallery_sharing_profile::Client(self.clone())
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn log_analytics(&self) -> log_analytics::Client {
+    pub fn log_analytics_client(&self) -> log_analytics::Client {
         log_analytics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proximity_placement_groups(&self) -> proximity_placement_groups::Client {
+    pub fn proximity_placement_groups_client(&self) -> proximity_placement_groups::Client {
         proximity_placement_groups::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn restore_point_collections(&self) -> restore_point_collections::Client {
+    pub fn restore_point_collections_client(&self) -> restore_point_collections::Client {
         restore_point_collections::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn shared_galleries(&self) -> shared_galleries::Client {
+    pub fn shared_galleries_client(&self) -> shared_galleries::Client {
         shared_galleries::Client(self.clone())
     }
-    pub fn shared_gallery_image_versions(&self) -> shared_gallery_image_versions::Client {
+    pub fn shared_gallery_image_versions_client(&self) -> shared_gallery_image_versions::Client {
         shared_gallery_image_versions::Client(self.clone())
     }
-    pub fn shared_gallery_images(&self) -> shared_gallery_images::Client {
+    pub fn shared_gallery_images_client(&self) -> shared_gallery_images::Client {
         shared_gallery_images::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn ssh_public_keys(&self) -> ssh_public_keys::Client {
+    pub fn ssh_public_keys_client(&self) -> ssh_public_keys::Client {
         ssh_public_keys::Client(self.clone())
     }
-    pub fn usage(&self) -> usage::Client {
+    pub fn usage_client(&self) -> usage::Client {
         usage::Client(self.clone())
     }
-    pub fn virtual_machine_extension_images(&self) -> virtual_machine_extension_images::Client {
+    pub fn virtual_machine_extension_images_client(&self) -> virtual_machine_extension_images::Client {
         virtual_machine_extension_images::Client(self.clone())
     }
-    pub fn virtual_machine_extensions(&self) -> virtual_machine_extensions::Client {
+    pub fn virtual_machine_extensions_client(&self) -> virtual_machine_extensions::Client {
         virtual_machine_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_images(&self) -> virtual_machine_images::Client {
+    pub fn virtual_machine_images_client(&self) -> virtual_machine_images::Client {
         virtual_machine_images::Client(self.clone())
     }
-    pub fn virtual_machine_images_edge_zone(&self) -> virtual_machine_images_edge_zone::Client {
+    pub fn virtual_machine_images_edge_zone_client(&self) -> virtual_machine_images_edge_zone::Client {
         virtual_machine_images_edge_zone::Client(self.clone())
     }
-    pub fn virtual_machine_run_commands(&self) -> virtual_machine_run_commands::Client {
+    pub fn virtual_machine_run_commands_client(&self) -> virtual_machine_run_commands::Client {
         virtual_machine_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_extensions(&self) -> virtual_machine_scale_set_extensions::Client {
+    pub fn virtual_machine_scale_set_extensions_client(&self) -> virtual_machine_scale_set_extensions::Client {
         virtual_machine_scale_set_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_rolling_upgrades(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
+    pub fn virtual_machine_scale_set_rolling_upgrades_client(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
         virtual_machine_scale_set_rolling_upgrades::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_v_ms(&self) -> virtual_machine_scale_set_v_ms::Client {
+    pub fn virtual_machine_scale_set_v_ms_client(&self) -> virtual_machine_scale_set_v_ms::Client {
         virtual_machine_scale_set_v_ms::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_extensions(&self) -> virtual_machine_scale_set_vm_extensions::Client {
+    pub fn virtual_machine_scale_set_vm_extensions_client(&self) -> virtual_machine_scale_set_vm_extensions::Client {
         virtual_machine_scale_set_vm_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_run_commands(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
+    pub fn virtual_machine_scale_set_vm_run_commands_client(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
         virtual_machine_scale_set_vm_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_sets(&self) -> virtual_machine_scale_sets::Client {
+    pub fn virtual_machine_scale_sets_client(&self) -> virtual_machine_scale_sets::Client {
         virtual_machine_scale_sets::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/compute/src/package_2022_03_01/operations.rs
+++ b/services/mgmt/compute/src/package_2022_03_01/operations.rs
@@ -74,151 +74,151 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_sets(&self) -> availability_sets::Client {
+    pub fn availability_sets_client(&self) -> availability_sets::Client {
         availability_sets::Client(self.clone())
     }
-    pub fn capacity_reservation_groups(&self) -> capacity_reservation_groups::Client {
+    pub fn capacity_reservation_groups_client(&self) -> capacity_reservation_groups::Client {
         capacity_reservation_groups::Client(self.clone())
     }
-    pub fn capacity_reservations(&self) -> capacity_reservations::Client {
+    pub fn capacity_reservations_client(&self) -> capacity_reservations::Client {
         capacity_reservations::Client(self.clone())
     }
-    pub fn cloud_service_operating_systems(&self) -> cloud_service_operating_systems::Client {
+    pub fn cloud_service_operating_systems_client(&self) -> cloud_service_operating_systems::Client {
         cloud_service_operating_systems::Client(self.clone())
     }
-    pub fn cloud_service_role_instances(&self) -> cloud_service_role_instances::Client {
+    pub fn cloud_service_role_instances_client(&self) -> cloud_service_role_instances::Client {
         cloud_service_role_instances::Client(self.clone())
     }
-    pub fn cloud_service_roles(&self) -> cloud_service_roles::Client {
+    pub fn cloud_service_roles_client(&self) -> cloud_service_roles::Client {
         cloud_service_roles::Client(self.clone())
     }
-    pub fn cloud_services(&self) -> cloud_services::Client {
+    pub fn cloud_services_client(&self) -> cloud_services::Client {
         cloud_services::Client(self.clone())
     }
-    pub fn cloud_services_update_domain(&self) -> cloud_services_update_domain::Client {
+    pub fn cloud_services_update_domain_client(&self) -> cloud_services_update_domain::Client {
         cloud_services_update_domain::Client(self.clone())
     }
-    pub fn community_galleries(&self) -> community_galleries::Client {
+    pub fn community_galleries_client(&self) -> community_galleries::Client {
         community_galleries::Client(self.clone())
     }
-    pub fn community_gallery_image_versions(&self) -> community_gallery_image_versions::Client {
+    pub fn community_gallery_image_versions_client(&self) -> community_gallery_image_versions::Client {
         community_gallery_image_versions::Client(self.clone())
     }
-    pub fn community_gallery_images(&self) -> community_gallery_images::Client {
+    pub fn community_gallery_images_client(&self) -> community_gallery_images::Client {
         community_gallery_images::Client(self.clone())
     }
-    pub fn dedicated_host_groups(&self) -> dedicated_host_groups::Client {
+    pub fn dedicated_host_groups_client(&self) -> dedicated_host_groups::Client {
         dedicated_host_groups::Client(self.clone())
     }
-    pub fn dedicated_hosts(&self) -> dedicated_hosts::Client {
+    pub fn dedicated_hosts_client(&self) -> dedicated_hosts::Client {
         dedicated_hosts::Client(self.clone())
     }
-    pub fn disk_accesses(&self) -> disk_accesses::Client {
+    pub fn disk_accesses_client(&self) -> disk_accesses::Client {
         disk_accesses::Client(self.clone())
     }
-    pub fn disk_encryption_sets(&self) -> disk_encryption_sets::Client {
+    pub fn disk_encryption_sets_client(&self) -> disk_encryption_sets::Client {
         disk_encryption_sets::Client(self.clone())
     }
-    pub fn disk_restore_point(&self) -> disk_restore_point::Client {
+    pub fn disk_restore_point_client(&self) -> disk_restore_point::Client {
         disk_restore_point::Client(self.clone())
     }
-    pub fn disks(&self) -> disks::Client {
+    pub fn disks_client(&self) -> disks::Client {
         disks::Client(self.clone())
     }
-    pub fn galleries(&self) -> galleries::Client {
+    pub fn galleries_client(&self) -> galleries::Client {
         galleries::Client(self.clone())
     }
-    pub fn gallery_application_versions(&self) -> gallery_application_versions::Client {
+    pub fn gallery_application_versions_client(&self) -> gallery_application_versions::Client {
         gallery_application_versions::Client(self.clone())
     }
-    pub fn gallery_applications(&self) -> gallery_applications::Client {
+    pub fn gallery_applications_client(&self) -> gallery_applications::Client {
         gallery_applications::Client(self.clone())
     }
-    pub fn gallery_image_versions(&self) -> gallery_image_versions::Client {
+    pub fn gallery_image_versions_client(&self) -> gallery_image_versions::Client {
         gallery_image_versions::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn gallery_sharing_profile(&self) -> gallery_sharing_profile::Client {
+    pub fn gallery_sharing_profile_client(&self) -> gallery_sharing_profile::Client {
         gallery_sharing_profile::Client(self.clone())
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn log_analytics(&self) -> log_analytics::Client {
+    pub fn log_analytics_client(&self) -> log_analytics::Client {
         log_analytics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proximity_placement_groups(&self) -> proximity_placement_groups::Client {
+    pub fn proximity_placement_groups_client(&self) -> proximity_placement_groups::Client {
         proximity_placement_groups::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn restore_point_collections(&self) -> restore_point_collections::Client {
+    pub fn restore_point_collections_client(&self) -> restore_point_collections::Client {
         restore_point_collections::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn shared_galleries(&self) -> shared_galleries::Client {
+    pub fn shared_galleries_client(&self) -> shared_galleries::Client {
         shared_galleries::Client(self.clone())
     }
-    pub fn shared_gallery_image_versions(&self) -> shared_gallery_image_versions::Client {
+    pub fn shared_gallery_image_versions_client(&self) -> shared_gallery_image_versions::Client {
         shared_gallery_image_versions::Client(self.clone())
     }
-    pub fn shared_gallery_images(&self) -> shared_gallery_images::Client {
+    pub fn shared_gallery_images_client(&self) -> shared_gallery_images::Client {
         shared_gallery_images::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn ssh_public_keys(&self) -> ssh_public_keys::Client {
+    pub fn ssh_public_keys_client(&self) -> ssh_public_keys::Client {
         ssh_public_keys::Client(self.clone())
     }
-    pub fn usage(&self) -> usage::Client {
+    pub fn usage_client(&self) -> usage::Client {
         usage::Client(self.clone())
     }
-    pub fn virtual_machine_extension_images(&self) -> virtual_machine_extension_images::Client {
+    pub fn virtual_machine_extension_images_client(&self) -> virtual_machine_extension_images::Client {
         virtual_machine_extension_images::Client(self.clone())
     }
-    pub fn virtual_machine_extensions(&self) -> virtual_machine_extensions::Client {
+    pub fn virtual_machine_extensions_client(&self) -> virtual_machine_extensions::Client {
         virtual_machine_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_images(&self) -> virtual_machine_images::Client {
+    pub fn virtual_machine_images_client(&self) -> virtual_machine_images::Client {
         virtual_machine_images::Client(self.clone())
     }
-    pub fn virtual_machine_images_edge_zone(&self) -> virtual_machine_images_edge_zone::Client {
+    pub fn virtual_machine_images_edge_zone_client(&self) -> virtual_machine_images_edge_zone::Client {
         virtual_machine_images_edge_zone::Client(self.clone())
     }
-    pub fn virtual_machine_run_commands(&self) -> virtual_machine_run_commands::Client {
+    pub fn virtual_machine_run_commands_client(&self) -> virtual_machine_run_commands::Client {
         virtual_machine_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_extensions(&self) -> virtual_machine_scale_set_extensions::Client {
+    pub fn virtual_machine_scale_set_extensions_client(&self) -> virtual_machine_scale_set_extensions::Client {
         virtual_machine_scale_set_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_rolling_upgrades(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
+    pub fn virtual_machine_scale_set_rolling_upgrades_client(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
         virtual_machine_scale_set_rolling_upgrades::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_v_ms(&self) -> virtual_machine_scale_set_v_ms::Client {
+    pub fn virtual_machine_scale_set_v_ms_client(&self) -> virtual_machine_scale_set_v_ms::Client {
         virtual_machine_scale_set_v_ms::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_extensions(&self) -> virtual_machine_scale_set_vm_extensions::Client {
+    pub fn virtual_machine_scale_set_vm_extensions_client(&self) -> virtual_machine_scale_set_vm_extensions::Client {
         virtual_machine_scale_set_vm_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_run_commands(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
+    pub fn virtual_machine_scale_set_vm_run_commands_client(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
         virtual_machine_scale_set_vm_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_sets(&self) -> virtual_machine_scale_sets::Client {
+    pub fn virtual_machine_scale_sets_client(&self) -> virtual_machine_scale_sets::Client {
         virtual_machine_scale_sets::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/compute/src/package_2022_03_02/operations.rs
+++ b/services/mgmt/compute/src/package_2022_03_02/operations.rs
@@ -74,151 +74,151 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_sets(&self) -> availability_sets::Client {
+    pub fn availability_sets_client(&self) -> availability_sets::Client {
         availability_sets::Client(self.clone())
     }
-    pub fn capacity_reservation_groups(&self) -> capacity_reservation_groups::Client {
+    pub fn capacity_reservation_groups_client(&self) -> capacity_reservation_groups::Client {
         capacity_reservation_groups::Client(self.clone())
     }
-    pub fn capacity_reservations(&self) -> capacity_reservations::Client {
+    pub fn capacity_reservations_client(&self) -> capacity_reservations::Client {
         capacity_reservations::Client(self.clone())
     }
-    pub fn cloud_service_operating_systems(&self) -> cloud_service_operating_systems::Client {
+    pub fn cloud_service_operating_systems_client(&self) -> cloud_service_operating_systems::Client {
         cloud_service_operating_systems::Client(self.clone())
     }
-    pub fn cloud_service_role_instances(&self) -> cloud_service_role_instances::Client {
+    pub fn cloud_service_role_instances_client(&self) -> cloud_service_role_instances::Client {
         cloud_service_role_instances::Client(self.clone())
     }
-    pub fn cloud_service_roles(&self) -> cloud_service_roles::Client {
+    pub fn cloud_service_roles_client(&self) -> cloud_service_roles::Client {
         cloud_service_roles::Client(self.clone())
     }
-    pub fn cloud_services(&self) -> cloud_services::Client {
+    pub fn cloud_services_client(&self) -> cloud_services::Client {
         cloud_services::Client(self.clone())
     }
-    pub fn cloud_services_update_domain(&self) -> cloud_services_update_domain::Client {
+    pub fn cloud_services_update_domain_client(&self) -> cloud_services_update_domain::Client {
         cloud_services_update_domain::Client(self.clone())
     }
-    pub fn community_galleries(&self) -> community_galleries::Client {
+    pub fn community_galleries_client(&self) -> community_galleries::Client {
         community_galleries::Client(self.clone())
     }
-    pub fn community_gallery_image_versions(&self) -> community_gallery_image_versions::Client {
+    pub fn community_gallery_image_versions_client(&self) -> community_gallery_image_versions::Client {
         community_gallery_image_versions::Client(self.clone())
     }
-    pub fn community_gallery_images(&self) -> community_gallery_images::Client {
+    pub fn community_gallery_images_client(&self) -> community_gallery_images::Client {
         community_gallery_images::Client(self.clone())
     }
-    pub fn dedicated_host_groups(&self) -> dedicated_host_groups::Client {
+    pub fn dedicated_host_groups_client(&self) -> dedicated_host_groups::Client {
         dedicated_host_groups::Client(self.clone())
     }
-    pub fn dedicated_hosts(&self) -> dedicated_hosts::Client {
+    pub fn dedicated_hosts_client(&self) -> dedicated_hosts::Client {
         dedicated_hosts::Client(self.clone())
     }
-    pub fn disk_accesses(&self) -> disk_accesses::Client {
+    pub fn disk_accesses_client(&self) -> disk_accesses::Client {
         disk_accesses::Client(self.clone())
     }
-    pub fn disk_encryption_sets(&self) -> disk_encryption_sets::Client {
+    pub fn disk_encryption_sets_client(&self) -> disk_encryption_sets::Client {
         disk_encryption_sets::Client(self.clone())
     }
-    pub fn disk_restore_point(&self) -> disk_restore_point::Client {
+    pub fn disk_restore_point_client(&self) -> disk_restore_point::Client {
         disk_restore_point::Client(self.clone())
     }
-    pub fn disks(&self) -> disks::Client {
+    pub fn disks_client(&self) -> disks::Client {
         disks::Client(self.clone())
     }
-    pub fn galleries(&self) -> galleries::Client {
+    pub fn galleries_client(&self) -> galleries::Client {
         galleries::Client(self.clone())
     }
-    pub fn gallery_application_versions(&self) -> gallery_application_versions::Client {
+    pub fn gallery_application_versions_client(&self) -> gallery_application_versions::Client {
         gallery_application_versions::Client(self.clone())
     }
-    pub fn gallery_applications(&self) -> gallery_applications::Client {
+    pub fn gallery_applications_client(&self) -> gallery_applications::Client {
         gallery_applications::Client(self.clone())
     }
-    pub fn gallery_image_versions(&self) -> gallery_image_versions::Client {
+    pub fn gallery_image_versions_client(&self) -> gallery_image_versions::Client {
         gallery_image_versions::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn gallery_sharing_profile(&self) -> gallery_sharing_profile::Client {
+    pub fn gallery_sharing_profile_client(&self) -> gallery_sharing_profile::Client {
         gallery_sharing_profile::Client(self.clone())
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn log_analytics(&self) -> log_analytics::Client {
+    pub fn log_analytics_client(&self) -> log_analytics::Client {
         log_analytics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn proximity_placement_groups(&self) -> proximity_placement_groups::Client {
+    pub fn proximity_placement_groups_client(&self) -> proximity_placement_groups::Client {
         proximity_placement_groups::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn restore_point_collections(&self) -> restore_point_collections::Client {
+    pub fn restore_point_collections_client(&self) -> restore_point_collections::Client {
         restore_point_collections::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn shared_galleries(&self) -> shared_galleries::Client {
+    pub fn shared_galleries_client(&self) -> shared_galleries::Client {
         shared_galleries::Client(self.clone())
     }
-    pub fn shared_gallery_image_versions(&self) -> shared_gallery_image_versions::Client {
+    pub fn shared_gallery_image_versions_client(&self) -> shared_gallery_image_versions::Client {
         shared_gallery_image_versions::Client(self.clone())
     }
-    pub fn shared_gallery_images(&self) -> shared_gallery_images::Client {
+    pub fn shared_gallery_images_client(&self) -> shared_gallery_images::Client {
         shared_gallery_images::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn ssh_public_keys(&self) -> ssh_public_keys::Client {
+    pub fn ssh_public_keys_client(&self) -> ssh_public_keys::Client {
         ssh_public_keys::Client(self.clone())
     }
-    pub fn usage(&self) -> usage::Client {
+    pub fn usage_client(&self) -> usage::Client {
         usage::Client(self.clone())
     }
-    pub fn virtual_machine_extension_images(&self) -> virtual_machine_extension_images::Client {
+    pub fn virtual_machine_extension_images_client(&self) -> virtual_machine_extension_images::Client {
         virtual_machine_extension_images::Client(self.clone())
     }
-    pub fn virtual_machine_extensions(&self) -> virtual_machine_extensions::Client {
+    pub fn virtual_machine_extensions_client(&self) -> virtual_machine_extensions::Client {
         virtual_machine_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_images(&self) -> virtual_machine_images::Client {
+    pub fn virtual_machine_images_client(&self) -> virtual_machine_images::Client {
         virtual_machine_images::Client(self.clone())
     }
-    pub fn virtual_machine_images_edge_zone(&self) -> virtual_machine_images_edge_zone::Client {
+    pub fn virtual_machine_images_edge_zone_client(&self) -> virtual_machine_images_edge_zone::Client {
         virtual_machine_images_edge_zone::Client(self.clone())
     }
-    pub fn virtual_machine_run_commands(&self) -> virtual_machine_run_commands::Client {
+    pub fn virtual_machine_run_commands_client(&self) -> virtual_machine_run_commands::Client {
         virtual_machine_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_extensions(&self) -> virtual_machine_scale_set_extensions::Client {
+    pub fn virtual_machine_scale_set_extensions_client(&self) -> virtual_machine_scale_set_extensions::Client {
         virtual_machine_scale_set_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_rolling_upgrades(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
+    pub fn virtual_machine_scale_set_rolling_upgrades_client(&self) -> virtual_machine_scale_set_rolling_upgrades::Client {
         virtual_machine_scale_set_rolling_upgrades::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_v_ms(&self) -> virtual_machine_scale_set_v_ms::Client {
+    pub fn virtual_machine_scale_set_v_ms_client(&self) -> virtual_machine_scale_set_v_ms::Client {
         virtual_machine_scale_set_v_ms::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_extensions(&self) -> virtual_machine_scale_set_vm_extensions::Client {
+    pub fn virtual_machine_scale_set_vm_extensions_client(&self) -> virtual_machine_scale_set_vm_extensions::Client {
         virtual_machine_scale_set_vm_extensions::Client(self.clone())
     }
-    pub fn virtual_machine_scale_set_vm_run_commands(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
+    pub fn virtual_machine_scale_set_vm_run_commands_client(&self) -> virtual_machine_scale_set_vm_run_commands::Client {
         virtual_machine_scale_set_vm_run_commands::Client(self.clone())
     }
-    pub fn virtual_machine_scale_sets(&self) -> virtual_machine_scale_sets::Client {
+    pub fn virtual_machine_scale_sets_client(&self) -> virtual_machine_scale_sets::Client {
         virtual_machine_scale_sets::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/confidentialledger/src/package_2020_12_01_preview/operations.rs
+++ b/services/mgmt/confidentialledger/src/package_2020_12_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn ledger(&self) -> ledger::Client {
+    pub fn ledger_client(&self) -> ledger::Client {
         ledger::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/confidentialledger/src/package_2021_05_13_preview/operations.rs
+++ b/services/mgmt/confidentialledger/src/package_2021_05_13_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn ledger(&self) -> ledger::Client {
+    pub fn ledger_client(&self) -> ledger::Client {
         ledger::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/confidentialledger/src/package_2022_05_13/operations.rs
+++ b/services/mgmt/confidentialledger/src/package_2022_05_13/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn ledger(&self) -> ledger::Client {
+    pub fn ledger_client(&self) -> ledger::Client {
         ledger::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/confluent/src/package_2020_03_01/operations.rs
+++ b/services/mgmt/confluent/src/package_2020_03_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn organization(&self) -> organization::Client {
+    pub fn organization_client(&self) -> organization::Client {
         organization::Client(self.clone())
     }
-    pub fn organization_operations(&self) -> organization_operations::Client {
+    pub fn organization_operations_client(&self) -> organization_operations::Client {
         organization_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/confluent/src/package_2020_03_01_preview/operations.rs
+++ b/services/mgmt/confluent/src/package_2020_03_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn organization(&self) -> organization::Client {
+    pub fn organization_client(&self) -> organization::Client {
         organization::Client(self.clone())
     }
-    pub fn organization_operations(&self) -> organization_operations::Client {
+    pub fn organization_operations_client(&self) -> organization_operations::Client {
         organization_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/confluent/src/package_2021_03_01_preview/operations.rs
+++ b/services/mgmt/confluent/src/package_2021_03_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn organization(&self) -> organization::Client {
+    pub fn organization_client(&self) -> organization::Client {
         organization::Client(self.clone())
     }
-    pub fn organization_operations(&self) -> organization_operations::Client {
+    pub fn organization_operations_client(&self) -> organization_operations::Client {
         organization_operations::Client(self.clone())
     }
-    pub fn validations(&self) -> validations::Client {
+    pub fn validations_client(&self) -> validations::Client {
         validations::Client(self.clone())
     }
 }

--- a/services/mgmt/confluent/src/package_2021_12_01/operations.rs
+++ b/services/mgmt/confluent/src/package_2021_12_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn organization(&self) -> organization::Client {
+    pub fn organization_client(&self) -> organization::Client {
         organization::Client(self.clone())
     }
-    pub fn organization_operations(&self) -> organization_operations::Client {
+    pub fn organization_operations_client(&self) -> organization_operations::Client {
         organization_operations::Client(self.clone())
     }
-    pub fn validations(&self) -> validations::Client {
+    pub fn validations_client(&self) -> validations::Client {
         validations::Client(self.clone())
     }
 }

--- a/services/mgmt/confluent/src/package_preview_2021_09/operations.rs
+++ b/services/mgmt/confluent/src/package_preview_2021_09/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn organization(&self) -> organization::Client {
+    pub fn organization_client(&self) -> organization::Client {
         organization::Client(self.clone())
     }
-    pub fn organization_operations(&self) -> organization_operations::Client {
+    pub fn organization_operations_client(&self) -> organization_operations::Client {
         organization_operations::Client(self.clone())
     }
-    pub fn validations(&self) -> validations::Client {
+    pub fn validations_client(&self) -> validations::Client {
         validations::Client(self.clone())
     }
 }

--- a/services/mgmt/connectedvmware/src/package_2020_10_01_preview/operations.rs
+++ b/services/mgmt/connectedvmware/src/package_2020_10_01_preview/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn datastores(&self) -> datastores::Client {
+    pub fn datastores_client(&self) -> datastores::Client {
         datastores::Client(self.clone())
     }
-    pub fn guest_agents(&self) -> guest_agents::Client {
+    pub fn guest_agents_client(&self) -> guest_agents::Client {
         guest_agents::Client(self.clone())
     }
-    pub fn hosts(&self) -> hosts::Client {
+    pub fn hosts_client(&self) -> hosts::Client {
         hosts::Client(self.clone())
     }
-    pub fn hybrid_identity_metadata(&self) -> hybrid_identity_metadata::Client {
+    pub fn hybrid_identity_metadata_client(&self) -> hybrid_identity_metadata::Client {
         hybrid_identity_metadata::Client(self.clone())
     }
-    pub fn inventory_items(&self) -> inventory_items::Client {
+    pub fn inventory_items_client(&self) -> inventory_items::Client {
         inventory_items::Client(self.clone())
     }
-    pub fn machine_extensions(&self) -> machine_extensions::Client {
+    pub fn machine_extensions_client(&self) -> machine_extensions::Client {
         machine_extensions::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn resource_pools(&self) -> resource_pools::Client {
+    pub fn resource_pools_client(&self) -> resource_pools::Client {
         resource_pools::Client(self.clone())
     }
-    pub fn v_centers(&self) -> v_centers::Client {
+    pub fn v_centers_client(&self) -> v_centers::Client {
         v_centers::Client(self.clone())
     }
-    pub fn virtual_machine_templates(&self) -> virtual_machine_templates::Client {
+    pub fn virtual_machine_templates_client(&self) -> virtual_machine_templates::Client {
         virtual_machine_templates::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
-    pub fn virtual_networks(&self) -> virtual_networks::Client {
+    pub fn virtual_networks_client(&self) -> virtual_networks::Client {
         virtual_networks::Client(self.clone())
     }
 }

--- a/services/mgmt/consumption/src/package_2019_10/operations.rs
+++ b/services/mgmt/consumption/src/package_2019_10/operations.rs
@@ -74,58 +74,58 @@ impl Client {
             pipeline,
         }
     }
-    pub fn aggregated_cost(&self) -> aggregated_cost::Client {
+    pub fn aggregated_cost_client(&self) -> aggregated_cost::Client {
         aggregated_cost::Client(self.clone())
     }
-    pub fn balances(&self) -> balances::Client {
+    pub fn balances_client(&self) -> balances::Client {
         balances::Client(self.clone())
     }
-    pub fn budgets(&self) -> budgets::Client {
+    pub fn budgets_client(&self) -> budgets::Client {
         budgets::Client(self.clone())
     }
-    pub fn charges(&self) -> charges::Client {
+    pub fn charges_client(&self) -> charges::Client {
         charges::Client(self.clone())
     }
-    pub fn credits(&self) -> credits::Client {
+    pub fn credits_client(&self) -> credits::Client {
         credits::Client(self.clone())
     }
-    pub fn events(&self) -> events::Client {
+    pub fn events_client(&self) -> events::Client {
         events::Client(self.clone())
     }
-    pub fn forecasts(&self) -> forecasts::Client {
+    pub fn forecasts_client(&self) -> forecasts::Client {
         forecasts::Client(self.clone())
     }
-    pub fn lots(&self) -> lots::Client {
+    pub fn lots_client(&self) -> lots::Client {
         lots::Client(self.clone())
     }
-    pub fn marketplaces(&self) -> marketplaces::Client {
+    pub fn marketplaces_client(&self) -> marketplaces::Client {
         marketplaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn price_sheet(&self) -> price_sheet::Client {
+    pub fn price_sheet_client(&self) -> price_sheet::Client {
         price_sheet::Client(self.clone())
     }
-    pub fn reservation_recommendation_details(&self) -> reservation_recommendation_details::Client {
+    pub fn reservation_recommendation_details_client(&self) -> reservation_recommendation_details::Client {
         reservation_recommendation_details::Client(self.clone())
     }
-    pub fn reservation_recommendations(&self) -> reservation_recommendations::Client {
+    pub fn reservation_recommendations_client(&self) -> reservation_recommendations::Client {
         reservation_recommendations::Client(self.clone())
     }
-    pub fn reservation_transactions(&self) -> reservation_transactions::Client {
+    pub fn reservation_transactions_client(&self) -> reservation_transactions::Client {
         reservation_transactions::Client(self.clone())
     }
-    pub fn reservations_details(&self) -> reservations_details::Client {
+    pub fn reservations_details_client(&self) -> reservations_details::Client {
         reservations_details::Client(self.clone())
     }
-    pub fn reservations_summaries(&self) -> reservations_summaries::Client {
+    pub fn reservations_summaries_client(&self) -> reservations_summaries::Client {
         reservations_summaries::Client(self.clone())
     }
-    pub fn tags(&self) -> tags::Client {
+    pub fn tags_client(&self) -> tags::Client {
         tags::Client(self.clone())
     }
-    pub fn usage_details(&self) -> usage_details::Client {
+    pub fn usage_details_client(&self) -> usage_details::Client {
         usage_details::Client(self.clone())
     }
 }

--- a/services/mgmt/consumption/src/package_2021_10/operations.rs
+++ b/services/mgmt/consumption/src/package_2021_10/operations.rs
@@ -74,55 +74,55 @@ impl Client {
             pipeline,
         }
     }
-    pub fn aggregated_cost(&self) -> aggregated_cost::Client {
+    pub fn aggregated_cost_client(&self) -> aggregated_cost::Client {
         aggregated_cost::Client(self.clone())
     }
-    pub fn balances(&self) -> balances::Client {
+    pub fn balances_client(&self) -> balances::Client {
         balances::Client(self.clone())
     }
-    pub fn budgets(&self) -> budgets::Client {
+    pub fn budgets_client(&self) -> budgets::Client {
         budgets::Client(self.clone())
     }
-    pub fn charges(&self) -> charges::Client {
+    pub fn charges_client(&self) -> charges::Client {
         charges::Client(self.clone())
     }
-    pub fn credits(&self) -> credits::Client {
+    pub fn credits_client(&self) -> credits::Client {
         credits::Client(self.clone())
     }
-    pub fn events(&self) -> events::Client {
+    pub fn events_client(&self) -> events::Client {
         events::Client(self.clone())
     }
-    pub fn lots(&self) -> lots::Client {
+    pub fn lots_client(&self) -> lots::Client {
         lots::Client(self.clone())
     }
-    pub fn marketplaces(&self) -> marketplaces::Client {
+    pub fn marketplaces_client(&self) -> marketplaces::Client {
         marketplaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn price_sheet(&self) -> price_sheet::Client {
+    pub fn price_sheet_client(&self) -> price_sheet::Client {
         price_sheet::Client(self.clone())
     }
-    pub fn reservation_recommendation_details(&self) -> reservation_recommendation_details::Client {
+    pub fn reservation_recommendation_details_client(&self) -> reservation_recommendation_details::Client {
         reservation_recommendation_details::Client(self.clone())
     }
-    pub fn reservation_recommendations(&self) -> reservation_recommendations::Client {
+    pub fn reservation_recommendations_client(&self) -> reservation_recommendations::Client {
         reservation_recommendations::Client(self.clone())
     }
-    pub fn reservation_transactions(&self) -> reservation_transactions::Client {
+    pub fn reservation_transactions_client(&self) -> reservation_transactions::Client {
         reservation_transactions::Client(self.clone())
     }
-    pub fn reservations_details(&self) -> reservations_details::Client {
+    pub fn reservations_details_client(&self) -> reservations_details::Client {
         reservations_details::Client(self.clone())
     }
-    pub fn reservations_summaries(&self) -> reservations_summaries::Client {
+    pub fn reservations_summaries_client(&self) -> reservations_summaries::Client {
         reservations_summaries::Client(self.clone())
     }
-    pub fn tags(&self) -> tags::Client {
+    pub fn tags_client(&self) -> tags::Client {
         tags::Client(self.clone())
     }
-    pub fn usage_details(&self) -> usage_details::Client {
+    pub fn usage_details_client(&self) -> usage_details::Client {
         usage_details::Client(self.clone())
     }
 }

--- a/services/mgmt/consumption/src/package_preview_2018_11/operations.rs
+++ b/services/mgmt/consumption/src/package_preview_2018_11/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn billing_profile_pricesheet(&self) -> billing_profile_pricesheet::Client {
+    pub fn billing_profile_pricesheet_client(&self) -> billing_profile_pricesheet::Client {
         billing_profile_pricesheet::Client(self.clone())
     }
-    pub fn charges_by_billing_account(&self) -> charges_by_billing_account::Client {
+    pub fn charges_by_billing_account_client(&self) -> charges_by_billing_account::Client {
         charges_by_billing_account::Client(self.clone())
     }
-    pub fn charges_by_billing_profile(&self) -> charges_by_billing_profile::Client {
+    pub fn charges_by_billing_profile_client(&self) -> charges_by_billing_profile::Client {
         charges_by_billing_profile::Client(self.clone())
     }
-    pub fn charges_by_invoice_section(&self) -> charges_by_invoice_section::Client {
+    pub fn charges_by_invoice_section_client(&self) -> charges_by_invoice_section::Client {
         charges_by_invoice_section::Client(self.clone())
     }
-    pub fn credit_summary_by_billing_profile(&self) -> credit_summary_by_billing_profile::Client {
+    pub fn credit_summary_by_billing_profile_client(&self) -> credit_summary_by_billing_profile::Client {
         credit_summary_by_billing_profile::Client(self.clone())
     }
-    pub fn events_by_billing_profile(&self) -> events_by_billing_profile::Client {
+    pub fn events_by_billing_profile_client(&self) -> events_by_billing_profile::Client {
         events_by_billing_profile::Client(self.clone())
     }
-    pub fn invoice_pricesheet(&self) -> invoice_pricesheet::Client {
+    pub fn invoice_pricesheet_client(&self) -> invoice_pricesheet::Client {
         invoice_pricesheet::Client(self.clone())
     }
-    pub fn lots_by_billing_profile(&self) -> lots_by_billing_profile::Client {
+    pub fn lots_by_billing_profile_client(&self) -> lots_by_billing_profile::Client {
         lots_by_billing_profile::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/consumption/src/package_preview_2019_04/operations.rs
+++ b/services/mgmt/consumption/src/package_preview_2019_04/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn aggregated_cost(&self) -> aggregated_cost::Client {
+    pub fn aggregated_cost_client(&self) -> aggregated_cost::Client {
         aggregated_cost::Client(self.clone())
     }
-    pub fn balances(&self) -> balances::Client {
+    pub fn balances_client(&self) -> balances::Client {
         balances::Client(self.clone())
     }
-    pub fn budgets(&self) -> budgets::Client {
+    pub fn budgets_client(&self) -> budgets::Client {
         budgets::Client(self.clone())
     }
-    pub fn charges(&self) -> charges::Client {
+    pub fn charges_client(&self) -> charges::Client {
         charges::Client(self.clone())
     }
-    pub fn forecasts(&self) -> forecasts::Client {
+    pub fn forecasts_client(&self) -> forecasts::Client {
         forecasts::Client(self.clone())
     }
-    pub fn marketplaces(&self) -> marketplaces::Client {
+    pub fn marketplaces_client(&self) -> marketplaces::Client {
         marketplaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn price_sheet(&self) -> price_sheet::Client {
+    pub fn price_sheet_client(&self) -> price_sheet::Client {
         price_sheet::Client(self.clone())
     }
-    pub fn reservation_recommendations(&self) -> reservation_recommendations::Client {
+    pub fn reservation_recommendations_client(&self) -> reservation_recommendations::Client {
         reservation_recommendations::Client(self.clone())
     }
-    pub fn reservations_details(&self) -> reservations_details::Client {
+    pub fn reservations_details_client(&self) -> reservations_details::Client {
         reservations_details::Client(self.clone())
     }
-    pub fn reservations_summaries(&self) -> reservations_summaries::Client {
+    pub fn reservations_summaries_client(&self) -> reservations_summaries::Client {
         reservations_summaries::Client(self.clone())
     }
-    pub fn tags(&self) -> tags::Client {
+    pub fn tags_client(&self) -> tags::Client {
         tags::Client(self.clone())
     }
-    pub fn usage_details(&self) -> usage_details::Client {
+    pub fn usage_details_client(&self) -> usage_details::Client {
         usage_details::Client(self.clone())
     }
 }

--- a/services/mgmt/consumption/src/package_preview_2019_05/operations.rs
+++ b/services/mgmt/consumption/src/package_preview_2019_05/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn aggregated_cost(&self) -> aggregated_cost::Client {
+    pub fn aggregated_cost_client(&self) -> aggregated_cost::Client {
         aggregated_cost::Client(self.clone())
     }
-    pub fn balances(&self) -> balances::Client {
+    pub fn balances_client(&self) -> balances::Client {
         balances::Client(self.clone())
     }
-    pub fn budgets(&self) -> budgets::Client {
+    pub fn budgets_client(&self) -> budgets::Client {
         budgets::Client(self.clone())
     }
-    pub fn charges(&self) -> charges::Client {
+    pub fn charges_client(&self) -> charges::Client {
         charges::Client(self.clone())
     }
-    pub fn forecasts(&self) -> forecasts::Client {
+    pub fn forecasts_client(&self) -> forecasts::Client {
         forecasts::Client(self.clone())
     }
-    pub fn marketplaces(&self) -> marketplaces::Client {
+    pub fn marketplaces_client(&self) -> marketplaces::Client {
         marketplaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn price_sheet(&self) -> price_sheet::Client {
+    pub fn price_sheet_client(&self) -> price_sheet::Client {
         price_sheet::Client(self.clone())
     }
-    pub fn reservation_recommendations(&self) -> reservation_recommendations::Client {
+    pub fn reservation_recommendations_client(&self) -> reservation_recommendations::Client {
         reservation_recommendations::Client(self.clone())
     }
-    pub fn reservations_details(&self) -> reservations_details::Client {
+    pub fn reservations_details_client(&self) -> reservations_details::Client {
         reservations_details::Client(self.clone())
     }
-    pub fn reservations_summaries(&self) -> reservations_summaries::Client {
+    pub fn reservations_summaries_client(&self) -> reservations_summaries::Client {
         reservations_summaries::Client(self.clone())
     }
-    pub fn tags(&self) -> tags::Client {
+    pub fn tags_client(&self) -> tags::Client {
         tags::Client(self.clone())
     }
-    pub fn usage_details(&self) -> usage_details::Client {
+    pub fn usage_details_client(&self) -> usage_details::Client {
         usage_details::Client(self.clone())
     }
 }

--- a/services/mgmt/containerinstance/src/package_2020_11/operations.rs
+++ b/services/mgmt/containerinstance/src/package_2020_11/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn container_groups(&self) -> container_groups::Client {
+    pub fn container_groups_client(&self) -> container_groups::Client {
         container_groups::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/containerinstance/src/package_2021_03/operations.rs
+++ b/services/mgmt/containerinstance/src/package_2021_03/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn container_groups(&self) -> container_groups::Client {
+    pub fn container_groups_client(&self) -> container_groups::Client {
         container_groups::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/containerinstance/src/package_2021_07/operations.rs
+++ b/services/mgmt/containerinstance/src/package_2021_07/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn container_groups(&self) -> container_groups::Client {
+    pub fn container_groups_client(&self) -> container_groups::Client {
         container_groups::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/containerinstance/src/package_2021_09/operations.rs
+++ b/services/mgmt/containerinstance/src/package_2021_09/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn container_groups(&self) -> container_groups::Client {
+    pub fn container_groups_client(&self) -> container_groups::Client {
         container_groups::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/containerinstance/src/package_2021_10/operations.rs
+++ b/services/mgmt/containerinstance/src/package_2021_10/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn container_groups(&self) -> container_groups::Client {
+    pub fn container_groups_client(&self) -> container_groups::Client {
         container_groups::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/containerregistry/src/package_2021_06_preview/operations.rs
+++ b/services/mgmt/containerregistry/src/package_2021_06_preview/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn connected_registries(&self) -> connected_registries::Client {
+    pub fn connected_registries_client(&self) -> connected_registries::Client {
         connected_registries::Client(self.clone())
     }
-    pub fn export_pipelines(&self) -> export_pipelines::Client {
+    pub fn export_pipelines_client(&self) -> export_pipelines::Client {
         export_pipelines::Client(self.clone())
     }
-    pub fn import_pipelines(&self) -> import_pipelines::Client {
+    pub fn import_pipelines_client(&self) -> import_pipelines::Client {
         import_pipelines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_runs(&self) -> pipeline_runs::Client {
+    pub fn pipeline_runs_client(&self) -> pipeline_runs::Client {
         pipeline_runs::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn registries(&self) -> registries::Client {
+    pub fn registries_client(&self) -> registries::Client {
         registries::Client(self.clone())
     }
-    pub fn replications(&self) -> replications::Client {
+    pub fn replications_client(&self) -> replications::Client {
         replications::Client(self.clone())
     }
-    pub fn runs(&self) -> runs::Client {
+    pub fn runs_client(&self) -> runs::Client {
         runs::Client(self.clone())
     }
-    pub fn scope_maps(&self) -> scope_maps::Client {
+    pub fn scope_maps_client(&self) -> scope_maps::Client {
         scope_maps::Client(self.clone())
     }
-    pub fn task_runs(&self) -> task_runs::Client {
+    pub fn task_runs_client(&self) -> task_runs::Client {
         task_runs::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn tokens(&self) -> tokens::Client {
+    pub fn tokens_client(&self) -> tokens::Client {
         tokens::Client(self.clone())
     }
-    pub fn webhooks(&self) -> webhooks::Client {
+    pub fn webhooks_client(&self) -> webhooks::Client {
         webhooks::Client(self.clone())
     }
 }

--- a/services/mgmt/containerregistry/src/package_2021_08_preview/operations.rs
+++ b/services/mgmt/containerregistry/src/package_2021_08_preview/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn connected_registries(&self) -> connected_registries::Client {
+    pub fn connected_registries_client(&self) -> connected_registries::Client {
         connected_registries::Client(self.clone())
     }
-    pub fn export_pipelines(&self) -> export_pipelines::Client {
+    pub fn export_pipelines_client(&self) -> export_pipelines::Client {
         export_pipelines::Client(self.clone())
     }
-    pub fn import_pipelines(&self) -> import_pipelines::Client {
+    pub fn import_pipelines_client(&self) -> import_pipelines::Client {
         import_pipelines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_runs(&self) -> pipeline_runs::Client {
+    pub fn pipeline_runs_client(&self) -> pipeline_runs::Client {
         pipeline_runs::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn registries(&self) -> registries::Client {
+    pub fn registries_client(&self) -> registries::Client {
         registries::Client(self.clone())
     }
-    pub fn replications(&self) -> replications::Client {
+    pub fn replications_client(&self) -> replications::Client {
         replications::Client(self.clone())
     }
-    pub fn runs(&self) -> runs::Client {
+    pub fn runs_client(&self) -> runs::Client {
         runs::Client(self.clone())
     }
-    pub fn scope_maps(&self) -> scope_maps::Client {
+    pub fn scope_maps_client(&self) -> scope_maps::Client {
         scope_maps::Client(self.clone())
     }
-    pub fn task_runs(&self) -> task_runs::Client {
+    pub fn task_runs_client(&self) -> task_runs::Client {
         task_runs::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn tokens(&self) -> tokens::Client {
+    pub fn tokens_client(&self) -> tokens::Client {
         tokens::Client(self.clone())
     }
-    pub fn webhooks(&self) -> webhooks::Client {
+    pub fn webhooks_client(&self) -> webhooks::Client {
         webhooks::Client(self.clone())
     }
 }

--- a/services/mgmt/containerregistry/src/package_2021_09/operations.rs
+++ b/services/mgmt/containerregistry/src/package_2021_09/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn registries(&self) -> registries::Client {
+    pub fn registries_client(&self) -> registries::Client {
         registries::Client(self.clone())
     }
-    pub fn replications(&self) -> replications::Client {
+    pub fn replications_client(&self) -> replications::Client {
         replications::Client(self.clone())
     }
-    pub fn runs(&self) -> runs::Client {
+    pub fn runs_client(&self) -> runs::Client {
         runs::Client(self.clone())
     }
-    pub fn task_runs(&self) -> task_runs::Client {
+    pub fn task_runs_client(&self) -> task_runs::Client {
         task_runs::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn webhooks(&self) -> webhooks::Client {
+    pub fn webhooks_client(&self) -> webhooks::Client {
         webhooks::Client(self.clone())
     }
 }

--- a/services/mgmt/containerregistry/src/package_2021_12_preview/operations.rs
+++ b/services/mgmt/containerregistry/src/package_2021_12_preview/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn connected_registries(&self) -> connected_registries::Client {
+    pub fn connected_registries_client(&self) -> connected_registries::Client {
         connected_registries::Client(self.clone())
     }
-    pub fn export_pipelines(&self) -> export_pipelines::Client {
+    pub fn export_pipelines_client(&self) -> export_pipelines::Client {
         export_pipelines::Client(self.clone())
     }
-    pub fn import_pipelines(&self) -> import_pipelines::Client {
+    pub fn import_pipelines_client(&self) -> import_pipelines::Client {
         import_pipelines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_runs(&self) -> pipeline_runs::Client {
+    pub fn pipeline_runs_client(&self) -> pipeline_runs::Client {
         pipeline_runs::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn registries(&self) -> registries::Client {
+    pub fn registries_client(&self) -> registries::Client {
         registries::Client(self.clone())
     }
-    pub fn replications(&self) -> replications::Client {
+    pub fn replications_client(&self) -> replications::Client {
         replications::Client(self.clone())
     }
-    pub fn runs(&self) -> runs::Client {
+    pub fn runs_client(&self) -> runs::Client {
         runs::Client(self.clone())
     }
-    pub fn scope_maps(&self) -> scope_maps::Client {
+    pub fn scope_maps_client(&self) -> scope_maps::Client {
         scope_maps::Client(self.clone())
     }
-    pub fn task_runs(&self) -> task_runs::Client {
+    pub fn task_runs_client(&self) -> task_runs::Client {
         task_runs::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn tokens(&self) -> tokens::Client {
+    pub fn tokens_client(&self) -> tokens::Client {
         tokens::Client(self.clone())
     }
-    pub fn webhooks(&self) -> webhooks::Client {
+    pub fn webhooks_client(&self) -> webhooks::Client {
         webhooks::Client(self.clone())
     }
 }

--- a/services/mgmt/containerregistry/src/package_2022_02_preview/operations.rs
+++ b/services/mgmt/containerregistry/src/package_2022_02_preview/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn connected_registries(&self) -> connected_registries::Client {
+    pub fn connected_registries_client(&self) -> connected_registries::Client {
         connected_registries::Client(self.clone())
     }
-    pub fn export_pipelines(&self) -> export_pipelines::Client {
+    pub fn export_pipelines_client(&self) -> export_pipelines::Client {
         export_pipelines::Client(self.clone())
     }
-    pub fn import_pipelines(&self) -> import_pipelines::Client {
+    pub fn import_pipelines_client(&self) -> import_pipelines::Client {
         import_pipelines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_runs(&self) -> pipeline_runs::Client {
+    pub fn pipeline_runs_client(&self) -> pipeline_runs::Client {
         pipeline_runs::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn registries(&self) -> registries::Client {
+    pub fn registries_client(&self) -> registries::Client {
         registries::Client(self.clone())
     }
-    pub fn replications(&self) -> replications::Client {
+    pub fn replications_client(&self) -> replications::Client {
         replications::Client(self.clone())
     }
-    pub fn runs(&self) -> runs::Client {
+    pub fn runs_client(&self) -> runs::Client {
         runs::Client(self.clone())
     }
-    pub fn scope_maps(&self) -> scope_maps::Client {
+    pub fn scope_maps_client(&self) -> scope_maps::Client {
         scope_maps::Client(self.clone())
     }
-    pub fn task_runs(&self) -> task_runs::Client {
+    pub fn task_runs_client(&self) -> task_runs::Client {
         task_runs::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn tokens(&self) -> tokens::Client {
+    pub fn tokens_client(&self) -> tokens::Client {
         tokens::Client(self.clone())
     }
-    pub fn webhooks(&self) -> webhooks::Client {
+    pub fn webhooks_client(&self) -> webhooks::Client {
         webhooks::Client(self.clone())
     }
 }

--- a/services/mgmt/containerservice/src/package_preview_2022_02/operations.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_02/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn managed_cluster_snapshots(&self) -> managed_cluster_snapshots::Client {
+    pub fn managed_cluster_snapshots_client(&self) -> managed_cluster_snapshots::Client {
         managed_cluster_snapshots::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resolve_private_link_service_id(&self) -> resolve_private_link_service_id::Client {
+    pub fn resolve_private_link_service_id_client(&self) -> resolve_private_link_service_id::Client {
         resolve_private_link_service_id::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
 }

--- a/services/mgmt/containerservice/src/package_preview_2022_03/operations.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_03/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn managed_cluster_snapshots(&self) -> managed_cluster_snapshots::Client {
+    pub fn managed_cluster_snapshots_client(&self) -> managed_cluster_snapshots::Client {
         managed_cluster_snapshots::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resolve_private_link_service_id(&self) -> resolve_private_link_service_id::Client {
+    pub fn resolve_private_link_service_id_client(&self) -> resolve_private_link_service_id::Client {
         resolve_private_link_service_id::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
 }

--- a/services/mgmt/containerservice/src/package_preview_2022_04/operations.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_04/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn managed_cluster_snapshots(&self) -> managed_cluster_snapshots::Client {
+    pub fn managed_cluster_snapshots_client(&self) -> managed_cluster_snapshots::Client {
         managed_cluster_snapshots::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resolve_private_link_service_id(&self) -> resolve_private_link_service_id::Client {
+    pub fn resolve_private_link_service_id_client(&self) -> resolve_private_link_service_id::Client {
         resolve_private_link_service_id::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn trusted_access_role_bindings(&self) -> trusted_access_role_bindings::Client {
+    pub fn trusted_access_role_bindings_client(&self) -> trusted_access_role_bindings::Client {
         trusted_access_role_bindings::Client(self.clone())
     }
-    pub fn trusted_access_roles(&self) -> trusted_access_roles::Client {
+    pub fn trusted_access_roles_client(&self) -> trusted_access_roles::Client {
         trusted_access_roles::Client(self.clone())
     }
 }

--- a/services/mgmt/containerservice/src/package_preview_2022_05/operations.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_05/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn managed_cluster_snapshots(&self) -> managed_cluster_snapshots::Client {
+    pub fn managed_cluster_snapshots_client(&self) -> managed_cluster_snapshots::Client {
         managed_cluster_snapshots::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resolve_private_link_service_id(&self) -> resolve_private_link_service_id::Client {
+    pub fn resolve_private_link_service_id_client(&self) -> resolve_private_link_service_id::Client {
         resolve_private_link_service_id::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn trusted_access_role_bindings(&self) -> trusted_access_role_bindings::Client {
+    pub fn trusted_access_role_bindings_client(&self) -> trusted_access_role_bindings::Client {
         trusted_access_role_bindings::Client(self.clone())
     }
-    pub fn trusted_access_roles(&self) -> trusted_access_roles::Client {
+    pub fn trusted_access_roles_client(&self) -> trusted_access_roles::Client {
         trusted_access_roles::Client(self.clone())
     }
 }

--- a/services/mgmt/containerservice/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/containerservice/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn agent_pools(&self) -> agent_pools::Client {
+    pub fn agent_pools_client(&self) -> agent_pools::Client {
         agent_pools::Client(self.clone())
     }
-    pub fn container_services(&self) -> container_services::Client {
+    pub fn container_services_client(&self) -> container_services::Client {
         container_services::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resolve_private_link_service_id(&self) -> resolve_private_link_service_id::Client {
+    pub fn resolve_private_link_service_id_client(&self) -> resolve_private_link_service_id::Client {
         resolve_private_link_service_id::Client(self.clone())
     }
 }

--- a/services/mgmt/cosmosdb/src/package_2021_10/operations.rs
+++ b/services/mgmt/cosmosdb/src/package_2021_10/operations.rs
@@ -74,97 +74,97 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cassandra_clusters(&self) -> cassandra_clusters::Client {
+    pub fn cassandra_clusters_client(&self) -> cassandra_clusters::Client {
         cassandra_clusters::Client(self.clone())
     }
-    pub fn cassandra_data_centers(&self) -> cassandra_data_centers::Client {
+    pub fn cassandra_data_centers_client(&self) -> cassandra_data_centers::Client {
         cassandra_data_centers::Client(self.clone())
     }
-    pub fn cassandra_resources(&self) -> cassandra_resources::Client {
+    pub fn cassandra_resources_client(&self) -> cassandra_resources::Client {
         cassandra_resources::Client(self.clone())
     }
-    pub fn collection(&self) -> collection::Client {
+    pub fn collection_client(&self) -> collection::Client {
         collection::Client(self.clone())
     }
-    pub fn collection_partition(&self) -> collection_partition::Client {
+    pub fn collection_partition_client(&self) -> collection_partition::Client {
         collection_partition::Client(self.clone())
     }
-    pub fn collection_partition_region(&self) -> collection_partition_region::Client {
+    pub fn collection_partition_region_client(&self) -> collection_partition_region::Client {
         collection_partition_region::Client(self.clone())
     }
-    pub fn collection_region(&self) -> collection_region::Client {
+    pub fn collection_region_client(&self) -> collection_region::Client {
         collection_region::Client(self.clone())
     }
-    pub fn database(&self) -> database::Client {
+    pub fn database_client(&self) -> database::Client {
         database::Client(self.clone())
     }
-    pub fn database_account_region(&self) -> database_account_region::Client {
+    pub fn database_account_region_client(&self) -> database_account_region::Client {
         database_account_region::Client(self.clone())
     }
-    pub fn database_accounts(&self) -> database_accounts::Client {
+    pub fn database_accounts_client(&self) -> database_accounts::Client {
         database_accounts::Client(self.clone())
     }
-    pub fn gremlin_resources(&self) -> gremlin_resources::Client {
+    pub fn gremlin_resources_client(&self) -> gremlin_resources::Client {
         gremlin_resources::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mongo_db_resources(&self) -> mongo_db_resources::Client {
+    pub fn mongo_db_resources_client(&self) -> mongo_db_resources::Client {
         mongo_db_resources::Client(self.clone())
     }
-    pub fn notebook_workspaces(&self) -> notebook_workspaces::Client {
+    pub fn notebook_workspaces_client(&self) -> notebook_workspaces::Client {
         notebook_workspaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn partition_key_range_id(&self) -> partition_key_range_id::Client {
+    pub fn partition_key_range_id_client(&self) -> partition_key_range_id::Client {
         partition_key_range_id::Client(self.clone())
     }
-    pub fn partition_key_range_id_region(&self) -> partition_key_range_id_region::Client {
+    pub fn partition_key_range_id_region_client(&self) -> partition_key_range_id_region::Client {
         partition_key_range_id_region::Client(self.clone())
     }
-    pub fn percentile(&self) -> percentile::Client {
+    pub fn percentile_client(&self) -> percentile::Client {
         percentile::Client(self.clone())
     }
-    pub fn percentile_source_target(&self) -> percentile_source_target::Client {
+    pub fn percentile_source_target_client(&self) -> percentile_source_target::Client {
         percentile_source_target::Client(self.clone())
     }
-    pub fn percentile_target(&self) -> percentile_target::Client {
+    pub fn percentile_target_client(&self) -> percentile_target::Client {
         percentile_target::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_database_accounts(&self) -> restorable_database_accounts::Client {
+    pub fn restorable_database_accounts_client(&self) -> restorable_database_accounts::Client {
         restorable_database_accounts::Client(self.clone())
     }
-    pub fn restorable_mongodb_collections(&self) -> restorable_mongodb_collections::Client {
+    pub fn restorable_mongodb_collections_client(&self) -> restorable_mongodb_collections::Client {
         restorable_mongodb_collections::Client(self.clone())
     }
-    pub fn restorable_mongodb_databases(&self) -> restorable_mongodb_databases::Client {
+    pub fn restorable_mongodb_databases_client(&self) -> restorable_mongodb_databases::Client {
         restorable_mongodb_databases::Client(self.clone())
     }
-    pub fn restorable_mongodb_resources(&self) -> restorable_mongodb_resources::Client {
+    pub fn restorable_mongodb_resources_client(&self) -> restorable_mongodb_resources::Client {
         restorable_mongodb_resources::Client(self.clone())
     }
-    pub fn restorable_sql_containers(&self) -> restorable_sql_containers::Client {
+    pub fn restorable_sql_containers_client(&self) -> restorable_sql_containers::Client {
         restorable_sql_containers::Client(self.clone())
     }
-    pub fn restorable_sql_databases(&self) -> restorable_sql_databases::Client {
+    pub fn restorable_sql_databases_client(&self) -> restorable_sql_databases::Client {
         restorable_sql_databases::Client(self.clone())
     }
-    pub fn restorable_sql_resources(&self) -> restorable_sql_resources::Client {
+    pub fn restorable_sql_resources_client(&self) -> restorable_sql_resources::Client {
         restorable_sql_resources::Client(self.clone())
     }
-    pub fn sql_resources(&self) -> sql_resources::Client {
+    pub fn sql_resources_client(&self) -> sql_resources::Client {
         sql_resources::Client(self.clone())
     }
-    pub fn table_resources(&self) -> table_resources::Client {
+    pub fn table_resources_client(&self) -> table_resources::Client {
         table_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/cosmosdb/src/package_preview_2021_04/operations.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2021_04/operations.rs
@@ -74,94 +74,94 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cassandra_clusters(&self) -> cassandra_clusters::Client {
+    pub fn cassandra_clusters_client(&self) -> cassandra_clusters::Client {
         cassandra_clusters::Client(self.clone())
     }
-    pub fn cassandra_data_centers(&self) -> cassandra_data_centers::Client {
+    pub fn cassandra_data_centers_client(&self) -> cassandra_data_centers::Client {
         cassandra_data_centers::Client(self.clone())
     }
-    pub fn cassandra_resources(&self) -> cassandra_resources::Client {
+    pub fn cassandra_resources_client(&self) -> cassandra_resources::Client {
         cassandra_resources::Client(self.clone())
     }
-    pub fn collection(&self) -> collection::Client {
+    pub fn collection_client(&self) -> collection::Client {
         collection::Client(self.clone())
     }
-    pub fn collection_partition(&self) -> collection_partition::Client {
+    pub fn collection_partition_client(&self) -> collection_partition::Client {
         collection_partition::Client(self.clone())
     }
-    pub fn collection_partition_region(&self) -> collection_partition_region::Client {
+    pub fn collection_partition_region_client(&self) -> collection_partition_region::Client {
         collection_partition_region::Client(self.clone())
     }
-    pub fn collection_region(&self) -> collection_region::Client {
+    pub fn collection_region_client(&self) -> collection_region::Client {
         collection_region::Client(self.clone())
     }
-    pub fn database(&self) -> database::Client {
+    pub fn database_client(&self) -> database::Client {
         database::Client(self.clone())
     }
-    pub fn database_account_region(&self) -> database_account_region::Client {
+    pub fn database_account_region_client(&self) -> database_account_region::Client {
         database_account_region::Client(self.clone())
     }
-    pub fn database_accounts(&self) -> database_accounts::Client {
+    pub fn database_accounts_client(&self) -> database_accounts::Client {
         database_accounts::Client(self.clone())
     }
-    pub fn gremlin_resources(&self) -> gremlin_resources::Client {
+    pub fn gremlin_resources_client(&self) -> gremlin_resources::Client {
         gremlin_resources::Client(self.clone())
     }
-    pub fn mongo_db_resources(&self) -> mongo_db_resources::Client {
+    pub fn mongo_db_resources_client(&self) -> mongo_db_resources::Client {
         mongo_db_resources::Client(self.clone())
     }
-    pub fn notebook_workspaces(&self) -> notebook_workspaces::Client {
+    pub fn notebook_workspaces_client(&self) -> notebook_workspaces::Client {
         notebook_workspaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn partition_key_range_id(&self) -> partition_key_range_id::Client {
+    pub fn partition_key_range_id_client(&self) -> partition_key_range_id::Client {
         partition_key_range_id::Client(self.clone())
     }
-    pub fn partition_key_range_id_region(&self) -> partition_key_range_id_region::Client {
+    pub fn partition_key_range_id_region_client(&self) -> partition_key_range_id_region::Client {
         partition_key_range_id_region::Client(self.clone())
     }
-    pub fn percentile(&self) -> percentile::Client {
+    pub fn percentile_client(&self) -> percentile::Client {
         percentile::Client(self.clone())
     }
-    pub fn percentile_source_target(&self) -> percentile_source_target::Client {
+    pub fn percentile_source_target_client(&self) -> percentile_source_target::Client {
         percentile_source_target::Client(self.clone())
     }
-    pub fn percentile_target(&self) -> percentile_target::Client {
+    pub fn percentile_target_client(&self) -> percentile_target::Client {
         percentile_target::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_database_accounts(&self) -> restorable_database_accounts::Client {
+    pub fn restorable_database_accounts_client(&self) -> restorable_database_accounts::Client {
         restorable_database_accounts::Client(self.clone())
     }
-    pub fn restorable_mongodb_collections(&self) -> restorable_mongodb_collections::Client {
+    pub fn restorable_mongodb_collections_client(&self) -> restorable_mongodb_collections::Client {
         restorable_mongodb_collections::Client(self.clone())
     }
-    pub fn restorable_mongodb_databases(&self) -> restorable_mongodb_databases::Client {
+    pub fn restorable_mongodb_databases_client(&self) -> restorable_mongodb_databases::Client {
         restorable_mongodb_databases::Client(self.clone())
     }
-    pub fn restorable_mongodb_resources(&self) -> restorable_mongodb_resources::Client {
+    pub fn restorable_mongodb_resources_client(&self) -> restorable_mongodb_resources::Client {
         restorable_mongodb_resources::Client(self.clone())
     }
-    pub fn restorable_sql_containers(&self) -> restorable_sql_containers::Client {
+    pub fn restorable_sql_containers_client(&self) -> restorable_sql_containers::Client {
         restorable_sql_containers::Client(self.clone())
     }
-    pub fn restorable_sql_databases(&self) -> restorable_sql_databases::Client {
+    pub fn restorable_sql_databases_client(&self) -> restorable_sql_databases::Client {
         restorable_sql_databases::Client(self.clone())
     }
-    pub fn restorable_sql_resources(&self) -> restorable_sql_resources::Client {
+    pub fn restorable_sql_resources_client(&self) -> restorable_sql_resources::Client {
         restorable_sql_resources::Client(self.clone())
     }
-    pub fn sql_resources(&self) -> sql_resources::Client {
+    pub fn sql_resources_client(&self) -> sql_resources::Client {
         sql_resources::Client(self.clone())
     }
-    pub fn table_resources(&self) -> table_resources::Client {
+    pub fn table_resources_client(&self) -> table_resources::Client {
         table_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/cosmosdb/src/package_preview_2021_10/operations.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2021_10/operations.rs
@@ -74,106 +74,106 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cassandra_clusters(&self) -> cassandra_clusters::Client {
+    pub fn cassandra_clusters_client(&self) -> cassandra_clusters::Client {
         cassandra_clusters::Client(self.clone())
     }
-    pub fn cassandra_data_centers(&self) -> cassandra_data_centers::Client {
+    pub fn cassandra_data_centers_client(&self) -> cassandra_data_centers::Client {
         cassandra_data_centers::Client(self.clone())
     }
-    pub fn cassandra_resources(&self) -> cassandra_resources::Client {
+    pub fn cassandra_resources_client(&self) -> cassandra_resources::Client {
         cassandra_resources::Client(self.clone())
     }
-    pub fn collection(&self) -> collection::Client {
+    pub fn collection_client(&self) -> collection::Client {
         collection::Client(self.clone())
     }
-    pub fn collection_partition(&self) -> collection_partition::Client {
+    pub fn collection_partition_client(&self) -> collection_partition::Client {
         collection_partition::Client(self.clone())
     }
-    pub fn collection_partition_region(&self) -> collection_partition_region::Client {
+    pub fn collection_partition_region_client(&self) -> collection_partition_region::Client {
         collection_partition_region::Client(self.clone())
     }
-    pub fn collection_region(&self) -> collection_region::Client {
+    pub fn collection_region_client(&self) -> collection_region::Client {
         collection_region::Client(self.clone())
     }
-    pub fn data_transfer_jobs(&self) -> data_transfer_jobs::Client {
+    pub fn data_transfer_jobs_client(&self) -> data_transfer_jobs::Client {
         data_transfer_jobs::Client(self.clone())
     }
-    pub fn database(&self) -> database::Client {
+    pub fn database_client(&self) -> database::Client {
         database::Client(self.clone())
     }
-    pub fn database_account_region(&self) -> database_account_region::Client {
+    pub fn database_account_region_client(&self) -> database_account_region::Client {
         database_account_region::Client(self.clone())
     }
-    pub fn database_accounts(&self) -> database_accounts::Client {
+    pub fn database_accounts_client(&self) -> database_accounts::Client {
         database_accounts::Client(self.clone())
     }
-    pub fn graph_resources(&self) -> graph_resources::Client {
+    pub fn graph_resources_client(&self) -> graph_resources::Client {
         graph_resources::Client(self.clone())
     }
-    pub fn gremlin_resources(&self) -> gremlin_resources::Client {
+    pub fn gremlin_resources_client(&self) -> gremlin_resources::Client {
         gremlin_resources::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mongo_db_resources(&self) -> mongo_db_resources::Client {
+    pub fn mongo_db_resources_client(&self) -> mongo_db_resources::Client {
         mongo_db_resources::Client(self.clone())
     }
-    pub fn notebook_workspaces(&self) -> notebook_workspaces::Client {
+    pub fn notebook_workspaces_client(&self) -> notebook_workspaces::Client {
         notebook_workspaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn partition_key_range_id(&self) -> partition_key_range_id::Client {
+    pub fn partition_key_range_id_client(&self) -> partition_key_range_id::Client {
         partition_key_range_id::Client(self.clone())
     }
-    pub fn partition_key_range_id_region(&self) -> partition_key_range_id_region::Client {
+    pub fn partition_key_range_id_region_client(&self) -> partition_key_range_id_region::Client {
         partition_key_range_id_region::Client(self.clone())
     }
-    pub fn percentile(&self) -> percentile::Client {
+    pub fn percentile_client(&self) -> percentile::Client {
         percentile::Client(self.clone())
     }
-    pub fn percentile_source_target(&self) -> percentile_source_target::Client {
+    pub fn percentile_source_target_client(&self) -> percentile_source_target::Client {
         percentile_source_target::Client(self.clone())
     }
-    pub fn percentile_target(&self) -> percentile_target::Client {
+    pub fn percentile_target_client(&self) -> percentile_target::Client {
         percentile_target::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_database_accounts(&self) -> restorable_database_accounts::Client {
+    pub fn restorable_database_accounts_client(&self) -> restorable_database_accounts::Client {
         restorable_database_accounts::Client(self.clone())
     }
-    pub fn restorable_mongodb_collections(&self) -> restorable_mongodb_collections::Client {
+    pub fn restorable_mongodb_collections_client(&self) -> restorable_mongodb_collections::Client {
         restorable_mongodb_collections::Client(self.clone())
     }
-    pub fn restorable_mongodb_databases(&self) -> restorable_mongodb_databases::Client {
+    pub fn restorable_mongodb_databases_client(&self) -> restorable_mongodb_databases::Client {
         restorable_mongodb_databases::Client(self.clone())
     }
-    pub fn restorable_mongodb_resources(&self) -> restorable_mongodb_resources::Client {
+    pub fn restorable_mongodb_resources_client(&self) -> restorable_mongodb_resources::Client {
         restorable_mongodb_resources::Client(self.clone())
     }
-    pub fn restorable_sql_containers(&self) -> restorable_sql_containers::Client {
+    pub fn restorable_sql_containers_client(&self) -> restorable_sql_containers::Client {
         restorable_sql_containers::Client(self.clone())
     }
-    pub fn restorable_sql_databases(&self) -> restorable_sql_databases::Client {
+    pub fn restorable_sql_databases_client(&self) -> restorable_sql_databases::Client {
         restorable_sql_databases::Client(self.clone())
     }
-    pub fn restorable_sql_resources(&self) -> restorable_sql_resources::Client {
+    pub fn restorable_sql_resources_client(&self) -> restorable_sql_resources::Client {
         restorable_sql_resources::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn sql_resources(&self) -> sql_resources::Client {
+    pub fn sql_resources_client(&self) -> sql_resources::Client {
         sql_resources::Client(self.clone())
     }
-    pub fn table_resources(&self) -> table_resources::Client {
+    pub fn table_resources_client(&self) -> table_resources::Client {
         table_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/cosmosdb/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2021_11/operations.rs
@@ -74,121 +74,121 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cassandra_clusters(&self) -> cassandra_clusters::Client {
+    pub fn cassandra_clusters_client(&self) -> cassandra_clusters::Client {
         cassandra_clusters::Client(self.clone())
     }
-    pub fn cassandra_data_centers(&self) -> cassandra_data_centers::Client {
+    pub fn cassandra_data_centers_client(&self) -> cassandra_data_centers::Client {
         cassandra_data_centers::Client(self.clone())
     }
-    pub fn cassandra_resources(&self) -> cassandra_resources::Client {
+    pub fn cassandra_resources_client(&self) -> cassandra_resources::Client {
         cassandra_resources::Client(self.clone())
     }
-    pub fn collection(&self) -> collection::Client {
+    pub fn collection_client(&self) -> collection::Client {
         collection::Client(self.clone())
     }
-    pub fn collection_partition(&self) -> collection_partition::Client {
+    pub fn collection_partition_client(&self) -> collection_partition::Client {
         collection_partition::Client(self.clone())
     }
-    pub fn collection_partition_region(&self) -> collection_partition_region::Client {
+    pub fn collection_partition_region_client(&self) -> collection_partition_region::Client {
         collection_partition_region::Client(self.clone())
     }
-    pub fn collection_region(&self) -> collection_region::Client {
+    pub fn collection_region_client(&self) -> collection_region::Client {
         collection_region::Client(self.clone())
     }
-    pub fn data_transfer_jobs(&self) -> data_transfer_jobs::Client {
+    pub fn data_transfer_jobs_client(&self) -> data_transfer_jobs::Client {
         data_transfer_jobs::Client(self.clone())
     }
-    pub fn database(&self) -> database::Client {
+    pub fn database_client(&self) -> database::Client {
         database::Client(self.clone())
     }
-    pub fn database_account_region(&self) -> database_account_region::Client {
+    pub fn database_account_region_client(&self) -> database_account_region::Client {
         database_account_region::Client(self.clone())
     }
-    pub fn database_accounts(&self) -> database_accounts::Client {
+    pub fn database_accounts_client(&self) -> database_accounts::Client {
         database_accounts::Client(self.clone())
     }
-    pub fn graph_resources(&self) -> graph_resources::Client {
+    pub fn graph_resources_client(&self) -> graph_resources::Client {
         graph_resources::Client(self.clone())
     }
-    pub fn gremlin_resources(&self) -> gremlin_resources::Client {
+    pub fn gremlin_resources_client(&self) -> gremlin_resources::Client {
         gremlin_resources::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mongo_db_resources(&self) -> mongo_db_resources::Client {
+    pub fn mongo_db_resources_client(&self) -> mongo_db_resources::Client {
         mongo_db_resources::Client(self.clone())
     }
-    pub fn notebook_workspaces(&self) -> notebook_workspaces::Client {
+    pub fn notebook_workspaces_client(&self) -> notebook_workspaces::Client {
         notebook_workspaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn partition_key_range_id(&self) -> partition_key_range_id::Client {
+    pub fn partition_key_range_id_client(&self) -> partition_key_range_id::Client {
         partition_key_range_id::Client(self.clone())
     }
-    pub fn partition_key_range_id_region(&self) -> partition_key_range_id_region::Client {
+    pub fn partition_key_range_id_region_client(&self) -> partition_key_range_id_region::Client {
         partition_key_range_id_region::Client(self.clone())
     }
-    pub fn percentile(&self) -> percentile::Client {
+    pub fn percentile_client(&self) -> percentile::Client {
         percentile::Client(self.clone())
     }
-    pub fn percentile_source_target(&self) -> percentile_source_target::Client {
+    pub fn percentile_source_target_client(&self) -> percentile_source_target::Client {
         percentile_source_target::Client(self.clone())
     }
-    pub fn percentile_target(&self) -> percentile_target::Client {
+    pub fn percentile_target_client(&self) -> percentile_target::Client {
         percentile_target::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_database_accounts(&self) -> restorable_database_accounts::Client {
+    pub fn restorable_database_accounts_client(&self) -> restorable_database_accounts::Client {
         restorable_database_accounts::Client(self.clone())
     }
-    pub fn restorable_gremlin_databases(&self) -> restorable_gremlin_databases::Client {
+    pub fn restorable_gremlin_databases_client(&self) -> restorable_gremlin_databases::Client {
         restorable_gremlin_databases::Client(self.clone())
     }
-    pub fn restorable_gremlin_graphs(&self) -> restorable_gremlin_graphs::Client {
+    pub fn restorable_gremlin_graphs_client(&self) -> restorable_gremlin_graphs::Client {
         restorable_gremlin_graphs::Client(self.clone())
     }
-    pub fn restorable_gremlin_resources(&self) -> restorable_gremlin_resources::Client {
+    pub fn restorable_gremlin_resources_client(&self) -> restorable_gremlin_resources::Client {
         restorable_gremlin_resources::Client(self.clone())
     }
-    pub fn restorable_mongodb_collections(&self) -> restorable_mongodb_collections::Client {
+    pub fn restorable_mongodb_collections_client(&self) -> restorable_mongodb_collections::Client {
         restorable_mongodb_collections::Client(self.clone())
     }
-    pub fn restorable_mongodb_databases(&self) -> restorable_mongodb_databases::Client {
+    pub fn restorable_mongodb_databases_client(&self) -> restorable_mongodb_databases::Client {
         restorable_mongodb_databases::Client(self.clone())
     }
-    pub fn restorable_mongodb_resources(&self) -> restorable_mongodb_resources::Client {
+    pub fn restorable_mongodb_resources_client(&self) -> restorable_mongodb_resources::Client {
         restorable_mongodb_resources::Client(self.clone())
     }
-    pub fn restorable_sql_containers(&self) -> restorable_sql_containers::Client {
+    pub fn restorable_sql_containers_client(&self) -> restorable_sql_containers::Client {
         restorable_sql_containers::Client(self.clone())
     }
-    pub fn restorable_sql_databases(&self) -> restorable_sql_databases::Client {
+    pub fn restorable_sql_databases_client(&self) -> restorable_sql_databases::Client {
         restorable_sql_databases::Client(self.clone())
     }
-    pub fn restorable_sql_resources(&self) -> restorable_sql_resources::Client {
+    pub fn restorable_sql_resources_client(&self) -> restorable_sql_resources::Client {
         restorable_sql_resources::Client(self.clone())
     }
-    pub fn restorable_table_resources(&self) -> restorable_table_resources::Client {
+    pub fn restorable_table_resources_client(&self) -> restorable_table_resources::Client {
         restorable_table_resources::Client(self.clone())
     }
-    pub fn restorable_tables(&self) -> restorable_tables::Client {
+    pub fn restorable_tables_client(&self) -> restorable_tables::Client {
         restorable_tables::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn sql_resources(&self) -> sql_resources::Client {
+    pub fn sql_resources_client(&self) -> sql_resources::Client {
         sql_resources::Client(self.clone())
     }
-    pub fn table_resources(&self) -> table_resources::Client {
+    pub fn table_resources_client(&self) -> table_resources::Client {
         table_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/cosmosdb/src/package_preview_2022_02/operations.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2022_02/operations.rs
@@ -74,121 +74,121 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cassandra_clusters(&self) -> cassandra_clusters::Client {
+    pub fn cassandra_clusters_client(&self) -> cassandra_clusters::Client {
         cassandra_clusters::Client(self.clone())
     }
-    pub fn cassandra_data_centers(&self) -> cassandra_data_centers::Client {
+    pub fn cassandra_data_centers_client(&self) -> cassandra_data_centers::Client {
         cassandra_data_centers::Client(self.clone())
     }
-    pub fn cassandra_resources(&self) -> cassandra_resources::Client {
+    pub fn cassandra_resources_client(&self) -> cassandra_resources::Client {
         cassandra_resources::Client(self.clone())
     }
-    pub fn collection(&self) -> collection::Client {
+    pub fn collection_client(&self) -> collection::Client {
         collection::Client(self.clone())
     }
-    pub fn collection_partition(&self) -> collection_partition::Client {
+    pub fn collection_partition_client(&self) -> collection_partition::Client {
         collection_partition::Client(self.clone())
     }
-    pub fn collection_partition_region(&self) -> collection_partition_region::Client {
+    pub fn collection_partition_region_client(&self) -> collection_partition_region::Client {
         collection_partition_region::Client(self.clone())
     }
-    pub fn collection_region(&self) -> collection_region::Client {
+    pub fn collection_region_client(&self) -> collection_region::Client {
         collection_region::Client(self.clone())
     }
-    pub fn data_transfer_jobs(&self) -> data_transfer_jobs::Client {
+    pub fn data_transfer_jobs_client(&self) -> data_transfer_jobs::Client {
         data_transfer_jobs::Client(self.clone())
     }
-    pub fn database(&self) -> database::Client {
+    pub fn database_client(&self) -> database::Client {
         database::Client(self.clone())
     }
-    pub fn database_account_region(&self) -> database_account_region::Client {
+    pub fn database_account_region_client(&self) -> database_account_region::Client {
         database_account_region::Client(self.clone())
     }
-    pub fn database_accounts(&self) -> database_accounts::Client {
+    pub fn database_accounts_client(&self) -> database_accounts::Client {
         database_accounts::Client(self.clone())
     }
-    pub fn graph_resources(&self) -> graph_resources::Client {
+    pub fn graph_resources_client(&self) -> graph_resources::Client {
         graph_resources::Client(self.clone())
     }
-    pub fn gremlin_resources(&self) -> gremlin_resources::Client {
+    pub fn gremlin_resources_client(&self) -> gremlin_resources::Client {
         gremlin_resources::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mongo_db_resources(&self) -> mongo_db_resources::Client {
+    pub fn mongo_db_resources_client(&self) -> mongo_db_resources::Client {
         mongo_db_resources::Client(self.clone())
     }
-    pub fn notebook_workspaces(&self) -> notebook_workspaces::Client {
+    pub fn notebook_workspaces_client(&self) -> notebook_workspaces::Client {
         notebook_workspaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn partition_key_range_id(&self) -> partition_key_range_id::Client {
+    pub fn partition_key_range_id_client(&self) -> partition_key_range_id::Client {
         partition_key_range_id::Client(self.clone())
     }
-    pub fn partition_key_range_id_region(&self) -> partition_key_range_id_region::Client {
+    pub fn partition_key_range_id_region_client(&self) -> partition_key_range_id_region::Client {
         partition_key_range_id_region::Client(self.clone())
     }
-    pub fn percentile(&self) -> percentile::Client {
+    pub fn percentile_client(&self) -> percentile::Client {
         percentile::Client(self.clone())
     }
-    pub fn percentile_source_target(&self) -> percentile_source_target::Client {
+    pub fn percentile_source_target_client(&self) -> percentile_source_target::Client {
         percentile_source_target::Client(self.clone())
     }
-    pub fn percentile_target(&self) -> percentile_target::Client {
+    pub fn percentile_target_client(&self) -> percentile_target::Client {
         percentile_target::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_database_accounts(&self) -> restorable_database_accounts::Client {
+    pub fn restorable_database_accounts_client(&self) -> restorable_database_accounts::Client {
         restorable_database_accounts::Client(self.clone())
     }
-    pub fn restorable_gremlin_databases(&self) -> restorable_gremlin_databases::Client {
+    pub fn restorable_gremlin_databases_client(&self) -> restorable_gremlin_databases::Client {
         restorable_gremlin_databases::Client(self.clone())
     }
-    pub fn restorable_gremlin_graphs(&self) -> restorable_gremlin_graphs::Client {
+    pub fn restorable_gremlin_graphs_client(&self) -> restorable_gremlin_graphs::Client {
         restorable_gremlin_graphs::Client(self.clone())
     }
-    pub fn restorable_gremlin_resources(&self) -> restorable_gremlin_resources::Client {
+    pub fn restorable_gremlin_resources_client(&self) -> restorable_gremlin_resources::Client {
         restorable_gremlin_resources::Client(self.clone())
     }
-    pub fn restorable_mongodb_collections(&self) -> restorable_mongodb_collections::Client {
+    pub fn restorable_mongodb_collections_client(&self) -> restorable_mongodb_collections::Client {
         restorable_mongodb_collections::Client(self.clone())
     }
-    pub fn restorable_mongodb_databases(&self) -> restorable_mongodb_databases::Client {
+    pub fn restorable_mongodb_databases_client(&self) -> restorable_mongodb_databases::Client {
         restorable_mongodb_databases::Client(self.clone())
     }
-    pub fn restorable_mongodb_resources(&self) -> restorable_mongodb_resources::Client {
+    pub fn restorable_mongodb_resources_client(&self) -> restorable_mongodb_resources::Client {
         restorable_mongodb_resources::Client(self.clone())
     }
-    pub fn restorable_sql_containers(&self) -> restorable_sql_containers::Client {
+    pub fn restorable_sql_containers_client(&self) -> restorable_sql_containers::Client {
         restorable_sql_containers::Client(self.clone())
     }
-    pub fn restorable_sql_databases(&self) -> restorable_sql_databases::Client {
+    pub fn restorable_sql_databases_client(&self) -> restorable_sql_databases::Client {
         restorable_sql_databases::Client(self.clone())
     }
-    pub fn restorable_sql_resources(&self) -> restorable_sql_resources::Client {
+    pub fn restorable_sql_resources_client(&self) -> restorable_sql_resources::Client {
         restorable_sql_resources::Client(self.clone())
     }
-    pub fn restorable_table_resources(&self) -> restorable_table_resources::Client {
+    pub fn restorable_table_resources_client(&self) -> restorable_table_resources::Client {
         restorable_table_resources::Client(self.clone())
     }
-    pub fn restorable_tables(&self) -> restorable_tables::Client {
+    pub fn restorable_tables_client(&self) -> restorable_tables::Client {
         restorable_tables::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn sql_resources(&self) -> sql_resources::Client {
+    pub fn sql_resources_client(&self) -> sql_resources::Client {
         sql_resources::Client(self.clone())
     }
-    pub fn table_resources(&self) -> table_resources::Client {
+    pub fn table_resources_client(&self) -> table_resources::Client {
         table_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/costmanagement/src/package_preview_2019_04/operations.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2019_04/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn budget(&self) -> budget::Client {
+    pub fn budget_client(&self) -> budget::Client {
         budget::Client(self.clone())
     }
-    pub fn budgets(&self) -> budgets::Client {
+    pub fn budgets_client(&self) -> budgets::Client {
         budgets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn views(&self) -> views::Client {
+    pub fn views_client(&self) -> views::Client {
         views::Client(self.clone())
     }
 }

--- a/services/mgmt/costmanagement/src/package_preview_2020_03/operations.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2020_03/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn cost_allocation_rules(&self) -> cost_allocation_rules::Client {
+    pub fn cost_allocation_rules_client(&self) -> cost_allocation_rules::Client {
         cost_allocation_rules::Client(self.clone())
     }
-    pub fn dimensions(&self) -> dimensions::Client {
+    pub fn dimensions_client(&self) -> dimensions::Client {
         dimensions::Client(self.clone())
     }
-    pub fn forecast(&self) -> forecast::Client {
+    pub fn forecast_client(&self) -> forecast::Client {
         forecast::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
-    pub fn views(&self) -> views::Client {
+    pub fn views_client(&self) -> views::Client {
         views::Client(self.clone())
     }
 }

--- a/services/mgmt/costmanagement/src/package_preview_2020_12/operations.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2020_12/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn dimensions(&self) -> dimensions::Client {
+    pub fn dimensions_client(&self) -> dimensions::Client {
         dimensions::Client(self.clone())
     }
-    pub fn exports(&self) -> exports::Client {
+    pub fn exports_client(&self) -> exports::Client {
         exports::Client(self.clone())
     }
-    pub fn forecast(&self) -> forecast::Client {
+    pub fn forecast_client(&self) -> forecast::Client {
         forecast::Client(self.clone())
     }
-    pub fn generate_detailed_cost_report(&self) -> generate_detailed_cost_report::Client {
+    pub fn generate_detailed_cost_report_client(&self) -> generate_detailed_cost_report::Client {
         generate_detailed_cost_report::Client(self.clone())
     }
-    pub fn generate_detailed_cost_report_operation_results(&self) -> generate_detailed_cost_report_operation_results::Client {
+    pub fn generate_detailed_cost_report_operation_results_client(&self) -> generate_detailed_cost_report_operation_results::Client {
         generate_detailed_cost_report_operation_results::Client(self.clone())
     }
-    pub fn generate_detailed_cost_report_operation_status(&self) -> generate_detailed_cost_report_operation_status::Client {
+    pub fn generate_detailed_cost_report_operation_status_client(&self) -> generate_detailed_cost_report_operation_status::Client {
         generate_detailed_cost_report_operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
-    pub fn views(&self) -> views::Client {
+    pub fn views_client(&self) -> views::Client {
         views::Client(self.clone())
     }
 }

--- a/services/mgmt/costmanagement/src/package_preview_2022_02/operations.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2022_02/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn price_sheet(&self) -> price_sheet::Client {
+    pub fn price_sheet_client(&self) -> price_sheet::Client {
         price_sheet::Client(self.clone())
     }
 }

--- a/services/mgmt/costmanagement/src/package_preview_2022_04/operations.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2022_04/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn dimensions(&self) -> dimensions::Client {
+    pub fn dimensions_client(&self) -> dimensions::Client {
         dimensions::Client(self.clone())
     }
-    pub fn exports(&self) -> exports::Client {
+    pub fn exports_client(&self) -> exports::Client {
         exports::Client(self.clone())
     }
-    pub fn forecast(&self) -> forecast::Client {
+    pub fn forecast_client(&self) -> forecast::Client {
         forecast::Client(self.clone())
     }
-    pub fn generate_reservation_details_report(&self) -> generate_reservation_details_report::Client {
+    pub fn generate_reservation_details_report_client(&self) -> generate_reservation_details_report::Client {
         generate_reservation_details_report::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
-    pub fn scheduled_actions(&self) -> scheduled_actions::Client {
+    pub fn scheduled_actions_client(&self) -> scheduled_actions::Client {
         scheduled_actions::Client(self.clone())
     }
-    pub fn views(&self) -> views::Client {
+    pub fn views_client(&self) -> views::Client {
         views::Client(self.clone())
     }
 }

--- a/services/mgmt/cpim/src/package_2019_01_01_preview/operations.rs
+++ b/services/mgmt/cpim/src/package_2019_01_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn b2c_tenants(&self) -> b2c_tenants::Client {
+    pub fn b2c_tenants_client(&self) -> b2c_tenants::Client {
         b2c_tenants::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/cpim/src/package_2020_05_01_preview/operations.rs
+++ b/services/mgmt/cpim/src/package_2020_05_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn guest_usages(&self) -> guest_usages::Client {
+    pub fn guest_usages_client(&self) -> guest_usages::Client {
         guest_usages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/cpim/src/package_2021_04_01/operations.rs
+++ b/services/mgmt/cpim/src/package_2021_04_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn b2c_tenants(&self) -> b2c_tenants::Client {
+    pub fn b2c_tenants_client(&self) -> b2c_tenants::Client {
         b2c_tenants::Client(self.clone())
     }
-    pub fn guest_usages(&self) -> guest_usages::Client {
+    pub fn guest_usages_client(&self) -> guest_usages::Client {
         guest_usages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/customerinsights/src/package_2017_01/operations.rs
+++ b/services/mgmt/customerinsights/src/package_2017_01/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn authorization_policies(&self) -> authorization_policies::Client {
+    pub fn authorization_policies_client(&self) -> authorization_policies::Client {
         authorization_policies::Client(self.clone())
     }
-    pub fn connector_mappings(&self) -> connector_mappings::Client {
+    pub fn connector_mappings_client(&self) -> connector_mappings::Client {
         connector_mappings::Client(self.clone())
     }
-    pub fn connectors(&self) -> connectors::Client {
+    pub fn connectors_client(&self) -> connectors::Client {
         connectors::Client(self.clone())
     }
-    pub fn hubs(&self) -> hubs::Client {
+    pub fn hubs_client(&self) -> hubs::Client {
         hubs::Client(self.clone())
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn interactions(&self) -> interactions::Client {
+    pub fn interactions_client(&self) -> interactions::Client {
         interactions::Client(self.clone())
     }
-    pub fn kpi(&self) -> kpi::Client {
+    pub fn kpi_client(&self) -> kpi::Client {
         kpi::Client(self.clone())
     }
-    pub fn links(&self) -> links::Client {
+    pub fn links_client(&self) -> links::Client {
         links::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn relationship_links(&self) -> relationship_links::Client {
+    pub fn relationship_links_client(&self) -> relationship_links::Client {
         relationship_links::Client(self.clone())
     }
-    pub fn relationships(&self) -> relationships::Client {
+    pub fn relationships_client(&self) -> relationships::Client {
         relationships::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn views(&self) -> views::Client {
+    pub fn views_client(&self) -> views::Client {
         views::Client(self.clone())
     }
-    pub fn widget_types(&self) -> widget_types::Client {
+    pub fn widget_types_client(&self) -> widget_types::Client {
         widget_types::Client(self.clone())
     }
 }

--- a/services/mgmt/customerinsights/src/package_2017_04/operations.rs
+++ b/services/mgmt/customerinsights/src/package_2017_04/operations.rs
@@ -74,55 +74,55 @@ impl Client {
             pipeline,
         }
     }
-    pub fn authorization_policies(&self) -> authorization_policies::Client {
+    pub fn authorization_policies_client(&self) -> authorization_policies::Client {
         authorization_policies::Client(self.clone())
     }
-    pub fn connector_mappings(&self) -> connector_mappings::Client {
+    pub fn connector_mappings_client(&self) -> connector_mappings::Client {
         connector_mappings::Client(self.clone())
     }
-    pub fn connectors(&self) -> connectors::Client {
+    pub fn connectors_client(&self) -> connectors::Client {
         connectors::Client(self.clone())
     }
-    pub fn hubs(&self) -> hubs::Client {
+    pub fn hubs_client(&self) -> hubs::Client {
         hubs::Client(self.clone())
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn interactions(&self) -> interactions::Client {
+    pub fn interactions_client(&self) -> interactions::Client {
         interactions::Client(self.clone())
     }
-    pub fn kpi(&self) -> kpi::Client {
+    pub fn kpi_client(&self) -> kpi::Client {
         kpi::Client(self.clone())
     }
-    pub fn links(&self) -> links::Client {
+    pub fn links_client(&self) -> links::Client {
         links::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn predictions(&self) -> predictions::Client {
+    pub fn predictions_client(&self) -> predictions::Client {
         predictions::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn relationship_links(&self) -> relationship_links::Client {
+    pub fn relationship_links_client(&self) -> relationship_links::Client {
         relationship_links::Client(self.clone())
     }
-    pub fn relationships(&self) -> relationships::Client {
+    pub fn relationships_client(&self) -> relationships::Client {
         relationships::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn views(&self) -> views::Client {
+    pub fn views_client(&self) -> views::Client {
         views::Client(self.clone())
     }
-    pub fn widget_types(&self) -> widget_types::Client {
+    pub fn widget_types_client(&self) -> widget_types::Client {
         widget_types::Client(self.clone())
     }
 }

--- a/services/mgmt/customerlockbox/src/package_2018_02_28_preview/operations.rs
+++ b/services/mgmt/customerlockbox/src/package_2018_02_28_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn get(&self) -> get::Client {
+    pub fn get_client(&self) -> get::Client {
         get::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn post(&self) -> post::Client {
+    pub fn post_client(&self) -> post::Client {
         post::Client(self.clone())
     }
-    pub fn requests(&self) -> requests::Client {
+    pub fn requests_client(&self) -> requests::Client {
         requests::Client(self.clone())
     }
 }

--- a/services/mgmt/customproviders/src/package_2018_09_01_preview/operations.rs
+++ b/services/mgmt/customproviders/src/package_2018_09_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn associations(&self) -> associations::Client {
+    pub fn associations_client(&self) -> associations::Client {
         associations::Client(self.clone())
     }
-    pub fn custom_resource_provider(&self) -> custom_resource_provider::Client {
+    pub fn custom_resource_provider_client(&self) -> custom_resource_provider::Client {
         custom_resource_provider::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/dashboard/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/dashboard/src/package_2021_09_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn grafana(&self) -> grafana::Client {
+    pub fn grafana_client(&self) -> grafana::Client {
         grafana::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/data/src/package_2017_03_01_preview/operations.rs
+++ b/services/mgmt/data/src/package_2017_03_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn sql_server_registrations(&self) -> sql_server_registrations::Client {
+    pub fn sql_server_registrations_client(&self) -> sql_server_registrations::Client {
         sql_server_registrations::Client(self.clone())
     }
-    pub fn sql_servers(&self) -> sql_servers::Client {
+    pub fn sql_servers_client(&self) -> sql_servers::Client {
         sql_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/data/src/package_preview_2019_07/operations.rs
+++ b/services/mgmt/data/src/package_preview_2019_07/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn sql_server_registrations(&self) -> sql_server_registrations::Client {
+    pub fn sql_server_registrations_client(&self) -> sql_server_registrations::Client {
         sql_server_registrations::Client(self.clone())
     }
-    pub fn sql_servers(&self) -> sql_servers::Client {
+    pub fn sql_servers_client(&self) -> sql_servers::Client {
         sql_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/databox/src/package_2021_03/operations.rs
+++ b/services/mgmt/databox/src/package_2021_03/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/mgmt/databox/src/package_2021_05/operations.rs
+++ b/services/mgmt/databox/src/package_2021_05/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/mgmt/databox/src/package_2021_08_preview/operations.rs
+++ b/services/mgmt/databox/src/package_2021_08_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/mgmt/databox/src/package_2021_12/operations.rs
+++ b/services/mgmt/databox/src/package_2021_12/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/mgmt/databox/src/package_2022_02/operations.rs
+++ b/services/mgmt/databox/src/package_2022_02/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/mgmt/databoxedge/src/package_2020_12_01/operations.rs
+++ b/services/mgmt/databoxedge/src/package_2020_12_01/operations.rs
@@ -74,58 +74,58 @@ impl Client {
             pipeline,
         }
     }
-    pub fn addons(&self) -> addons::Client {
+    pub fn addons_client(&self) -> addons::Client {
         addons::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn available_skus(&self) -> available_skus::Client {
+    pub fn available_skus_client(&self) -> available_skus::Client {
         available_skus::Client(self.clone())
     }
-    pub fn bandwidth_schedules(&self) -> bandwidth_schedules::Client {
+    pub fn bandwidth_schedules_client(&self) -> bandwidth_schedules::Client {
         bandwidth_schedules::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn monitoring_config(&self) -> monitoring_config::Client {
+    pub fn monitoring_config_client(&self) -> monitoring_config::Client {
         monitoring_config::Client(self.clone())
     }
-    pub fn nodes(&self) -> nodes::Client {
+    pub fn nodes_client(&self) -> nodes::Client {
         nodes::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn orders(&self) -> orders::Client {
+    pub fn orders_client(&self) -> orders::Client {
         orders::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn storage_account_credentials(&self) -> storage_account_credentials::Client {
+    pub fn storage_account_credentials_client(&self) -> storage_account_credentials::Client {
         storage_account_credentials::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/mgmt/databoxedge/src/package_2021_02_01/operations.rs
+++ b/services/mgmt/databoxedge/src/package_2021_02_01/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn addons(&self) -> addons::Client {
+    pub fn addons_client(&self) -> addons::Client {
         addons::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn available_skus(&self) -> available_skus::Client {
+    pub fn available_skus_client(&self) -> available_skus::Client {
         available_skus::Client(self.clone())
     }
-    pub fn bandwidth_schedules(&self) -> bandwidth_schedules::Client {
+    pub fn bandwidth_schedules_client(&self) -> bandwidth_schedules::Client {
         bandwidth_schedules::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn monitoring_config(&self) -> monitoring_config::Client {
+    pub fn monitoring_config_client(&self) -> monitoring_config::Client {
         monitoring_config::Client(self.clone())
     }
-    pub fn nodes(&self) -> nodes::Client {
+    pub fn nodes_client(&self) -> nodes::Client {
         nodes::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn orders(&self) -> orders::Client {
+    pub fn orders_client(&self) -> orders::Client {
         orders::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn storage_account_credentials(&self) -> storage_account_credentials::Client {
+    pub fn storage_account_credentials_client(&self) -> storage_account_credentials::Client {
         storage_account_credentials::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn support_packages(&self) -> support_packages::Client {
+    pub fn support_packages_client(&self) -> support_packages::Client {
         support_packages::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/mgmt/databoxedge/src/package_2021_02_01_preview/operations.rs
+++ b/services/mgmt/databoxedge/src/package_2021_02_01_preview/operations.rs
@@ -74,58 +74,58 @@ impl Client {
             pipeline,
         }
     }
-    pub fn addons(&self) -> addons::Client {
+    pub fn addons_client(&self) -> addons::Client {
         addons::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn available_skus(&self) -> available_skus::Client {
+    pub fn available_skus_client(&self) -> available_skus::Client {
         available_skus::Client(self.clone())
     }
-    pub fn bandwidth_schedules(&self) -> bandwidth_schedules::Client {
+    pub fn bandwidth_schedules_client(&self) -> bandwidth_schedules::Client {
         bandwidth_schedules::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn monitoring_config(&self) -> monitoring_config::Client {
+    pub fn monitoring_config_client(&self) -> monitoring_config::Client {
         monitoring_config::Client(self.clone())
     }
-    pub fn nodes(&self) -> nodes::Client {
+    pub fn nodes_client(&self) -> nodes::Client {
         nodes::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn orders(&self) -> orders::Client {
+    pub fn orders_client(&self) -> orders::Client {
         orders::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn storage_account_credentials(&self) -> storage_account_credentials::Client {
+    pub fn storage_account_credentials_client(&self) -> storage_account_credentials::Client {
         storage_account_credentials::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/mgmt/databoxedge/src/package_2021_06_01/operations.rs
+++ b/services/mgmt/databoxedge/src/package_2021_06_01/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn addons(&self) -> addons::Client {
+    pub fn addons_client(&self) -> addons::Client {
         addons::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn available_skus(&self) -> available_skus::Client {
+    pub fn available_skus_client(&self) -> available_skus::Client {
         available_skus::Client(self.clone())
     }
-    pub fn bandwidth_schedules(&self) -> bandwidth_schedules::Client {
+    pub fn bandwidth_schedules_client(&self) -> bandwidth_schedules::Client {
         bandwidth_schedules::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn monitoring_config(&self) -> monitoring_config::Client {
+    pub fn monitoring_config_client(&self) -> monitoring_config::Client {
         monitoring_config::Client(self.clone())
     }
-    pub fn nodes(&self) -> nodes::Client {
+    pub fn nodes_client(&self) -> nodes::Client {
         nodes::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn orders(&self) -> orders::Client {
+    pub fn orders_client(&self) -> orders::Client {
         orders::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn storage_account_credentials(&self) -> storage_account_credentials::Client {
+    pub fn storage_account_credentials_client(&self) -> storage_account_credentials::Client {
         storage_account_credentials::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn support_packages(&self) -> support_packages::Client {
+    pub fn support_packages_client(&self) -> support_packages::Client {
         support_packages::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/mgmt/databoxedge/src/package_2021_06_01_preview/operations.rs
+++ b/services/mgmt/databoxedge/src/package_2021_06_01_preview/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn addons(&self) -> addons::Client {
+    pub fn addons_client(&self) -> addons::Client {
         addons::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn available_skus(&self) -> available_skus::Client {
+    pub fn available_skus_client(&self) -> available_skus::Client {
         available_skus::Client(self.clone())
     }
-    pub fn bandwidth_schedules(&self) -> bandwidth_schedules::Client {
+    pub fn bandwidth_schedules_client(&self) -> bandwidth_schedules::Client {
         bandwidth_schedules::Client(self.clone())
     }
-    pub fn containers(&self) -> containers::Client {
+    pub fn containers_client(&self) -> containers::Client {
         containers::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn monitoring_config(&self) -> monitoring_config::Client {
+    pub fn monitoring_config_client(&self) -> monitoring_config::Client {
         monitoring_config::Client(self.clone())
     }
-    pub fn nodes(&self) -> nodes::Client {
+    pub fn nodes_client(&self) -> nodes::Client {
         nodes::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn orders(&self) -> orders::Client {
+    pub fn orders_client(&self) -> orders::Client {
         orders::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn storage_account_credentials(&self) -> storage_account_credentials::Client {
+    pub fn storage_account_credentials_client(&self) -> storage_account_credentials::Client {
         storage_account_credentials::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn support_packages(&self) -> support_packages::Client {
+    pub fn support_packages_client(&self) -> support_packages::Client {
         support_packages::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/mgmt/databricks/src/package_2018_04_01/operations.rs
+++ b/services/mgmt/databricks/src/package_2018_04_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn v_net_peering(&self) -> v_net_peering::Client {
+    pub fn v_net_peering_client(&self) -> v_net_peering::Client {
         v_net_peering::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/datacatalog/src/package_2016_03_30/operations.rs
+++ b/services/mgmt/datacatalog/src/package_2016_03_30/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn adc_catalogs(&self) -> adc_catalogs::Client {
+    pub fn adc_catalogs_client(&self) -> adc_catalogs::Client {
         adc_catalogs::Client(self.clone())
     }
-    pub fn adc_operations(&self) -> adc_operations::Client {
+    pub fn adc_operations_client(&self) -> adc_operations::Client {
         adc_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/datadog/src/package_2020_02_preview/operations.rs
+++ b/services/mgmt/datadog/src/package_2020_02_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn single_sign_on_configurations(&self) -> single_sign_on_configurations::Client {
+    pub fn single_sign_on_configurations_client(&self) -> single_sign_on_configurations::Client {
         single_sign_on_configurations::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/datadog/src/package_2021_03/operations.rs
+++ b/services/mgmt/datadog/src/package_2021_03/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn single_sign_on_configurations(&self) -> single_sign_on_configurations::Client {
+    pub fn single_sign_on_configurations_client(&self) -> single_sign_on_configurations::Client {
         single_sign_on_configurations::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/datafactory/src/package_2017_09_preview/operations.rs
+++ b/services/mgmt/datafactory/src/package_2017_09_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activity_runs(&self) -> activity_runs::Client {
+    pub fn activity_runs_client(&self) -> activity_runs::Client {
         activity_runs::Client(self.clone())
     }
-    pub fn datasets(&self) -> datasets::Client {
+    pub fn datasets_client(&self) -> datasets::Client {
         datasets::Client(self.clone())
     }
-    pub fn factories(&self) -> factories::Client {
+    pub fn factories_client(&self) -> factories::Client {
         factories::Client(self.clone())
     }
-    pub fn integration_runtime_nodes(&self) -> integration_runtime_nodes::Client {
+    pub fn integration_runtime_nodes_client(&self) -> integration_runtime_nodes::Client {
         integration_runtime_nodes::Client(self.clone())
     }
-    pub fn integration_runtimes(&self) -> integration_runtimes::Client {
+    pub fn integration_runtimes_client(&self) -> integration_runtimes::Client {
         integration_runtimes::Client(self.clone())
     }
-    pub fn linked_services(&self) -> linked_services::Client {
+    pub fn linked_services_client(&self) -> linked_services::Client {
         linked_services::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_runs(&self) -> pipeline_runs::Client {
+    pub fn pipeline_runs_client(&self) -> pipeline_runs::Client {
         pipeline_runs::Client(self.clone())
     }
-    pub fn pipelines(&self) -> pipelines::Client {
+    pub fn pipelines_client(&self) -> pipelines::Client {
         pipelines::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/mgmt/datafactory/src/package_2018_06/operations.rs
+++ b/services/mgmt/datafactory/src/package_2018_06/operations.rs
@@ -74,67 +74,67 @@ impl Client {
             pipeline,
         }
     }
-    pub fn activity_runs(&self) -> activity_runs::Client {
+    pub fn activity_runs_client(&self) -> activity_runs::Client {
         activity_runs::Client(self.clone())
     }
-    pub fn data_flow_debug_session(&self) -> data_flow_debug_session::Client {
+    pub fn data_flow_debug_session_client(&self) -> data_flow_debug_session::Client {
         data_flow_debug_session::Client(self.clone())
     }
-    pub fn data_flows(&self) -> data_flows::Client {
+    pub fn data_flows_client(&self) -> data_flows::Client {
         data_flows::Client(self.clone())
     }
-    pub fn datasets(&self) -> datasets::Client {
+    pub fn datasets_client(&self) -> datasets::Client {
         datasets::Client(self.clone())
     }
-    pub fn exposure_control(&self) -> exposure_control::Client {
+    pub fn exposure_control_client(&self) -> exposure_control::Client {
         exposure_control::Client(self.clone())
     }
-    pub fn factories(&self) -> factories::Client {
+    pub fn factories_client(&self) -> factories::Client {
         factories::Client(self.clone())
     }
-    pub fn global_parameters(&self) -> global_parameters::Client {
+    pub fn global_parameters_client(&self) -> global_parameters::Client {
         global_parameters::Client(self.clone())
     }
-    pub fn integration_runtime_nodes(&self) -> integration_runtime_nodes::Client {
+    pub fn integration_runtime_nodes_client(&self) -> integration_runtime_nodes::Client {
         integration_runtime_nodes::Client(self.clone())
     }
-    pub fn integration_runtime_object_metadata(&self) -> integration_runtime_object_metadata::Client {
+    pub fn integration_runtime_object_metadata_client(&self) -> integration_runtime_object_metadata::Client {
         integration_runtime_object_metadata::Client(self.clone())
     }
-    pub fn integration_runtimes(&self) -> integration_runtimes::Client {
+    pub fn integration_runtimes_client(&self) -> integration_runtimes::Client {
         integration_runtimes::Client(self.clone())
     }
-    pub fn linked_services(&self) -> linked_services::Client {
+    pub fn linked_services_client(&self) -> linked_services::Client {
         linked_services::Client(self.clone())
     }
-    pub fn managed_private_endpoints(&self) -> managed_private_endpoints::Client {
+    pub fn managed_private_endpoints_client(&self) -> managed_private_endpoints::Client {
         managed_private_endpoints::Client(self.clone())
     }
-    pub fn managed_virtual_networks(&self) -> managed_virtual_networks::Client {
+    pub fn managed_virtual_networks_client(&self) -> managed_virtual_networks::Client {
         managed_virtual_networks::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_runs(&self) -> pipeline_runs::Client {
+    pub fn pipeline_runs_client(&self) -> pipeline_runs::Client {
         pipeline_runs::Client(self.clone())
     }
-    pub fn pipelines(&self) -> pipelines::Client {
+    pub fn pipelines_client(&self) -> pipelines::Client {
         pipelines::Client(self.clone())
     }
-    pub fn private_end_point_connections(&self) -> private_end_point_connections::Client {
+    pub fn private_end_point_connections_client(&self) -> private_end_point_connections::Client {
         private_end_point_connections::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn trigger_runs(&self) -> trigger_runs::Client {
+    pub fn trigger_runs_client(&self) -> trigger_runs::Client {
         trigger_runs::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/mgmt/datalakeanalytics/src/package_2015_10_preview/operations.rs
+++ b/services/mgmt/datalakeanalytics/src/package_2015_10_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account(&self) -> account::Client {
+    pub fn account_client(&self) -> account::Client {
         account::Client(self.clone())
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn compute_policies(&self) -> compute_policies::Client {
+    pub fn compute_policies_client(&self) -> compute_policies::Client {
         compute_policies::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/datalakeanalytics/src/package_2016_11/operations.rs
+++ b/services/mgmt/datalakeanalytics/src/package_2016_11/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn compute_policies(&self) -> compute_policies::Client {
+    pub fn compute_policies_client(&self) -> compute_policies::Client {
         compute_policies::Client(self.clone())
     }
-    pub fn data_lake_store_accounts(&self) -> data_lake_store_accounts::Client {
+    pub fn data_lake_store_accounts_client(&self) -> data_lake_store_accounts::Client {
         data_lake_store_accounts::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
 }

--- a/services/mgmt/datalakeanalytics/src/package_preview_2019_11/operations.rs
+++ b/services/mgmt/datalakeanalytics/src/package_preview_2019_11/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn compute_policies(&self) -> compute_policies::Client {
+    pub fn compute_policies_client(&self) -> compute_policies::Client {
         compute_policies::Client(self.clone())
     }
-    pub fn data_lake_store_accounts(&self) -> data_lake_store_accounts::Client {
+    pub fn data_lake_store_accounts_client(&self) -> data_lake_store_accounts::Client {
         data_lake_store_accounts::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
 }

--- a/services/mgmt/datalakestore/src/package_2015_10_preview/operations.rs
+++ b/services/mgmt/datalakestore/src/package_2015_10_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account(&self) -> account::Client {
+    pub fn account_client(&self) -> account::Client {
         account::Client(self.clone())
     }
 }

--- a/services/mgmt/datalakestore/src/package_2016_11/operations.rs
+++ b/services/mgmt/datalakestore/src/package_2016_11/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn trusted_id_providers(&self) -> trusted_id_providers::Client {
+    pub fn trusted_id_providers_client(&self) -> trusted_id_providers::Client {
         trusted_id_providers::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/datamigration/src/package_2018_04_19/operations.rs
+++ b/services/mgmt/datamigration/src/package_2018_04_19/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/datamigration/src/package_2021_06/operations.rs
+++ b/services/mgmt/datamigration/src/package_2021_06/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn files(&self) -> files::Client {
+    pub fn files_client(&self) -> files::Client {
         files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn service_tasks(&self) -> service_tasks::Client {
+    pub fn service_tasks_client(&self) -> service_tasks::Client {
         service_tasks::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/datamigration/src/package_preview_2021_10/operations.rs
+++ b/services/mgmt/datamigration/src/package_preview_2021_10/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn database_migrations_sql_mi(&self) -> database_migrations_sql_mi::Client {
+    pub fn database_migrations_sql_mi_client(&self) -> database_migrations_sql_mi::Client {
         database_migrations_sql_mi::Client(self.clone())
     }
-    pub fn database_migrations_sql_vm(&self) -> database_migrations_sql_vm::Client {
+    pub fn database_migrations_sql_vm_client(&self) -> database_migrations_sql_vm::Client {
         database_migrations_sql_vm::Client(self.clone())
     }
-    pub fn files(&self) -> files::Client {
+    pub fn files_client(&self) -> files::Client {
         files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn service_tasks(&self) -> service_tasks::Client {
+    pub fn service_tasks_client(&self) -> service_tasks::Client {
         service_tasks::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn sql_migration_services(&self) -> sql_migration_services::Client {
+    pub fn sql_migration_services_client(&self) -> sql_migration_services::Client {
         sql_migration_services::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/datamigration/src/package_preview_2022_01/operations.rs
+++ b/services/mgmt/datamigration/src/package_preview_2022_01/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn database_migrations_sql_mi(&self) -> database_migrations_sql_mi::Client {
+    pub fn database_migrations_sql_mi_client(&self) -> database_migrations_sql_mi::Client {
         database_migrations_sql_mi::Client(self.clone())
     }
-    pub fn database_migrations_sql_vm(&self) -> database_migrations_sql_vm::Client {
+    pub fn database_migrations_sql_vm_client(&self) -> database_migrations_sql_vm::Client {
         database_migrations_sql_vm::Client(self.clone())
     }
-    pub fn files(&self) -> files::Client {
+    pub fn files_client(&self) -> files::Client {
         files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn service_tasks(&self) -> service_tasks::Client {
+    pub fn service_tasks_client(&self) -> service_tasks::Client {
         service_tasks::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn sql_migration_services(&self) -> sql_migration_services::Client {
+    pub fn sql_migration_services_client(&self) -> sql_migration_services::Client {
         sql_migration_services::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/datamigration/src/package_preview_2022_03/operations.rs
+++ b/services/mgmt/datamigration/src/package_preview_2022_03/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn database_migrations_sql_db(&self) -> database_migrations_sql_db::Client {
+    pub fn database_migrations_sql_db_client(&self) -> database_migrations_sql_db::Client {
         database_migrations_sql_db::Client(self.clone())
     }
-    pub fn database_migrations_sql_mi(&self) -> database_migrations_sql_mi::Client {
+    pub fn database_migrations_sql_mi_client(&self) -> database_migrations_sql_mi::Client {
         database_migrations_sql_mi::Client(self.clone())
     }
-    pub fn database_migrations_sql_vm(&self) -> database_migrations_sql_vm::Client {
+    pub fn database_migrations_sql_vm_client(&self) -> database_migrations_sql_vm::Client {
         database_migrations_sql_vm::Client(self.clone())
     }
-    pub fn files(&self) -> files::Client {
+    pub fn files_client(&self) -> files::Client {
         files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
-    pub fn service_tasks(&self) -> service_tasks::Client {
+    pub fn service_tasks_client(&self) -> service_tasks::Client {
         service_tasks::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn sql_migration_services(&self) -> sql_migration_services::Client {
+    pub fn sql_migration_services_client(&self) -> sql_migration_services::Client {
         sql_migration_services::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/dataprotection/src/package_2021_01/operations.rs
+++ b/services/mgmt/dataprotection/src/package_2021_01/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_instances(&self) -> backup_instances::Client {
+    pub fn backup_instances_client(&self) -> backup_instances::Client {
         backup_instances::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_vault_operation_results(&self) -> backup_vault_operation_results::Client {
+    pub fn backup_vault_operation_results_client(&self) -> backup_vault_operation_results::Client {
         backup_vault_operation_results::Client(self.clone())
     }
-    pub fn backup_vaults(&self) -> backup_vaults::Client {
+    pub fn backup_vaults_client(&self) -> backup_vaults::Client {
         backup_vaults::Client(self.clone())
     }
-    pub fn data_protection(&self) -> data_protection::Client {
+    pub fn data_protection_client(&self) -> data_protection::Client {
         data_protection::Client(self.clone())
     }
-    pub fn data_protection_operations(&self) -> data_protection_operations::Client {
+    pub fn data_protection_operations_client(&self) -> data_protection_operations::Client {
         data_protection_operations::Client(self.clone())
     }
-    pub fn export_jobs(&self) -> export_jobs::Client {
+    pub fn export_jobs_client(&self) -> export_jobs::Client {
         export_jobs::Client(self.clone())
     }
-    pub fn export_jobs_operation_result(&self) -> export_jobs_operation_result::Client {
+    pub fn export_jobs_operation_result_client(&self) -> export_jobs_operation_result::Client {
         export_jobs_operation_result::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation_result(&self) -> operation_result::Client {
+    pub fn operation_result_client(&self) -> operation_result::Client {
         operation_result::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn restorable_time_ranges(&self) -> restorable_time_ranges::Client {
+    pub fn restorable_time_ranges_client(&self) -> restorable_time_ranges::Client {
         restorable_time_ranges::Client(self.clone())
     }
 }

--- a/services/mgmt/dataprotection/src/package_2021_07/operations.rs
+++ b/services/mgmt/dataprotection/src/package_2021_07/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_instances(&self) -> backup_instances::Client {
+    pub fn backup_instances_client(&self) -> backup_instances::Client {
         backup_instances::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_vault_operation_results(&self) -> backup_vault_operation_results::Client {
+    pub fn backup_vault_operation_results_client(&self) -> backup_vault_operation_results::Client {
         backup_vault_operation_results::Client(self.clone())
     }
-    pub fn backup_vaults(&self) -> backup_vaults::Client {
+    pub fn backup_vaults_client(&self) -> backup_vaults::Client {
         backup_vaults::Client(self.clone())
     }
-    pub fn data_protection(&self) -> data_protection::Client {
+    pub fn data_protection_client(&self) -> data_protection::Client {
         data_protection::Client(self.clone())
     }
-    pub fn data_protection_operations(&self) -> data_protection_operations::Client {
+    pub fn data_protection_operations_client(&self) -> data_protection_operations::Client {
         data_protection_operations::Client(self.clone())
     }
-    pub fn export_jobs(&self) -> export_jobs::Client {
+    pub fn export_jobs_client(&self) -> export_jobs::Client {
         export_jobs::Client(self.clone())
     }
-    pub fn export_jobs_operation_result(&self) -> export_jobs_operation_result::Client {
+    pub fn export_jobs_operation_result_client(&self) -> export_jobs_operation_result::Client {
         export_jobs_operation_result::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation_result(&self) -> operation_result::Client {
+    pub fn operation_result_client(&self) -> operation_result::Client {
         operation_result::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn resource_guards(&self) -> resource_guards::Client {
+    pub fn resource_guards_client(&self) -> resource_guards::Client {
         resource_guards::Client(self.clone())
     }
-    pub fn restorable_time_ranges(&self) -> restorable_time_ranges::Client {
+    pub fn restorable_time_ranges_client(&self) -> restorable_time_ranges::Client {
         restorable_time_ranges::Client(self.clone())
     }
 }

--- a/services/mgmt/dataprotection/src/package_2022_01/operations.rs
+++ b/services/mgmt/dataprotection/src/package_2022_01/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_instances(&self) -> backup_instances::Client {
+    pub fn backup_instances_client(&self) -> backup_instances::Client {
         backup_instances::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_vault_operation_results(&self) -> backup_vault_operation_results::Client {
+    pub fn backup_vault_operation_results_client(&self) -> backup_vault_operation_results::Client {
         backup_vault_operation_results::Client(self.clone())
     }
-    pub fn backup_vaults(&self) -> backup_vaults::Client {
+    pub fn backup_vaults_client(&self) -> backup_vaults::Client {
         backup_vaults::Client(self.clone())
     }
-    pub fn data_protection(&self) -> data_protection::Client {
+    pub fn data_protection_client(&self) -> data_protection::Client {
         data_protection::Client(self.clone())
     }
-    pub fn data_protection_operations(&self) -> data_protection_operations::Client {
+    pub fn data_protection_operations_client(&self) -> data_protection_operations::Client {
         data_protection_operations::Client(self.clone())
     }
-    pub fn export_jobs(&self) -> export_jobs::Client {
+    pub fn export_jobs_client(&self) -> export_jobs::Client {
         export_jobs::Client(self.clone())
     }
-    pub fn export_jobs_operation_result(&self) -> export_jobs_operation_result::Client {
+    pub fn export_jobs_operation_result_client(&self) -> export_jobs_operation_result::Client {
         export_jobs_operation_result::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation_result(&self) -> operation_result::Client {
+    pub fn operation_result_client(&self) -> operation_result::Client {
         operation_result::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operation_status_backup_vault_context(&self) -> operation_status_backup_vault_context::Client {
+    pub fn operation_status_backup_vault_context_client(&self) -> operation_status_backup_vault_context::Client {
         operation_status_backup_vault_context::Client(self.clone())
     }
-    pub fn operation_status_resource_group_context(&self) -> operation_status_resource_group_context::Client {
+    pub fn operation_status_resource_group_context_client(&self) -> operation_status_resource_group_context::Client {
         operation_status_resource_group_context::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn resource_guards(&self) -> resource_guards::Client {
+    pub fn resource_guards_client(&self) -> resource_guards::Client {
         resource_guards::Client(self.clone())
     }
-    pub fn restorable_time_ranges(&self) -> restorable_time_ranges::Client {
+    pub fn restorable_time_ranges_client(&self) -> restorable_time_ranges::Client {
         restorable_time_ranges::Client(self.clone())
     }
 }

--- a/services/mgmt/dataprotection/src/package_2022_03/operations.rs
+++ b/services/mgmt/dataprotection/src/package_2022_03/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_instances(&self) -> backup_instances::Client {
+    pub fn backup_instances_client(&self) -> backup_instances::Client {
         backup_instances::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_vault_operation_results(&self) -> backup_vault_operation_results::Client {
+    pub fn backup_vault_operation_results_client(&self) -> backup_vault_operation_results::Client {
         backup_vault_operation_results::Client(self.clone())
     }
-    pub fn backup_vaults(&self) -> backup_vaults::Client {
+    pub fn backup_vaults_client(&self) -> backup_vaults::Client {
         backup_vaults::Client(self.clone())
     }
-    pub fn data_protection(&self) -> data_protection::Client {
+    pub fn data_protection_client(&self) -> data_protection::Client {
         data_protection::Client(self.clone())
     }
-    pub fn data_protection_operations(&self) -> data_protection_operations::Client {
+    pub fn data_protection_operations_client(&self) -> data_protection_operations::Client {
         data_protection_operations::Client(self.clone())
     }
-    pub fn export_jobs(&self) -> export_jobs::Client {
+    pub fn export_jobs_client(&self) -> export_jobs::Client {
         export_jobs::Client(self.clone())
     }
-    pub fn export_jobs_operation_result(&self) -> export_jobs_operation_result::Client {
+    pub fn export_jobs_operation_result_client(&self) -> export_jobs_operation_result::Client {
         export_jobs_operation_result::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation_result(&self) -> operation_result::Client {
+    pub fn operation_result_client(&self) -> operation_result::Client {
         operation_result::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operation_status_backup_vault_context(&self) -> operation_status_backup_vault_context::Client {
+    pub fn operation_status_backup_vault_context_client(&self) -> operation_status_backup_vault_context::Client {
         operation_status_backup_vault_context::Client(self.clone())
     }
-    pub fn operation_status_resource_group_context(&self) -> operation_status_resource_group_context::Client {
+    pub fn operation_status_resource_group_context_client(&self) -> operation_status_resource_group_context::Client {
         operation_status_resource_group_context::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn resource_guards(&self) -> resource_guards::Client {
+    pub fn resource_guards_client(&self) -> resource_guards::Client {
         resource_guards::Client(self.clone())
     }
-    pub fn restorable_time_ranges(&self) -> restorable_time_ranges::Client {
+    pub fn restorable_time_ranges_client(&self) -> restorable_time_ranges::Client {
         restorable_time_ranges::Client(self.clone())
     }
 }

--- a/services/mgmt/dataprotection/src/package_2022_04/operations.rs
+++ b/services/mgmt/dataprotection/src/package_2022_04/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_instances(&self) -> backup_instances::Client {
+    pub fn backup_instances_client(&self) -> backup_instances::Client {
         backup_instances::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_vault_operation_results(&self) -> backup_vault_operation_results::Client {
+    pub fn backup_vault_operation_results_client(&self) -> backup_vault_operation_results::Client {
         backup_vault_operation_results::Client(self.clone())
     }
-    pub fn backup_vaults(&self) -> backup_vaults::Client {
+    pub fn backup_vaults_client(&self) -> backup_vaults::Client {
         backup_vaults::Client(self.clone())
     }
-    pub fn data_protection(&self) -> data_protection::Client {
+    pub fn data_protection_client(&self) -> data_protection::Client {
         data_protection::Client(self.clone())
     }
-    pub fn data_protection_operations(&self) -> data_protection_operations::Client {
+    pub fn data_protection_operations_client(&self) -> data_protection_operations::Client {
         data_protection_operations::Client(self.clone())
     }
-    pub fn export_jobs(&self) -> export_jobs::Client {
+    pub fn export_jobs_client(&self) -> export_jobs::Client {
         export_jobs::Client(self.clone())
     }
-    pub fn export_jobs_operation_result(&self) -> export_jobs_operation_result::Client {
+    pub fn export_jobs_operation_result_client(&self) -> export_jobs_operation_result::Client {
         export_jobs_operation_result::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation_result(&self) -> operation_result::Client {
+    pub fn operation_result_client(&self) -> operation_result::Client {
         operation_result::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operation_status_backup_vault_context(&self) -> operation_status_backup_vault_context::Client {
+    pub fn operation_status_backup_vault_context_client(&self) -> operation_status_backup_vault_context::Client {
         operation_status_backup_vault_context::Client(self.clone())
     }
-    pub fn operation_status_resource_group_context(&self) -> operation_status_resource_group_context::Client {
+    pub fn operation_status_resource_group_context_client(&self) -> operation_status_resource_group_context::Client {
         operation_status_resource_group_context::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn resource_guards(&self) -> resource_guards::Client {
+    pub fn resource_guards_client(&self) -> resource_guards::Client {
         resource_guards::Client(self.clone())
     }
-    pub fn restorable_time_ranges(&self) -> restorable_time_ranges::Client {
+    pub fn restorable_time_ranges_client(&self) -> restorable_time_ranges::Client {
         restorable_time_ranges::Client(self.clone())
     }
 }

--- a/services/mgmt/datashare/src/package_2018_11_01_preview/operations.rs
+++ b/services/mgmt/datashare/src/package_2018_11_01_preview/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn consumer_invitations(&self) -> consumer_invitations::Client {
+    pub fn consumer_invitations_client(&self) -> consumer_invitations::Client {
         consumer_invitations::Client(self.clone())
     }
-    pub fn consumer_source_data_sets(&self) -> consumer_source_data_sets::Client {
+    pub fn consumer_source_data_sets_client(&self) -> consumer_source_data_sets::Client {
         consumer_source_data_sets::Client(self.clone())
     }
-    pub fn data_set_mappings(&self) -> data_set_mappings::Client {
+    pub fn data_set_mappings_client(&self) -> data_set_mappings::Client {
         data_set_mappings::Client(self.clone())
     }
-    pub fn data_sets(&self) -> data_sets::Client {
+    pub fn data_sets_client(&self) -> data_sets::Client {
         data_sets::Client(self.clone())
     }
-    pub fn invitations(&self) -> invitations::Client {
+    pub fn invitations_client(&self) -> invitations::Client {
         invitations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_share_subscriptions(&self) -> provider_share_subscriptions::Client {
+    pub fn provider_share_subscriptions_client(&self) -> provider_share_subscriptions::Client {
         provider_share_subscriptions::Client(self.clone())
     }
-    pub fn share_subscriptions(&self) -> share_subscriptions::Client {
+    pub fn share_subscriptions_client(&self) -> share_subscriptions::Client {
         share_subscriptions::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn synchronization_settings(&self) -> synchronization_settings::Client {
+    pub fn synchronization_settings_client(&self) -> synchronization_settings::Client {
         synchronization_settings::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/mgmt/datashare/src/package_2019_11_01/operations.rs
+++ b/services/mgmt/datashare/src/package_2019_11_01/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn consumer_invitations(&self) -> consumer_invitations::Client {
+    pub fn consumer_invitations_client(&self) -> consumer_invitations::Client {
         consumer_invitations::Client(self.clone())
     }
-    pub fn consumer_source_data_sets(&self) -> consumer_source_data_sets::Client {
+    pub fn consumer_source_data_sets_client(&self) -> consumer_source_data_sets::Client {
         consumer_source_data_sets::Client(self.clone())
     }
-    pub fn data_set_mappings(&self) -> data_set_mappings::Client {
+    pub fn data_set_mappings_client(&self) -> data_set_mappings::Client {
         data_set_mappings::Client(self.clone())
     }
-    pub fn data_sets(&self) -> data_sets::Client {
+    pub fn data_sets_client(&self) -> data_sets::Client {
         data_sets::Client(self.clone())
     }
-    pub fn email_registrations(&self) -> email_registrations::Client {
+    pub fn email_registrations_client(&self) -> email_registrations::Client {
         email_registrations::Client(self.clone())
     }
-    pub fn invitations(&self) -> invitations::Client {
+    pub fn invitations_client(&self) -> invitations::Client {
         invitations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_share_subscriptions(&self) -> provider_share_subscriptions::Client {
+    pub fn provider_share_subscriptions_client(&self) -> provider_share_subscriptions::Client {
         provider_share_subscriptions::Client(self.clone())
     }
-    pub fn share_subscriptions(&self) -> share_subscriptions::Client {
+    pub fn share_subscriptions_client(&self) -> share_subscriptions::Client {
         share_subscriptions::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn synchronization_settings(&self) -> synchronization_settings::Client {
+    pub fn synchronization_settings_client(&self) -> synchronization_settings::Client {
         synchronization_settings::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/mgmt/datashare/src/package_2020_09_01/operations.rs
+++ b/services/mgmt/datashare/src/package_2020_09_01/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn consumer_invitations(&self) -> consumer_invitations::Client {
+    pub fn consumer_invitations_client(&self) -> consumer_invitations::Client {
         consumer_invitations::Client(self.clone())
     }
-    pub fn consumer_source_data_sets(&self) -> consumer_source_data_sets::Client {
+    pub fn consumer_source_data_sets_client(&self) -> consumer_source_data_sets::Client {
         consumer_source_data_sets::Client(self.clone())
     }
-    pub fn data_set_mappings(&self) -> data_set_mappings::Client {
+    pub fn data_set_mappings_client(&self) -> data_set_mappings::Client {
         data_set_mappings::Client(self.clone())
     }
-    pub fn data_sets(&self) -> data_sets::Client {
+    pub fn data_sets_client(&self) -> data_sets::Client {
         data_sets::Client(self.clone())
     }
-    pub fn email_registrations(&self) -> email_registrations::Client {
+    pub fn email_registrations_client(&self) -> email_registrations::Client {
         email_registrations::Client(self.clone())
     }
-    pub fn invitations(&self) -> invitations::Client {
+    pub fn invitations_client(&self) -> invitations::Client {
         invitations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_share_subscriptions(&self) -> provider_share_subscriptions::Client {
+    pub fn provider_share_subscriptions_client(&self) -> provider_share_subscriptions::Client {
         provider_share_subscriptions::Client(self.clone())
     }
-    pub fn share_subscriptions(&self) -> share_subscriptions::Client {
+    pub fn share_subscriptions_client(&self) -> share_subscriptions::Client {
         share_subscriptions::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn synchronization_settings(&self) -> synchronization_settings::Client {
+    pub fn synchronization_settings_client(&self) -> synchronization_settings::Client {
         synchronization_settings::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/mgmt/datashare/src/package_2020_10_01_preview/operations.rs
+++ b/services/mgmt/datashare/src/package_2020_10_01_preview/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn consumer_invitations(&self) -> consumer_invitations::Client {
+    pub fn consumer_invitations_client(&self) -> consumer_invitations::Client {
         consumer_invitations::Client(self.clone())
     }
-    pub fn consumer_source_data_sets(&self) -> consumer_source_data_sets::Client {
+    pub fn consumer_source_data_sets_client(&self) -> consumer_source_data_sets::Client {
         consumer_source_data_sets::Client(self.clone())
     }
-    pub fn data_set_mappings(&self) -> data_set_mappings::Client {
+    pub fn data_set_mappings_client(&self) -> data_set_mappings::Client {
         data_set_mappings::Client(self.clone())
     }
-    pub fn data_sets(&self) -> data_sets::Client {
+    pub fn data_sets_client(&self) -> data_sets::Client {
         data_sets::Client(self.clone())
     }
-    pub fn invitations(&self) -> invitations::Client {
+    pub fn invitations_client(&self) -> invitations::Client {
         invitations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_share_subscriptions(&self) -> provider_share_subscriptions::Client {
+    pub fn provider_share_subscriptions_client(&self) -> provider_share_subscriptions::Client {
         provider_share_subscriptions::Client(self.clone())
     }
-    pub fn share_subscriptions(&self) -> share_subscriptions::Client {
+    pub fn share_subscriptions_client(&self) -> share_subscriptions::Client {
         share_subscriptions::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn synchronization_settings(&self) -> synchronization_settings::Client {
+    pub fn synchronization_settings_client(&self) -> synchronization_settings::Client {
         synchronization_settings::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/mgmt/datashare/src/package_2021_08_01/operations.rs
+++ b/services/mgmt/datashare/src/package_2021_08_01/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn consumer_invitations(&self) -> consumer_invitations::Client {
+    pub fn consumer_invitations_client(&self) -> consumer_invitations::Client {
         consumer_invitations::Client(self.clone())
     }
-    pub fn consumer_source_data_sets(&self) -> consumer_source_data_sets::Client {
+    pub fn consumer_source_data_sets_client(&self) -> consumer_source_data_sets::Client {
         consumer_source_data_sets::Client(self.clone())
     }
-    pub fn data_set_mappings(&self) -> data_set_mappings::Client {
+    pub fn data_set_mappings_client(&self) -> data_set_mappings::Client {
         data_set_mappings::Client(self.clone())
     }
-    pub fn data_sets(&self) -> data_sets::Client {
+    pub fn data_sets_client(&self) -> data_sets::Client {
         data_sets::Client(self.clone())
     }
-    pub fn email_registrations(&self) -> email_registrations::Client {
+    pub fn email_registrations_client(&self) -> email_registrations::Client {
         email_registrations::Client(self.clone())
     }
-    pub fn invitations(&self) -> invitations::Client {
+    pub fn invitations_client(&self) -> invitations::Client {
         invitations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_share_subscriptions(&self) -> provider_share_subscriptions::Client {
+    pub fn provider_share_subscriptions_client(&self) -> provider_share_subscriptions::Client {
         provider_share_subscriptions::Client(self.clone())
     }
-    pub fn share_subscriptions(&self) -> share_subscriptions::Client {
+    pub fn share_subscriptions_client(&self) -> share_subscriptions::Client {
         share_subscriptions::Client(self.clone())
     }
-    pub fn shares(&self) -> shares::Client {
+    pub fn shares_client(&self) -> shares::Client {
         shares::Client(self.clone())
     }
-    pub fn synchronization_settings(&self) -> synchronization_settings::Client {
+    pub fn synchronization_settings_client(&self) -> synchronization_settings::Client {
         synchronization_settings::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/mgmt/deploymentmanager/src/package_2019_11_01_preview/operations.rs
+++ b/services/mgmt/deploymentmanager/src/package_2019_11_01_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn artifact_sources(&self) -> artifact_sources::Client {
+    pub fn artifact_sources_client(&self) -> artifact_sources::Client {
         artifact_sources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn rollouts(&self) -> rollouts::Client {
+    pub fn rollouts_client(&self) -> rollouts::Client {
         rollouts::Client(self.clone())
     }
-    pub fn service_topologies(&self) -> service_topologies::Client {
+    pub fn service_topologies_client(&self) -> service_topologies::Client {
         service_topologies::Client(self.clone())
     }
-    pub fn service_units(&self) -> service_units::Client {
+    pub fn service_units_client(&self) -> service_units::Client {
         service_units::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn steps(&self) -> steps::Client {
+    pub fn steps_client(&self) -> steps::Client {
         steps::Client(self.clone())
     }
 }

--- a/services/mgmt/desktopvirtualization/src/package_2021_03_09_preview/operations.rs
+++ b/services/mgmt/desktopvirtualization/src/package_2021_03_09_preview/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_groups(&self) -> application_groups::Client {
+    pub fn application_groups_client(&self) -> application_groups::Client {
         application_groups::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn desktops(&self) -> desktops::Client {
+    pub fn desktops_client(&self) -> desktops::Client {
         desktops::Client(self.clone())
     }
-    pub fn host_pools(&self) -> host_pools::Client {
+    pub fn host_pools_client(&self) -> host_pools::Client {
         host_pools::Client(self.clone())
     }
-    pub fn msix_images(&self) -> msix_images::Client {
+    pub fn msix_images_client(&self) -> msix_images::Client {
         msix_images::Client(self.clone())
     }
-    pub fn msix_packages(&self) -> msix_packages::Client {
+    pub fn msix_packages_client(&self) -> msix_packages::Client {
         msix_packages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn scaling_plans(&self) -> scaling_plans::Client {
+    pub fn scaling_plans_client(&self) -> scaling_plans::Client {
         scaling_plans::Client(self.clone())
     }
-    pub fn session_hosts(&self) -> session_hosts::Client {
+    pub fn session_hosts_client(&self) -> session_hosts::Client {
         session_hosts::Client(self.clone())
     }
-    pub fn start_menu_items(&self) -> start_menu_items::Client {
+    pub fn start_menu_items_client(&self) -> start_menu_items::Client {
         start_menu_items::Client(self.clone())
     }
-    pub fn user_sessions(&self) -> user_sessions::Client {
+    pub fn user_sessions_client(&self) -> user_sessions::Client {
         user_sessions::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/desktopvirtualization/src/package_2021_04_01_preview/operations.rs
+++ b/services/mgmt/desktopvirtualization/src/package_2021_04_01_preview/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_groups(&self) -> application_groups::Client {
+    pub fn application_groups_client(&self) -> application_groups::Client {
         application_groups::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn desktops(&self) -> desktops::Client {
+    pub fn desktops_client(&self) -> desktops::Client {
         desktops::Client(self.clone())
     }
-    pub fn host_pools(&self) -> host_pools::Client {
+    pub fn host_pools_client(&self) -> host_pools::Client {
         host_pools::Client(self.clone())
     }
-    pub fn msix_images(&self) -> msix_images::Client {
+    pub fn msix_images_client(&self) -> msix_images::Client {
         msix_images::Client(self.clone())
     }
-    pub fn msix_packages(&self) -> msix_packages::Client {
+    pub fn msix_packages_client(&self) -> msix_packages::Client {
         msix_packages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn scaling_plans(&self) -> scaling_plans::Client {
+    pub fn scaling_plans_client(&self) -> scaling_plans::Client {
         scaling_plans::Client(self.clone())
     }
-    pub fn session_hosts(&self) -> session_hosts::Client {
+    pub fn session_hosts_client(&self) -> session_hosts::Client {
         session_hosts::Client(self.clone())
     }
-    pub fn start_menu_items(&self) -> start_menu_items::Client {
+    pub fn start_menu_items_client(&self) -> start_menu_items::Client {
         start_menu_items::Client(self.clone())
     }
-    pub fn user_sessions(&self) -> user_sessions::Client {
+    pub fn user_sessions_client(&self) -> user_sessions::Client {
         user_sessions::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/desktopvirtualization/src/package_2021_07/operations.rs
+++ b/services/mgmt/desktopvirtualization/src/package_2021_07/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_groups(&self) -> application_groups::Client {
+    pub fn application_groups_client(&self) -> application_groups::Client {
         application_groups::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn desktops(&self) -> desktops::Client {
+    pub fn desktops_client(&self) -> desktops::Client {
         desktops::Client(self.clone())
     }
-    pub fn host_pools(&self) -> host_pools::Client {
+    pub fn host_pools_client(&self) -> host_pools::Client {
         host_pools::Client(self.clone())
     }
-    pub fn msix_images(&self) -> msix_images::Client {
+    pub fn msix_images_client(&self) -> msix_images::Client {
         msix_images::Client(self.clone())
     }
-    pub fn msix_packages(&self) -> msix_packages::Client {
+    pub fn msix_packages_client(&self) -> msix_packages::Client {
         msix_packages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn scaling_plans(&self) -> scaling_plans::Client {
+    pub fn scaling_plans_client(&self) -> scaling_plans::Client {
         scaling_plans::Client(self.clone())
     }
-    pub fn session_hosts(&self) -> session_hosts::Client {
+    pub fn session_hosts_client(&self) -> session_hosts::Client {
         session_hosts::Client(self.clone())
     }
-    pub fn start_menu_items(&self) -> start_menu_items::Client {
+    pub fn start_menu_items_client(&self) -> start_menu_items::Client {
         start_menu_items::Client(self.clone())
     }
-    pub fn user_sessions(&self) -> user_sessions::Client {
+    pub fn user_sessions_client(&self) -> user_sessions::Client {
         user_sessions::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/desktopvirtualization/src/package_preview_2021_09/operations.rs
+++ b/services/mgmt/desktopvirtualization/src/package_preview_2021_09/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_groups(&self) -> application_groups::Client {
+    pub fn application_groups_client(&self) -> application_groups::Client {
         application_groups::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn desktops(&self) -> desktops::Client {
+    pub fn desktops_client(&self) -> desktops::Client {
         desktops::Client(self.clone())
     }
-    pub fn host_pools(&self) -> host_pools::Client {
+    pub fn host_pools_client(&self) -> host_pools::Client {
         host_pools::Client(self.clone())
     }
-    pub fn msix_images(&self) -> msix_images::Client {
+    pub fn msix_images_client(&self) -> msix_images::Client {
         msix_images::Client(self.clone())
     }
-    pub fn msix_packages(&self) -> msix_packages::Client {
+    pub fn msix_packages_client(&self) -> msix_packages::Client {
         msix_packages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn scaling_plans(&self) -> scaling_plans::Client {
+    pub fn scaling_plans_client(&self) -> scaling_plans::Client {
         scaling_plans::Client(self.clone())
     }
-    pub fn session_hosts(&self) -> session_hosts::Client {
+    pub fn session_hosts_client(&self) -> session_hosts::Client {
         session_hosts::Client(self.clone())
     }
-    pub fn start_menu_items(&self) -> start_menu_items::Client {
+    pub fn start_menu_items_client(&self) -> start_menu_items::Client {
         start_menu_items::Client(self.clone())
     }
-    pub fn user_sessions(&self) -> user_sessions::Client {
+    pub fn user_sessions_client(&self) -> user_sessions::Client {
         user_sessions::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/desktopvirtualization/src/package_preview_2022_02/operations.rs
+++ b/services/mgmt/desktopvirtualization/src/package_preview_2022_02/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_groups(&self) -> application_groups::Client {
+    pub fn application_groups_client(&self) -> application_groups::Client {
         application_groups::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn desktops(&self) -> desktops::Client {
+    pub fn desktops_client(&self) -> desktops::Client {
         desktops::Client(self.clone())
     }
-    pub fn host_pools(&self) -> host_pools::Client {
+    pub fn host_pools_client(&self) -> host_pools::Client {
         host_pools::Client(self.clone())
     }
-    pub fn msix_images(&self) -> msix_images::Client {
+    pub fn msix_images_client(&self) -> msix_images::Client {
         msix_images::Client(self.clone())
     }
-    pub fn msix_packages(&self) -> msix_packages::Client {
+    pub fn msix_packages_client(&self) -> msix_packages::Client {
         msix_packages::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn scaling_plans(&self) -> scaling_plans::Client {
+    pub fn scaling_plans_client(&self) -> scaling_plans::Client {
         scaling_plans::Client(self.clone())
     }
-    pub fn session_hosts(&self) -> session_hosts::Client {
+    pub fn session_hosts_client(&self) -> session_hosts::Client {
         session_hosts::Client(self.clone())
     }
-    pub fn start_menu_items(&self) -> start_menu_items::Client {
+    pub fn start_menu_items_client(&self) -> start_menu_items::Client {
         start_menu_items::Client(self.clone())
     }
-    pub fn user_sessions(&self) -> user_sessions::Client {
+    pub fn user_sessions_client(&self) -> user_sessions::Client {
         user_sessions::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/deviceupdate/src/package_2020_03_01_preview/operations.rs
+++ b/services/mgmt/deviceupdate/src/package_2020_03_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connection_proxies(&self) -> private_endpoint_connection_proxies::Client {
+    pub fn private_endpoint_connection_proxies_client(&self) -> private_endpoint_connection_proxies::Client {
         private_endpoint_connection_proxies::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/deviceupdate/src/package_2022_04_01_preview/operations.rs
+++ b/services/mgmt/deviceupdate/src/package_2022_04_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connection_proxies(&self) -> private_endpoint_connection_proxies::Client {
+    pub fn private_endpoint_connection_proxies_client(&self) -> private_endpoint_connection_proxies::Client {
         private_endpoint_connection_proxies::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/devops/src/package_2019_07_01_preview/operations.rs
+++ b/services/mgmt/devops/src/package_2019_07_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_template_definitions(&self) -> pipeline_template_definitions::Client {
+    pub fn pipeline_template_definitions_client(&self) -> pipeline_template_definitions::Client {
         pipeline_template_definitions::Client(self.clone())
     }
-    pub fn pipelines(&self) -> pipelines::Client {
+    pub fn pipelines_client(&self) -> pipelines::Client {
         pipelines::Client(self.clone())
     }
 }

--- a/services/mgmt/devops/src/package_2020_07_13_preview/operations.rs
+++ b/services/mgmt/devops/src/package_2020_07_13_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_template_definitions(&self) -> pipeline_template_definitions::Client {
+    pub fn pipeline_template_definitions_client(&self) -> pipeline_template_definitions::Client {
         pipeline_template_definitions::Client(self.clone())
     }
-    pub fn pipelines(&self) -> pipelines::Client {
+    pub fn pipelines_client(&self) -> pipelines::Client {
         pipelines::Client(self.clone())
     }
 }

--- a/services/mgmt/devspaces/src/package_2019_04_01/operations.rs
+++ b/services/mgmt/devspaces/src/package_2019_04_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn container_host_mappings(&self) -> container_host_mappings::Client {
+    pub fn container_host_mappings_client(&self) -> container_host_mappings::Client {
         container_host_mappings::Client(self.clone())
     }
-    pub fn controllers(&self) -> controllers::Client {
+    pub fn controllers_client(&self) -> controllers::Client {
         controllers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/devtestlabs/src/package_2015_05_preview/operations.rs
+++ b/services/mgmt/devtestlabs/src/package_2015_05_preview/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn artifact(&self) -> artifact::Client {
+    pub fn artifact_client(&self) -> artifact::Client {
         artifact::Client(self.clone())
     }
-    pub fn artifact_source(&self) -> artifact_source::Client {
+    pub fn artifact_source_client(&self) -> artifact_source::Client {
         artifact_source::Client(self.clone())
     }
-    pub fn cost(&self) -> cost::Client {
+    pub fn cost_client(&self) -> cost::Client {
         cost::Client(self.clone())
     }
-    pub fn cost_insight(&self) -> cost_insight::Client {
+    pub fn cost_insight_client(&self) -> cost_insight::Client {
         cost_insight::Client(self.clone())
     }
-    pub fn custom_image(&self) -> custom_image::Client {
+    pub fn custom_image_client(&self) -> custom_image::Client {
         custom_image::Client(self.clone())
     }
-    pub fn formula(&self) -> formula::Client {
+    pub fn formula_client(&self) -> formula::Client {
         formula::Client(self.clone())
     }
-    pub fn gallery_image(&self) -> gallery_image::Client {
+    pub fn gallery_image_client(&self) -> gallery_image::Client {
         gallery_image::Client(self.clone())
     }
-    pub fn lab(&self) -> lab::Client {
+    pub fn lab_client(&self) -> lab::Client {
         lab::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_set(&self) -> policy_set::Client {
+    pub fn policy_set_client(&self) -> policy_set::Client {
         policy_set::Client(self.clone())
     }
-    pub fn schedule(&self) -> schedule::Client {
+    pub fn schedule_client(&self) -> schedule::Client {
         schedule::Client(self.clone())
     }
-    pub fn virtual_machine(&self) -> virtual_machine::Client {
+    pub fn virtual_machine_client(&self) -> virtual_machine::Client {
         virtual_machine::Client(self.clone())
     }
-    pub fn virtual_network(&self) -> virtual_network::Client {
+    pub fn virtual_network_client(&self) -> virtual_network::Client {
         virtual_network::Client(self.clone())
     }
 }

--- a/services/mgmt/devtestlabs/src/package_2016_05/operations.rs
+++ b/services/mgmt/devtestlabs/src/package_2016_05/operations.rs
@@ -74,73 +74,73 @@ impl Client {
             pipeline,
         }
     }
-    pub fn arm_templates(&self) -> arm_templates::Client {
+    pub fn arm_templates_client(&self) -> arm_templates::Client {
         arm_templates::Client(self.clone())
     }
-    pub fn artifact_sources(&self) -> artifact_sources::Client {
+    pub fn artifact_sources_client(&self) -> artifact_sources::Client {
         artifact_sources::Client(self.clone())
     }
-    pub fn artifacts(&self) -> artifacts::Client {
+    pub fn artifacts_client(&self) -> artifacts::Client {
         artifacts::Client(self.clone())
     }
-    pub fn costs(&self) -> costs::Client {
+    pub fn costs_client(&self) -> costs::Client {
         costs::Client(self.clone())
     }
-    pub fn custom_images(&self) -> custom_images::Client {
+    pub fn custom_images_client(&self) -> custom_images::Client {
         custom_images::Client(self.clone())
     }
-    pub fn disks(&self) -> disks::Client {
+    pub fn disks_client(&self) -> disks::Client {
         disks::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn formulas(&self) -> formulas::Client {
+    pub fn formulas_client(&self) -> formulas::Client {
         formulas::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn global_schedules(&self) -> global_schedules::Client {
+    pub fn global_schedules_client(&self) -> global_schedules::Client {
         global_schedules::Client(self.clone())
     }
-    pub fn labs(&self) -> labs::Client {
+    pub fn labs_client(&self) -> labs::Client {
         labs::Client(self.clone())
     }
-    pub fn notification_channels(&self) -> notification_channels::Client {
+    pub fn notification_channels_client(&self) -> notification_channels::Client {
         notification_channels::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn policy_sets(&self) -> policy_sets::Client {
+    pub fn policy_sets_client(&self) -> policy_sets::Client {
         policy_sets::Client(self.clone())
     }
-    pub fn provider_operations(&self) -> provider_operations::Client {
+    pub fn provider_operations_client(&self) -> provider_operations::Client {
         provider_operations::Client(self.clone())
     }
-    pub fn schedules(&self) -> schedules::Client {
+    pub fn schedules_client(&self) -> schedules::Client {
         schedules::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn service_runners(&self) -> service_runners::Client {
+    pub fn service_runners_client(&self) -> service_runners::Client {
         service_runners::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
-    pub fn virtual_machine_schedules(&self) -> virtual_machine_schedules::Client {
+    pub fn virtual_machine_schedules_client(&self) -> virtual_machine_schedules::Client {
         virtual_machine_schedules::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
-    pub fn virtual_networks(&self) -> virtual_networks::Client {
+    pub fn virtual_networks_client(&self) -> virtual_networks::Client {
         virtual_networks::Client(self.clone())
     }
 }

--- a/services/mgmt/devtestlabs/src/package_2018_09/operations.rs
+++ b/services/mgmt/devtestlabs/src/package_2018_09/operations.rs
@@ -74,79 +74,79 @@ impl Client {
             pipeline,
         }
     }
-    pub fn arm_templates(&self) -> arm_templates::Client {
+    pub fn arm_templates_client(&self) -> arm_templates::Client {
         arm_templates::Client(self.clone())
     }
-    pub fn artifact_sources(&self) -> artifact_sources::Client {
+    pub fn artifact_sources_client(&self) -> artifact_sources::Client {
         artifact_sources::Client(self.clone())
     }
-    pub fn artifacts(&self) -> artifacts::Client {
+    pub fn artifacts_client(&self) -> artifacts::Client {
         artifacts::Client(self.clone())
     }
-    pub fn costs(&self) -> costs::Client {
+    pub fn costs_client(&self) -> costs::Client {
         costs::Client(self.clone())
     }
-    pub fn custom_images(&self) -> custom_images::Client {
+    pub fn custom_images_client(&self) -> custom_images::Client {
         custom_images::Client(self.clone())
     }
-    pub fn disks(&self) -> disks::Client {
+    pub fn disks_client(&self) -> disks::Client {
         disks::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn formulas(&self) -> formulas::Client {
+    pub fn formulas_client(&self) -> formulas::Client {
         formulas::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn global_schedules(&self) -> global_schedules::Client {
+    pub fn global_schedules_client(&self) -> global_schedules::Client {
         global_schedules::Client(self.clone())
     }
-    pub fn labs(&self) -> labs::Client {
+    pub fn labs_client(&self) -> labs::Client {
         labs::Client(self.clone())
     }
-    pub fn notification_channels(&self) -> notification_channels::Client {
+    pub fn notification_channels_client(&self) -> notification_channels::Client {
         notification_channels::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn policy_sets(&self) -> policy_sets::Client {
+    pub fn policy_sets_client(&self) -> policy_sets::Client {
         policy_sets::Client(self.clone())
     }
-    pub fn provider_operations(&self) -> provider_operations::Client {
+    pub fn provider_operations_client(&self) -> provider_operations::Client {
         provider_operations::Client(self.clone())
     }
-    pub fn schedules(&self) -> schedules::Client {
+    pub fn schedules_client(&self) -> schedules::Client {
         schedules::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn service_fabric_schedules(&self) -> service_fabric_schedules::Client {
+    pub fn service_fabric_schedules_client(&self) -> service_fabric_schedules::Client {
         service_fabric_schedules::Client(self.clone())
     }
-    pub fn service_fabrics(&self) -> service_fabrics::Client {
+    pub fn service_fabrics_client(&self) -> service_fabrics::Client {
         service_fabrics::Client(self.clone())
     }
-    pub fn service_runners(&self) -> service_runners::Client {
+    pub fn service_runners_client(&self) -> service_runners::Client {
         service_runners::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
-    pub fn virtual_machine_schedules(&self) -> virtual_machine_schedules::Client {
+    pub fn virtual_machine_schedules_client(&self) -> virtual_machine_schedules::Client {
         virtual_machine_schedules::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
-    pub fn virtual_networks(&self) -> virtual_networks::Client {
+    pub fn virtual_networks_client(&self) -> virtual_networks::Client {
         virtual_networks::Client(self.clone())
     }
 }

--- a/services/mgmt/dfp/src/package_2021_02_01_preview/operations.rs
+++ b/services/mgmt/dfp/src/package_2021_02_01_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
 }

--- a/services/mgmt/digitaltwins/src/package_2020_03_01_preview/operations.rs
+++ b/services/mgmt/digitaltwins/src/package_2020_03_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn digital_twins_endpoint(&self) -> digital_twins_endpoint::Client {
+    pub fn digital_twins_endpoint_client(&self) -> digital_twins_endpoint::Client {
         digital_twins_endpoint::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/digitaltwins/src/package_2020_10/operations.rs
+++ b/services/mgmt/digitaltwins/src/package_2020_10/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn digital_twins_endpoint(&self) -> digital_twins_endpoint::Client {
+    pub fn digital_twins_endpoint_client(&self) -> digital_twins_endpoint::Client {
         digital_twins_endpoint::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/digitaltwins/src/package_2020_12/operations.rs
+++ b/services/mgmt/digitaltwins/src/package_2020_12/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn digital_twins_endpoint(&self) -> digital_twins_endpoint::Client {
+    pub fn digital_twins_endpoint_client(&self) -> digital_twins_endpoint::Client {
         digital_twins_endpoint::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/digitaltwins/src/package_2021_06_30_preview/operations.rs
+++ b/services/mgmt/digitaltwins/src/package_2021_06_30_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn digital_twins_endpoint(&self) -> digital_twins_endpoint::Client {
+    pub fn digital_twins_endpoint_client(&self) -> digital_twins_endpoint::Client {
         digital_twins_endpoint::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn time_series_database_connections(&self) -> time_series_database_connections::Client {
+    pub fn time_series_database_connections_client(&self) -> time_series_database_connections::Client {
         time_series_database_connections::Client(self.clone())
     }
 }

--- a/services/mgmt/digitaltwins/src/package_2022_05/operations.rs
+++ b/services/mgmt/digitaltwins/src/package_2022_05/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn digital_twins_endpoint(&self) -> digital_twins_endpoint::Client {
+    pub fn digital_twins_endpoint_client(&self) -> digital_twins_endpoint::Client {
         digital_twins_endpoint::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn time_series_database_connections(&self) -> time_series_database_connections::Client {
+    pub fn time_series_database_connections_client(&self) -> time_series_database_connections::Client {
         time_series_database_connections::Client(self.clone())
     }
 }

--- a/services/mgmt/dnc/src/package_2020_08_08_preview/operations.rs
+++ b/services/mgmt/dnc/src/package_2020_08_08_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn controller(&self) -> controller::Client {
+    pub fn controller_client(&self) -> controller::Client {
         controller::Client(self.clone())
     }
-    pub fn delegated_network(&self) -> delegated_network::Client {
+    pub fn delegated_network_client(&self) -> delegated_network::Client {
         delegated_network::Client(self.clone())
     }
-    pub fn delegated_subnet_service(&self) -> delegated_subnet_service::Client {
+    pub fn delegated_subnet_service_client(&self) -> delegated_subnet_service::Client {
         delegated_subnet_service::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn orchestrator_instance_service(&self) -> orchestrator_instance_service::Client {
+    pub fn orchestrator_instance_service_client(&self) -> orchestrator_instance_service::Client {
         orchestrator_instance_service::Client(self.clone())
     }
 }

--- a/services/mgmt/dnc/src/package_2021_03_15/operations.rs
+++ b/services/mgmt/dnc/src/package_2021_03_15/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn controller(&self) -> controller::Client {
+    pub fn controller_client(&self) -> controller::Client {
         controller::Client(self.clone())
     }
-    pub fn delegated_network(&self) -> delegated_network::Client {
+    pub fn delegated_network_client(&self) -> delegated_network::Client {
         delegated_network::Client(self.clone())
     }
-    pub fn delegated_subnet_service(&self) -> delegated_subnet_service::Client {
+    pub fn delegated_subnet_service_client(&self) -> delegated_subnet_service::Client {
         delegated_subnet_service::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn orchestrator_instance_service(&self) -> orchestrator_instance_service::Client {
+    pub fn orchestrator_instance_service_client(&self) -> orchestrator_instance_service::Client {
         orchestrator_instance_service::Client(self.clone())
     }
 }

--- a/services/mgmt/dns/src/package_2017_09/operations.rs
+++ b/services/mgmt/dns/src/package_2017_09/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn zones(&self) -> zones::Client {
+    pub fn zones_client(&self) -> zones::Client {
         zones::Client(self.clone())
     }
 }

--- a/services/mgmt/dns/src/package_2017_10/operations.rs
+++ b/services/mgmt/dns/src/package_2017_10/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn zones(&self) -> zones::Client {
+    pub fn zones_client(&self) -> zones::Client {
         zones::Client(self.clone())
     }
 }

--- a/services/mgmt/dns/src/package_2018_03_preview/operations.rs
+++ b/services/mgmt/dns/src/package_2018_03_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn zones(&self) -> zones::Client {
+    pub fn zones_client(&self) -> zones::Client {
         zones::Client(self.clone())
     }
 }

--- a/services/mgmt/dns/src/package_2018_05/operations.rs
+++ b/services/mgmt/dns/src/package_2018_05/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dns_resource_reference(&self) -> dns_resource_reference::Client {
+    pub fn dns_resource_reference_client(&self) -> dns_resource_reference::Client {
         dns_resource_reference::Client(self.clone())
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn zones(&self) -> zones::Client {
+    pub fn zones_client(&self) -> zones::Client {
         zones::Client(self.clone())
     }
 }

--- a/services/mgmt/dns/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/dns/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn zones(&self) -> zones::Client {
+    pub fn zones_client(&self) -> zones::Client {
         zones::Client(self.clone())
     }
 }

--- a/services/mgmt/dnsresolver/src/package_2020_04_preview/operations.rs
+++ b/services/mgmt/dnsresolver/src/package_2020_04_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dns_forwarding_rulesets(&self) -> dns_forwarding_rulesets::Client {
+    pub fn dns_forwarding_rulesets_client(&self) -> dns_forwarding_rulesets::Client {
         dns_forwarding_rulesets::Client(self.clone())
     }
-    pub fn dns_resolvers(&self) -> dns_resolvers::Client {
+    pub fn dns_resolvers_client(&self) -> dns_resolvers::Client {
         dns_resolvers::Client(self.clone())
     }
-    pub fn forwarding_rules(&self) -> forwarding_rules::Client {
+    pub fn forwarding_rules_client(&self) -> forwarding_rules::Client {
         forwarding_rules::Client(self.clone())
     }
-    pub fn inbound_endpoints(&self) -> inbound_endpoints::Client {
+    pub fn inbound_endpoints_client(&self) -> inbound_endpoints::Client {
         inbound_endpoints::Client(self.clone())
     }
-    pub fn outbound_endpoints(&self) -> outbound_endpoints::Client {
+    pub fn outbound_endpoints_client(&self) -> outbound_endpoints::Client {
         outbound_endpoints::Client(self.clone())
     }
-    pub fn virtual_network_links(&self) -> virtual_network_links::Client {
+    pub fn virtual_network_links_client(&self) -> virtual_network_links::Client {
         virtual_network_links::Client(self.clone())
     }
 }

--- a/services/mgmt/domainservices/src/package_2017_01/operations.rs
+++ b/services/mgmt/domainservices/src/package_2017_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn domain_service_operations(&self) -> domain_service_operations::Client {
+    pub fn domain_service_operations_client(&self) -> domain_service_operations::Client {
         domain_service_operations::Client(self.clone())
     }
-    pub fn domain_services(&self) -> domain_services::Client {
+    pub fn domain_services_client(&self) -> domain_services::Client {
         domain_services::Client(self.clone())
     }
 }

--- a/services/mgmt/domainservices/src/package_2017_06/operations.rs
+++ b/services/mgmt/domainservices/src/package_2017_06/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn domain_service_operations(&self) -> domain_service_operations::Client {
+    pub fn domain_service_operations_client(&self) -> domain_service_operations::Client {
         domain_service_operations::Client(self.clone())
     }
-    pub fn domain_services(&self) -> domain_services::Client {
+    pub fn domain_services_client(&self) -> domain_services::Client {
         domain_services::Client(self.clone())
     }
-    pub fn ou_container(&self) -> ou_container::Client {
+    pub fn ou_container_client(&self) -> ou_container::Client {
         ou_container::Client(self.clone())
     }
-    pub fn ou_container_operations(&self) -> ou_container_operations::Client {
+    pub fn ou_container_operations_client(&self) -> ou_container_operations::Client {
         ou_container_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/domainservices/src/package_2020_01/operations.rs
+++ b/services/mgmt/domainservices/src/package_2020_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn domain_service_operations(&self) -> domain_service_operations::Client {
+    pub fn domain_service_operations_client(&self) -> domain_service_operations::Client {
         domain_service_operations::Client(self.clone())
     }
-    pub fn domain_services(&self) -> domain_services::Client {
+    pub fn domain_services_client(&self) -> domain_services::Client {
         domain_services::Client(self.clone())
     }
-    pub fn ou_container(&self) -> ou_container::Client {
+    pub fn ou_container_client(&self) -> ou_container::Client {
         ou_container::Client(self.clone())
     }
-    pub fn ou_container_operations(&self) -> ou_container_operations::Client {
+    pub fn ou_container_operations_client(&self) -> ou_container_operations::Client {
         ou_container_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/domainservices/src/package_2021_03/operations.rs
+++ b/services/mgmt/domainservices/src/package_2021_03/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn domain_service_operations(&self) -> domain_service_operations::Client {
+    pub fn domain_service_operations_client(&self) -> domain_service_operations::Client {
         domain_service_operations::Client(self.clone())
     }
-    pub fn domain_services(&self) -> domain_services::Client {
+    pub fn domain_services_client(&self) -> domain_services::Client {
         domain_services::Client(self.clone())
     }
-    pub fn ou_container(&self) -> ou_container::Client {
+    pub fn ou_container_client(&self) -> ou_container::Client {
         ou_container::Client(self.clone())
     }
-    pub fn ou_container_operations(&self) -> ou_container_operations::Client {
+    pub fn ou_container_operations_client(&self) -> ou_container_operations::Client {
         ou_container_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/domainservices/src/package_2021_05/operations.rs
+++ b/services/mgmt/domainservices/src/package_2021_05/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn domain_service_operations(&self) -> domain_service_operations::Client {
+    pub fn domain_service_operations_client(&self) -> domain_service_operations::Client {
         domain_service_operations::Client(self.clone())
     }
-    pub fn domain_services(&self) -> domain_services::Client {
+    pub fn domain_services_client(&self) -> domain_services::Client {
         domain_services::Client(self.clone())
     }
-    pub fn ou_container(&self) -> ou_container::Client {
+    pub fn ou_container_client(&self) -> ou_container::Client {
         ou_container::Client(self.clone())
     }
-    pub fn ou_container_operations(&self) -> ou_container_operations::Client {
+    pub fn ou_container_operations_client(&self) -> ou_container_operations::Client {
         ou_container_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/dynatrace/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/dynatrace/src/package_2021_09_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn single_sign_on(&self) -> single_sign_on::Client {
+    pub fn single_sign_on_client(&self) -> single_sign_on::Client {
         single_sign_on::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/education/src/package_2021_12_01_preview/operations.rs
+++ b/services/mgmt/education/src/package_2021_12_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn grants(&self) -> grants::Client {
+    pub fn grants_client(&self) -> grants::Client {
         grants::Client(self.clone())
     }
-    pub fn join_requests(&self) -> join_requests::Client {
+    pub fn join_requests_client(&self) -> join_requests::Client {
         join_requests::Client(self.clone())
     }
-    pub fn labs(&self) -> labs::Client {
+    pub fn labs_client(&self) -> labs::Client {
         labs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn student_labs(&self) -> student_labs::Client {
+    pub fn student_labs_client(&self) -> student_labs::Client {
         student_labs::Client(self.clone())
     }
-    pub fn students(&self) -> students::Client {
+    pub fn students_client(&self) -> students::Client {
         students::Client(self.clone())
     }
 }

--- a/services/mgmt/elastic/src/package_2020_07_01/operations.rs
+++ b/services/mgmt/elastic/src/package_2020_07_01/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn deployment_info(&self) -> deployment_info::Client {
+    pub fn deployment_info_client(&self) -> deployment_info::Client {
         deployment_info::Client(self.clone())
     }
-    pub fn monitored_resources(&self) -> monitored_resources::Client {
+    pub fn monitored_resources_client(&self) -> monitored_resources::Client {
         monitored_resources::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
-    pub fn vm_collection(&self) -> vm_collection::Client {
+    pub fn vm_collection_client(&self) -> vm_collection::Client {
         vm_collection::Client(self.clone())
     }
-    pub fn vm_host(&self) -> vm_host::Client {
+    pub fn vm_host_client(&self) -> vm_host::Client {
         vm_host::Client(self.clone())
     }
-    pub fn vm_ingestion(&self) -> vm_ingestion::Client {
+    pub fn vm_ingestion_client(&self) -> vm_ingestion::Client {
         vm_ingestion::Client(self.clone())
     }
 }

--- a/services/mgmt/elastic/src/package_2020_07_01_preview/operations.rs
+++ b/services/mgmt/elastic/src/package_2020_07_01_preview/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn deployment_info(&self) -> deployment_info::Client {
+    pub fn deployment_info_client(&self) -> deployment_info::Client {
         deployment_info::Client(self.clone())
     }
-    pub fn monitored_resources(&self) -> monitored_resources::Client {
+    pub fn monitored_resources_client(&self) -> monitored_resources::Client {
         monitored_resources::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
-    pub fn vm_collection(&self) -> vm_collection::Client {
+    pub fn vm_collection_client(&self) -> vm_collection::Client {
         vm_collection::Client(self.clone())
     }
-    pub fn vm_host(&self) -> vm_host::Client {
+    pub fn vm_host_client(&self) -> vm_host::Client {
         vm_host::Client(self.clone())
     }
-    pub fn vm_ingestion(&self) -> vm_ingestion::Client {
+    pub fn vm_ingestion_client(&self) -> vm_ingestion::Client {
         vm_ingestion::Client(self.clone())
     }
 }

--- a/services/mgmt/elastic/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/elastic/src/package_2021_09_01_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn deployment_info(&self) -> deployment_info::Client {
+    pub fn deployment_info_client(&self) -> deployment_info::Client {
         deployment_info::Client(self.clone())
     }
-    pub fn external_user(&self) -> external_user::Client {
+    pub fn external_user_client(&self) -> external_user::Client {
         external_user::Client(self.clone())
     }
-    pub fn monitored_resources(&self) -> monitored_resources::Client {
+    pub fn monitored_resources_client(&self) -> monitored_resources::Client {
         monitored_resources::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
-    pub fn vm_collection(&self) -> vm_collection::Client {
+    pub fn vm_collection_client(&self) -> vm_collection::Client {
         vm_collection::Client(self.clone())
     }
-    pub fn vm_host(&self) -> vm_host::Client {
+    pub fn vm_host_client(&self) -> vm_host::Client {
         vm_host::Client(self.clone())
     }
-    pub fn vm_ingestion(&self) -> vm_ingestion::Client {
+    pub fn vm_ingestion_client(&self) -> vm_ingestion::Client {
         vm_ingestion::Client(self.clone())
     }
 }

--- a/services/mgmt/elastic/src/package_2021_10_01_preview/operations.rs
+++ b/services/mgmt/elastic/src/package_2021_10_01_preview/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn deployment_info(&self) -> deployment_info::Client {
+    pub fn deployment_info_client(&self) -> deployment_info::Client {
         deployment_info::Client(self.clone())
     }
-    pub fn external_user(&self) -> external_user::Client {
+    pub fn external_user_client(&self) -> external_user::Client {
         external_user::Client(self.clone())
     }
-    pub fn monitor(&self) -> monitor::Client {
+    pub fn monitor_client(&self) -> monitor::Client {
         monitor::Client(self.clone())
     }
-    pub fn monitored_resources(&self) -> monitored_resources::Client {
+    pub fn monitored_resources_client(&self) -> monitored_resources::Client {
         monitored_resources::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
-    pub fn upgradable_versions(&self) -> upgradable_versions::Client {
+    pub fn upgradable_versions_client(&self) -> upgradable_versions::Client {
         upgradable_versions::Client(self.clone())
     }
-    pub fn vm_collection(&self) -> vm_collection::Client {
+    pub fn vm_collection_client(&self) -> vm_collection::Client {
         vm_collection::Client(self.clone())
     }
-    pub fn vm_host(&self) -> vm_host::Client {
+    pub fn vm_host_client(&self) -> vm_host::Client {
         vm_host::Client(self.clone())
     }
-    pub fn vm_ingestion(&self) -> vm_ingestion::Client {
+    pub fn vm_ingestion_client(&self) -> vm_ingestion::Client {
         vm_ingestion::Client(self.clone())
     }
 }

--- a/services/mgmt/elasticsan/src/package_2021_11_20_preview/operations.rs
+++ b/services/mgmt/elasticsan/src/package_2021_11_20_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn elastic_sans(&self) -> elastic_sans::Client {
+    pub fn elastic_sans_client(&self) -> elastic_sans::Client {
         elastic_sans::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn volume_groups(&self) -> volume_groups::Client {
+    pub fn volume_groups_client(&self) -> volume_groups::Client {
         volume_groups::Client(self.clone())
     }
-    pub fn volumes(&self) -> volumes::Client {
+    pub fn volumes_client(&self) -> volumes::Client {
         volumes::Client(self.clone())
     }
 }

--- a/services/mgmt/engagementfabric/src/package_2018_09_preview/operations.rs
+++ b/services/mgmt/engagementfabric/src/package_2018_09_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn channels(&self) -> channels::Client {
+    pub fn channels_client(&self) -> channels::Client {
         channels::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn sk_us(&self) -> sk_us::Client {
+    pub fn sk_us_client(&self) -> sk_us::Client {
         sk_us::Client(self.clone())
     }
 }

--- a/services/mgmt/enterpriseknowledgegraph/src/package_2018_12_03/operations.rs
+++ b/services/mgmt/enterpriseknowledgegraph/src/package_2018_12_03/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn enterprise_knowledge_graph(&self) -> enterprise_knowledge_graph::Client {
+    pub fn enterprise_knowledge_graph_client(&self) -> enterprise_knowledge_graph::Client {
         enterprise_knowledge_graph::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/eventgrid/src/package_2021_10_preview/operations.rs
+++ b/services/mgmt/eventgrid/src/package_2021_10_preview/operations.rs
@@ -74,73 +74,73 @@ impl Client {
             pipeline,
         }
     }
-    pub fn channels(&self) -> channels::Client {
+    pub fn channels_client(&self) -> channels::Client {
         channels::Client(self.clone())
     }
-    pub fn domain_event_subscriptions(&self) -> domain_event_subscriptions::Client {
+    pub fn domain_event_subscriptions_client(&self) -> domain_event_subscriptions::Client {
         domain_event_subscriptions::Client(self.clone())
     }
-    pub fn domain_topic_event_subscriptions(&self) -> domain_topic_event_subscriptions::Client {
+    pub fn domain_topic_event_subscriptions_client(&self) -> domain_topic_event_subscriptions::Client {
         domain_topic_event_subscriptions::Client(self.clone())
     }
-    pub fn domain_topics(&self) -> domain_topics::Client {
+    pub fn domain_topics_client(&self) -> domain_topics::Client {
         domain_topics::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn event_channels(&self) -> event_channels::Client {
+    pub fn event_channels_client(&self) -> event_channels::Client {
         event_channels::Client(self.clone())
     }
-    pub fn event_subscriptions(&self) -> event_subscriptions::Client {
+    pub fn event_subscriptions_client(&self) -> event_subscriptions::Client {
         event_subscriptions::Client(self.clone())
     }
-    pub fn extension_topics(&self) -> extension_topics::Client {
+    pub fn extension_topics_client(&self) -> extension_topics::Client {
         extension_topics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn partner_configurations(&self) -> partner_configurations::Client {
+    pub fn partner_configurations_client(&self) -> partner_configurations::Client {
         partner_configurations::Client(self.clone())
     }
-    pub fn partner_destinations(&self) -> partner_destinations::Client {
+    pub fn partner_destinations_client(&self) -> partner_destinations::Client {
         partner_destinations::Client(self.clone())
     }
-    pub fn partner_namespaces(&self) -> partner_namespaces::Client {
+    pub fn partner_namespaces_client(&self) -> partner_namespaces::Client {
         partner_namespaces::Client(self.clone())
     }
-    pub fn partner_registrations(&self) -> partner_registrations::Client {
+    pub fn partner_registrations_client(&self) -> partner_registrations::Client {
         partner_registrations::Client(self.clone())
     }
-    pub fn partner_topic_event_subscriptions(&self) -> partner_topic_event_subscriptions::Client {
+    pub fn partner_topic_event_subscriptions_client(&self) -> partner_topic_event_subscriptions::Client {
         partner_topic_event_subscriptions::Client(self.clone())
     }
-    pub fn partner_topics(&self) -> partner_topics::Client {
+    pub fn partner_topics_client(&self) -> partner_topics::Client {
         partner_topics::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn system_topic_event_subscriptions(&self) -> system_topic_event_subscriptions::Client {
+    pub fn system_topic_event_subscriptions_client(&self) -> system_topic_event_subscriptions::Client {
         system_topic_event_subscriptions::Client(self.clone())
     }
-    pub fn system_topics(&self) -> system_topics::Client {
+    pub fn system_topics_client(&self) -> system_topics::Client {
         system_topics::Client(self.clone())
     }
-    pub fn topic_event_subscriptions(&self) -> topic_event_subscriptions::Client {
+    pub fn topic_event_subscriptions_client(&self) -> topic_event_subscriptions::Client {
         topic_event_subscriptions::Client(self.clone())
     }
-    pub fn topic_types(&self) -> topic_types::Client {
+    pub fn topic_types_client(&self) -> topic_types::Client {
         topic_types::Client(self.clone())
     }
-    pub fn topics(&self) -> topics::Client {
+    pub fn topics_client(&self) -> topics::Client {
         topics::Client(self.clone())
     }
-    pub fn verified_partners(&self) -> verified_partners::Client {
+    pub fn verified_partners_client(&self) -> verified_partners::Client {
         verified_partners::Client(self.clone())
     }
 }

--- a/services/mgmt/eventgrid/src/package_2021_12/operations.rs
+++ b/services/mgmt/eventgrid/src/package_2021_12/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn domain_topics(&self) -> domain_topics::Client {
+    pub fn domain_topics_client(&self) -> domain_topics::Client {
         domain_topics::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn event_subscriptions(&self) -> event_subscriptions::Client {
+    pub fn event_subscriptions_client(&self) -> event_subscriptions::Client {
         event_subscriptions::Client(self.clone())
     }
-    pub fn extension_topics(&self) -> extension_topics::Client {
+    pub fn extension_topics_client(&self) -> extension_topics::Client {
         extension_topics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn system_topic_event_subscriptions(&self) -> system_topic_event_subscriptions::Client {
+    pub fn system_topic_event_subscriptions_client(&self) -> system_topic_event_subscriptions::Client {
         system_topic_event_subscriptions::Client(self.clone())
     }
-    pub fn system_topics(&self) -> system_topics::Client {
+    pub fn system_topics_client(&self) -> system_topics::Client {
         system_topics::Client(self.clone())
     }
-    pub fn topic_types(&self) -> topic_types::Client {
+    pub fn topic_types_client(&self) -> topic_types::Client {
         topic_types::Client(self.clone())
     }
-    pub fn topics(&self) -> topics::Client {
+    pub fn topics_client(&self) -> topics::Client {
         topics::Client(self.clone())
     }
 }

--- a/services/mgmt/eventhub/src/package_2021_01_preview/operations.rs
+++ b/services/mgmt/eventhub/src/package_2021_01_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn consumer_groups(&self) -> consumer_groups::Client {
+    pub fn consumer_groups_client(&self) -> consumer_groups::Client {
         consumer_groups::Client(self.clone())
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn event_hubs(&self) -> event_hubs::Client {
+    pub fn event_hubs_client(&self) -> event_hubs::Client {
         event_hubs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/eventhub/src/package_2021_06_preview/operations.rs
+++ b/services/mgmt/eventhub/src/package_2021_06_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn configuration(&self) -> configuration::Client {
+    pub fn configuration_client(&self) -> configuration::Client {
         configuration::Client(self.clone())
     }
-    pub fn consumer_groups(&self) -> consumer_groups::Client {
+    pub fn consumer_groups_client(&self) -> consumer_groups::Client {
         consumer_groups::Client(self.clone())
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn event_hubs(&self) -> event_hubs::Client {
+    pub fn event_hubs_client(&self) -> event_hubs::Client {
         event_hubs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/eventhub/src/package_2021_11/operations.rs
+++ b/services/mgmt/eventhub/src/package_2021_11/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn configuration(&self) -> configuration::Client {
+    pub fn configuration_client(&self) -> configuration::Client {
         configuration::Client(self.clone())
     }
-    pub fn consumer_groups(&self) -> consumer_groups::Client {
+    pub fn consumer_groups_client(&self) -> consumer_groups::Client {
         consumer_groups::Client(self.clone())
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn event_hubs(&self) -> event_hubs::Client {
+    pub fn event_hubs_client(&self) -> event_hubs::Client {
         event_hubs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn schema_registry(&self) -> schema_registry::Client {
+    pub fn schema_registry_client(&self) -> schema_registry::Client {
         schema_registry::Client(self.clone())
     }
 }

--- a/services/mgmt/eventhub/src/package_2022_01_preview/operations.rs
+++ b/services/mgmt/eventhub/src/package_2022_01_preview/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_group(&self) -> application_group::Client {
+    pub fn application_group_client(&self) -> application_group::Client {
         application_group::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn configuration(&self) -> configuration::Client {
+    pub fn configuration_client(&self) -> configuration::Client {
         configuration::Client(self.clone())
     }
-    pub fn consumer_groups(&self) -> consumer_groups::Client {
+    pub fn consumer_groups_client(&self) -> consumer_groups::Client {
         consumer_groups::Client(self.clone())
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn event_hubs(&self) -> event_hubs::Client {
+    pub fn event_hubs_client(&self) -> event_hubs::Client {
         event_hubs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn network_security_perimeter_configuration(&self) -> network_security_perimeter_configuration::Client {
+    pub fn network_security_perimeter_configuration_client(&self) -> network_security_perimeter_configuration::Client {
         network_security_perimeter_configuration::Client(self.clone())
     }
-    pub fn network_security_perimeter_configurations(&self) -> network_security_perimeter_configurations::Client {
+    pub fn network_security_perimeter_configurations_client(&self) -> network_security_perimeter_configurations::Client {
         network_security_perimeter_configurations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn schema_registry(&self) -> schema_registry::Client {
+    pub fn schema_registry_client(&self) -> schema_registry::Client {
         schema_registry::Client(self.clone())
     }
 }

--- a/services/mgmt/eventhub/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/eventhub/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn consumer_groups(&self) -> consumer_groups::Client {
+    pub fn consumer_groups_client(&self) -> consumer_groups::Client {
         consumer_groups::Client(self.clone())
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn event_hubs(&self) -> event_hubs::Client {
+    pub fn event_hubs_client(&self) -> event_hubs::Client {
         event_hubs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn regions(&self) -> regions::Client {
+    pub fn regions_client(&self) -> regions::Client {
         regions::Client(self.clone())
     }
 }

--- a/services/mgmt/extendedlocation/src/package_2021_03_15_preview/operations.rs
+++ b/services/mgmt/extendedlocation/src/package_2021_03_15_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_locations(&self) -> custom_locations::Client {
+    pub fn custom_locations_client(&self) -> custom_locations::Client {
         custom_locations::Client(self.clone())
     }
 }

--- a/services/mgmt/extendedlocation/src/package_2021_08_15/operations.rs
+++ b/services/mgmt/extendedlocation/src/package_2021_08_15/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_locations(&self) -> custom_locations::Client {
+    pub fn custom_locations_client(&self) -> custom_locations::Client {
         custom_locations::Client(self.clone())
     }
 }

--- a/services/mgmt/extendedlocation/src/package_2021_08_31_preview/operations.rs
+++ b/services/mgmt/extendedlocation/src/package_2021_08_31_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_locations(&self) -> custom_locations::Client {
+    pub fn custom_locations_client(&self) -> custom_locations::Client {
         custom_locations::Client(self.clone())
     }
-    pub fn resource_sync_rules(&self) -> resource_sync_rules::Client {
+    pub fn resource_sync_rules_client(&self) -> resource_sync_rules::Client {
         resource_sync_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/fluidrelay/src/package_2021_08_30_preview/operations.rs
+++ b/services/mgmt/fluidrelay/src/package_2021_08_30_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn fluid_relay_containers(&self) -> fluid_relay_containers::Client {
+    pub fn fluid_relay_containers_client(&self) -> fluid_relay_containers::Client {
         fluid_relay_containers::Client(self.clone())
     }
-    pub fn fluid_relay_operations(&self) -> fluid_relay_operations::Client {
+    pub fn fluid_relay_operations_client(&self) -> fluid_relay_operations::Client {
         fluid_relay_operations::Client(self.clone())
     }
-    pub fn fluid_relay_servers(&self) -> fluid_relay_servers::Client {
+    pub fn fluid_relay_servers_client(&self) -> fluid_relay_servers::Client {
         fluid_relay_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/fluidrelay/src/package_2021_09_10_preview/operations.rs
+++ b/services/mgmt/fluidrelay/src/package_2021_09_10_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn fluid_relay_containers(&self) -> fluid_relay_containers::Client {
+    pub fn fluid_relay_containers_client(&self) -> fluid_relay_containers::Client {
         fluid_relay_containers::Client(self.clone())
     }
-    pub fn fluid_relay_operations(&self) -> fluid_relay_operations::Client {
+    pub fn fluid_relay_operations_client(&self) -> fluid_relay_operations::Client {
         fluid_relay_operations::Client(self.clone())
     }
-    pub fn fluid_relay_servers(&self) -> fluid_relay_servers::Client {
+    pub fn fluid_relay_servers_client(&self) -> fluid_relay_servers::Client {
         fluid_relay_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/fluidrelay/src/package_2022_02_15/operations.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_02_15/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn fluid_relay_containers(&self) -> fluid_relay_containers::Client {
+    pub fn fluid_relay_containers_client(&self) -> fluid_relay_containers::Client {
         fluid_relay_containers::Client(self.clone())
     }
-    pub fn fluid_relay_operations(&self) -> fluid_relay_operations::Client {
+    pub fn fluid_relay_operations_client(&self) -> fluid_relay_operations::Client {
         fluid_relay_operations::Client(self.clone())
     }
-    pub fn fluid_relay_servers(&self) -> fluid_relay_servers::Client {
+    pub fn fluid_relay_servers_client(&self) -> fluid_relay_servers::Client {
         fluid_relay_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/fluidrelay/src/package_2022_04_21/operations.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_04_21/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn fluid_relay_containers(&self) -> fluid_relay_containers::Client {
+    pub fn fluid_relay_containers_client(&self) -> fluid_relay_containers::Client {
         fluid_relay_containers::Client(self.clone())
     }
-    pub fn fluid_relay_operations(&self) -> fluid_relay_operations::Client {
+    pub fn fluid_relay_operations_client(&self) -> fluid_relay_operations::Client {
         fluid_relay_operations::Client(self.clone())
     }
-    pub fn fluid_relay_servers(&self) -> fluid_relay_servers::Client {
+    pub fn fluid_relay_servers_client(&self) -> fluid_relay_servers::Client {
         fluid_relay_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/fluidrelay/src/package_2022_05_11/operations.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_05_11/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn fluid_relay_containers(&self) -> fluid_relay_containers::Client {
+    pub fn fluid_relay_containers_client(&self) -> fluid_relay_containers::Client {
         fluid_relay_containers::Client(self.clone())
     }
-    pub fn fluid_relay_operations(&self) -> fluid_relay_operations::Client {
+    pub fn fluid_relay_operations_client(&self) -> fluid_relay_operations::Client {
         fluid_relay_operations::Client(self.clone())
     }
-    pub fn fluid_relay_servers(&self) -> fluid_relay_servers::Client {
+    pub fn fluid_relay_servers_client(&self) -> fluid_relay_servers::Client {
         fluid_relay_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/frontdoor/src/package_2019_11/operations.rs
+++ b/services/mgmt/frontdoor/src/package_2019_11/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn experiments(&self) -> experiments::Client {
+    pub fn experiments_client(&self) -> experiments::Client {
         experiments::Client(self.clone())
     }
-    pub fn front_doors(&self) -> front_doors::Client {
+    pub fn front_doors_client(&self) -> front_doors::Client {
         front_doors::Client(self.clone())
     }
-    pub fn frontend_endpoints(&self) -> frontend_endpoints::Client {
+    pub fn frontend_endpoints_client(&self) -> frontend_endpoints::Client {
         frontend_endpoints::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn network_experiment_profiles(&self) -> network_experiment_profiles::Client {
+    pub fn network_experiment_profiles_client(&self) -> network_experiment_profiles::Client {
         network_experiment_profiles::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn preconfigured_endpoints(&self) -> preconfigured_endpoints::Client {
+    pub fn preconfigured_endpoints_client(&self) -> preconfigured_endpoints::Client {
         preconfigured_endpoints::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
 }

--- a/services/mgmt/frontdoor/src/package_2020_01/operations.rs
+++ b/services/mgmt/frontdoor/src/package_2020_01/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn experiments(&self) -> experiments::Client {
+    pub fn experiments_client(&self) -> experiments::Client {
         experiments::Client(self.clone())
     }
-    pub fn front_doors(&self) -> front_doors::Client {
+    pub fn front_doors_client(&self) -> front_doors::Client {
         front_doors::Client(self.clone())
     }
-    pub fn frontend_endpoints(&self) -> frontend_endpoints::Client {
+    pub fn frontend_endpoints_client(&self) -> frontend_endpoints::Client {
         frontend_endpoints::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn network_experiment_profiles(&self) -> network_experiment_profiles::Client {
+    pub fn network_experiment_profiles_client(&self) -> network_experiment_profiles::Client {
         network_experiment_profiles::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn preconfigured_endpoints(&self) -> preconfigured_endpoints::Client {
+    pub fn preconfigured_endpoints_client(&self) -> preconfigured_endpoints::Client {
         preconfigured_endpoints::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn rules_engines(&self) -> rules_engines::Client {
+    pub fn rules_engines_client(&self) -> rules_engines::Client {
         rules_engines::Client(self.clone())
     }
 }

--- a/services/mgmt/frontdoor/src/package_2020_04/operations.rs
+++ b/services/mgmt/frontdoor/src/package_2020_04/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn experiments(&self) -> experiments::Client {
+    pub fn experiments_client(&self) -> experiments::Client {
         experiments::Client(self.clone())
     }
-    pub fn front_doors(&self) -> front_doors::Client {
+    pub fn front_doors_client(&self) -> front_doors::Client {
         front_doors::Client(self.clone())
     }
-    pub fn frontend_endpoints(&self) -> frontend_endpoints::Client {
+    pub fn frontend_endpoints_client(&self) -> frontend_endpoints::Client {
         frontend_endpoints::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn network_experiment_profiles(&self) -> network_experiment_profiles::Client {
+    pub fn network_experiment_profiles_client(&self) -> network_experiment_profiles::Client {
         network_experiment_profiles::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn preconfigured_endpoints(&self) -> preconfigured_endpoints::Client {
+    pub fn preconfigured_endpoints_client(&self) -> preconfigured_endpoints::Client {
         preconfigured_endpoints::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn rules_engines(&self) -> rules_engines::Client {
+    pub fn rules_engines_client(&self) -> rules_engines::Client {
         rules_engines::Client(self.clone())
     }
 }

--- a/services/mgmt/frontdoor/src/package_2020_05/operations.rs
+++ b/services/mgmt/frontdoor/src/package_2020_05/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn experiments(&self) -> experiments::Client {
+    pub fn experiments_client(&self) -> experiments::Client {
         experiments::Client(self.clone())
     }
-    pub fn front_door_name_availability(&self) -> front_door_name_availability::Client {
+    pub fn front_door_name_availability_client(&self) -> front_door_name_availability::Client {
         front_door_name_availability::Client(self.clone())
     }
-    pub fn front_door_name_availability_with_subscription(&self) -> front_door_name_availability_with_subscription::Client {
+    pub fn front_door_name_availability_with_subscription_client(&self) -> front_door_name_availability_with_subscription::Client {
         front_door_name_availability_with_subscription::Client(self.clone())
     }
-    pub fn front_doors(&self) -> front_doors::Client {
+    pub fn front_doors_client(&self) -> front_doors::Client {
         front_doors::Client(self.clone())
     }
-    pub fn frontend_endpoints(&self) -> frontend_endpoints::Client {
+    pub fn frontend_endpoints_client(&self) -> frontend_endpoints::Client {
         frontend_endpoints::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn network_experiment_profiles(&self) -> network_experiment_profiles::Client {
+    pub fn network_experiment_profiles_client(&self) -> network_experiment_profiles::Client {
         network_experiment_profiles::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn preconfigured_endpoints(&self) -> preconfigured_endpoints::Client {
+    pub fn preconfigured_endpoints_client(&self) -> preconfigured_endpoints::Client {
         preconfigured_endpoints::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn rules_engines(&self) -> rules_engines::Client {
+    pub fn rules_engines_client(&self) -> rules_engines::Client {
         rules_engines::Client(self.clone())
     }
 }

--- a/services/mgmt/frontdoor/src/package_2020_11/operations.rs
+++ b/services/mgmt/frontdoor/src/package_2020_11/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn experiments(&self) -> experiments::Client {
+    pub fn experiments_client(&self) -> experiments::Client {
         experiments::Client(self.clone())
     }
-    pub fn front_door_name_availability(&self) -> front_door_name_availability::Client {
+    pub fn front_door_name_availability_client(&self) -> front_door_name_availability::Client {
         front_door_name_availability::Client(self.clone())
     }
-    pub fn front_door_name_availability_with_subscription(&self) -> front_door_name_availability_with_subscription::Client {
+    pub fn front_door_name_availability_with_subscription_client(&self) -> front_door_name_availability_with_subscription::Client {
         front_door_name_availability_with_subscription::Client(self.clone())
     }
-    pub fn front_doors(&self) -> front_doors::Client {
+    pub fn front_doors_client(&self) -> front_doors::Client {
         front_doors::Client(self.clone())
     }
-    pub fn frontend_endpoints(&self) -> frontend_endpoints::Client {
+    pub fn frontend_endpoints_client(&self) -> frontend_endpoints::Client {
         frontend_endpoints::Client(self.clone())
     }
-    pub fn managed_rule_sets(&self) -> managed_rule_sets::Client {
+    pub fn managed_rule_sets_client(&self) -> managed_rule_sets::Client {
         managed_rule_sets::Client(self.clone())
     }
-    pub fn network_experiment_profiles(&self) -> network_experiment_profiles::Client {
+    pub fn network_experiment_profiles_client(&self) -> network_experiment_profiles::Client {
         network_experiment_profiles::Client(self.clone())
     }
-    pub fn policies(&self) -> policies::Client {
+    pub fn policies_client(&self) -> policies::Client {
         policies::Client(self.clone())
     }
-    pub fn preconfigured_endpoints(&self) -> preconfigured_endpoints::Client {
+    pub fn preconfigured_endpoints_client(&self) -> preconfigured_endpoints::Client {
         preconfigured_endpoints::Client(self.clone())
     }
-    pub fn reports(&self) -> reports::Client {
+    pub fn reports_client(&self) -> reports::Client {
         reports::Client(self.clone())
     }
-    pub fn rules_engines(&self) -> rules_engines::Client {
+    pub fn rules_engines_client(&self) -> rules_engines::Client {
         rules_engines::Client(self.clone())
     }
 }

--- a/services/mgmt/guestconfiguration/src/package_2018_06_30_preview/operations.rs
+++ b/services/mgmt/guestconfiguration/src/package_2018_06_30_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn guest_configuration_assignment_reports(&self) -> guest_configuration_assignment_reports::Client {
+    pub fn guest_configuration_assignment_reports_client(&self) -> guest_configuration_assignment_reports::Client {
         guest_configuration_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_assignments(&self) -> guest_configuration_assignments::Client {
+    pub fn guest_configuration_assignments_client(&self) -> guest_configuration_assignments::Client {
         guest_configuration_assignments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/guestconfiguration/src/package_2018_11_20/operations.rs
+++ b/services/mgmt/guestconfiguration/src/package_2018_11_20/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn guest_configuration_assignment_reports(&self) -> guest_configuration_assignment_reports::Client {
+    pub fn guest_configuration_assignment_reports_client(&self) -> guest_configuration_assignment_reports::Client {
         guest_configuration_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_assignments(&self) -> guest_configuration_assignments::Client {
+    pub fn guest_configuration_assignments_client(&self) -> guest_configuration_assignments::Client {
         guest_configuration_assignments::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignment_reports(&self) -> guest_configuration_hcrp_assignment_reports::Client {
+    pub fn guest_configuration_hcrp_assignment_reports_client(&self) -> guest_configuration_hcrp_assignment_reports::Client {
         guest_configuration_hcrp_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignments(&self) -> guest_configuration_hcrp_assignments::Client {
+    pub fn guest_configuration_hcrp_assignments_client(&self) -> guest_configuration_hcrp_assignments::Client {
         guest_configuration_hcrp_assignments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/guestconfiguration/src/package_2020_06_25/operations.rs
+++ b/services/mgmt/guestconfiguration/src/package_2020_06_25/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn guest_configuration_assignment_reports(&self) -> guest_configuration_assignment_reports::Client {
+    pub fn guest_configuration_assignment_reports_client(&self) -> guest_configuration_assignment_reports::Client {
         guest_configuration_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_assignments(&self) -> guest_configuration_assignments::Client {
+    pub fn guest_configuration_assignments_client(&self) -> guest_configuration_assignments::Client {
         guest_configuration_assignments::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignment_reports(&self) -> guest_configuration_hcrp_assignment_reports::Client {
+    pub fn guest_configuration_hcrp_assignment_reports_client(&self) -> guest_configuration_hcrp_assignment_reports::Client {
         guest_configuration_hcrp_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignments(&self) -> guest_configuration_hcrp_assignments::Client {
+    pub fn guest_configuration_hcrp_assignments_client(&self) -> guest_configuration_hcrp_assignments::Client {
         guest_configuration_hcrp_assignments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/guestconfiguration/src/package_2021_01_25/operations.rs
+++ b/services/mgmt/guestconfiguration/src/package_2021_01_25/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn guest_configuration_assignment_reports(&self) -> guest_configuration_assignment_reports::Client {
+    pub fn guest_configuration_assignment_reports_client(&self) -> guest_configuration_assignment_reports::Client {
         guest_configuration_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_assignment_reports_vmss(&self) -> guest_configuration_assignment_reports_vmss::Client {
+    pub fn guest_configuration_assignment_reports_vmss_client(&self) -> guest_configuration_assignment_reports_vmss::Client {
         guest_configuration_assignment_reports_vmss::Client(self.clone())
     }
-    pub fn guest_configuration_assignments(&self) -> guest_configuration_assignments::Client {
+    pub fn guest_configuration_assignments_client(&self) -> guest_configuration_assignments::Client {
         guest_configuration_assignments::Client(self.clone())
     }
-    pub fn guest_configuration_assignments_vmss(&self) -> guest_configuration_assignments_vmss::Client {
+    pub fn guest_configuration_assignments_vmss_client(&self) -> guest_configuration_assignments_vmss::Client {
         guest_configuration_assignments_vmss::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignment_reports(&self) -> guest_configuration_hcrp_assignment_reports::Client {
+    pub fn guest_configuration_hcrp_assignment_reports_client(&self) -> guest_configuration_hcrp_assignment_reports::Client {
         guest_configuration_hcrp_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignments(&self) -> guest_configuration_hcrp_assignments::Client {
+    pub fn guest_configuration_hcrp_assignments_client(&self) -> guest_configuration_hcrp_assignments::Client {
         guest_configuration_hcrp_assignments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/guestconfiguration/src/package_2022_01_25/operations.rs
+++ b/services/mgmt/guestconfiguration/src/package_2022_01_25/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn guest_configuration_assignment_reports(&self) -> guest_configuration_assignment_reports::Client {
+    pub fn guest_configuration_assignment_reports_client(&self) -> guest_configuration_assignment_reports::Client {
         guest_configuration_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_assignment_reports_vmss(&self) -> guest_configuration_assignment_reports_vmss::Client {
+    pub fn guest_configuration_assignment_reports_vmss_client(&self) -> guest_configuration_assignment_reports_vmss::Client {
         guest_configuration_assignment_reports_vmss::Client(self.clone())
     }
-    pub fn guest_configuration_assignments(&self) -> guest_configuration_assignments::Client {
+    pub fn guest_configuration_assignments_client(&self) -> guest_configuration_assignments::Client {
         guest_configuration_assignments::Client(self.clone())
     }
-    pub fn guest_configuration_assignments_vmss(&self) -> guest_configuration_assignments_vmss::Client {
+    pub fn guest_configuration_assignments_vmss_client(&self) -> guest_configuration_assignments_vmss::Client {
         guest_configuration_assignments_vmss::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignment_reports(&self) -> guest_configuration_hcrp_assignment_reports::Client {
+    pub fn guest_configuration_hcrp_assignment_reports_client(&self) -> guest_configuration_hcrp_assignment_reports::Client {
         guest_configuration_hcrp_assignment_reports::Client(self.clone())
     }
-    pub fn guest_configuration_hcrp_assignments(&self) -> guest_configuration_hcrp_assignments::Client {
+    pub fn guest_configuration_hcrp_assignments_client(&self) -> guest_configuration_hcrp_assignments::Client {
         guest_configuration_hcrp_assignments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hanaon/src/package_2017_11/operations.rs
+++ b/services/mgmt/hanaon/src/package_2017_11/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hana_instances(&self) -> hana_instances::Client {
+    pub fn hana_instances_client(&self) -> hana_instances::Client {
         hana_instances::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hanaon/src/package_2020_02_07_preview/operations.rs
+++ b/services/mgmt/hanaon/src/package_2020_02_07_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_instances(&self) -> provider_instances::Client {
+    pub fn provider_instances_client(&self) -> provider_instances::Client {
         provider_instances::Client(self.clone())
     }
-    pub fn sap_monitors(&self) -> sap_monitors::Client {
+    pub fn sap_monitors_client(&self) -> sap_monitors::Client {
         sap_monitors::Client(self.clone())
     }
 }

--- a/services/mgmt/hardwaresecuritymodules/src/package_2018_10/operations.rs
+++ b/services/mgmt/hardwaresecuritymodules/src/package_2018_10/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dedicated_hsm(&self) -> dedicated_hsm::Client {
+    pub fn dedicated_hsm_client(&self) -> dedicated_hsm::Client {
         dedicated_hsm::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hardwaresecuritymodules/src/package_2021_11/operations.rs
+++ b/services/mgmt/hardwaresecuritymodules/src/package_2021_11/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dedicated_hsm(&self) -> dedicated_hsm::Client {
+    pub fn dedicated_hsm_client(&self) -> dedicated_hsm::Client {
         dedicated_hsm::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hdinsight/src/package_2015_03_preview/operations.rs
+++ b/services/mgmt/hdinsight/src/package_2015_03_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn extension(&self) -> extension::Client {
+    pub fn extension_client(&self) -> extension::Client {
         extension::Client(self.clone())
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn script_actions(&self) -> script_actions::Client {
+    pub fn script_actions_client(&self) -> script_actions::Client {
         script_actions::Client(self.clone())
     }
-    pub fn script_execution_history(&self) -> script_execution_history::Client {
+    pub fn script_execution_history_client(&self) -> script_execution_history::Client {
         script_execution_history::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/hdinsight/src/package_2018_06_preview/operations.rs
+++ b/services/mgmt/hdinsight/src/package_2018_06_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn script_actions(&self) -> script_actions::Client {
+    pub fn script_actions_client(&self) -> script_actions::Client {
         script_actions::Client(self.clone())
     }
-    pub fn script_execution_history(&self) -> script_execution_history::Client {
+    pub fn script_execution_history_client(&self) -> script_execution_history::Client {
         script_execution_history::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/hdinsight/src/package_2021_06/operations.rs
+++ b/services/mgmt/hdinsight/src/package_2021_06/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn script_actions(&self) -> script_actions::Client {
+    pub fn script_actions_client(&self) -> script_actions::Client {
         script_actions::Client(self.clone())
     }
-    pub fn script_execution_history(&self) -> script_execution_history::Client {
+    pub fn script_execution_history_client(&self) -> script_execution_history::Client {
         script_execution_history::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/healthbot/src/package_2020_10_20_preview/operations.rs
+++ b/services/mgmt/healthbot/src/package_2020_10_20_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn create(&self) -> create::Client {
+    pub fn create_client(&self) -> create::Client {
         create::Client(self.clone())
     }
-    pub fn delete(&self) -> delete::Client {
+    pub fn delete_client(&self) -> delete::Client {
         delete::Client(self.clone())
     }
-    pub fn get(&self) -> get::Client {
+    pub fn get_client(&self) -> get::Client {
         get::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn patch(&self) -> patch::Client {
+    pub fn patch_client(&self) -> patch::Client {
         patch::Client(self.clone())
     }
 }

--- a/services/mgmt/healthbot/src/package_2020_12_08/operations.rs
+++ b/services/mgmt/healthbot/src/package_2020_12_08/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/healthbot/src/package_2020_12_08_preview/operations.rs
+++ b/services/mgmt/healthbot/src/package_2020_12_08_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/healthbot/src/package_2021_06_10/operations.rs
+++ b/services/mgmt/healthbot/src/package_2021_06_10/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/healthbot/src/package_2021_08_24/operations.rs
+++ b/services/mgmt/healthbot/src/package_2021_08_24/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bots(&self) -> bots::Client {
+    pub fn bots_client(&self) -> bots::Client {
         bots::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/healthcareapis/src/package_2021_01/operations.rs
+++ b/services/mgmt/healthcareapis/src/package_2021_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/healthcareapis/src/package_2021_11/operations.rs
+++ b/services/mgmt/healthcareapis/src/package_2021_11/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dicom_services(&self) -> dicom_services::Client {
+    pub fn dicom_services_client(&self) -> dicom_services::Client {
         dicom_services::Client(self.clone())
     }
-    pub fn fhir_destinations(&self) -> fhir_destinations::Client {
+    pub fn fhir_destinations_client(&self) -> fhir_destinations::Client {
         fhir_destinations::Client(self.clone())
     }
-    pub fn fhir_services(&self) -> fhir_services::Client {
+    pub fn fhir_services_client(&self) -> fhir_services::Client {
         fhir_services::Client(self.clone())
     }
-    pub fn iot_connector_fhir_destination(&self) -> iot_connector_fhir_destination::Client {
+    pub fn iot_connector_fhir_destination_client(&self) -> iot_connector_fhir_destination::Client {
         iot_connector_fhir_destination::Client(self.clone())
     }
-    pub fn iot_connectors(&self) -> iot_connectors::Client {
+    pub fn iot_connectors_client(&self) -> iot_connectors::Client {
         iot_connectors::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn workspace_private_endpoint_connections(&self) -> workspace_private_endpoint_connections::Client {
+    pub fn workspace_private_endpoint_connections_client(&self) -> workspace_private_endpoint_connections::Client {
         workspace_private_endpoint_connections::Client(self.clone())
     }
-    pub fn workspace_private_link_resources(&self) -> workspace_private_link_resources::Client {
+    pub fn workspace_private_link_resources_client(&self) -> workspace_private_link_resources::Client {
         workspace_private_link_resources::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/healthcareapis/src/package_2022_05/operations.rs
+++ b/services/mgmt/healthcareapis/src/package_2022_05/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dicom_services(&self) -> dicom_services::Client {
+    pub fn dicom_services_client(&self) -> dicom_services::Client {
         dicom_services::Client(self.clone())
     }
-    pub fn fhir_destinations(&self) -> fhir_destinations::Client {
+    pub fn fhir_destinations_client(&self) -> fhir_destinations::Client {
         fhir_destinations::Client(self.clone())
     }
-    pub fn fhir_services(&self) -> fhir_services::Client {
+    pub fn fhir_services_client(&self) -> fhir_services::Client {
         fhir_services::Client(self.clone())
     }
-    pub fn iot_connector_fhir_destination(&self) -> iot_connector_fhir_destination::Client {
+    pub fn iot_connector_fhir_destination_client(&self) -> iot_connector_fhir_destination::Client {
         iot_connector_fhir_destination::Client(self.clone())
     }
-    pub fn iot_connectors(&self) -> iot_connectors::Client {
+    pub fn iot_connectors_client(&self) -> iot_connectors::Client {
         iot_connectors::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn workspace_private_endpoint_connections(&self) -> workspace_private_endpoint_connections::Client {
+    pub fn workspace_private_endpoint_connections_client(&self) -> workspace_private_endpoint_connections::Client {
         workspace_private_endpoint_connections::Client(self.clone())
     }
-    pub fn workspace_private_link_resources(&self) -> workspace_private_link_resources::Client {
+    pub fn workspace_private_link_resources_client(&self) -> workspace_private_link_resources::Client {
         workspace_private_link_resources::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/healthcareapis/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/healthcareapis/src/package_preview_2021_06/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dicom_services(&self) -> dicom_services::Client {
+    pub fn dicom_services_client(&self) -> dicom_services::Client {
         dicom_services::Client(self.clone())
     }
-    pub fn fhir_destinations(&self) -> fhir_destinations::Client {
+    pub fn fhir_destinations_client(&self) -> fhir_destinations::Client {
         fhir_destinations::Client(self.clone())
     }
-    pub fn fhir_services(&self) -> fhir_services::Client {
+    pub fn fhir_services_client(&self) -> fhir_services::Client {
         fhir_services::Client(self.clone())
     }
-    pub fn iot_connector_fhir_destination(&self) -> iot_connector_fhir_destination::Client {
+    pub fn iot_connector_fhir_destination_client(&self) -> iot_connector_fhir_destination::Client {
         iot_connector_fhir_destination::Client(self.clone())
     }
-    pub fn iot_connectors(&self) -> iot_connectors::Client {
+    pub fn iot_connectors_client(&self) -> iot_connectors::Client {
         iot_connectors::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/healthcareapis/src/package_preview_2022_01/operations.rs
+++ b/services/mgmt/healthcareapis/src/package_preview_2022_01/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dicom_services(&self) -> dicom_services::Client {
+    pub fn dicom_services_client(&self) -> dicom_services::Client {
         dicom_services::Client(self.clone())
     }
-    pub fn fhir_destinations(&self) -> fhir_destinations::Client {
+    pub fn fhir_destinations_client(&self) -> fhir_destinations::Client {
         fhir_destinations::Client(self.clone())
     }
-    pub fn fhir_services(&self) -> fhir_services::Client {
+    pub fn fhir_services_client(&self) -> fhir_services::Client {
         fhir_services::Client(self.clone())
     }
-    pub fn iot_connector_fhir_destination(&self) -> iot_connector_fhir_destination::Client {
+    pub fn iot_connector_fhir_destination_client(&self) -> iot_connector_fhir_destination::Client {
         iot_connector_fhir_destination::Client(self.clone())
     }
-    pub fn iot_connectors(&self) -> iot_connectors::Client {
+    pub fn iot_connectors_client(&self) -> iot_connectors::Client {
         iot_connectors::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn workspace_private_endpoint_connections(&self) -> workspace_private_endpoint_connections::Client {
+    pub fn workspace_private_endpoint_connections_client(&self) -> workspace_private_endpoint_connections::Client {
         workspace_private_endpoint_connections::Client(self.clone())
     }
-    pub fn workspace_private_link_resources(&self) -> workspace_private_link_resources::Client {
+    pub fn workspace_private_link_resources_client(&self) -> workspace_private_link_resources::Client {
         workspace_private_link_resources::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridcompute/src/package_preview_2021_03/operations.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_03/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn machine_extensions(&self) -> machine_extensions::Client {
+    pub fn machine_extensions_client(&self) -> machine_extensions::Client {
         machine_extensions::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridcompute/src/package_preview_2021_04/operations.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_04/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn machine_extensions(&self) -> machine_extensions::Client {
+    pub fn machine_extensions_client(&self) -> machine_extensions::Client {
         machine_extensions::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridcompute/src/package_preview_2021_05/operations.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_05/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn machine_extensions(&self) -> machine_extensions::Client {
+    pub fn machine_extensions_client(&self) -> machine_extensions::Client {
         machine_extensions::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridcompute/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_06/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn machine_extensions(&self) -> machine_extensions::Client {
+    pub fn machine_extensions_client(&self) -> machine_extensions::Client {
         machine_extensions::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridcompute/src/package_preview_2021_12/operations.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_12/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn machine_extensions(&self) -> machine_extensions::Client {
+    pub fn machine_extensions_client(&self) -> machine_extensions::Client {
         machine_extensions::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridconnectivity/src/package_2021_10_06_preview/operations.rs
+++ b/services/mgmt/hybridconnectivity/src/package_2021_10_06_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridconnectivity/src/package_2022_05_01_preview/operations.rs
+++ b/services/mgmt/hybridconnectivity/src/package_2022_05_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hybriddatamanager/src/package_2016_06/operations.rs
+++ b/services/mgmt/hybriddatamanager/src/package_2016_06/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_managers(&self) -> data_managers::Client {
+    pub fn data_managers_client(&self) -> data_managers::Client {
         data_managers::Client(self.clone())
     }
-    pub fn data_services(&self) -> data_services::Client {
+    pub fn data_services_client(&self) -> data_services::Client {
         data_services::Client(self.clone())
     }
-    pub fn data_store_types(&self) -> data_store_types::Client {
+    pub fn data_store_types_client(&self) -> data_store_types::Client {
         data_store_types::Client(self.clone())
     }
-    pub fn data_stores(&self) -> data_stores::Client {
+    pub fn data_stores_client(&self) -> data_stores::Client {
         data_stores::Client(self.clone())
     }
-    pub fn job_definitions(&self) -> job_definitions::Client {
+    pub fn job_definitions_client(&self) -> job_definitions::Client {
         job_definitions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn public_keys(&self) -> public_keys::Client {
+    pub fn public_keys_client(&self) -> public_keys::Client {
         public_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/hybriddatamanager/src/package_2019_06/operations.rs
+++ b/services/mgmt/hybriddatamanager/src/package_2019_06/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_managers(&self) -> data_managers::Client {
+    pub fn data_managers_client(&self) -> data_managers::Client {
         data_managers::Client(self.clone())
     }
-    pub fn data_services(&self) -> data_services::Client {
+    pub fn data_services_client(&self) -> data_services::Client {
         data_services::Client(self.clone())
     }
-    pub fn data_store_types(&self) -> data_store_types::Client {
+    pub fn data_store_types_client(&self) -> data_store_types::Client {
         data_store_types::Client(self.clone())
     }
-    pub fn data_stores(&self) -> data_stores::Client {
+    pub fn data_stores_client(&self) -> data_stores::Client {
         data_stores::Client(self.clone())
     }
-    pub fn job_definitions(&self) -> job_definitions::Client {
+    pub fn job_definitions_client(&self) -> job_definitions::Client {
         job_definitions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn public_keys(&self) -> public_keys::Client {
+    pub fn public_keys_client(&self) -> public_keys::Client {
         public_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridkubernetes/src/package_2020_01_01_preview/operations.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2020_01_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn connected_cluster(&self) -> connected_cluster::Client {
+    pub fn connected_cluster_client(&self) -> connected_cluster::Client {
         connected_cluster::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridkubernetes/src/package_2021_03_01/operations.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2021_03_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn connected_cluster(&self) -> connected_cluster::Client {
+    pub fn connected_cluster_client(&self) -> connected_cluster::Client {
         connected_cluster::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridkubernetes/src/package_2021_04_01_preview/operations.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2021_04_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn connected_cluster(&self) -> connected_cluster::Client {
+    pub fn connected_cluster_client(&self) -> connected_cluster::Client {
         connected_cluster::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridkubernetes/src/package_2021_10_01/operations.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2021_10_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn connected_cluster(&self) -> connected_cluster::Client {
+    pub fn connected_cluster_client(&self) -> connected_cluster::Client {
         connected_cluster::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridkubernetes/src/package_2022_05_01_preview/operations.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2022_05_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn connected_cluster(&self) -> connected_cluster::Client {
+    pub fn connected_cluster_client(&self) -> connected_cluster::Client {
         connected_cluster::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridnetwork/src/package_2020_01_01_preview/operations.rs
+++ b/services/mgmt/hybridnetwork/src/package_2020_01_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn network_function_vendor_skus(&self) -> network_function_vendor_skus::Client {
+    pub fn network_function_vendor_skus_client(&self) -> network_function_vendor_skus::Client {
         network_function_vendor_skus::Client(self.clone())
     }
-    pub fn network_function_vendors(&self) -> network_function_vendors::Client {
+    pub fn network_function_vendors_client(&self) -> network_function_vendors::Client {
         network_function_vendors::Client(self.clone())
     }
-    pub fn network_functions(&self) -> network_functions::Client {
+    pub fn network_functions_client(&self) -> network_functions::Client {
         network_functions::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn role_instances(&self) -> role_instances::Client {
+    pub fn role_instances_client(&self) -> role_instances::Client {
         role_instances::Client(self.clone())
     }
-    pub fn vendor_network_functions(&self) -> vendor_network_functions::Client {
+    pub fn vendor_network_functions_client(&self) -> vendor_network_functions::Client {
         vendor_network_functions::Client(self.clone())
     }
-    pub fn vendor_sku_preview(&self) -> vendor_sku_preview::Client {
+    pub fn vendor_sku_preview_client(&self) -> vendor_sku_preview::Client {
         vendor_sku_preview::Client(self.clone())
     }
-    pub fn vendor_skus(&self) -> vendor_skus::Client {
+    pub fn vendor_skus_client(&self) -> vendor_skus::Client {
         vendor_skus::Client(self.clone())
     }
-    pub fn vendors(&self) -> vendors::Client {
+    pub fn vendors_client(&self) -> vendors::Client {
         vendors::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridnetwork/src/package_2021_05_01/operations.rs
+++ b/services/mgmt/hybridnetwork/src/package_2021_05_01/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn network_function_vendor_skus(&self) -> network_function_vendor_skus::Client {
+    pub fn network_function_vendor_skus_client(&self) -> network_function_vendor_skus::Client {
         network_function_vendor_skus::Client(self.clone())
     }
-    pub fn network_function_vendors(&self) -> network_function_vendors::Client {
+    pub fn network_function_vendors_client(&self) -> network_function_vendors::Client {
         network_function_vendors::Client(self.clone())
     }
-    pub fn network_functions(&self) -> network_functions::Client {
+    pub fn network_functions_client(&self) -> network_functions::Client {
         network_functions::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn role_instances(&self) -> role_instances::Client {
+    pub fn role_instances_client(&self) -> role_instances::Client {
         role_instances::Client(self.clone())
     }
-    pub fn vendor_network_functions(&self) -> vendor_network_functions::Client {
+    pub fn vendor_network_functions_client(&self) -> vendor_network_functions::Client {
         vendor_network_functions::Client(self.clone())
     }
-    pub fn vendor_sku_preview(&self) -> vendor_sku_preview::Client {
+    pub fn vendor_sku_preview_client(&self) -> vendor_sku_preview::Client {
         vendor_sku_preview::Client(self.clone())
     }
-    pub fn vendor_skus(&self) -> vendor_skus::Client {
+    pub fn vendor_skus_client(&self) -> vendor_skus::Client {
         vendor_skus::Client(self.clone())
     }
-    pub fn vendors(&self) -> vendors::Client {
+    pub fn vendors_client(&self) -> vendors::Client {
         vendors::Client(self.clone())
     }
 }

--- a/services/mgmt/hybridnetwork/src/package_2022_01_01_preview/operations.rs
+++ b/services/mgmt/hybridnetwork/src/package_2022_01_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn network_function_vendor_skus(&self) -> network_function_vendor_skus::Client {
+    pub fn network_function_vendor_skus_client(&self) -> network_function_vendor_skus::Client {
         network_function_vendor_skus::Client(self.clone())
     }
-    pub fn network_function_vendors(&self) -> network_function_vendors::Client {
+    pub fn network_function_vendors_client(&self) -> network_function_vendors::Client {
         network_function_vendors::Client(self.clone())
     }
-    pub fn network_functions(&self) -> network_functions::Client {
+    pub fn network_functions_client(&self) -> network_functions::Client {
         network_functions::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn role_instances(&self) -> role_instances::Client {
+    pub fn role_instances_client(&self) -> role_instances::Client {
         role_instances::Client(self.clone())
     }
-    pub fn vendor_network_functions(&self) -> vendor_network_functions::Client {
+    pub fn vendor_network_functions_client(&self) -> vendor_network_functions::Client {
         vendor_network_functions::Client(self.clone())
     }
-    pub fn vendor_sku_preview(&self) -> vendor_sku_preview::Client {
+    pub fn vendor_sku_preview_client(&self) -> vendor_sku_preview::Client {
         vendor_sku_preview::Client(self.clone())
     }
-    pub fn vendor_skus(&self) -> vendor_skus::Client {
+    pub fn vendor_skus_client(&self) -> vendor_skus::Client {
         vendor_skus::Client(self.clone())
     }
-    pub fn vendors(&self) -> vendors::Client {
+    pub fn vendors_client(&self) -> vendors::Client {
         vendors::Client(self.clone())
     }
 }

--- a/services/mgmt/imagebuilder/src/package_2019_02/operations.rs
+++ b/services/mgmt/imagebuilder/src/package_2019_02/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn virtual_machine_image_templates(&self) -> virtual_machine_image_templates::Client {
+    pub fn virtual_machine_image_templates_client(&self) -> virtual_machine_image_templates::Client {
         virtual_machine_image_templates::Client(self.clone())
     }
 }

--- a/services/mgmt/imagebuilder/src/package_2020_02/operations.rs
+++ b/services/mgmt/imagebuilder/src/package_2020_02/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn virtual_machine_image_templates(&self) -> virtual_machine_image_templates::Client {
+    pub fn virtual_machine_image_templates_client(&self) -> virtual_machine_image_templates::Client {
         virtual_machine_image_templates::Client(self.clone())
     }
 }

--- a/services/mgmt/imagebuilder/src/package_2021_10/operations.rs
+++ b/services/mgmt/imagebuilder/src/package_2021_10/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn virtual_machine_image_templates(&self) -> virtual_machine_image_templates::Client {
+    pub fn virtual_machine_image_templates_client(&self) -> virtual_machine_image_templates::Client {
         virtual_machine_image_templates::Client(self.clone())
     }
 }

--- a/services/mgmt/imagebuilder/src/package_2022_02/operations.rs
+++ b/services/mgmt/imagebuilder/src/package_2022_02/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn virtual_machine_image_templates(&self) -> virtual_machine_image_templates::Client {
+    pub fn virtual_machine_image_templates_client(&self) -> virtual_machine_image_templates::Client {
         virtual_machine_image_templates::Client(self.clone())
     }
 }

--- a/services/mgmt/imagebuilder/src/package_preview_2019_05/operations.rs
+++ b/services/mgmt/imagebuilder/src/package_preview_2019_05/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn virtual_machine_image_templates(&self) -> virtual_machine_image_templates::Client {
+    pub fn virtual_machine_image_templates_client(&self) -> virtual_machine_image_templates::Client {
         virtual_machine_image_templates::Client(self.clone())
     }
 }

--- a/services/mgmt/intune/src/package_2015_01_preview/operations.rs
+++ b/services/mgmt/intune/src/package_2015_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn android(&self) -> android::Client {
+    pub fn android_client(&self) -> android::Client {
         android::Client(self.clone())
     }
-    pub fn ios(&self) -> ios::Client {
+    pub fn ios_client(&self) -> ios::Client {
         ios::Client(self.clone())
     }
 }

--- a/services/mgmt/intune/src/package_2015_01_privatepreview/operations.rs
+++ b/services/mgmt/intune/src/package_2015_01_privatepreview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn android(&self) -> android::Client {
+    pub fn android_client(&self) -> android::Client {
         android::Client(self.clone())
     }
-    pub fn ios(&self) -> ios::Client {
+    pub fn ios_client(&self) -> ios::Client {
         ios::Client(self.clone())
     }
 }

--- a/services/mgmt/iotcentral/src/package_2018_09_01/operations.rs
+++ b/services/mgmt/iotcentral/src/package_2018_09_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/iotcentral/src/package_2021_06/operations.rs
+++ b/services/mgmt/iotcentral/src/package_2021_06/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/iotcentral/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/iotcentral/src/package_preview_2021_11/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apps(&self) -> apps::Client {
+    pub fn apps_client(&self) -> apps::Client {
         apps::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_links(&self) -> private_links::Client {
+    pub fn private_links_client(&self) -> private_links::Client {
         private_links::Client(self.clone())
     }
 }

--- a/services/mgmt/iothub/src/package_preview_2020_08_31/operations.rs
+++ b/services/mgmt/iothub/src/package_preview_2020_08_31/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn iot_hub(&self) -> iot_hub::Client {
+    pub fn iot_hub_client(&self) -> iot_hub::Client {
         iot_hub::Client(self.clone())
     }
-    pub fn iot_hub_resource(&self) -> iot_hub_resource::Client {
+    pub fn iot_hub_resource_client(&self) -> iot_hub_resource::Client {
         iot_hub_resource::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_provider_common(&self) -> resource_provider_common::Client {
+    pub fn resource_provider_common_client(&self) -> resource_provider_common::Client {
         resource_provider_common::Client(self.clone())
     }
 }

--- a/services/mgmt/iothub/src/package_preview_2021_02/operations.rs
+++ b/services/mgmt/iothub/src/package_preview_2021_02/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn iot_hub(&self) -> iot_hub::Client {
+    pub fn iot_hub_client(&self) -> iot_hub::Client {
         iot_hub::Client(self.clone())
     }
-    pub fn iot_hub_resource(&self) -> iot_hub_resource::Client {
+    pub fn iot_hub_resource_client(&self) -> iot_hub_resource::Client {
         iot_hub_resource::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_provider_common(&self) -> resource_provider_common::Client {
+    pub fn resource_provider_common_client(&self) -> resource_provider_common::Client {
         resource_provider_common::Client(self.clone())
     }
 }

--- a/services/mgmt/iothub/src/package_preview_2021_03/operations.rs
+++ b/services/mgmt/iothub/src/package_preview_2021_03/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn iot_hub(&self) -> iot_hub::Client {
+    pub fn iot_hub_client(&self) -> iot_hub::Client {
         iot_hub::Client(self.clone())
     }
-    pub fn iot_hub_resource(&self) -> iot_hub_resource::Client {
+    pub fn iot_hub_resource_client(&self) -> iot_hub_resource::Client {
         iot_hub_resource::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_provider_common(&self) -> resource_provider_common::Client {
+    pub fn resource_provider_common_client(&self) -> resource_provider_common::Client {
         resource_provider_common::Client(self.clone())
     }
 }

--- a/services/mgmt/iothub/src/package_preview_2021_07_02/operations.rs
+++ b/services/mgmt/iothub/src/package_preview_2021_07_02/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn iot_hub(&self) -> iot_hub::Client {
+    pub fn iot_hub_client(&self) -> iot_hub::Client {
         iot_hub::Client(self.clone())
     }
-    pub fn iot_hub_resource(&self) -> iot_hub_resource::Client {
+    pub fn iot_hub_resource_client(&self) -> iot_hub_resource::Client {
         iot_hub_resource::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn resource_provider_common(&self) -> resource_provider_common::Client {
+    pub fn resource_provider_common_client(&self) -> resource_provider_common::Client {
         resource_provider_common::Client(self.clone())
     }
 }

--- a/services/mgmt/iothub/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/iothub/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn iot_hub(&self) -> iot_hub::Client {
+    pub fn iot_hub_client(&self) -> iot_hub::Client {
         iot_hub::Client(self.clone())
     }
-    pub fn iot_hub_resource(&self) -> iot_hub_resource::Client {
+    pub fn iot_hub_resource_client(&self) -> iot_hub_resource::Client {
         iot_hub_resource::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn resource_provider_common(&self) -> resource_provider_common::Client {
+    pub fn resource_provider_common_client(&self) -> resource_provider_common::Client {
         resource_provider_common::Client(self.clone())
     }
 }

--- a/services/mgmt/keyvault/src/package_preview_2021_04/operations.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_04/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn managed_hsms(&self) -> managed_hsms::Client {
+    pub fn managed_hsms_client(&self) -> managed_hsms::Client {
         managed_hsms::Client(self.clone())
     }
-    pub fn mhsm_private_endpoint_connections(&self) -> mhsm_private_endpoint_connections::Client {
+    pub fn mhsm_private_endpoint_connections_client(&self) -> mhsm_private_endpoint_connections::Client {
         mhsm_private_endpoint_connections::Client(self.clone())
     }
-    pub fn mhsm_private_link_resources(&self) -> mhsm_private_link_resources::Client {
+    pub fn mhsm_private_link_resources_client(&self) -> mhsm_private_link_resources::Client {
         mhsm_private_link_resources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/keyvault/src/package_preview_2021_04_full/operations.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_04_full/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn managed_hsms(&self) -> managed_hsms::Client {
+    pub fn managed_hsms_client(&self) -> managed_hsms::Client {
         managed_hsms::Client(self.clone())
     }
-    pub fn mhsm_private_endpoint_connections(&self) -> mhsm_private_endpoint_connections::Client {
+    pub fn mhsm_private_endpoint_connections_client(&self) -> mhsm_private_endpoint_connections::Client {
         mhsm_private_endpoint_connections::Client(self.clone())
     }
-    pub fn mhsm_private_link_resources(&self) -> mhsm_private_link_resources::Client {
+    pub fn mhsm_private_link_resources_client(&self) -> mhsm_private_link_resources::Client {
         mhsm_private_link_resources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/keyvault/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_06/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn managed_hsms(&self) -> managed_hsms::Client {
+    pub fn managed_hsms_client(&self) -> managed_hsms::Client {
         managed_hsms::Client(self.clone())
     }
-    pub fn mhsm_private_endpoint_connections(&self) -> mhsm_private_endpoint_connections::Client {
+    pub fn mhsm_private_endpoint_connections_client(&self) -> mhsm_private_endpoint_connections::Client {
         mhsm_private_endpoint_connections::Client(self.clone())
     }
-    pub fn mhsm_private_link_resources(&self) -> mhsm_private_link_resources::Client {
+    pub fn mhsm_private_link_resources_client(&self) -> mhsm_private_link_resources::Client {
         mhsm_private_link_resources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/keyvault/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_11/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn managed_hsms(&self) -> managed_hsms::Client {
+    pub fn managed_hsms_client(&self) -> managed_hsms::Client {
         managed_hsms::Client(self.clone())
     }
-    pub fn mhsm_private_endpoint_connections(&self) -> mhsm_private_endpoint_connections::Client {
+    pub fn mhsm_private_endpoint_connections_client(&self) -> mhsm_private_endpoint_connections::Client {
         mhsm_private_endpoint_connections::Client(self.clone())
     }
-    pub fn mhsm_private_link_resources(&self) -> mhsm_private_link_resources::Client {
+    pub fn mhsm_private_link_resources_client(&self) -> mhsm_private_link_resources::Client {
         mhsm_private_link_resources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/keyvault/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/keyvault/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn secrets(&self) -> secrets::Client {
+    pub fn secrets_client(&self) -> secrets::Client {
         secrets::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/kubernetesconfiguration/src/package_2022_03/operations.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_2022_03/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn flux_config_operation_status(&self) -> flux_config_operation_status::Client {
+    pub fn flux_config_operation_status_client(&self) -> flux_config_operation_status::Client {
         flux_config_operation_status::Client(self.clone())
     }
-    pub fn flux_configurations(&self) -> flux_configurations::Client {
+    pub fn flux_configurations_client(&self) -> flux_configurations::Client {
         flux_configurations::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn source_control_configurations(&self) -> source_control_configurations::Client {
+    pub fn source_control_configurations_client(&self) -> source_control_configurations::Client {
         source_control_configurations::Client(self.clone())
     }
 }

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2021_11/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cluster_extension_type(&self) -> cluster_extension_type::Client {
+    pub fn cluster_extension_type_client(&self) -> cluster_extension_type::Client {
         cluster_extension_type::Client(self.clone())
     }
-    pub fn cluster_extension_types(&self) -> cluster_extension_types::Client {
+    pub fn cluster_extension_types_client(&self) -> cluster_extension_types::Client {
         cluster_extension_types::Client(self.clone())
     }
-    pub fn extension_type_versions(&self) -> extension_type_versions::Client {
+    pub fn extension_type_versions_client(&self) -> extension_type_versions::Client {
         extension_type_versions::Client(self.clone())
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn flux_config_operation_status(&self) -> flux_config_operation_status::Client {
+    pub fn flux_config_operation_status_client(&self) -> flux_config_operation_status::Client {
         flux_config_operation_status::Client(self.clone())
     }
-    pub fn flux_configurations(&self) -> flux_configurations::Client {
+    pub fn flux_configurations_client(&self) -> flux_configurations::Client {
         flux_configurations::Client(self.clone())
     }
-    pub fn location_extension_types(&self) -> location_extension_types::Client {
+    pub fn location_extension_types_client(&self) -> location_extension_types::Client {
         location_extension_types::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn source_control_configurations(&self) -> source_control_configurations::Client {
+    pub fn source_control_configurations_client(&self) -> source_control_configurations::Client {
         source_control_configurations::Client(self.clone())
     }
 }

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01/operations.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cluster_extension_type(&self) -> cluster_extension_type::Client {
+    pub fn cluster_extension_type_client(&self) -> cluster_extension_type::Client {
         cluster_extension_type::Client(self.clone())
     }
-    pub fn cluster_extension_types(&self) -> cluster_extension_types::Client {
+    pub fn cluster_extension_types_client(&self) -> cluster_extension_types::Client {
         cluster_extension_types::Client(self.clone())
     }
-    pub fn extension_type_versions(&self) -> extension_type_versions::Client {
+    pub fn extension_type_versions_client(&self) -> extension_type_versions::Client {
         extension_type_versions::Client(self.clone())
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn flux_config_operation_status(&self) -> flux_config_operation_status::Client {
+    pub fn flux_config_operation_status_client(&self) -> flux_config_operation_status::Client {
         flux_config_operation_status::Client(self.clone())
     }
-    pub fn flux_configurations(&self) -> flux_configurations::Client {
+    pub fn flux_configurations_client(&self) -> flux_configurations::Client {
         flux_configurations::Client(self.clone())
     }
-    pub fn location_extension_types(&self) -> location_extension_types::Client {
+    pub fn location_extension_types_client(&self) -> location_extension_types::Client {
         location_extension_types::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn source_control_configurations(&self) -> source_control_configurations::Client {
+    pub fn source_control_configurations_client(&self) -> source_control_configurations::Client {
         source_control_configurations::Client(self.clone())
     }
 }

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01_15/operations.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01_15/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cluster_extension_type(&self) -> cluster_extension_type::Client {
+    pub fn cluster_extension_type_client(&self) -> cluster_extension_type::Client {
         cluster_extension_type::Client(self.clone())
     }
-    pub fn cluster_extension_types(&self) -> cluster_extension_types::Client {
+    pub fn cluster_extension_types_client(&self) -> cluster_extension_types::Client {
         cluster_extension_types::Client(self.clone())
     }
-    pub fn extension_type_versions(&self) -> extension_type_versions::Client {
+    pub fn extension_type_versions_client(&self) -> extension_type_versions::Client {
         extension_type_versions::Client(self.clone())
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn flux_config_operation_status(&self) -> flux_config_operation_status::Client {
+    pub fn flux_config_operation_status_client(&self) -> flux_config_operation_status::Client {
         flux_config_operation_status::Client(self.clone())
     }
-    pub fn flux_configurations(&self) -> flux_configurations::Client {
+    pub fn flux_configurations_client(&self) -> flux_configurations::Client {
         flux_configurations::Client(self.clone())
     }
-    pub fn location_extension_types(&self) -> location_extension_types::Client {
+    pub fn location_extension_types_client(&self) -> location_extension_types::Client {
         location_extension_types::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn source_control_configurations(&self) -> source_control_configurations::Client {
+    pub fn source_control_configurations_client(&self) -> source_control_configurations::Client {
         source_control_configurations::Client(self.clone())
     }
 }

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2022_04/operations.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2022_04/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn flux_config_operation_status(&self) -> flux_config_operation_status::Client {
+    pub fn flux_config_operation_status_client(&self) -> flux_config_operation_status::Client {
         flux_config_operation_status::Client(self.clone())
     }
-    pub fn flux_configurations(&self) -> flux_configurations::Client {
+    pub fn flux_configurations_client(&self) -> flux_configurations::Client {
         flux_configurations::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
-    pub fn source_control_configurations(&self) -> source_control_configurations::Client {
+    pub fn source_control_configurations_client(&self) -> source_control_configurations::Client {
         source_control_configurations::Client(self.clone())
     }
 }

--- a/services/mgmt/kusto/src/schema_2017_09_07_privatepreview/operations.rs
+++ b/services/mgmt/kusto/src/schema_2017_09_07_privatepreview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn event_hub_connections(&self) -> event_hub_connections::Client {
+    pub fn event_hub_connections_client(&self) -> event_hub_connections::Client {
         event_hub_connections::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/kusto/src/schema_2018_09_07_preview/operations.rs
+++ b/services/mgmt/kusto/src/schema_2018_09_07_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn event_hub_connections(&self) -> event_hub_connections::Client {
+    pub fn event_hub_connections_client(&self) -> event_hub_connections::Client {
         event_hub_connections::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/kusto/src/schema_2019_01_21/operations.rs
+++ b/services/mgmt/kusto/src/schema_2019_01_21/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_connections(&self) -> data_connections::Client {
+    pub fn data_connections_client(&self) -> data_connections::Client {
         data_connections::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/kusto/src/schema_2019_05_15/operations.rs
+++ b/services/mgmt/kusto/src/schema_2019_05_15/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_connections(&self) -> data_connections::Client {
+    pub fn data_connections_client(&self) -> data_connections::Client {
         data_connections::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/kusto/src/schema_2019_09_07/operations.rs
+++ b/services/mgmt/kusto/src/schema_2019_09_07/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attached_database_configurations(&self) -> attached_database_configurations::Client {
+    pub fn attached_database_configurations_client(&self) -> attached_database_configurations::Client {
         attached_database_configurations::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_connections(&self) -> data_connections::Client {
+    pub fn data_connections_client(&self) -> data_connections::Client {
         data_connections::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/labservices/src/package_2018_10/operations.rs
+++ b/services/mgmt/labservices/src/package_2018_10/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn environment_settings(&self) -> environment_settings::Client {
+    pub fn environment_settings_client(&self) -> environment_settings::Client {
         environment_settings::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn gallery_images(&self) -> gallery_images::Client {
+    pub fn gallery_images_client(&self) -> gallery_images::Client {
         gallery_images::Client(self.clone())
     }
-    pub fn global_users(&self) -> global_users::Client {
+    pub fn global_users_client(&self) -> global_users::Client {
         global_users::Client(self.clone())
     }
-    pub fn lab_accounts(&self) -> lab_accounts::Client {
+    pub fn lab_accounts_client(&self) -> lab_accounts::Client {
         lab_accounts::Client(self.clone())
     }
-    pub fn labs(&self) -> labs::Client {
+    pub fn labs_client(&self) -> labs::Client {
         labs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_operations(&self) -> provider_operations::Client {
+    pub fn provider_operations_client(&self) -> provider_operations::Client {
         provider_operations::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/mgmt/labservices/src/package_preview_2021_10/operations.rs
+++ b/services/mgmt/labservices/src/package_preview_2021_10/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn lab_plans(&self) -> lab_plans::Client {
+    pub fn lab_plans_client(&self) -> lab_plans::Client {
         lab_plans::Client(self.clone())
     }
-    pub fn labs(&self) -> labs::Client {
+    pub fn labs_client(&self) -> labs::Client {
         labs::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn schedules(&self) -> schedules::Client {
+    pub fn schedules_client(&self) -> schedules::Client {
         schedules::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/labservices/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/labservices/src/package_preview_2021_11/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn images(&self) -> images::Client {
+    pub fn images_client(&self) -> images::Client {
         images::Client(self.clone())
     }
-    pub fn lab_plans(&self) -> lab_plans::Client {
+    pub fn lab_plans_client(&self) -> lab_plans::Client {
         lab_plans::Client(self.clone())
     }
-    pub fn labs(&self) -> labs::Client {
+    pub fn labs_client(&self) -> labs::Client {
         labs::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn schedules(&self) -> schedules::Client {
+    pub fn schedules_client(&self) -> schedules::Client {
         schedules::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/loadtestservice/src/package_2021_12_01_preview/operations.rs
+++ b/services/mgmt/loadtestservice/src/package_2021_12_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn load_tests(&self) -> load_tests::Client {
+    pub fn load_tests_client(&self) -> load_tests::Client {
         load_tests::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/loadtestservice/src/package_2022_04_15_preview/operations.rs
+++ b/services/mgmt/loadtestservice/src/package_2022_04_15_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn load_tests(&self) -> load_tests::Client {
+    pub fn load_tests_client(&self) -> load_tests::Client {
         load_tests::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/logic/src/package_2018_07_preview/operations.rs
+++ b/services/mgmt/logic/src/package_2018_07_preview/operations.rs
@@ -74,70 +74,70 @@ impl Client {
             pipeline,
         }
     }
-    pub fn integration_account_agreements(&self) -> integration_account_agreements::Client {
+    pub fn integration_account_agreements_client(&self) -> integration_account_agreements::Client {
         integration_account_agreements::Client(self.clone())
     }
-    pub fn integration_account_assemblies(&self) -> integration_account_assemblies::Client {
+    pub fn integration_account_assemblies_client(&self) -> integration_account_assemblies::Client {
         integration_account_assemblies::Client(self.clone())
     }
-    pub fn integration_account_batch_configurations(&self) -> integration_account_batch_configurations::Client {
+    pub fn integration_account_batch_configurations_client(&self) -> integration_account_batch_configurations::Client {
         integration_account_batch_configurations::Client(self.clone())
     }
-    pub fn integration_account_certificates(&self) -> integration_account_certificates::Client {
+    pub fn integration_account_certificates_client(&self) -> integration_account_certificates::Client {
         integration_account_certificates::Client(self.clone())
     }
-    pub fn integration_account_maps(&self) -> integration_account_maps::Client {
+    pub fn integration_account_maps_client(&self) -> integration_account_maps::Client {
         integration_account_maps::Client(self.clone())
     }
-    pub fn integration_account_partners(&self) -> integration_account_partners::Client {
+    pub fn integration_account_partners_client(&self) -> integration_account_partners::Client {
         integration_account_partners::Client(self.clone())
     }
-    pub fn integration_account_schemas(&self) -> integration_account_schemas::Client {
+    pub fn integration_account_schemas_client(&self) -> integration_account_schemas::Client {
         integration_account_schemas::Client(self.clone())
     }
-    pub fn integration_account_sessions(&self) -> integration_account_sessions::Client {
+    pub fn integration_account_sessions_client(&self) -> integration_account_sessions::Client {
         integration_account_sessions::Client(self.clone())
     }
-    pub fn integration_accounts(&self) -> integration_accounts::Client {
+    pub fn integration_accounts_client(&self) -> integration_accounts::Client {
         integration_accounts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn workflow_run_action_repetitions(&self) -> workflow_run_action_repetitions::Client {
+    pub fn workflow_run_action_repetitions_client(&self) -> workflow_run_action_repetitions::Client {
         workflow_run_action_repetitions::Client(self.clone())
     }
-    pub fn workflow_run_action_repetitions_request_histories(&self) -> workflow_run_action_repetitions_request_histories::Client {
+    pub fn workflow_run_action_repetitions_request_histories_client(&self) -> workflow_run_action_repetitions_request_histories::Client {
         workflow_run_action_repetitions_request_histories::Client(self.clone())
     }
-    pub fn workflow_run_action_request_histories(&self) -> workflow_run_action_request_histories::Client {
+    pub fn workflow_run_action_request_histories_client(&self) -> workflow_run_action_request_histories::Client {
         workflow_run_action_request_histories::Client(self.clone())
     }
-    pub fn workflow_run_action_scope_repetitions(&self) -> workflow_run_action_scope_repetitions::Client {
+    pub fn workflow_run_action_scope_repetitions_client(&self) -> workflow_run_action_scope_repetitions::Client {
         workflow_run_action_scope_repetitions::Client(self.clone())
     }
-    pub fn workflow_run_actions(&self) -> workflow_run_actions::Client {
+    pub fn workflow_run_actions_client(&self) -> workflow_run_actions::Client {
         workflow_run_actions::Client(self.clone())
     }
-    pub fn workflow_run_operations(&self) -> workflow_run_operations::Client {
+    pub fn workflow_run_operations_client(&self) -> workflow_run_operations::Client {
         workflow_run_operations::Client(self.clone())
     }
-    pub fn workflow_runs(&self) -> workflow_runs::Client {
+    pub fn workflow_runs_client(&self) -> workflow_runs::Client {
         workflow_runs::Client(self.clone())
     }
-    pub fn workflow_trigger_histories(&self) -> workflow_trigger_histories::Client {
+    pub fn workflow_trigger_histories_client(&self) -> workflow_trigger_histories::Client {
         workflow_trigger_histories::Client(self.clone())
     }
-    pub fn workflow_triggers(&self) -> workflow_triggers::Client {
+    pub fn workflow_triggers_client(&self) -> workflow_triggers::Client {
         workflow_triggers::Client(self.clone())
     }
-    pub fn workflow_version_triggers(&self) -> workflow_version_triggers::Client {
+    pub fn workflow_version_triggers_client(&self) -> workflow_version_triggers::Client {
         workflow_version_triggers::Client(self.clone())
     }
-    pub fn workflow_versions(&self) -> workflow_versions::Client {
+    pub fn workflow_versions_client(&self) -> workflow_versions::Client {
         workflow_versions::Client(self.clone())
     }
-    pub fn workflows(&self) -> workflows::Client {
+    pub fn workflows_client(&self) -> workflows::Client {
         workflows::Client(self.clone())
     }
 }

--- a/services/mgmt/logic/src/package_2019_05/operations.rs
+++ b/services/mgmt/logic/src/package_2019_05/operations.rs
@@ -74,85 +74,87 @@ impl Client {
             pipeline,
         }
     }
-    pub fn integration_account_agreements(&self) -> integration_account_agreements::Client {
+    pub fn integration_account_agreements_client(&self) -> integration_account_agreements::Client {
         integration_account_agreements::Client(self.clone())
     }
-    pub fn integration_account_assemblies(&self) -> integration_account_assemblies::Client {
+    pub fn integration_account_assemblies_client(&self) -> integration_account_assemblies::Client {
         integration_account_assemblies::Client(self.clone())
     }
-    pub fn integration_account_batch_configurations(&self) -> integration_account_batch_configurations::Client {
+    pub fn integration_account_batch_configurations_client(&self) -> integration_account_batch_configurations::Client {
         integration_account_batch_configurations::Client(self.clone())
     }
-    pub fn integration_account_certificates(&self) -> integration_account_certificates::Client {
+    pub fn integration_account_certificates_client(&self) -> integration_account_certificates::Client {
         integration_account_certificates::Client(self.clone())
     }
-    pub fn integration_account_maps(&self) -> integration_account_maps::Client {
+    pub fn integration_account_maps_client(&self) -> integration_account_maps::Client {
         integration_account_maps::Client(self.clone())
     }
-    pub fn integration_account_partners(&self) -> integration_account_partners::Client {
+    pub fn integration_account_partners_client(&self) -> integration_account_partners::Client {
         integration_account_partners::Client(self.clone())
     }
-    pub fn integration_account_schemas(&self) -> integration_account_schemas::Client {
+    pub fn integration_account_schemas_client(&self) -> integration_account_schemas::Client {
         integration_account_schemas::Client(self.clone())
     }
-    pub fn integration_account_sessions(&self) -> integration_account_sessions::Client {
+    pub fn integration_account_sessions_client(&self) -> integration_account_sessions::Client {
         integration_account_sessions::Client(self.clone())
     }
-    pub fn integration_accounts(&self) -> integration_accounts::Client {
+    pub fn integration_accounts_client(&self) -> integration_accounts::Client {
         integration_accounts::Client(self.clone())
     }
-    pub fn integration_service_environment_managed_api_operations(&self) -> integration_service_environment_managed_api_operations::Client {
+    pub fn integration_service_environment_managed_api_operations_client(
+        &self,
+    ) -> integration_service_environment_managed_api_operations::Client {
         integration_service_environment_managed_api_operations::Client(self.clone())
     }
-    pub fn integration_service_environment_managed_apis(&self) -> integration_service_environment_managed_apis::Client {
+    pub fn integration_service_environment_managed_apis_client(&self) -> integration_service_environment_managed_apis::Client {
         integration_service_environment_managed_apis::Client(self.clone())
     }
-    pub fn integration_service_environment_network_health(&self) -> integration_service_environment_network_health::Client {
+    pub fn integration_service_environment_network_health_client(&self) -> integration_service_environment_network_health::Client {
         integration_service_environment_network_health::Client(self.clone())
     }
-    pub fn integration_service_environment_skus(&self) -> integration_service_environment_skus::Client {
+    pub fn integration_service_environment_skus_client(&self) -> integration_service_environment_skus::Client {
         integration_service_environment_skus::Client(self.clone())
     }
-    pub fn integration_service_environments(&self) -> integration_service_environments::Client {
+    pub fn integration_service_environments_client(&self) -> integration_service_environments::Client {
         integration_service_environments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn workflow_run_action_repetitions(&self) -> workflow_run_action_repetitions::Client {
+    pub fn workflow_run_action_repetitions_client(&self) -> workflow_run_action_repetitions::Client {
         workflow_run_action_repetitions::Client(self.clone())
     }
-    pub fn workflow_run_action_repetitions_request_histories(&self) -> workflow_run_action_repetitions_request_histories::Client {
+    pub fn workflow_run_action_repetitions_request_histories_client(&self) -> workflow_run_action_repetitions_request_histories::Client {
         workflow_run_action_repetitions_request_histories::Client(self.clone())
     }
-    pub fn workflow_run_action_request_histories(&self) -> workflow_run_action_request_histories::Client {
+    pub fn workflow_run_action_request_histories_client(&self) -> workflow_run_action_request_histories::Client {
         workflow_run_action_request_histories::Client(self.clone())
     }
-    pub fn workflow_run_action_scope_repetitions(&self) -> workflow_run_action_scope_repetitions::Client {
+    pub fn workflow_run_action_scope_repetitions_client(&self) -> workflow_run_action_scope_repetitions::Client {
         workflow_run_action_scope_repetitions::Client(self.clone())
     }
-    pub fn workflow_run_actions(&self) -> workflow_run_actions::Client {
+    pub fn workflow_run_actions_client(&self) -> workflow_run_actions::Client {
         workflow_run_actions::Client(self.clone())
     }
-    pub fn workflow_run_operations(&self) -> workflow_run_operations::Client {
+    pub fn workflow_run_operations_client(&self) -> workflow_run_operations::Client {
         workflow_run_operations::Client(self.clone())
     }
-    pub fn workflow_runs(&self) -> workflow_runs::Client {
+    pub fn workflow_runs_client(&self) -> workflow_runs::Client {
         workflow_runs::Client(self.clone())
     }
-    pub fn workflow_trigger_histories(&self) -> workflow_trigger_histories::Client {
+    pub fn workflow_trigger_histories_client(&self) -> workflow_trigger_histories::Client {
         workflow_trigger_histories::Client(self.clone())
     }
-    pub fn workflow_triggers(&self) -> workflow_triggers::Client {
+    pub fn workflow_triggers_client(&self) -> workflow_triggers::Client {
         workflow_triggers::Client(self.clone())
     }
-    pub fn workflow_version_triggers(&self) -> workflow_version_triggers::Client {
+    pub fn workflow_version_triggers_client(&self) -> workflow_version_triggers::Client {
         workflow_version_triggers::Client(self.clone())
     }
-    pub fn workflow_versions(&self) -> workflow_versions::Client {
+    pub fn workflow_versions_client(&self) -> workflow_versions::Client {
         workflow_versions::Client(self.clone())
     }
-    pub fn workflows(&self) -> workflows::Client {
+    pub fn workflows_client(&self) -> workflows::Client {
         workflows::Client(self.clone())
     }
 }

--- a/services/mgmt/logz/src/package_2020_10_01/operations.rs
+++ b/services/mgmt/logz/src/package_2020_10_01/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn monitor(&self) -> monitor::Client {
+    pub fn monitor_client(&self) -> monitor::Client {
         monitor::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn single_sign_on(&self) -> single_sign_on::Client {
+    pub fn single_sign_on_client(&self) -> single_sign_on::Client {
         single_sign_on::Client(self.clone())
     }
-    pub fn sub_account(&self) -> sub_account::Client {
+    pub fn sub_account_client(&self) -> sub_account::Client {
         sub_account::Client(self.clone())
     }
-    pub fn sub_account_tag_rules(&self) -> sub_account_tag_rules::Client {
+    pub fn sub_account_tag_rules_client(&self) -> sub_account_tag_rules::Client {
         sub_account_tag_rules::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/logz/src/package_2020_10_01_preview/operations.rs
+++ b/services/mgmt/logz/src/package_2020_10_01_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn monitor(&self) -> monitor::Client {
+    pub fn monitor_client(&self) -> monitor::Client {
         monitor::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn single_sign_on(&self) -> single_sign_on::Client {
+    pub fn single_sign_on_client(&self) -> single_sign_on::Client {
         single_sign_on::Client(self.clone())
     }
-    pub fn sub_account(&self) -> sub_account::Client {
+    pub fn sub_account_client(&self) -> sub_account::Client {
         sub_account::Client(self.clone())
     }
-    pub fn sub_account_tag_rules(&self) -> sub_account_tag_rules::Client {
+    pub fn sub_account_tag_rules_client(&self) -> sub_account_tag_rules::Client {
         sub_account_tag_rules::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/logz/src/package_2022_01_01_preview/operations.rs
+++ b/services/mgmt/logz/src/package_2022_01_01_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn metrics_source(&self) -> metrics_source::Client {
+    pub fn metrics_source_client(&self) -> metrics_source::Client {
         metrics_source::Client(self.clone())
     }
-    pub fn metrics_source_tag_rules(&self) -> metrics_source_tag_rules::Client {
+    pub fn metrics_source_tag_rules_client(&self) -> metrics_source_tag_rules::Client {
         metrics_source_tag_rules::Client(self.clone())
     }
-    pub fn monitor(&self) -> monitor::Client {
+    pub fn monitor_client(&self) -> monitor::Client {
         monitor::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn single_sign_on(&self) -> single_sign_on::Client {
+    pub fn single_sign_on_client(&self) -> single_sign_on::Client {
         single_sign_on::Client(self.clone())
     }
-    pub fn sub_account(&self) -> sub_account::Client {
+    pub fn sub_account_client(&self) -> sub_account::Client {
         sub_account::Client(self.clone())
     }
-    pub fn sub_account_tag_rules(&self) -> sub_account_tag_rules::Client {
+    pub fn sub_account_tag_rules_client(&self) -> sub_account_tag_rules::Client {
         sub_account_tag_rules::Client(self.clone())
     }
-    pub fn tag_rules(&self) -> tag_rules::Client {
+    pub fn tag_rules_client(&self) -> tag_rules::Client {
         tag_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/m365securityandcompliance/src/package_2021_03_25_preview/operations.rs
+++ b/services/mgmt/m365securityandcompliance/src/package_2021_03_25_preview/operations.rs
@@ -74,67 +74,69 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections_adt_api(&self) -> private_endpoint_connections_adt_api::Client {
+    pub fn private_endpoint_connections_adt_api_client(&self) -> private_endpoint_connections_adt_api::Client {
         private_endpoint_connections_adt_api::Client(self.clone())
     }
-    pub fn private_endpoint_connections_comp(&self) -> private_endpoint_connections_comp::Client {
+    pub fn private_endpoint_connections_comp_client(&self) -> private_endpoint_connections_comp::Client {
         private_endpoint_connections_comp::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_edm(&self) -> private_endpoint_connections_for_edm::Client {
+    pub fn private_endpoint_connections_for_edm_client(&self) -> private_endpoint_connections_for_edm::Client {
         private_endpoint_connections_for_edm::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_mip_policy_sync(&self) -> private_endpoint_connections_for_mip_policy_sync::Client {
+    pub fn private_endpoint_connections_for_mip_policy_sync_client(&self) -> private_endpoint_connections_for_mip_policy_sync::Client {
         private_endpoint_connections_for_mip_policy_sync::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_scc_powershell(&self) -> private_endpoint_connections_for_scc_powershell::Client {
+    pub fn private_endpoint_connections_for_scc_powershell_client(&self) -> private_endpoint_connections_for_scc_powershell::Client {
         private_endpoint_connections_for_scc_powershell::Client(self.clone())
     }
-    pub fn private_endpoint_connections_sec(&self) -> private_endpoint_connections_sec::Client {
+    pub fn private_endpoint_connections_sec_client(&self) -> private_endpoint_connections_sec::Client {
         private_endpoint_connections_sec::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_resources_adt_api(&self) -> private_link_resources_adt_api::Client {
+    pub fn private_link_resources_adt_api_client(&self) -> private_link_resources_adt_api::Client {
         private_link_resources_adt_api::Client(self.clone())
     }
-    pub fn private_link_resources_comp(&self) -> private_link_resources_comp::Client {
+    pub fn private_link_resources_comp_client(&self) -> private_link_resources_comp::Client {
         private_link_resources_comp::Client(self.clone())
     }
-    pub fn private_link_resources_for_mip_policy_sync(&self) -> private_link_resources_for_mip_policy_sync::Client {
+    pub fn private_link_resources_for_mip_policy_sync_client(&self) -> private_link_resources_for_mip_policy_sync::Client {
         private_link_resources_for_mip_policy_sync::Client(self.clone())
     }
-    pub fn private_link_resources_for_scc_powershell(&self) -> private_link_resources_for_scc_powershell::Client {
+    pub fn private_link_resources_for_scc_powershell_client(&self) -> private_link_resources_for_scc_powershell::Client {
         private_link_resources_for_scc_powershell::Client(self.clone())
     }
-    pub fn private_link_resources_sec(&self) -> private_link_resources_sec::Client {
+    pub fn private_link_resources_sec_client(&self) -> private_link_resources_sec::Client {
         private_link_resources_sec::Client(self.clone())
     }
-    pub fn private_link_services_for_edm_upload(&self) -> private_link_services_for_edm_upload::Client {
+    pub fn private_link_services_for_edm_upload_client(&self) -> private_link_services_for_edm_upload::Client {
         private_link_services_for_edm_upload::Client(self.clone())
     }
-    pub fn private_link_services_for_m365_compliance_center(&self) -> private_link_services_for_m365_compliance_center::Client {
+    pub fn private_link_services_for_m365_compliance_center_client(&self) -> private_link_services_for_m365_compliance_center::Client {
         private_link_services_for_m365_compliance_center::Client(self.clone())
     }
-    pub fn private_link_services_for_m365_security_center(&self) -> private_link_services_for_m365_security_center::Client {
+    pub fn private_link_services_for_m365_security_center_client(&self) -> private_link_services_for_m365_security_center::Client {
         private_link_services_for_m365_security_center::Client(self.clone())
     }
-    pub fn private_link_services_for_mip_policy_sync(&self) -> private_link_services_for_mip_policy_sync::Client {
+    pub fn private_link_services_for_mip_policy_sync_client(&self) -> private_link_services_for_mip_policy_sync::Client {
         private_link_services_for_mip_policy_sync::Client(self.clone())
     }
-    pub fn private_link_services_for_o365_management_activity_api(&self) -> private_link_services_for_o365_management_activity_api::Client {
+    pub fn private_link_services_for_o365_management_activity_api_client(
+        &self,
+    ) -> private_link_services_for_o365_management_activity_api::Client {
         private_link_services_for_o365_management_activity_api::Client(self.clone())
     }
-    pub fn private_link_services_for_scc_powershell(&self) -> private_link_services_for_scc_powershell::Client {
+    pub fn private_link_services_for_scc_powershell_client(&self) -> private_link_services_for_scc_powershell::Client {
         private_link_services_for_scc_powershell::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearning/src/package_commitmentplans_2016_05_preview/operations.rs
+++ b/services/mgmt/machinelearning/src/package_commitmentplans_2016_05_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn commitment_associations(&self) -> commitment_associations::Client {
+    pub fn commitment_associations_client(&self) -> commitment_associations::Client {
         commitment_associations::Client(self.clone())
     }
-    pub fn commitment_plans(&self) -> commitment_plans::Client {
+    pub fn commitment_plans_client(&self) -> commitment_plans::Client {
         commitment_plans::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn usage_history(&self) -> usage_history::Client {
+    pub fn usage_history_client(&self) -> usage_history::Client {
         usage_history::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearning/src/package_webservices_2016_05_preview/operations.rs
+++ b/services/mgmt/machinelearning/src/package_webservices_2016_05_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn web_services(&self) -> web_services::Client {
+    pub fn web_services_client(&self) -> web_services::Client {
         web_services::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearning/src/package_webservices_2017_01/operations.rs
+++ b/services/mgmt/machinelearning/src/package_webservices_2017_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn web_services(&self) -> web_services::Client {
+    pub fn web_services_client(&self) -> web_services::Client {
         web_services::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearning/src/package_workspaces_2016_04/operations.rs
+++ b/services/mgmt/machinelearning/src/package_workspaces_2016_04/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearning/src/package_workspaces_2019_10/operations.rs
+++ b/services/mgmt/machinelearning/src/package_workspaces_2019_10/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningcompute/src/package_2017_06_preview/operations.rs
+++ b/services/mgmt/machinelearningcompute/src/package_2017_06_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn machine_learning_compute(&self) -> machine_learning_compute::Client {
+    pub fn machine_learning_compute_client(&self) -> machine_learning_compute::Client {
         machine_learning_compute::Client(self.clone())
     }
-    pub fn operationalization_clusters(&self) -> operationalization_clusters::Client {
+    pub fn operationalization_clusters_client(&self) -> operationalization_clusters::Client {
         operationalization_clusters::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningcompute/src/package_2017_08_preview/operations.rs
+++ b/services/mgmt/machinelearningcompute/src/package_2017_08_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn machine_learning_compute(&self) -> machine_learning_compute::Client {
+    pub fn machine_learning_compute_client(&self) -> machine_learning_compute::Client {
         machine_learning_compute::Client(self.clone())
     }
-    pub fn operationalization_clusters(&self) -> operationalization_clusters::Client {
+    pub fn operationalization_clusters_client(&self) -> operationalization_clusters::Client {
         operationalization_clusters::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningexperimentation/src/package_2017_05_preview/operations.rs
+++ b/services/mgmt/machinelearningexperimentation/src/package_2017_05_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningservices/src/package_2021_07_01/operations.rs
+++ b/services/mgmt/machinelearningservices/src/package_2021_07_01/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn compute(&self) -> compute::Client {
+    pub fn compute_client(&self) -> compute::Client {
         compute::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn workspace_connections(&self) -> workspace_connections::Client {
+    pub fn workspace_connections_client(&self) -> workspace_connections::Client {
         workspace_connections::Client(self.clone())
     }
-    pub fn workspace_features(&self) -> workspace_features::Client {
+    pub fn workspace_features_client(&self) -> workspace_features::Client {
         workspace_features::Client(self.clone())
     }
-    pub fn workspace_skus(&self) -> workspace_skus::Client {
+    pub fn workspace_skus_client(&self) -> workspace_skus::Client {
         workspace_skus::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningservices/src/package_2022_01_01_preview/operations.rs
+++ b/services/mgmt/machinelearningservices/src/package_2022_01_01_preview/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn compute(&self) -> compute::Client {
+    pub fn compute_client(&self) -> compute::Client {
         compute::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn workspace_connections(&self) -> workspace_connections::Client {
+    pub fn workspace_connections_client(&self) -> workspace_connections::Client {
         workspace_connections::Client(self.clone())
     }
-    pub fn workspace_features(&self) -> workspace_features::Client {
+    pub fn workspace_features_client(&self) -> workspace_features::Client {
         workspace_features::Client(self.clone())
     }
-    pub fn workspace_skus(&self) -> workspace_skus::Client {
+    pub fn workspace_skus_client(&self) -> workspace_skus::Client {
         workspace_skus::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningservices/src/package_2022_02_01_preview/operations.rs
+++ b/services/mgmt/machinelearningservices/src/package_2022_02_01_preview/operations.rs
@@ -74,82 +74,82 @@ impl Client {
             pipeline,
         }
     }
-    pub fn batch_deployments(&self) -> batch_deployments::Client {
+    pub fn batch_deployments_client(&self) -> batch_deployments::Client {
         batch_deployments::Client(self.clone())
     }
-    pub fn batch_endpoints(&self) -> batch_endpoints::Client {
+    pub fn batch_endpoints_client(&self) -> batch_endpoints::Client {
         batch_endpoints::Client(self.clone())
     }
-    pub fn code_containers(&self) -> code_containers::Client {
+    pub fn code_containers_client(&self) -> code_containers::Client {
         code_containers::Client(self.clone())
     }
-    pub fn code_versions(&self) -> code_versions::Client {
+    pub fn code_versions_client(&self) -> code_versions::Client {
         code_versions::Client(self.clone())
     }
-    pub fn component_containers(&self) -> component_containers::Client {
+    pub fn component_containers_client(&self) -> component_containers::Client {
         component_containers::Client(self.clone())
     }
-    pub fn component_versions(&self) -> component_versions::Client {
+    pub fn component_versions_client(&self) -> component_versions::Client {
         component_versions::Client(self.clone())
     }
-    pub fn compute(&self) -> compute::Client {
+    pub fn compute_client(&self) -> compute::Client {
         compute::Client(self.clone())
     }
-    pub fn data_containers(&self) -> data_containers::Client {
+    pub fn data_containers_client(&self) -> data_containers::Client {
         data_containers::Client(self.clone())
     }
-    pub fn data_versions(&self) -> data_versions::Client {
+    pub fn data_versions_client(&self) -> data_versions::Client {
         data_versions::Client(self.clone())
     }
-    pub fn datastores(&self) -> datastores::Client {
+    pub fn datastores_client(&self) -> datastores::Client {
         datastores::Client(self.clone())
     }
-    pub fn environment_containers(&self) -> environment_containers::Client {
+    pub fn environment_containers_client(&self) -> environment_containers::Client {
         environment_containers::Client(self.clone())
     }
-    pub fn environment_versions(&self) -> environment_versions::Client {
+    pub fn environment_versions_client(&self) -> environment_versions::Client {
         environment_versions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn model_containers(&self) -> model_containers::Client {
+    pub fn model_containers_client(&self) -> model_containers::Client {
         model_containers::Client(self.clone())
     }
-    pub fn model_versions(&self) -> model_versions::Client {
+    pub fn model_versions_client(&self) -> model_versions::Client {
         model_versions::Client(self.clone())
     }
-    pub fn online_deployments(&self) -> online_deployments::Client {
+    pub fn online_deployments_client(&self) -> online_deployments::Client {
         online_deployments::Client(self.clone())
     }
-    pub fn online_endpoints(&self) -> online_endpoints::Client {
+    pub fn online_endpoints_client(&self) -> online_endpoints::Client {
         online_endpoints::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn workspace_connections(&self) -> workspace_connections::Client {
+    pub fn workspace_connections_client(&self) -> workspace_connections::Client {
         workspace_connections::Client(self.clone())
     }
-    pub fn workspace_features(&self) -> workspace_features::Client {
+    pub fn workspace_features_client(&self) -> workspace_features::Client {
         workspace_features::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningservices/src/package_2022_05_01/operations.rs
+++ b/services/mgmt/machinelearningservices/src/package_2022_05_01/operations.rs
@@ -74,82 +74,82 @@ impl Client {
             pipeline,
         }
     }
-    pub fn batch_deployments(&self) -> batch_deployments::Client {
+    pub fn batch_deployments_client(&self) -> batch_deployments::Client {
         batch_deployments::Client(self.clone())
     }
-    pub fn batch_endpoints(&self) -> batch_endpoints::Client {
+    pub fn batch_endpoints_client(&self) -> batch_endpoints::Client {
         batch_endpoints::Client(self.clone())
     }
-    pub fn code_containers(&self) -> code_containers::Client {
+    pub fn code_containers_client(&self) -> code_containers::Client {
         code_containers::Client(self.clone())
     }
-    pub fn code_versions(&self) -> code_versions::Client {
+    pub fn code_versions_client(&self) -> code_versions::Client {
         code_versions::Client(self.clone())
     }
-    pub fn component_containers(&self) -> component_containers::Client {
+    pub fn component_containers_client(&self) -> component_containers::Client {
         component_containers::Client(self.clone())
     }
-    pub fn component_versions(&self) -> component_versions::Client {
+    pub fn component_versions_client(&self) -> component_versions::Client {
         component_versions::Client(self.clone())
     }
-    pub fn compute(&self) -> compute::Client {
+    pub fn compute_client(&self) -> compute::Client {
         compute::Client(self.clone())
     }
-    pub fn data_containers(&self) -> data_containers::Client {
+    pub fn data_containers_client(&self) -> data_containers::Client {
         data_containers::Client(self.clone())
     }
-    pub fn data_versions(&self) -> data_versions::Client {
+    pub fn data_versions_client(&self) -> data_versions::Client {
         data_versions::Client(self.clone())
     }
-    pub fn datastores(&self) -> datastores::Client {
+    pub fn datastores_client(&self) -> datastores::Client {
         datastores::Client(self.clone())
     }
-    pub fn environment_containers(&self) -> environment_containers::Client {
+    pub fn environment_containers_client(&self) -> environment_containers::Client {
         environment_containers::Client(self.clone())
     }
-    pub fn environment_versions(&self) -> environment_versions::Client {
+    pub fn environment_versions_client(&self) -> environment_versions::Client {
         environment_versions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn model_containers(&self) -> model_containers::Client {
+    pub fn model_containers_client(&self) -> model_containers::Client {
         model_containers::Client(self.clone())
     }
-    pub fn model_versions(&self) -> model_versions::Client {
+    pub fn model_versions_client(&self) -> model_versions::Client {
         model_versions::Client(self.clone())
     }
-    pub fn online_deployments(&self) -> online_deployments::Client {
+    pub fn online_deployments_client(&self) -> online_deployments::Client {
         online_deployments::Client(self.clone())
     }
-    pub fn online_endpoints(&self) -> online_endpoints::Client {
+    pub fn online_endpoints_client(&self) -> online_endpoints::Client {
         online_endpoints::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn workspace_connections(&self) -> workspace_connections::Client {
+    pub fn workspace_connections_client(&self) -> workspace_connections::Client {
         workspace_connections::Client(self.clone())
     }
-    pub fn workspace_features(&self) -> workspace_features::Client {
+    pub fn workspace_features_client(&self) -> workspace_features::Client {
         workspace_features::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/machinelearningservices/src/package_preview_2020_05/operations.rs
+++ b/services/mgmt/machinelearningservices/src/package_preview_2020_05/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn linked_workspaces(&self) -> linked_workspaces::Client {
+    pub fn linked_workspaces_client(&self) -> linked_workspaces::Client {
         linked_workspaces::Client(self.clone())
     }
-    pub fn machine_learning_compute(&self) -> machine_learning_compute::Client {
+    pub fn machine_learning_compute_client(&self) -> machine_learning_compute::Client {
         machine_learning_compute::Client(self.clone())
     }
-    pub fn machine_learning_service(&self) -> machine_learning_service::Client {
+    pub fn machine_learning_service_client(&self) -> machine_learning_service::Client {
         machine_learning_service::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_machine_sizes(&self) -> virtual_machine_sizes::Client {
+    pub fn virtual_machine_sizes_client(&self) -> virtual_machine_sizes::Client {
         virtual_machine_sizes::Client(self.clone())
     }
-    pub fn workspace_features(&self) -> workspace_features::Client {
+    pub fn workspace_features_client(&self) -> workspace_features::Client {
         workspace_features::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/maintenance/src/package_2020_04/operations.rs
+++ b/services/mgmt/maintenance/src/package_2020_04/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apply_updates(&self) -> apply_updates::Client {
+    pub fn apply_updates_client(&self) -> apply_updates::Client {
         apply_updates::Client(self.clone())
     }
-    pub fn configuration_assignments(&self) -> configuration_assignments::Client {
+    pub fn configuration_assignments_client(&self) -> configuration_assignments::Client {
         configuration_assignments::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn updates(&self) -> updates::Client {
+    pub fn updates_client(&self) -> updates::Client {
         updates::Client(self.clone())
     }
 }

--- a/services/mgmt/maintenance/src/package_2021_05/operations.rs
+++ b/services/mgmt/maintenance/src/package_2021_05/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apply_update_for_resource_group(&self) -> apply_update_for_resource_group::Client {
+    pub fn apply_update_for_resource_group_client(&self) -> apply_update_for_resource_group::Client {
         apply_update_for_resource_group::Client(self.clone())
     }
-    pub fn apply_updates(&self) -> apply_updates::Client {
+    pub fn apply_updates_client(&self) -> apply_updates::Client {
         apply_updates::Client(self.clone())
     }
-    pub fn configuration_assignments(&self) -> configuration_assignments::Client {
+    pub fn configuration_assignments_client(&self) -> configuration_assignments::Client {
         configuration_assignments::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn maintenance_configurations_for_resource_group(&self) -> maintenance_configurations_for_resource_group::Client {
+    pub fn maintenance_configurations_for_resource_group_client(&self) -> maintenance_configurations_for_resource_group::Client {
         maintenance_configurations_for_resource_group::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn public_maintenance_configurations(&self) -> public_maintenance_configurations::Client {
+    pub fn public_maintenance_configurations_client(&self) -> public_maintenance_configurations::Client {
         public_maintenance_configurations::Client(self.clone())
     }
-    pub fn updates(&self) -> updates::Client {
+    pub fn updates_client(&self) -> updates::Client {
         updates::Client(self.clone())
     }
 }

--- a/services/mgmt/maintenance/src/package_preview_2020_07/operations.rs
+++ b/services/mgmt/maintenance/src/package_preview_2020_07/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apply_updates(&self) -> apply_updates::Client {
+    pub fn apply_updates_client(&self) -> apply_updates::Client {
         apply_updates::Client(self.clone())
     }
-    pub fn configuration_assignments(&self) -> configuration_assignments::Client {
+    pub fn configuration_assignments_client(&self) -> configuration_assignments::Client {
         configuration_assignments::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn public_maintenance_configurations(&self) -> public_maintenance_configurations::Client {
+    pub fn public_maintenance_configurations_client(&self) -> public_maintenance_configurations::Client {
         public_maintenance_configurations::Client(self.clone())
     }
-    pub fn updates(&self) -> updates::Client {
+    pub fn updates_client(&self) -> updates::Client {
         updates::Client(self.clone())
     }
 }

--- a/services/mgmt/maintenance/src/package_preview_2021_04/operations.rs
+++ b/services/mgmt/maintenance/src/package_preview_2021_04/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apply_update_for_resource_group(&self) -> apply_update_for_resource_group::Client {
+    pub fn apply_update_for_resource_group_client(&self) -> apply_update_for_resource_group::Client {
         apply_update_for_resource_group::Client(self.clone())
     }
-    pub fn apply_updates(&self) -> apply_updates::Client {
+    pub fn apply_updates_client(&self) -> apply_updates::Client {
         apply_updates::Client(self.clone())
     }
-    pub fn configuration_assignments(&self) -> configuration_assignments::Client {
+    pub fn configuration_assignments_client(&self) -> configuration_assignments::Client {
         configuration_assignments::Client(self.clone())
     }
-    pub fn configuration_assignments_within_subscription(&self) -> configuration_assignments_within_subscription::Client {
+    pub fn configuration_assignments_within_subscription_client(&self) -> configuration_assignments_within_subscription::Client {
         configuration_assignments_within_subscription::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn maintenance_configurations_for_resource_group(&self) -> maintenance_configurations_for_resource_group::Client {
+    pub fn maintenance_configurations_for_resource_group_client(&self) -> maintenance_configurations_for_resource_group::Client {
         maintenance_configurations_for_resource_group::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn public_maintenance_configurations(&self) -> public_maintenance_configurations::Client {
+    pub fn public_maintenance_configurations_client(&self) -> public_maintenance_configurations::Client {
         public_maintenance_configurations::Client(self.clone())
     }
-    pub fn updates(&self) -> updates::Client {
+    pub fn updates_client(&self) -> updates::Client {
         updates::Client(self.clone())
     }
 }

--- a/services/mgmt/maintenance/src/package_preview_2021_09/operations.rs
+++ b/services/mgmt/maintenance/src/package_preview_2021_09/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn apply_update_for_resource_group(&self) -> apply_update_for_resource_group::Client {
+    pub fn apply_update_for_resource_group_client(&self) -> apply_update_for_resource_group::Client {
         apply_update_for_resource_group::Client(self.clone())
     }
-    pub fn apply_updates(&self) -> apply_updates::Client {
+    pub fn apply_updates_client(&self) -> apply_updates::Client {
         apply_updates::Client(self.clone())
     }
-    pub fn configuration_assignments(&self) -> configuration_assignments::Client {
+    pub fn configuration_assignments_client(&self) -> configuration_assignments::Client {
         configuration_assignments::Client(self.clone())
     }
-    pub fn configuration_assignments_within_subscription(&self) -> configuration_assignments_within_subscription::Client {
+    pub fn configuration_assignments_within_subscription_client(&self) -> configuration_assignments_within_subscription::Client {
         configuration_assignments_within_subscription::Client(self.clone())
     }
-    pub fn maintenance_configurations(&self) -> maintenance_configurations::Client {
+    pub fn maintenance_configurations_client(&self) -> maintenance_configurations::Client {
         maintenance_configurations::Client(self.clone())
     }
-    pub fn maintenance_configurations_for_resource_group(&self) -> maintenance_configurations_for_resource_group::Client {
+    pub fn maintenance_configurations_for_resource_group_client(&self) -> maintenance_configurations_for_resource_group::Client {
         maintenance_configurations_for_resource_group::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn public_maintenance_configurations(&self) -> public_maintenance_configurations::Client {
+    pub fn public_maintenance_configurations_client(&self) -> public_maintenance_configurations::Client {
         public_maintenance_configurations::Client(self.clone())
     }
-    pub fn updates(&self) -> updates::Client {
+    pub fn updates_client(&self) -> updates::Client {
         updates::Client(self.clone())
     }
 }

--- a/services/mgmt/managednetwork/src/package_2019_06_01_preview/operations.rs
+++ b/services/mgmt/managednetwork/src/package_2019_06_01_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn managed_network_groups(&self) -> managed_network_groups::Client {
+    pub fn managed_network_groups_client(&self) -> managed_network_groups::Client {
         managed_network_groups::Client(self.clone())
     }
-    pub fn managed_network_peering_policies(&self) -> managed_network_peering_policies::Client {
+    pub fn managed_network_peering_policies_client(&self) -> managed_network_peering_policies::Client {
         managed_network_peering_policies::Client(self.clone())
     }
-    pub fn managed_networks(&self) -> managed_networks::Client {
+    pub fn managed_networks_client(&self) -> managed_networks::Client {
         managed_networks::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn scope_assignments(&self) -> scope_assignments::Client {
+    pub fn scope_assignments_client(&self) -> scope_assignments::Client {
         scope_assignments::Client(self.clone())
     }
 }

--- a/services/mgmt/managedservices/src/package_2019_04_preview/operations.rs
+++ b/services/mgmt/managedservices/src/package_2019_04_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn registration_assignments(&self) -> registration_assignments::Client {
+    pub fn registration_assignments_client(&self) -> registration_assignments::Client {
         registration_assignments::Client(self.clone())
     }
-    pub fn registration_definitions(&self) -> registration_definitions::Client {
+    pub fn registration_definitions_client(&self) -> registration_definitions::Client {
         registration_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/managedservices/src/package_2019_06/operations.rs
+++ b/services/mgmt/managedservices/src/package_2019_06/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn registration_assignments(&self) -> registration_assignments::Client {
+    pub fn registration_assignments_client(&self) -> registration_assignments::Client {
         registration_assignments::Client(self.clone())
     }
-    pub fn registration_definitions(&self) -> registration_definitions::Client {
+    pub fn registration_definitions_client(&self) -> registration_definitions::Client {
         registration_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/managedservices/src/package_2019_09/operations.rs
+++ b/services/mgmt/managedservices/src/package_2019_09/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_registration_definitions(&self) -> marketplace_registration_definitions::Client {
+    pub fn marketplace_registration_definitions_client(&self) -> marketplace_registration_definitions::Client {
         marketplace_registration_definitions::Client(self.clone())
     }
-    pub fn marketplace_registration_definitions_without_scope(&self) -> marketplace_registration_definitions_without_scope::Client {
+    pub fn marketplace_registration_definitions_without_scope_client(&self) -> marketplace_registration_definitions_without_scope::Client {
         marketplace_registration_definitions_without_scope::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn registration_assignments(&self) -> registration_assignments::Client {
+    pub fn registration_assignments_client(&self) -> registration_assignments::Client {
         registration_assignments::Client(self.clone())
     }
-    pub fn registration_definitions(&self) -> registration_definitions::Client {
+    pub fn registration_definitions_client(&self) -> registration_definitions::Client {
         registration_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/managedservices/src/package_2020_02_preview/operations.rs
+++ b/services/mgmt/managedservices/src/package_2020_02_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_registration_definitions(&self) -> marketplace_registration_definitions::Client {
+    pub fn marketplace_registration_definitions_client(&self) -> marketplace_registration_definitions::Client {
         marketplace_registration_definitions::Client(self.clone())
     }
-    pub fn marketplace_registration_definitions_without_scope(&self) -> marketplace_registration_definitions_without_scope::Client {
+    pub fn marketplace_registration_definitions_without_scope_client(&self) -> marketplace_registration_definitions_without_scope::Client {
         marketplace_registration_definitions_without_scope::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn registration_assignments(&self) -> registration_assignments::Client {
+    pub fn registration_assignments_client(&self) -> registration_assignments::Client {
         registration_assignments::Client(self.clone())
     }
-    pub fn registration_definitions(&self) -> registration_definitions::Client {
+    pub fn registration_definitions_client(&self) -> registration_definitions::Client {
         registration_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/managedservices/src/package_preview_2022_01/operations.rs
+++ b/services/mgmt/managedservices/src/package_preview_2022_01/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_registration_definitions(&self) -> marketplace_registration_definitions::Client {
+    pub fn marketplace_registration_definitions_client(&self) -> marketplace_registration_definitions::Client {
         marketplace_registration_definitions::Client(self.clone())
     }
-    pub fn marketplace_registration_definitions_without_scope(&self) -> marketplace_registration_definitions_without_scope::Client {
+    pub fn marketplace_registration_definitions_without_scope_client(&self) -> marketplace_registration_definitions_without_scope::Client {
         marketplace_registration_definitions_without_scope::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_with_scope(&self) -> operations_with_scope::Client {
+    pub fn operations_with_scope_client(&self) -> operations_with_scope::Client {
         operations_with_scope::Client(self.clone())
     }
-    pub fn registration_assignments(&self) -> registration_assignments::Client {
+    pub fn registration_assignments_client(&self) -> registration_assignments::Client {
         registration_assignments::Client(self.clone())
     }
-    pub fn registration_definitions(&self) -> registration_definitions::Client {
+    pub fn registration_definitions_client(&self) -> registration_definitions::Client {
         registration_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/managementgroups/src/package_2019_11/operations.rs
+++ b/services/mgmt/managementgroups/src/package_2019_11/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn management_group_subscriptions(&self) -> management_group_subscriptions::Client {
+    pub fn management_group_subscriptions_client(&self) -> management_group_subscriptions::Client {
         management_group_subscriptions::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/managementgroups/src/package_2020_02/operations.rs
+++ b/services/mgmt/managementgroups/src/package_2020_02/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn hierarchy_settings(&self) -> hierarchy_settings::Client {
+    pub fn hierarchy_settings_client(&self) -> hierarchy_settings::Client {
         hierarchy_settings::Client(self.clone())
     }
-    pub fn management_group_subscriptions(&self) -> management_group_subscriptions::Client {
+    pub fn management_group_subscriptions_client(&self) -> management_group_subscriptions::Client {
         management_group_subscriptions::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/managementgroups/src/package_2020_05/operations.rs
+++ b/services/mgmt/managementgroups/src/package_2020_05/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn hierarchy_settings(&self) -> hierarchy_settings::Client {
+    pub fn hierarchy_settings_client(&self) -> hierarchy_settings::Client {
         hierarchy_settings::Client(self.clone())
     }
-    pub fn management_group_subscriptions(&self) -> management_group_subscriptions::Client {
+    pub fn management_group_subscriptions_client(&self) -> management_group_subscriptions::Client {
         management_group_subscriptions::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/managementgroups/src/package_2020_10/operations.rs
+++ b/services/mgmt/managementgroups/src/package_2020_10/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn hierarchy_settings(&self) -> hierarchy_settings::Client {
+    pub fn hierarchy_settings_client(&self) -> hierarchy_settings::Client {
         hierarchy_settings::Client(self.clone())
     }
-    pub fn management_group_subscriptions(&self) -> management_group_subscriptions::Client {
+    pub fn management_group_subscriptions_client(&self) -> management_group_subscriptions::Client {
         management_group_subscriptions::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/managementgroups/src/package_2021_04/operations.rs
+++ b/services/mgmt/managementgroups/src/package_2021_04/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn hierarchy_settings(&self) -> hierarchy_settings::Client {
+    pub fn hierarchy_settings_client(&self) -> hierarchy_settings::Client {
         hierarchy_settings::Client(self.clone())
     }
-    pub fn management_group_subscriptions(&self) -> management_group_subscriptions::Client {
+    pub fn management_group_subscriptions_client(&self) -> management_group_subscriptions::Client {
         management_group_subscriptions::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/managementpartner/src/package_2018_02/operations.rs
+++ b/services/mgmt/managementpartner/src/package_2018_02/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn partner(&self) -> partner::Client {
+    pub fn partner_client(&self) -> partner::Client {
         partner::Client(self.clone())
     }
-    pub fn partners(&self) -> partners::Client {
+    pub fn partners_client(&self) -> partners::Client {
         partners::Client(self.clone())
     }
 }

--- a/services/mgmt/maps/src/package_2018_05/operations.rs
+++ b/services/mgmt/maps/src/package_2018_05/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
 }

--- a/services/mgmt/maps/src/package_2021_02/operations.rs
+++ b/services/mgmt/maps/src/package_2021_02/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn creators(&self) -> creators::Client {
+    pub fn creators_client(&self) -> creators::Client {
         creators::Client(self.clone())
     }
-    pub fn maps(&self) -> maps::Client {
+    pub fn maps_client(&self) -> maps::Client {
         maps::Client(self.clone())
     }
 }

--- a/services/mgmt/maps/src/package_preview_2020_02/operations.rs
+++ b/services/mgmt/maps/src/package_preview_2020_02/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn creators(&self) -> creators::Client {
+    pub fn creators_client(&self) -> creators::Client {
         creators::Client(self.clone())
     }
-    pub fn maps(&self) -> maps::Client {
+    pub fn maps_client(&self) -> maps::Client {
         maps::Client(self.clone())
     }
-    pub fn private_atlases(&self) -> private_atlases::Client {
+    pub fn private_atlases_client(&self) -> private_atlases::Client {
         private_atlases::Client(self.clone())
     }
 }

--- a/services/mgmt/maps/src/package_preview_2021_07/operations.rs
+++ b/services/mgmt/maps/src/package_preview_2021_07/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn creators(&self) -> creators::Client {
+    pub fn creators_client(&self) -> creators::Client {
         creators::Client(self.clone())
     }
-    pub fn maps(&self) -> maps::Client {
+    pub fn maps_client(&self) -> maps::Client {
         maps::Client(self.clone())
     }
 }

--- a/services/mgmt/maps/src/package_preview_2021_12/operations.rs
+++ b/services/mgmt/maps/src/package_preview_2021_12/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn creators(&self) -> creators::Client {
+    pub fn creators_client(&self) -> creators::Client {
         creators::Client(self.clone())
     }
-    pub fn maps(&self) -> maps::Client {
+    pub fn maps_client(&self) -> maps::Client {
         maps::Client(self.clone())
     }
 }

--- a/services/mgmt/mariadb/src/package_2018_06_01/operations.rs
+++ b/services/mgmt/mariadb/src/package_2018_06_01/operations.rs
@@ -74,75 +74,75 @@ impl Client {
             pipeline,
         }
     }
-    pub fn advisors(&self) -> advisors::Client {
+    pub fn advisors_client(&self) -> advisors::Client {
         advisors::Client(self.clone())
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn location_based_performance_tier(&self) -> location_based_performance_tier::Client {
+    pub fn location_based_performance_tier_client(&self) -> location_based_performance_tier::Client {
         location_based_performance_tier::Client(self.clone())
     }
-    pub fn location_based_recommended_action_sessions_operation_status(
+    pub fn location_based_recommended_action_sessions_operation_status_client(
         &self,
     ) -> location_based_recommended_action_sessions_operation_status::Client {
         location_based_recommended_action_sessions_operation_status::Client(self.clone())
     }
-    pub fn location_based_recommended_action_sessions_result(&self) -> location_based_recommended_action_sessions_result::Client {
+    pub fn location_based_recommended_action_sessions_result_client(&self) -> location_based_recommended_action_sessions_result::Client {
         location_based_recommended_action_sessions_result::Client(self.clone())
     }
-    pub fn log_files(&self) -> log_files::Client {
+    pub fn log_files_client(&self) -> log_files::Client {
         log_files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_texts(&self) -> query_texts::Client {
+    pub fn query_texts_client(&self) -> query_texts::Client {
         query_texts::Client(self.clone())
     }
-    pub fn recommended_actions(&self) -> recommended_actions::Client {
+    pub fn recommended_actions_client(&self) -> recommended_actions::Client {
         recommended_actions::Client(self.clone())
     }
-    pub fn recoverable_servers(&self) -> recoverable_servers::Client {
+    pub fn recoverable_servers_client(&self) -> recoverable_servers::Client {
         recoverable_servers::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn server_based_performance_tier(&self) -> server_based_performance_tier::Client {
+    pub fn server_based_performance_tier_client(&self) -> server_based_performance_tier::Client {
         server_based_performance_tier::Client(self.clone())
     }
-    pub fn server_parameters(&self) -> server_parameters::Client {
+    pub fn server_parameters_client(&self) -> server_parameters::Client {
         server_parameters::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn top_query_statistics(&self) -> top_query_statistics::Client {
+    pub fn top_query_statistics_client(&self) -> top_query_statistics::Client {
         top_query_statistics::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn wait_statistics(&self) -> wait_statistics::Client {
+    pub fn wait_statistics_client(&self) -> wait_statistics::Client {
         wait_statistics::Client(self.clone())
     }
 }

--- a/services/mgmt/mariadb/src/package_2018_06_01_preview/operations.rs
+++ b/services/mgmt/mariadb/src/package_2018_06_01_preview/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn location_based_performance_tier(&self) -> location_based_performance_tier::Client {
+    pub fn location_based_performance_tier_client(&self) -> location_based_performance_tier::Client {
         location_based_performance_tier::Client(self.clone())
     }
-    pub fn log_files(&self) -> log_files::Client {
+    pub fn log_files_client(&self) -> log_files::Client {
         log_files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recoverable_servers(&self) -> recoverable_servers::Client {
+    pub fn recoverable_servers_client(&self) -> recoverable_servers::Client {
         recoverable_servers::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn server_based_performance_tier(&self) -> server_based_performance_tier::Client {
+    pub fn server_based_performance_tier_client(&self) -> server_based_performance_tier::Client {
         server_based_performance_tier::Client(self.clone())
     }
-    pub fn server_parameters(&self) -> server_parameters::Client {
+    pub fn server_parameters_client(&self) -> server_parameters::Client {
         server_parameters::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
 }

--- a/services/mgmt/mariadb/src/package_2018_06_01_privatepreview/operations.rs
+++ b/services/mgmt/mariadb/src/package_2018_06_01_privatepreview/operations.rs
@@ -74,66 +74,66 @@ impl Client {
             pipeline,
         }
     }
-    pub fn advisors(&self) -> advisors::Client {
+    pub fn advisors_client(&self) -> advisors::Client {
         advisors::Client(self.clone())
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn location_based_performance_tier(&self) -> location_based_performance_tier::Client {
+    pub fn location_based_performance_tier_client(&self) -> location_based_performance_tier::Client {
         location_based_performance_tier::Client(self.clone())
     }
-    pub fn location_based_recommended_action_sessions_operation_status(
+    pub fn location_based_recommended_action_sessions_operation_status_client(
         &self,
     ) -> location_based_recommended_action_sessions_operation_status::Client {
         location_based_recommended_action_sessions_operation_status::Client(self.clone())
     }
-    pub fn location_based_recommended_action_sessions_result(&self) -> location_based_recommended_action_sessions_result::Client {
+    pub fn location_based_recommended_action_sessions_result_client(&self) -> location_based_recommended_action_sessions_result::Client {
         location_based_recommended_action_sessions_result::Client(self.clone())
     }
-    pub fn log_files(&self) -> log_files::Client {
+    pub fn log_files_client(&self) -> log_files::Client {
         log_files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_texts(&self) -> query_texts::Client {
+    pub fn query_texts_client(&self) -> query_texts::Client {
         query_texts::Client(self.clone())
     }
-    pub fn recommended_actions(&self) -> recommended_actions::Client {
+    pub fn recommended_actions_client(&self) -> recommended_actions::Client {
         recommended_actions::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn top_query_statistics(&self) -> top_query_statistics::Client {
+    pub fn top_query_statistics_client(&self) -> top_query_statistics::Client {
         top_query_statistics::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn wait_statistics(&self) -> wait_statistics::Client {
+    pub fn wait_statistics_client(&self) -> wait_statistics::Client {
         wait_statistics::Client(self.clone())
     }
 }

--- a/services/mgmt/mariadb/src/package_2020_01_01/operations.rs
+++ b/services/mgmt/mariadb/src/package_2020_01_01/operations.rs
@@ -74,75 +74,75 @@ impl Client {
             pipeline,
         }
     }
-    pub fn advisors(&self) -> advisors::Client {
+    pub fn advisors_client(&self) -> advisors::Client {
         advisors::Client(self.clone())
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn location_based_performance_tier(&self) -> location_based_performance_tier::Client {
+    pub fn location_based_performance_tier_client(&self) -> location_based_performance_tier::Client {
         location_based_performance_tier::Client(self.clone())
     }
-    pub fn location_based_recommended_action_sessions_operation_status(
+    pub fn location_based_recommended_action_sessions_operation_status_client(
         &self,
     ) -> location_based_recommended_action_sessions_operation_status::Client {
         location_based_recommended_action_sessions_operation_status::Client(self.clone())
     }
-    pub fn location_based_recommended_action_sessions_result(&self) -> location_based_recommended_action_sessions_result::Client {
+    pub fn location_based_recommended_action_sessions_result_client(&self) -> location_based_recommended_action_sessions_result::Client {
         location_based_recommended_action_sessions_result::Client(self.clone())
     }
-    pub fn log_files(&self) -> log_files::Client {
+    pub fn log_files_client(&self) -> log_files::Client {
         log_files::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_texts(&self) -> query_texts::Client {
+    pub fn query_texts_client(&self) -> query_texts::Client {
         query_texts::Client(self.clone())
     }
-    pub fn recommended_actions(&self) -> recommended_actions::Client {
+    pub fn recommended_actions_client(&self) -> recommended_actions::Client {
         recommended_actions::Client(self.clone())
     }
-    pub fn recoverable_servers(&self) -> recoverable_servers::Client {
+    pub fn recoverable_servers_client(&self) -> recoverable_servers::Client {
         recoverable_servers::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn server_based_performance_tier(&self) -> server_based_performance_tier::Client {
+    pub fn server_based_performance_tier_client(&self) -> server_based_performance_tier::Client {
         server_based_performance_tier::Client(self.clone())
     }
-    pub fn server_parameters(&self) -> server_parameters::Client {
+    pub fn server_parameters_client(&self) -> server_parameters::Client {
         server_parameters::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn top_query_statistics(&self) -> top_query_statistics::Client {
+    pub fn top_query_statistics_client(&self) -> top_query_statistics::Client {
         top_query_statistics::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn wait_statistics(&self) -> wait_statistics::Client {
+    pub fn wait_statistics_client(&self) -> wait_statistics::Client {
         wait_statistics::Client(self.clone())
     }
 }

--- a/services/mgmt/mariadb/src/package_2020_01_01_privatepreview/operations.rs
+++ b/services/mgmt/mariadb/src/package_2020_01_01_privatepreview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/marketplace/src/package_2021_06_01/operations.rs
+++ b/services/mgmt/marketplace/src/package_2021_06_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_store(&self) -> private_store::Client {
+    pub fn private_store_client(&self) -> private_store::Client {
         private_store::Client(self.clone())
     }
-    pub fn private_store_collection(&self) -> private_store_collection::Client {
+    pub fn private_store_collection_client(&self) -> private_store_collection::Client {
         private_store_collection::Client(self.clone())
     }
-    pub fn private_store_collection_offer(&self) -> private_store_collection_offer::Client {
+    pub fn private_store_collection_offer_client(&self) -> private_store_collection_offer::Client {
         private_store_collection_offer::Client(self.clone())
     }
 }

--- a/services/mgmt/marketplace/src/package_2021_12/operations.rs
+++ b/services/mgmt/marketplace/src/package_2021_12/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_store(&self) -> private_store::Client {
+    pub fn private_store_client(&self) -> private_store::Client {
         private_store::Client(self.clone())
     }
-    pub fn private_store_collection(&self) -> private_store_collection::Client {
+    pub fn private_store_collection_client(&self) -> private_store_collection::Client {
         private_store_collection::Client(self.clone())
     }
-    pub fn private_store_collection_offer(&self) -> private_store_collection_offer::Client {
+    pub fn private_store_collection_offer_client(&self) -> private_store_collection_offer::Client {
         private_store_collection_offer::Client(self.clone())
     }
 }

--- a/services/mgmt/marketplace/src/package_2022_03/operations.rs
+++ b/services/mgmt/marketplace/src/package_2022_03/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_store(&self) -> private_store::Client {
+    pub fn private_store_client(&self) -> private_store::Client {
         private_store::Client(self.clone())
     }
-    pub fn private_store_collection(&self) -> private_store_collection::Client {
+    pub fn private_store_collection_client(&self) -> private_store_collection::Client {
         private_store_collection::Client(self.clone())
     }
-    pub fn private_store_collection_offer(&self) -> private_store_collection_offer::Client {
+    pub fn private_store_collection_offer_client(&self) -> private_store_collection_offer::Client {
         private_store_collection_offer::Client(self.clone())
     }
 }

--- a/services/mgmt/marketplacenotifications/src/package_2021_03_03/operations.rs
+++ b/services/mgmt/marketplacenotifications/src/package_2021_03_03/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn notification(&self) -> notification::Client {
+    pub fn notification_client(&self) -> notification::Client {
         notification::Client(self.clone())
     }
-    pub fn notifications(&self) -> notifications::Client {
+    pub fn notifications_client(&self) -> notifications::Client {
         notifications::Client(self.clone())
     }
 }

--- a/services/mgmt/marketplacenotifications/src/package_composite_v1/operations.rs
+++ b/services/mgmt/marketplacenotifications/src/package_composite_v1/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn notification(&self) -> notification::Client {
+    pub fn notification_client(&self) -> notification::Client {
         notification::Client(self.clone())
     }
-    pub fn notifications(&self) -> notifications::Client {
+    pub fn notifications_client(&self) -> notifications::Client {
         notifications::Client(self.clone())
     }
 }

--- a/services/mgmt/marketplaceordering/src/package_2015_06_01/operations.rs
+++ b/services/mgmt/marketplaceordering/src/package_2015_06_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/marketplaceordering/src/package_2021_01_01/operations.rs
+++ b/services/mgmt/marketplaceordering/src/package_2021_01_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn marketplace_agreements(&self) -> marketplace_agreements::Client {
+    pub fn marketplace_agreements_client(&self) -> marketplace_agreements::Client {
         marketplace_agreements::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/mediaservices/src/package_2020_02_preview/operations.rs
+++ b/services/mgmt/mediaservices/src/package_2020_02_preview/operations.rs
@@ -74,55 +74,55 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_filters(&self) -> account_filters::Client {
+    pub fn account_filters_client(&self) -> account_filters::Client {
         account_filters::Client(self.clone())
     }
-    pub fn asset_filters(&self) -> asset_filters::Client {
+    pub fn asset_filters_client(&self) -> asset_filters::Client {
         asset_filters::Client(self.clone())
     }
-    pub fn assets(&self) -> assets::Client {
+    pub fn assets_client(&self) -> assets::Client {
         assets::Client(self.clone())
     }
-    pub fn content_key_policies(&self) -> content_key_policies::Client {
+    pub fn content_key_policies_client(&self) -> content_key_policies::Client {
         content_key_policies::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn live_events(&self) -> live_events::Client {
+    pub fn live_events_client(&self) -> live_events::Client {
         live_events::Client(self.clone())
     }
-    pub fn live_outputs(&self) -> live_outputs::Client {
+    pub fn live_outputs_client(&self) -> live_outputs::Client {
         live_outputs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn media_graphs(&self) -> media_graphs::Client {
+    pub fn media_graphs_client(&self) -> media_graphs::Client {
         media_graphs::Client(self.clone())
     }
-    pub fn mediaservices(&self) -> mediaservices::Client {
+    pub fn mediaservices_client(&self) -> mediaservices::Client {
         mediaservices::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn streaming_endpoints(&self) -> streaming_endpoints::Client {
+    pub fn streaming_endpoints_client(&self) -> streaming_endpoints::Client {
         streaming_endpoints::Client(self.clone())
     }
-    pub fn streaming_locators(&self) -> streaming_locators::Client {
+    pub fn streaming_locators_client(&self) -> streaming_locators::Client {
         streaming_locators::Client(self.clone())
     }
-    pub fn streaming_policies(&self) -> streaming_policies::Client {
+    pub fn streaming_policies_client(&self) -> streaming_policies::Client {
         streaming_policies::Client(self.clone())
     }
-    pub fn transforms(&self) -> transforms::Client {
+    pub fn transforms_client(&self) -> transforms::Client {
         transforms::Client(self.clone())
     }
 }

--- a/services/mgmt/mediaservices/src/package_2020_05/operations.rs
+++ b/services/mgmt/mediaservices/src/package_2020_05/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_filters(&self) -> account_filters::Client {
+    pub fn account_filters_client(&self) -> account_filters::Client {
         account_filters::Client(self.clone())
     }
-    pub fn asset_filters(&self) -> asset_filters::Client {
+    pub fn asset_filters_client(&self) -> asset_filters::Client {
         asset_filters::Client(self.clone())
     }
-    pub fn assets(&self) -> assets::Client {
+    pub fn assets_client(&self) -> assets::Client {
         assets::Client(self.clone())
     }
-    pub fn content_key_policies(&self) -> content_key_policies::Client {
+    pub fn content_key_policies_client(&self) -> content_key_policies::Client {
         content_key_policies::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn live_events(&self) -> live_events::Client {
+    pub fn live_events_client(&self) -> live_events::Client {
         live_events::Client(self.clone())
     }
-    pub fn live_outputs(&self) -> live_outputs::Client {
+    pub fn live_outputs_client(&self) -> live_outputs::Client {
         live_outputs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mediaservices(&self) -> mediaservices::Client {
+    pub fn mediaservices_client(&self) -> mediaservices::Client {
         mediaservices::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn streaming_endpoints(&self) -> streaming_endpoints::Client {
+    pub fn streaming_endpoints_client(&self) -> streaming_endpoints::Client {
         streaming_endpoints::Client(self.clone())
     }
-    pub fn streaming_locators(&self) -> streaming_locators::Client {
+    pub fn streaming_locators_client(&self) -> streaming_locators::Client {
         streaming_locators::Client(self.clone())
     }
-    pub fn streaming_policies(&self) -> streaming_policies::Client {
+    pub fn streaming_policies_client(&self) -> streaming_policies::Client {
         streaming_policies::Client(self.clone())
     }
-    pub fn transforms(&self) -> transforms::Client {
+    pub fn transforms_client(&self) -> transforms::Client {
         transforms::Client(self.clone())
     }
 }

--- a/services/mgmt/mediaservices/src/package_2021_05/operations.rs
+++ b/services/mgmt/mediaservices/src/package_2021_05/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_filters(&self) -> account_filters::Client {
+    pub fn account_filters_client(&self) -> account_filters::Client {
         account_filters::Client(self.clone())
     }
-    pub fn asset_filters(&self) -> asset_filters::Client {
+    pub fn asset_filters_client(&self) -> asset_filters::Client {
         asset_filters::Client(self.clone())
     }
-    pub fn assets(&self) -> assets::Client {
+    pub fn assets_client(&self) -> assets::Client {
         assets::Client(self.clone())
     }
-    pub fn content_key_policies(&self) -> content_key_policies::Client {
+    pub fn content_key_policies_client(&self) -> content_key_policies::Client {
         content_key_policies::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn live_events(&self) -> live_events::Client {
+    pub fn live_events_client(&self) -> live_events::Client {
         live_events::Client(self.clone())
     }
-    pub fn live_outputs(&self) -> live_outputs::Client {
+    pub fn live_outputs_client(&self) -> live_outputs::Client {
         live_outputs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mediaservices(&self) -> mediaservices::Client {
+    pub fn mediaservices_client(&self) -> mediaservices::Client {
         mediaservices::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn streaming_endpoints(&self) -> streaming_endpoints::Client {
+    pub fn streaming_endpoints_client(&self) -> streaming_endpoints::Client {
         streaming_endpoints::Client(self.clone())
     }
-    pub fn streaming_locators(&self) -> streaming_locators::Client {
+    pub fn streaming_locators_client(&self) -> streaming_locators::Client {
         streaming_locators::Client(self.clone())
     }
-    pub fn streaming_policies(&self) -> streaming_policies::Client {
+    pub fn streaming_policies_client(&self) -> streaming_policies::Client {
         streaming_policies::Client(self.clone())
     }
-    pub fn transforms(&self) -> transforms::Client {
+    pub fn transforms_client(&self) -> transforms::Client {
         transforms::Client(self.clone())
     }
 }

--- a/services/mgmt/mediaservices/src/package_2021_06/operations.rs
+++ b/services/mgmt/mediaservices/src/package_2021_06/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_filters(&self) -> account_filters::Client {
+    pub fn account_filters_client(&self) -> account_filters::Client {
         account_filters::Client(self.clone())
     }
-    pub fn asset_filters(&self) -> asset_filters::Client {
+    pub fn asset_filters_client(&self) -> asset_filters::Client {
         asset_filters::Client(self.clone())
     }
-    pub fn assets(&self) -> assets::Client {
+    pub fn assets_client(&self) -> assets::Client {
         assets::Client(self.clone())
     }
-    pub fn content_key_policies(&self) -> content_key_policies::Client {
+    pub fn content_key_policies_client(&self) -> content_key_policies::Client {
         content_key_policies::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn live_events(&self) -> live_events::Client {
+    pub fn live_events_client(&self) -> live_events::Client {
         live_events::Client(self.clone())
     }
-    pub fn live_outputs(&self) -> live_outputs::Client {
+    pub fn live_outputs_client(&self) -> live_outputs::Client {
         live_outputs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mediaservices(&self) -> mediaservices::Client {
+    pub fn mediaservices_client(&self) -> mediaservices::Client {
         mediaservices::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn streaming_endpoints(&self) -> streaming_endpoints::Client {
+    pub fn streaming_endpoints_client(&self) -> streaming_endpoints::Client {
         streaming_endpoints::Client(self.clone())
     }
-    pub fn streaming_locators(&self) -> streaming_locators::Client {
+    pub fn streaming_locators_client(&self) -> streaming_locators::Client {
         streaming_locators::Client(self.clone())
     }
-    pub fn streaming_policies(&self) -> streaming_policies::Client {
+    pub fn streaming_policies_client(&self) -> streaming_policies::Client {
         streaming_policies::Client(self.clone())
     }
-    pub fn transforms(&self) -> transforms::Client {
+    pub fn transforms_client(&self) -> transforms::Client {
         transforms::Client(self.clone())
     }
 }

--- a/services/mgmt/mediaservices/src/package_2021_11/operations.rs
+++ b/services/mgmt/mediaservices/src/package_2021_11/operations.rs
@@ -74,61 +74,61 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_filters(&self) -> account_filters::Client {
+    pub fn account_filters_client(&self) -> account_filters::Client {
         account_filters::Client(self.clone())
     }
-    pub fn asset_filters(&self) -> asset_filters::Client {
+    pub fn asset_filters_client(&self) -> asset_filters::Client {
         asset_filters::Client(self.clone())
     }
-    pub fn assets(&self) -> assets::Client {
+    pub fn assets_client(&self) -> assets::Client {
         assets::Client(self.clone())
     }
-    pub fn content_key_policies(&self) -> content_key_policies::Client {
+    pub fn content_key_policies_client(&self) -> content_key_policies::Client {
         content_key_policies::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn live_events(&self) -> live_events::Client {
+    pub fn live_events_client(&self) -> live_events::Client {
         live_events::Client(self.clone())
     }
-    pub fn live_outputs(&self) -> live_outputs::Client {
+    pub fn live_outputs_client(&self) -> live_outputs::Client {
         live_outputs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mediaservices(&self) -> mediaservices::Client {
+    pub fn mediaservices_client(&self) -> mediaservices::Client {
         mediaservices::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn streaming_endpoints(&self) -> streaming_endpoints::Client {
+    pub fn streaming_endpoints_client(&self) -> streaming_endpoints::Client {
         streaming_endpoints::Client(self.clone())
     }
-    pub fn streaming_locators(&self) -> streaming_locators::Client {
+    pub fn streaming_locators_client(&self) -> streaming_locators::Client {
         streaming_locators::Client(self.clone())
     }
-    pub fn streaming_policies(&self) -> streaming_policies::Client {
+    pub fn streaming_policies_client(&self) -> streaming_policies::Client {
         streaming_policies::Client(self.clone())
     }
-    pub fn tracks(&self) -> tracks::Client {
+    pub fn tracks_client(&self) -> tracks::Client {
         tracks::Client(self.clone())
     }
-    pub fn transforms(&self) -> transforms::Client {
+    pub fn transforms_client(&self) -> transforms::Client {
         transforms::Client(self.clone())
     }
 }

--- a/services/mgmt/migrate/src/package_2018_02/operations.rs
+++ b/services/mgmt/migrate/src/package_2018_02/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn assessed_machines(&self) -> assessed_machines::Client {
+    pub fn assessed_machines_client(&self) -> assessed_machines::Client {
         assessed_machines::Client(self.clone())
     }
-    pub fn assessment_options(&self) -> assessment_options::Client {
+    pub fn assessment_options_client(&self) -> assessment_options::Client {
         assessment_options::Client(self.clone())
     }
-    pub fn assessments(&self) -> assessments::Client {
+    pub fn assessments_client(&self) -> assessments::Client {
         assessments::Client(self.clone())
     }
-    pub fn groups(&self) -> groups::Client {
+    pub fn groups_client(&self) -> groups::Client {
         groups::Client(self.clone())
     }
-    pub fn location(&self) -> location::Client {
+    pub fn location_client(&self) -> location::Client {
         location::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
 }

--- a/services/mgmt/migrate/src/package_2019_10/operations.rs
+++ b/services/mgmt/migrate/src/package_2019_10/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn assessed_machines(&self) -> assessed_machines::Client {
+    pub fn assessed_machines_client(&self) -> assessed_machines::Client {
         assessed_machines::Client(self.clone())
     }
-    pub fn assessments(&self) -> assessments::Client {
+    pub fn assessments_client(&self) -> assessments::Client {
         assessments::Client(self.clone())
     }
-    pub fn groups(&self) -> groups::Client {
+    pub fn groups_client(&self) -> groups::Client {
         groups::Client(self.clone())
     }
-    pub fn hyper_v_collectors(&self) -> hyper_v_collectors::Client {
+    pub fn hyper_v_collectors_client(&self) -> hyper_v_collectors::Client {
         hyper_v_collectors::Client(self.clone())
     }
-    pub fn import_collectors(&self) -> import_collectors::Client {
+    pub fn import_collectors_client(&self) -> import_collectors::Client {
         import_collectors::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resource(&self) -> private_link_resource::Client {
+    pub fn private_link_resource_client(&self) -> private_link_resource::Client {
         private_link_resource::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
-    pub fn server_collectors(&self) -> server_collectors::Client {
+    pub fn server_collectors_client(&self) -> server_collectors::Client {
         server_collectors::Client(self.clone())
     }
-    pub fn v_mware_collectors(&self) -> v_mware_collectors::Client {
+    pub fn v_mware_collectors_client(&self) -> v_mware_collectors::Client {
         v_mware_collectors::Client(self.clone())
     }
 }

--- a/services/mgmt/migrate/src/package_2020_01/operations.rs
+++ b/services/mgmt/migrate/src/package_2020_01/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hyper_v_cluster(&self) -> hyper_v_cluster::Client {
+    pub fn hyper_v_cluster_client(&self) -> hyper_v_cluster::Client {
         hyper_v_cluster::Client(self.clone())
     }
-    pub fn hyper_v_host(&self) -> hyper_v_host::Client {
+    pub fn hyper_v_host_client(&self) -> hyper_v_host::Client {
         hyper_v_host::Client(self.clone())
     }
-    pub fn hyper_v_jobs(&self) -> hyper_v_jobs::Client {
+    pub fn hyper_v_jobs_client(&self) -> hyper_v_jobs::Client {
         hyper_v_jobs::Client(self.clone())
     }
-    pub fn hyper_v_machines(&self) -> hyper_v_machines::Client {
+    pub fn hyper_v_machines_client(&self) -> hyper_v_machines::Client {
         hyper_v_machines::Client(self.clone())
     }
-    pub fn hyper_v_operations_status(&self) -> hyper_v_operations_status::Client {
+    pub fn hyper_v_operations_status_client(&self) -> hyper_v_operations_status::Client {
         hyper_v_operations_status::Client(self.clone())
     }
-    pub fn hyper_v_run_as_accounts(&self) -> hyper_v_run_as_accounts::Client {
+    pub fn hyper_v_run_as_accounts_client(&self) -> hyper_v_run_as_accounts::Client {
         hyper_v_run_as_accounts::Client(self.clone())
     }
-    pub fn hyper_v_sites(&self) -> hyper_v_sites::Client {
+    pub fn hyper_v_sites_client(&self) -> hyper_v_sites::Client {
         hyper_v_sites::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn run_as_accounts(&self) -> run_as_accounts::Client {
+    pub fn run_as_accounts_client(&self) -> run_as_accounts::Client {
         run_as_accounts::Client(self.clone())
     }
-    pub fn sites(&self) -> sites::Client {
+    pub fn sites_client(&self) -> sites::Client {
         sites::Client(self.clone())
     }
-    pub fn v_center(&self) -> v_center::Client {
+    pub fn v_center_client(&self) -> v_center::Client {
         v_center::Client(self.clone())
     }
-    pub fn v_mware_operations_status(&self) -> v_mware_operations_status::Client {
+    pub fn v_mware_operations_status_client(&self) -> v_mware_operations_status::Client {
         v_mware_operations_status::Client(self.clone())
     }
 }

--- a/services/mgmt/migrate/src/package_2020_05/operations.rs
+++ b/services/mgmt/migrate/src/package_2020_05/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn migrate_projects_controller(&self) -> migrate_projects_controller::Client {
+    pub fn migrate_projects_controller_client(&self) -> migrate_projects_controller::Client {
         migrate_projects_controller::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connection_controller(&self) -> private_endpoint_connection_controller::Client {
+    pub fn private_endpoint_connection_controller_client(&self) -> private_endpoint_connection_controller::Client {
         private_endpoint_connection_controller::Client(self.clone())
     }
-    pub fn private_endpoint_connections_controller(&self) -> private_endpoint_connections_controller::Client {
+    pub fn private_endpoint_connections_controller_client(&self) -> private_endpoint_connections_controller::Client {
         private_endpoint_connections_controller::Client(self.clone())
     }
-    pub fn private_link_resource_controller(&self) -> private_link_resource_controller::Client {
+    pub fn private_link_resource_controller_client(&self) -> private_link_resource_controller::Client {
         private_link_resource_controller::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
 }

--- a/services/mgmt/migrate/src/package_2020_07/operations.rs
+++ b/services/mgmt/migrate/src/package_2020_07/operations.rs
@@ -74,58 +74,58 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hyper_v_cluster(&self) -> hyper_v_cluster::Client {
+    pub fn hyper_v_cluster_client(&self) -> hyper_v_cluster::Client {
         hyper_v_cluster::Client(self.clone())
     }
-    pub fn hyper_v_host(&self) -> hyper_v_host::Client {
+    pub fn hyper_v_host_client(&self) -> hyper_v_host::Client {
         hyper_v_host::Client(self.clone())
     }
-    pub fn hyper_v_jobs(&self) -> hyper_v_jobs::Client {
+    pub fn hyper_v_jobs_client(&self) -> hyper_v_jobs::Client {
         hyper_v_jobs::Client(self.clone())
     }
-    pub fn hyper_v_machines(&self) -> hyper_v_machines::Client {
+    pub fn hyper_v_machines_client(&self) -> hyper_v_machines::Client {
         hyper_v_machines::Client(self.clone())
     }
-    pub fn hyper_v_operations_status(&self) -> hyper_v_operations_status::Client {
+    pub fn hyper_v_operations_status_client(&self) -> hyper_v_operations_status::Client {
         hyper_v_operations_status::Client(self.clone())
     }
-    pub fn hyper_v_run_as_accounts(&self) -> hyper_v_run_as_accounts::Client {
+    pub fn hyper_v_run_as_accounts_client(&self) -> hyper_v_run_as_accounts::Client {
         hyper_v_run_as_accounts::Client(self.clone())
     }
-    pub fn hyper_v_sites(&self) -> hyper_v_sites::Client {
+    pub fn hyper_v_sites_client(&self) -> hyper_v_sites::Client {
         hyper_v_sites::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn master_sites(&self) -> master_sites::Client {
+    pub fn master_sites_client(&self) -> master_sites::Client {
         master_sites::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn run_as_accounts(&self) -> run_as_accounts::Client {
+    pub fn run_as_accounts_client(&self) -> run_as_accounts::Client {
         run_as_accounts::Client(self.clone())
     }
-    pub fn sites(&self) -> sites::Client {
+    pub fn sites_client(&self) -> sites::Client {
         sites::Client(self.clone())
     }
-    pub fn v_center(&self) -> v_center::Client {
+    pub fn v_center_client(&self) -> v_center::Client {
         v_center::Client(self.clone())
     }
-    pub fn v_mware_operations_status(&self) -> v_mware_operations_status::Client {
+    pub fn v_mware_operations_status_client(&self) -> v_mware_operations_status::Client {
         v_mware_operations_status::Client(self.clone())
     }
-    pub fn v_mware_sites(&self) -> v_mware_sites::Client {
+    pub fn v_mware_sites_client(&self) -> v_mware_sites::Client {
         v_mware_sites::Client(self.clone())
     }
 }

--- a/services/mgmt/migrateprojects/src/package_2018_09/operations.rs
+++ b/services/mgmt/migrateprojects/src/package_2018_09/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn database_instances(&self) -> database_instances::Client {
+    pub fn database_instances_client(&self) -> database_instances::Client {
         database_instances::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn events(&self) -> events::Client {
+    pub fn events_client(&self) -> events::Client {
         events::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn migrate_projects(&self) -> migrate_projects::Client {
+    pub fn migrate_projects_client(&self) -> migrate_projects::Client {
         migrate_projects::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn solutions(&self) -> solutions::Client {
+    pub fn solutions_client(&self) -> solutions::Client {
         solutions::Client(self.clone())
     }
 }

--- a/services/mgmt/mobilenetwork/src/package_2022_01_01_preview/operations.rs
+++ b/services/mgmt/mobilenetwork/src/package_2022_01_01_preview/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attached_data_networks(&self) -> attached_data_networks::Client {
+    pub fn attached_data_networks_client(&self) -> attached_data_networks::Client {
         attached_data_networks::Client(self.clone())
     }
-    pub fn data_networks(&self) -> data_networks::Client {
+    pub fn data_networks_client(&self) -> data_networks::Client {
         data_networks::Client(self.clone())
     }
-    pub fn mobile_networks(&self) -> mobile_networks::Client {
+    pub fn mobile_networks_client(&self) -> mobile_networks::Client {
         mobile_networks::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn packet_core_control_planes(&self) -> packet_core_control_planes::Client {
+    pub fn packet_core_control_planes_client(&self) -> packet_core_control_planes::Client {
         packet_core_control_planes::Client(self.clone())
     }
-    pub fn packet_core_data_planes(&self) -> packet_core_data_planes::Client {
+    pub fn packet_core_data_planes_client(&self) -> packet_core_data_planes::Client {
         packet_core_data_planes::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn sim_policies(&self) -> sim_policies::Client {
+    pub fn sim_policies_client(&self) -> sim_policies::Client {
         sim_policies::Client(self.clone())
     }
-    pub fn sims(&self) -> sims::Client {
+    pub fn sims_client(&self) -> sims::Client {
         sims::Client(self.clone())
     }
-    pub fn sites(&self) -> sites::Client {
+    pub fn sites_client(&self) -> sites::Client {
         sites::Client(self.clone())
     }
-    pub fn slices(&self) -> slices::Client {
+    pub fn slices_client(&self) -> slices::Client {
         slices::Client(self.clone())
     }
 }

--- a/services/mgmt/mobilenetwork/src/package_2022_03_01_preview/operations.rs
+++ b/services/mgmt/mobilenetwork/src/package_2022_03_01_preview/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attached_data_networks(&self) -> attached_data_networks::Client {
+    pub fn attached_data_networks_client(&self) -> attached_data_networks::Client {
         attached_data_networks::Client(self.clone())
     }
-    pub fn data_networks(&self) -> data_networks::Client {
+    pub fn data_networks_client(&self) -> data_networks::Client {
         data_networks::Client(self.clone())
     }
-    pub fn mobile_networks(&self) -> mobile_networks::Client {
+    pub fn mobile_networks_client(&self) -> mobile_networks::Client {
         mobile_networks::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn packet_core_control_planes(&self) -> packet_core_control_planes::Client {
+    pub fn packet_core_control_planes_client(&self) -> packet_core_control_planes::Client {
         packet_core_control_planes::Client(self.clone())
     }
-    pub fn packet_core_data_planes(&self) -> packet_core_data_planes::Client {
+    pub fn packet_core_data_planes_client(&self) -> packet_core_data_planes::Client {
         packet_core_data_planes::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn sim_policies(&self) -> sim_policies::Client {
+    pub fn sim_policies_client(&self) -> sim_policies::Client {
         sim_policies::Client(self.clone())
     }
-    pub fn sims(&self) -> sims::Client {
+    pub fn sims_client(&self) -> sims::Client {
         sims::Client(self.clone())
     }
-    pub fn sites(&self) -> sites::Client {
+    pub fn sites_client(&self) -> sites::Client {
         sites::Client(self.clone())
     }
-    pub fn slices(&self) -> slices::Client {
+    pub fn slices_client(&self) -> slices::Client {
         slices::Client(self.clone())
     }
 }

--- a/services/mgmt/monitor/src/package_2019_11/operations.rs
+++ b/services/mgmt/monitor/src/package_2019_11/operations.rs
@@ -74,82 +74,82 @@ impl Client {
             pipeline,
         }
     }
-    pub fn action_groups(&self) -> action_groups::Client {
+    pub fn action_groups_client(&self) -> action_groups::Client {
         action_groups::Client(self.clone())
     }
-    pub fn activity_log_alerts(&self) -> activity_log_alerts::Client {
+    pub fn activity_log_alerts_client(&self) -> activity_log_alerts::Client {
         activity_log_alerts::Client(self.clone())
     }
-    pub fn activity_logs(&self) -> activity_logs::Client {
+    pub fn activity_logs_client(&self) -> activity_logs::Client {
         activity_logs::Client(self.clone())
     }
-    pub fn alert_rule_incidents(&self) -> alert_rule_incidents::Client {
+    pub fn alert_rule_incidents_client(&self) -> alert_rule_incidents::Client {
         alert_rule_incidents::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn autoscale_settings(&self) -> autoscale_settings::Client {
+    pub fn autoscale_settings_client(&self) -> autoscale_settings::Client {
         autoscale_settings::Client(self.clone())
     }
-    pub fn baselines(&self) -> baselines::Client {
+    pub fn baselines_client(&self) -> baselines::Client {
         baselines::Client(self.clone())
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn diagnostic_settings_category(&self) -> diagnostic_settings_category::Client {
+    pub fn diagnostic_settings_category_client(&self) -> diagnostic_settings_category::Client {
         diagnostic_settings_category::Client(self.clone())
     }
-    pub fn event_categories(&self) -> event_categories::Client {
+    pub fn event_categories_client(&self) -> event_categories::Client {
         event_categories::Client(self.clone())
     }
-    pub fn log_profiles(&self) -> log_profiles::Client {
+    pub fn log_profiles_client(&self) -> log_profiles::Client {
         log_profiles::Client(self.clone())
     }
-    pub fn metric_alerts(&self) -> metric_alerts::Client {
+    pub fn metric_alerts_client(&self) -> metric_alerts::Client {
         metric_alerts::Client(self.clone())
     }
-    pub fn metric_alerts_status(&self) -> metric_alerts_status::Client {
+    pub fn metric_alerts_status_client(&self) -> metric_alerts_status::Client {
         metric_alerts_status::Client(self.clone())
     }
-    pub fn metric_definitions(&self) -> metric_definitions::Client {
+    pub fn metric_definitions_client(&self) -> metric_definitions::Client {
         metric_definitions::Client(self.clone())
     }
-    pub fn metric_namespaces(&self) -> metric_namespaces::Client {
+    pub fn metric_namespaces_client(&self) -> metric_namespaces::Client {
         metric_namespaces::Client(self.clone())
     }
-    pub fn metrics(&self) -> metrics::Client {
+    pub fn metrics_client(&self) -> metrics::Client {
         metrics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scope_operation_status(&self) -> private_link_scope_operation_status::Client {
+    pub fn private_link_scope_operation_status_client(&self) -> private_link_scope_operation_status::Client {
         private_link_scope_operation_status::Client(self.clone())
     }
-    pub fn private_link_scoped_resources(&self) -> private_link_scoped_resources::Client {
+    pub fn private_link_scoped_resources_client(&self) -> private_link_scoped_resources::Client {
         private_link_scoped_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
-    pub fn scheduled_query_rules(&self) -> scheduled_query_rules::Client {
+    pub fn scheduled_query_rules_client(&self) -> scheduled_query_rules::Client {
         scheduled_query_rules::Client(self.clone())
     }
-    pub fn subscription_diagnostic_settings(&self) -> subscription_diagnostic_settings::Client {
+    pub fn subscription_diagnostic_settings_client(&self) -> subscription_diagnostic_settings::Client {
         subscription_diagnostic_settings::Client(self.clone())
     }
-    pub fn tenant_activity_logs(&self) -> tenant_activity_logs::Client {
+    pub fn tenant_activity_logs_client(&self) -> tenant_activity_logs::Client {
         tenant_activity_logs::Client(self.clone())
     }
-    pub fn vm_insights(&self) -> vm_insights::Client {
+    pub fn vm_insights_client(&self) -> vm_insights::Client {
         vm_insights::Client(self.clone())
     }
 }

--- a/services/mgmt/monitor/src/package_2020_03/operations.rs
+++ b/services/mgmt/monitor/src/package_2020_03/operations.rs
@@ -74,79 +74,79 @@ impl Client {
             pipeline,
         }
     }
-    pub fn action_groups(&self) -> action_groups::Client {
+    pub fn action_groups_client(&self) -> action_groups::Client {
         action_groups::Client(self.clone())
     }
-    pub fn activity_log_alerts(&self) -> activity_log_alerts::Client {
+    pub fn activity_log_alerts_client(&self) -> activity_log_alerts::Client {
         activity_log_alerts::Client(self.clone())
     }
-    pub fn activity_logs(&self) -> activity_logs::Client {
+    pub fn activity_logs_client(&self) -> activity_logs::Client {
         activity_logs::Client(self.clone())
     }
-    pub fn alert_rule_incidents(&self) -> alert_rule_incidents::Client {
+    pub fn alert_rule_incidents_client(&self) -> alert_rule_incidents::Client {
         alert_rule_incidents::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn autoscale_settings(&self) -> autoscale_settings::Client {
+    pub fn autoscale_settings_client(&self) -> autoscale_settings::Client {
         autoscale_settings::Client(self.clone())
     }
-    pub fn baselines(&self) -> baselines::Client {
+    pub fn baselines_client(&self) -> baselines::Client {
         baselines::Client(self.clone())
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn diagnostic_settings_category(&self) -> diagnostic_settings_category::Client {
+    pub fn diagnostic_settings_category_client(&self) -> diagnostic_settings_category::Client {
         diagnostic_settings_category::Client(self.clone())
     }
-    pub fn event_categories(&self) -> event_categories::Client {
+    pub fn event_categories_client(&self) -> event_categories::Client {
         event_categories::Client(self.clone())
     }
-    pub fn log_profiles(&self) -> log_profiles::Client {
+    pub fn log_profiles_client(&self) -> log_profiles::Client {
         log_profiles::Client(self.clone())
     }
-    pub fn metric_alerts(&self) -> metric_alerts::Client {
+    pub fn metric_alerts_client(&self) -> metric_alerts::Client {
         metric_alerts::Client(self.clone())
     }
-    pub fn metric_alerts_status(&self) -> metric_alerts_status::Client {
+    pub fn metric_alerts_status_client(&self) -> metric_alerts_status::Client {
         metric_alerts_status::Client(self.clone())
     }
-    pub fn metric_definitions(&self) -> metric_definitions::Client {
+    pub fn metric_definitions_client(&self) -> metric_definitions::Client {
         metric_definitions::Client(self.clone())
     }
-    pub fn metric_namespaces(&self) -> metric_namespaces::Client {
+    pub fn metric_namespaces_client(&self) -> metric_namespaces::Client {
         metric_namespaces::Client(self.clone())
     }
-    pub fn metrics(&self) -> metrics::Client {
+    pub fn metrics_client(&self) -> metrics::Client {
         metrics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scope_operation_status(&self) -> private_link_scope_operation_status::Client {
+    pub fn private_link_scope_operation_status_client(&self) -> private_link_scope_operation_status::Client {
         private_link_scope_operation_status::Client(self.clone())
     }
-    pub fn private_link_scoped_resources(&self) -> private_link_scoped_resources::Client {
+    pub fn private_link_scoped_resources_client(&self) -> private_link_scoped_resources::Client {
         private_link_scoped_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
-    pub fn scheduled_query_rules(&self) -> scheduled_query_rules::Client {
+    pub fn scheduled_query_rules_client(&self) -> scheduled_query_rules::Client {
         scheduled_query_rules::Client(self.clone())
     }
-    pub fn tenant_activity_logs(&self) -> tenant_activity_logs::Client {
+    pub fn tenant_activity_logs_client(&self) -> tenant_activity_logs::Client {
         tenant_activity_logs::Client(self.clone())
     }
-    pub fn vm_insights(&self) -> vm_insights::Client {
+    pub fn vm_insights_client(&self) -> vm_insights::Client {
         vm_insights::Client(self.clone())
     }
 }

--- a/services/mgmt/monitor/src/package_2021_04/operations.rs
+++ b/services/mgmt/monitor/src/package_2021_04/operations.rs
@@ -74,88 +74,88 @@ impl Client {
             pipeline,
         }
     }
-    pub fn action_groups(&self) -> action_groups::Client {
+    pub fn action_groups_client(&self) -> action_groups::Client {
         action_groups::Client(self.clone())
     }
-    pub fn activity_log_alerts(&self) -> activity_log_alerts::Client {
+    pub fn activity_log_alerts_client(&self) -> activity_log_alerts::Client {
         activity_log_alerts::Client(self.clone())
     }
-    pub fn activity_logs(&self) -> activity_logs::Client {
+    pub fn activity_logs_client(&self) -> activity_logs::Client {
         activity_logs::Client(self.clone())
     }
-    pub fn alert_rule_incidents(&self) -> alert_rule_incidents::Client {
+    pub fn alert_rule_incidents_client(&self) -> alert_rule_incidents::Client {
         alert_rule_incidents::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn autoscale_settings(&self) -> autoscale_settings::Client {
+    pub fn autoscale_settings_client(&self) -> autoscale_settings::Client {
         autoscale_settings::Client(self.clone())
     }
-    pub fn baselines(&self) -> baselines::Client {
+    pub fn baselines_client(&self) -> baselines::Client {
         baselines::Client(self.clone())
     }
-    pub fn data_collection_endpoints(&self) -> data_collection_endpoints::Client {
+    pub fn data_collection_endpoints_client(&self) -> data_collection_endpoints::Client {
         data_collection_endpoints::Client(self.clone())
     }
-    pub fn data_collection_rule_associations(&self) -> data_collection_rule_associations::Client {
+    pub fn data_collection_rule_associations_client(&self) -> data_collection_rule_associations::Client {
         data_collection_rule_associations::Client(self.clone())
     }
-    pub fn data_collection_rules(&self) -> data_collection_rules::Client {
+    pub fn data_collection_rules_client(&self) -> data_collection_rules::Client {
         data_collection_rules::Client(self.clone())
     }
-    pub fn diagnostic_settings(&self) -> diagnostic_settings::Client {
+    pub fn diagnostic_settings_client(&self) -> diagnostic_settings::Client {
         diagnostic_settings::Client(self.clone())
     }
-    pub fn diagnostic_settings_category(&self) -> diagnostic_settings_category::Client {
+    pub fn diagnostic_settings_category_client(&self) -> diagnostic_settings_category::Client {
         diagnostic_settings_category::Client(self.clone())
     }
-    pub fn event_categories(&self) -> event_categories::Client {
+    pub fn event_categories_client(&self) -> event_categories::Client {
         event_categories::Client(self.clone())
     }
-    pub fn log_profiles(&self) -> log_profiles::Client {
+    pub fn log_profiles_client(&self) -> log_profiles::Client {
         log_profiles::Client(self.clone())
     }
-    pub fn metric_alerts(&self) -> metric_alerts::Client {
+    pub fn metric_alerts_client(&self) -> metric_alerts::Client {
         metric_alerts::Client(self.clone())
     }
-    pub fn metric_alerts_status(&self) -> metric_alerts_status::Client {
+    pub fn metric_alerts_status_client(&self) -> metric_alerts_status::Client {
         metric_alerts_status::Client(self.clone())
     }
-    pub fn metric_definitions(&self) -> metric_definitions::Client {
+    pub fn metric_definitions_client(&self) -> metric_definitions::Client {
         metric_definitions::Client(self.clone())
     }
-    pub fn metric_namespaces(&self) -> metric_namespaces::Client {
+    pub fn metric_namespaces_client(&self) -> metric_namespaces::Client {
         metric_namespaces::Client(self.clone())
     }
-    pub fn metrics(&self) -> metrics::Client {
+    pub fn metrics_client(&self) -> metrics::Client {
         metrics::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_scope_operation_status(&self) -> private_link_scope_operation_status::Client {
+    pub fn private_link_scope_operation_status_client(&self) -> private_link_scope_operation_status::Client {
         private_link_scope_operation_status::Client(self.clone())
     }
-    pub fn private_link_scoped_resources(&self) -> private_link_scoped_resources::Client {
+    pub fn private_link_scoped_resources_client(&self) -> private_link_scoped_resources::Client {
         private_link_scoped_resources::Client(self.clone())
     }
-    pub fn private_link_scopes(&self) -> private_link_scopes::Client {
+    pub fn private_link_scopes_client(&self) -> private_link_scopes::Client {
         private_link_scopes::Client(self.clone())
     }
-    pub fn scheduled_query_rules(&self) -> scheduled_query_rules::Client {
+    pub fn scheduled_query_rules_client(&self) -> scheduled_query_rules::Client {
         scheduled_query_rules::Client(self.clone())
     }
-    pub fn tenant_activity_logs(&self) -> tenant_activity_logs::Client {
+    pub fn tenant_activity_logs_client(&self) -> tenant_activity_logs::Client {
         tenant_activity_logs::Client(self.clone())
     }
-    pub fn vm_insights(&self) -> vm_insights::Client {
+    pub fn vm_insights_client(&self) -> vm_insights::Client {
         vm_insights::Client(self.clone())
     }
 }

--- a/services/mgmt/msi/src/package_2015_08_31_preview/operations.rs
+++ b/services/mgmt/msi/src/package_2015_08_31_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn system_assigned_identities(&self) -> system_assigned_identities::Client {
+    pub fn system_assigned_identities_client(&self) -> system_assigned_identities::Client {
         system_assigned_identities::Client(self.clone())
     }
-    pub fn user_assigned_identities(&self) -> user_assigned_identities::Client {
+    pub fn user_assigned_identities_client(&self) -> user_assigned_identities::Client {
         user_assigned_identities::Client(self.clone())
     }
 }

--- a/services/mgmt/msi/src/package_2018_11_30/operations.rs
+++ b/services/mgmt/msi/src/package_2018_11_30/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn system_assigned_identities(&self) -> system_assigned_identities::Client {
+    pub fn system_assigned_identities_client(&self) -> system_assigned_identities::Client {
         system_assigned_identities::Client(self.clone())
     }
-    pub fn user_assigned_identities(&self) -> user_assigned_identities::Client {
+    pub fn user_assigned_identities_client(&self) -> user_assigned_identities::Client {
         user_assigned_identities::Client(self.clone())
     }
 }

--- a/services/mgmt/msi/src/package_preview_2021_09_30/operations.rs
+++ b/services/mgmt/msi/src/package_preview_2021_09_30/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn system_assigned_identities(&self) -> system_assigned_identities::Client {
+    pub fn system_assigned_identities_client(&self) -> system_assigned_identities::Client {
         system_assigned_identities::Client(self.clone())
     }
-    pub fn user_assigned_identities(&self) -> user_assigned_identities::Client {
+    pub fn user_assigned_identities_client(&self) -> user_assigned_identities::Client {
         user_assigned_identities::Client(self.clone())
     }
 }

--- a/services/mgmt/mysql/src/package_2020_01_01_privatepreview/operations.rs
+++ b/services/mgmt/mysql/src/package_2020_01_01_privatepreview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/mysql/src/package_2020_07_01_preview/operations.rs
+++ b/services/mgmt/mysql/src/package_2020_07_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn check_virtual_network_subnet_usage(&self) -> check_virtual_network_subnet_usage::Client {
+    pub fn check_virtual_network_subnet_usage_client(&self) -> check_virtual_network_subnet_usage::Client {
         check_virtual_network_subnet_usage::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/mysql/src/package_2020_07_01_privatepreview/operations.rs
+++ b/services/mgmt/mysql/src/package_2020_07_01_privatepreview/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn check_virtual_network_subnet_usage(&self) -> check_virtual_network_subnet_usage::Client {
+    pub fn check_virtual_network_subnet_usage_client(&self) -> check_virtual_network_subnet_usage::Client {
         check_virtual_network_subnet_usage::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
-    pub fn server_parameters(&self) -> server_parameters::Client {
+    pub fn server_parameters_client(&self) -> server_parameters::Client {
         server_parameters::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/mysql/src/package_flexibleserver_2021_05_01/operations.rs
+++ b/services/mgmt/mysql/src/package_flexibleserver_2021_05_01/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn check_virtual_network_subnet_usage(&self) -> check_virtual_network_subnet_usage::Client {
+    pub fn check_virtual_network_subnet_usage_client(&self) -> check_virtual_network_subnet_usage::Client {
         check_virtual_network_subnet_usage::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn get_private_dns_zone_suffix(&self) -> get_private_dns_zone_suffix::Client {
+    pub fn get_private_dns_zone_suffix_client(&self) -> get_private_dns_zone_suffix::Client {
         get_private_dns_zone_suffix::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/mysql/src/package_flexibleserver_2021_05_01_preview/operations.rs
+++ b/services/mgmt/mysql/src/package_flexibleserver_2021_05_01_preview/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn check_virtual_network_subnet_usage(&self) -> check_virtual_network_subnet_usage::Client {
+    pub fn check_virtual_network_subnet_usage_client(&self) -> check_virtual_network_subnet_usage::Client {
         check_virtual_network_subnet_usage::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn get_private_dns_zone_suffix(&self) -> get_private_dns_zone_suffix::Client {
+    pub fn get_private_dns_zone_suffix_client(&self) -> get_private_dns_zone_suffix::Client {
         get_private_dns_zone_suffix::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn replicas(&self) -> replicas::Client {
+    pub fn replicas_client(&self) -> replicas::Client {
         replicas::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/netapp/src/package_netapp_2021_04_01_preview/operations.rs
+++ b/services/mgmt/netapp/src/package_netapp_2021_04_01_preview/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_backups(&self) -> account_backups::Client {
+    pub fn account_backups_client(&self) -> account_backups::Client {
         account_backups::Client(self.clone())
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn net_app_resource(&self) -> net_app_resource::Client {
+    pub fn net_app_resource_client(&self) -> net_app_resource::Client {
         net_app_resource::Client(self.clone())
     }
-    pub fn net_app_resource_region_info(&self) -> net_app_resource_region_info::Client {
+    pub fn net_app_resource_region_info_client(&self) -> net_app_resource_region_info::Client {
         net_app_resource_region_info::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pools(&self) -> pools::Client {
+    pub fn pools_client(&self) -> pools::Client {
         pools::Client(self.clone())
     }
-    pub fn snapshot_policies(&self) -> snapshot_policies::Client {
+    pub fn snapshot_policies_client(&self) -> snapshot_policies::Client {
         snapshot_policies::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
-    pub fn volumes(&self) -> volumes::Client {
+    pub fn volumes_client(&self) -> volumes::Client {
         volumes::Client(self.clone())
     }
 }

--- a/services/mgmt/netapp/src/package_netapp_2021_06_01/operations.rs
+++ b/services/mgmt/netapp/src/package_netapp_2021_06_01/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_backups(&self) -> account_backups::Client {
+    pub fn account_backups_client(&self) -> account_backups::Client {
         account_backups::Client(self.clone())
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn net_app_resource(&self) -> net_app_resource::Client {
+    pub fn net_app_resource_client(&self) -> net_app_resource::Client {
         net_app_resource::Client(self.clone())
     }
-    pub fn net_app_resource_quota_limits(&self) -> net_app_resource_quota_limits::Client {
+    pub fn net_app_resource_quota_limits_client(&self) -> net_app_resource_quota_limits::Client {
         net_app_resource_quota_limits::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pools(&self) -> pools::Client {
+    pub fn pools_client(&self) -> pools::Client {
         pools::Client(self.clone())
     }
-    pub fn snapshot_policies(&self) -> snapshot_policies::Client {
+    pub fn snapshot_policies_client(&self) -> snapshot_policies::Client {
         snapshot_policies::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
-    pub fn volumes(&self) -> volumes::Client {
+    pub fn volumes_client(&self) -> volumes::Client {
         volumes::Client(self.clone())
     }
 }

--- a/services/mgmt/netapp/src/package_netapp_2021_08_01/operations.rs
+++ b/services/mgmt/netapp/src/package_netapp_2021_08_01/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_backups(&self) -> account_backups::Client {
+    pub fn account_backups_client(&self) -> account_backups::Client {
         account_backups::Client(self.clone())
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn net_app_resource(&self) -> net_app_resource::Client {
+    pub fn net_app_resource_client(&self) -> net_app_resource::Client {
         net_app_resource::Client(self.clone())
     }
-    pub fn net_app_resource_quota_limits(&self) -> net_app_resource_quota_limits::Client {
+    pub fn net_app_resource_quota_limits_client(&self) -> net_app_resource_quota_limits::Client {
         net_app_resource_quota_limits::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pools(&self) -> pools::Client {
+    pub fn pools_client(&self) -> pools::Client {
         pools::Client(self.clone())
     }
-    pub fn snapshot_policies(&self) -> snapshot_policies::Client {
+    pub fn snapshot_policies_client(&self) -> snapshot_policies::Client {
         snapshot_policies::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
-    pub fn volume_groups(&self) -> volume_groups::Client {
+    pub fn volume_groups_client(&self) -> volume_groups::Client {
         volume_groups::Client(self.clone())
     }
-    pub fn volumes(&self) -> volumes::Client {
+    pub fn volumes_client(&self) -> volumes::Client {
         volumes::Client(self.clone())
     }
 }

--- a/services/mgmt/netapp/src/package_netapp_2021_10_01/operations.rs
+++ b/services/mgmt/netapp/src/package_netapp_2021_10_01/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_backups(&self) -> account_backups::Client {
+    pub fn account_backups_client(&self) -> account_backups::Client {
         account_backups::Client(self.clone())
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn net_app_resource(&self) -> net_app_resource::Client {
+    pub fn net_app_resource_client(&self) -> net_app_resource::Client {
         net_app_resource::Client(self.clone())
     }
-    pub fn net_app_resource_quota_limits(&self) -> net_app_resource_quota_limits::Client {
+    pub fn net_app_resource_quota_limits_client(&self) -> net_app_resource_quota_limits::Client {
         net_app_resource_quota_limits::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pools(&self) -> pools::Client {
+    pub fn pools_client(&self) -> pools::Client {
         pools::Client(self.clone())
     }
-    pub fn snapshot_policies(&self) -> snapshot_policies::Client {
+    pub fn snapshot_policies_client(&self) -> snapshot_policies::Client {
         snapshot_policies::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn subvolumes(&self) -> subvolumes::Client {
+    pub fn subvolumes_client(&self) -> subvolumes::Client {
         subvolumes::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
-    pub fn volume_groups(&self) -> volume_groups::Client {
+    pub fn volume_groups_client(&self) -> volume_groups::Client {
         volume_groups::Client(self.clone())
     }
-    pub fn volumes(&self) -> volumes::Client {
+    pub fn volumes_client(&self) -> volumes::Client {
         volumes::Client(self.clone())
     }
 }

--- a/services/mgmt/netapp/src/package_netapp_2022_01_01/operations.rs
+++ b/services/mgmt/netapp/src/package_netapp_2022_01_01/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account_backups(&self) -> account_backups::Client {
+    pub fn account_backups_client(&self) -> account_backups::Client {
         account_backups::Client(self.clone())
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn net_app_resource(&self) -> net_app_resource::Client {
+    pub fn net_app_resource_client(&self) -> net_app_resource::Client {
         net_app_resource::Client(self.clone())
     }
-    pub fn net_app_resource_quota_limits(&self) -> net_app_resource_quota_limits::Client {
+    pub fn net_app_resource_quota_limits_client(&self) -> net_app_resource_quota_limits::Client {
         net_app_resource_quota_limits::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pools(&self) -> pools::Client {
+    pub fn pools_client(&self) -> pools::Client {
         pools::Client(self.clone())
     }
-    pub fn snapshot_policies(&self) -> snapshot_policies::Client {
+    pub fn snapshot_policies_client(&self) -> snapshot_policies::Client {
         snapshot_policies::Client(self.clone())
     }
-    pub fn snapshots(&self) -> snapshots::Client {
+    pub fn snapshots_client(&self) -> snapshots::Client {
         snapshots::Client(self.clone())
     }
-    pub fn subvolumes(&self) -> subvolumes::Client {
+    pub fn subvolumes_client(&self) -> subvolumes::Client {
         subvolumes::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
-    pub fn volume_groups(&self) -> volume_groups::Client {
+    pub fn volume_groups_client(&self) -> volume_groups::Client {
         volume_groups::Client(self.clone())
     }
-    pub fn volume_quota_rules(&self) -> volume_quota_rules::Client {
+    pub fn volume_quota_rules_client(&self) -> volume_quota_rules::Client {
         volume_quota_rules::Client(self.clone())
     }
-    pub fn volumes(&self) -> volumes::Client {
+    pub fn volumes_client(&self) -> volumes::Client {
         volumes::Client(self.clone())
     }
 }

--- a/services/mgmt/network/examples/list_azure_service_addresses.rs
+++ b/services/mgmt/network/examples/list_azure_service_addresses.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subscription_id = AzureCliCredential::get_subscription()?;
     let client = azure_mgmt_network::ClientBuilder::new(credential).build();
 
-    let response = client.service_tags().list(location, subscription_id).into_future().await?;
+    let response = client.service_tags_client().list(location, subscription_id).into_future().await?;
     for entry in response.values {
         if let Some(name) = entry.name {
             if let Some(properties) = entry.properties {

--- a/services/mgmt/network/src/package_2021_05/operations.rs
+++ b/services/mgmt/network/src/package_2021_05/operations.rs
@@ -74,340 +74,342 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_gateway_private_endpoint_connections(&self) -> application_gateway_private_endpoint_connections::Client {
+    pub fn application_gateway_private_endpoint_connections_client(&self) -> application_gateway_private_endpoint_connections::Client {
         application_gateway_private_endpoint_connections::Client(self.clone())
     }
-    pub fn application_gateway_private_link_resources(&self) -> application_gateway_private_link_resources::Client {
+    pub fn application_gateway_private_link_resources_client(&self) -> application_gateway_private_link_resources::Client {
         application_gateway_private_link_resources::Client(self.clone())
     }
-    pub fn application_gateways(&self) -> application_gateways::Client {
+    pub fn application_gateways_client(&self) -> application_gateways::Client {
         application_gateways::Client(self.clone())
     }
-    pub fn application_security_groups(&self) -> application_security_groups::Client {
+    pub fn application_security_groups_client(&self) -> application_security_groups::Client {
         application_security_groups::Client(self.clone())
     }
-    pub fn available_delegations(&self) -> available_delegations::Client {
+    pub fn available_delegations_client(&self) -> available_delegations::Client {
         available_delegations::Client(self.clone())
     }
-    pub fn available_endpoint_services(&self) -> available_endpoint_services::Client {
+    pub fn available_endpoint_services_client(&self) -> available_endpoint_services::Client {
         available_endpoint_services::Client(self.clone())
     }
-    pub fn available_private_endpoint_types(&self) -> available_private_endpoint_types::Client {
+    pub fn available_private_endpoint_types_client(&self) -> available_private_endpoint_types::Client {
         available_private_endpoint_types::Client(self.clone())
     }
-    pub fn available_resource_group_delegations(&self) -> available_resource_group_delegations::Client {
+    pub fn available_resource_group_delegations_client(&self) -> available_resource_group_delegations::Client {
         available_resource_group_delegations::Client(self.clone())
     }
-    pub fn available_service_aliases(&self) -> available_service_aliases::Client {
+    pub fn available_service_aliases_client(&self) -> available_service_aliases::Client {
         available_service_aliases::Client(self.clone())
     }
-    pub fn azure_firewall_fqdn_tags(&self) -> azure_firewall_fqdn_tags::Client {
+    pub fn azure_firewall_fqdn_tags_client(&self) -> azure_firewall_fqdn_tags::Client {
         azure_firewall_fqdn_tags::Client(self.clone())
     }
-    pub fn azure_firewalls(&self) -> azure_firewalls::Client {
+    pub fn azure_firewalls_client(&self) -> azure_firewalls::Client {
         azure_firewalls::Client(self.clone())
     }
-    pub fn bastion_hosts(&self) -> bastion_hosts::Client {
+    pub fn bastion_hosts_client(&self) -> bastion_hosts::Client {
         bastion_hosts::Client(self.clone())
     }
-    pub fn bgp_service_communities(&self) -> bgp_service_communities::Client {
+    pub fn bgp_service_communities_client(&self) -> bgp_service_communities::Client {
         bgp_service_communities::Client(self.clone())
     }
-    pub fn connection_monitors(&self) -> connection_monitors::Client {
+    pub fn connection_monitors_client(&self) -> connection_monitors::Client {
         connection_monitors::Client(self.clone())
     }
-    pub fn custom_ip_prefixes(&self) -> custom_ip_prefixes::Client {
+    pub fn custom_ip_prefixes_client(&self) -> custom_ip_prefixes::Client {
         custom_ip_prefixes::Client(self.clone())
     }
-    pub fn ddos_custom_policies(&self) -> ddos_custom_policies::Client {
+    pub fn ddos_custom_policies_client(&self) -> ddos_custom_policies::Client {
         ddos_custom_policies::Client(self.clone())
     }
-    pub fn ddos_protection_plans(&self) -> ddos_protection_plans::Client {
+    pub fn ddos_protection_plans_client(&self) -> ddos_protection_plans::Client {
         ddos_protection_plans::Client(self.clone())
     }
-    pub fn default_security_rules(&self) -> default_security_rules::Client {
+    pub fn default_security_rules_client(&self) -> default_security_rules::Client {
         default_security_rules::Client(self.clone())
     }
-    pub fn dscp_configuration(&self) -> dscp_configuration::Client {
+    pub fn dscp_configuration_client(&self) -> dscp_configuration::Client {
         dscp_configuration::Client(self.clone())
     }
-    pub fn express_route_circuit_authorizations(&self) -> express_route_circuit_authorizations::Client {
+    pub fn express_route_circuit_authorizations_client(&self) -> express_route_circuit_authorizations::Client {
         express_route_circuit_authorizations::Client(self.clone())
     }
-    pub fn express_route_circuit_connections(&self) -> express_route_circuit_connections::Client {
+    pub fn express_route_circuit_connections_client(&self) -> express_route_circuit_connections::Client {
         express_route_circuit_connections::Client(self.clone())
     }
-    pub fn express_route_circuit_peerings(&self) -> express_route_circuit_peerings::Client {
+    pub fn express_route_circuit_peerings_client(&self) -> express_route_circuit_peerings::Client {
         express_route_circuit_peerings::Client(self.clone())
     }
-    pub fn express_route_circuits(&self) -> express_route_circuits::Client {
+    pub fn express_route_circuits_client(&self) -> express_route_circuits::Client {
         express_route_circuits::Client(self.clone())
     }
-    pub fn express_route_connections(&self) -> express_route_connections::Client {
+    pub fn express_route_connections_client(&self) -> express_route_connections::Client {
         express_route_connections::Client(self.clone())
     }
-    pub fn express_route_cross_connection_peerings(&self) -> express_route_cross_connection_peerings::Client {
+    pub fn express_route_cross_connection_peerings_client(&self) -> express_route_cross_connection_peerings::Client {
         express_route_cross_connection_peerings::Client(self.clone())
     }
-    pub fn express_route_cross_connections(&self) -> express_route_cross_connections::Client {
+    pub fn express_route_cross_connections_client(&self) -> express_route_cross_connections::Client {
         express_route_cross_connections::Client(self.clone())
     }
-    pub fn express_route_gateways(&self) -> express_route_gateways::Client {
+    pub fn express_route_gateways_client(&self) -> express_route_gateways::Client {
         express_route_gateways::Client(self.clone())
     }
-    pub fn express_route_links(&self) -> express_route_links::Client {
+    pub fn express_route_links_client(&self) -> express_route_links::Client {
         express_route_links::Client(self.clone())
     }
-    pub fn express_route_ports(&self) -> express_route_ports::Client {
+    pub fn express_route_ports_client(&self) -> express_route_ports::Client {
         express_route_ports::Client(self.clone())
     }
-    pub fn express_route_ports_locations(&self) -> express_route_ports_locations::Client {
+    pub fn express_route_ports_locations_client(&self) -> express_route_ports_locations::Client {
         express_route_ports_locations::Client(self.clone())
     }
-    pub fn express_route_service_providers(&self) -> express_route_service_providers::Client {
+    pub fn express_route_service_providers_client(&self) -> express_route_service_providers::Client {
         express_route_service_providers::Client(self.clone())
     }
-    pub fn firewall_policies(&self) -> firewall_policies::Client {
+    pub fn firewall_policies_client(&self) -> firewall_policies::Client {
         firewall_policies::Client(self.clone())
     }
-    pub fn firewall_policy_idps_signatures(&self) -> firewall_policy_idps_signatures::Client {
+    pub fn firewall_policy_idps_signatures_client(&self) -> firewall_policy_idps_signatures::Client {
         firewall_policy_idps_signatures::Client(self.clone())
     }
-    pub fn firewall_policy_idps_signatures_filter_values(&self) -> firewall_policy_idps_signatures_filter_values::Client {
+    pub fn firewall_policy_idps_signatures_filter_values_client(&self) -> firewall_policy_idps_signatures_filter_values::Client {
         firewall_policy_idps_signatures_filter_values::Client(self.clone())
     }
-    pub fn firewall_policy_idps_signatures_overrides(&self) -> firewall_policy_idps_signatures_overrides::Client {
+    pub fn firewall_policy_idps_signatures_overrides_client(&self) -> firewall_policy_idps_signatures_overrides::Client {
         firewall_policy_idps_signatures_overrides::Client(self.clone())
     }
-    pub fn firewall_policy_rule_collection_groups(&self) -> firewall_policy_rule_collection_groups::Client {
+    pub fn firewall_policy_rule_collection_groups_client(&self) -> firewall_policy_rule_collection_groups::Client {
         firewall_policy_rule_collection_groups::Client(self.clone())
     }
-    pub fn flow_logs(&self) -> flow_logs::Client {
+    pub fn flow_logs_client(&self) -> flow_logs::Client {
         flow_logs::Client(self.clone())
     }
-    pub fn hub_route_tables(&self) -> hub_route_tables::Client {
+    pub fn hub_route_tables_client(&self) -> hub_route_tables::Client {
         hub_route_tables::Client(self.clone())
     }
-    pub fn hub_virtual_network_connections(&self) -> hub_virtual_network_connections::Client {
+    pub fn hub_virtual_network_connections_client(&self) -> hub_virtual_network_connections::Client {
         hub_virtual_network_connections::Client(self.clone())
     }
-    pub fn inbound_nat_rules(&self) -> inbound_nat_rules::Client {
+    pub fn inbound_nat_rules_client(&self) -> inbound_nat_rules::Client {
         inbound_nat_rules::Client(self.clone())
     }
-    pub fn inbound_security_rule(&self) -> inbound_security_rule::Client {
+    pub fn inbound_security_rule_client(&self) -> inbound_security_rule::Client {
         inbound_security_rule::Client(self.clone())
     }
-    pub fn ip_allocations(&self) -> ip_allocations::Client {
+    pub fn ip_allocations_client(&self) -> ip_allocations::Client {
         ip_allocations::Client(self.clone())
     }
-    pub fn ip_groups(&self) -> ip_groups::Client {
+    pub fn ip_groups_client(&self) -> ip_groups::Client {
         ip_groups::Client(self.clone())
     }
-    pub fn load_balancer_backend_address_pools(&self) -> load_balancer_backend_address_pools::Client {
+    pub fn load_balancer_backend_address_pools_client(&self) -> load_balancer_backend_address_pools::Client {
         load_balancer_backend_address_pools::Client(self.clone())
     }
-    pub fn load_balancer_frontend_ip_configurations(&self) -> load_balancer_frontend_ip_configurations::Client {
+    pub fn load_balancer_frontend_ip_configurations_client(&self) -> load_balancer_frontend_ip_configurations::Client {
         load_balancer_frontend_ip_configurations::Client(self.clone())
     }
-    pub fn load_balancer_load_balancing_rules(&self) -> load_balancer_load_balancing_rules::Client {
+    pub fn load_balancer_load_balancing_rules_client(&self) -> load_balancer_load_balancing_rules::Client {
         load_balancer_load_balancing_rules::Client(self.clone())
     }
-    pub fn load_balancer_network_interfaces(&self) -> load_balancer_network_interfaces::Client {
+    pub fn load_balancer_network_interfaces_client(&self) -> load_balancer_network_interfaces::Client {
         load_balancer_network_interfaces::Client(self.clone())
     }
-    pub fn load_balancer_outbound_rules(&self) -> load_balancer_outbound_rules::Client {
+    pub fn load_balancer_outbound_rules_client(&self) -> load_balancer_outbound_rules::Client {
         load_balancer_outbound_rules::Client(self.clone())
     }
-    pub fn load_balancer_probes(&self) -> load_balancer_probes::Client {
+    pub fn load_balancer_probes_client(&self) -> load_balancer_probes::Client {
         load_balancer_probes::Client(self.clone())
     }
-    pub fn load_balancers(&self) -> load_balancers::Client {
+    pub fn load_balancers_client(&self) -> load_balancers::Client {
         load_balancers::Client(self.clone())
     }
-    pub fn local_network_gateways(&self) -> local_network_gateways::Client {
+    pub fn local_network_gateways_client(&self) -> local_network_gateways::Client {
         local_network_gateways::Client(self.clone())
     }
-    pub fn nat_gateways(&self) -> nat_gateways::Client {
+    pub fn nat_gateways_client(&self) -> nat_gateways::Client {
         nat_gateways::Client(self.clone())
     }
-    pub fn nat_rules(&self) -> nat_rules::Client {
+    pub fn nat_rules_client(&self) -> nat_rules::Client {
         nat_rules::Client(self.clone())
     }
-    pub fn network_interface_ip_configurations(&self) -> network_interface_ip_configurations::Client {
+    pub fn network_interface_ip_configurations_client(&self) -> network_interface_ip_configurations::Client {
         network_interface_ip_configurations::Client(self.clone())
     }
-    pub fn network_interface_load_balancers(&self) -> network_interface_load_balancers::Client {
+    pub fn network_interface_load_balancers_client(&self) -> network_interface_load_balancers::Client {
         network_interface_load_balancers::Client(self.clone())
     }
-    pub fn network_interface_tap_configurations(&self) -> network_interface_tap_configurations::Client {
+    pub fn network_interface_tap_configurations_client(&self) -> network_interface_tap_configurations::Client {
         network_interface_tap_configurations::Client(self.clone())
     }
-    pub fn network_interfaces(&self) -> network_interfaces::Client {
+    pub fn network_interfaces_client(&self) -> network_interfaces::Client {
         network_interfaces::Client(self.clone())
     }
-    pub fn network_profiles(&self) -> network_profiles::Client {
+    pub fn network_profiles_client(&self) -> network_profiles::Client {
         network_profiles::Client(self.clone())
     }
-    pub fn network_security_groups(&self) -> network_security_groups::Client {
+    pub fn network_security_groups_client(&self) -> network_security_groups::Client {
         network_security_groups::Client(self.clone())
     }
-    pub fn network_virtual_appliances(&self) -> network_virtual_appliances::Client {
+    pub fn network_virtual_appliances_client(&self) -> network_virtual_appliances::Client {
         network_virtual_appliances::Client(self.clone())
     }
-    pub fn network_watchers(&self) -> network_watchers::Client {
+    pub fn network_watchers_client(&self) -> network_watchers::Client {
         network_watchers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn p2s_vpn_gateways(&self) -> p2s_vpn_gateways::Client {
+    pub fn p2s_vpn_gateways_client(&self) -> p2s_vpn_gateways::Client {
         p2s_vpn_gateways::Client(self.clone())
     }
-    pub fn packet_captures(&self) -> packet_captures::Client {
+    pub fn packet_captures_client(&self) -> packet_captures::Client {
         packet_captures::Client(self.clone())
     }
-    pub fn peer_express_route_circuit_connections(&self) -> peer_express_route_circuit_connections::Client {
+    pub fn peer_express_route_circuit_connections_client(&self) -> peer_express_route_circuit_connections::Client {
         peer_express_route_circuit_connections::Client(self.clone())
     }
-    pub fn private_dns_zone_groups(&self) -> private_dns_zone_groups::Client {
+    pub fn private_dns_zone_groups_client(&self) -> private_dns_zone_groups::Client {
         private_dns_zone_groups::Client(self.clone())
     }
-    pub fn private_endpoints(&self) -> private_endpoints::Client {
+    pub fn private_endpoints_client(&self) -> private_endpoints::Client {
         private_endpoints::Client(self.clone())
     }
-    pub fn private_link_services(&self) -> private_link_services::Client {
+    pub fn private_link_services_client(&self) -> private_link_services::Client {
         private_link_services::Client(self.clone())
     }
-    pub fn public_ip_addresses(&self) -> public_ip_addresses::Client {
+    pub fn public_ip_addresses_client(&self) -> public_ip_addresses::Client {
         public_ip_addresses::Client(self.clone())
     }
-    pub fn public_ip_prefixes(&self) -> public_ip_prefixes::Client {
+    pub fn public_ip_prefixes_client(&self) -> public_ip_prefixes::Client {
         public_ip_prefixes::Client(self.clone())
     }
-    pub fn resource_navigation_links(&self) -> resource_navigation_links::Client {
+    pub fn resource_navigation_links_client(&self) -> resource_navigation_links::Client {
         resource_navigation_links::Client(self.clone())
     }
-    pub fn route_filter_rules(&self) -> route_filter_rules::Client {
+    pub fn route_filter_rules_client(&self) -> route_filter_rules::Client {
         route_filter_rules::Client(self.clone())
     }
-    pub fn route_filters(&self) -> route_filters::Client {
+    pub fn route_filters_client(&self) -> route_filters::Client {
         route_filters::Client(self.clone())
     }
-    pub fn route_tables(&self) -> route_tables::Client {
+    pub fn route_tables_client(&self) -> route_tables::Client {
         route_tables::Client(self.clone())
     }
-    pub fn routes(&self) -> routes::Client {
+    pub fn routes_client(&self) -> routes::Client {
         routes::Client(self.clone())
     }
-    pub fn routing_intent(&self) -> routing_intent::Client {
+    pub fn routing_intent_client(&self) -> routing_intent::Client {
         routing_intent::Client(self.clone())
     }
-    pub fn security_partner_providers(&self) -> security_partner_providers::Client {
+    pub fn security_partner_providers_client(&self) -> security_partner_providers::Client {
         security_partner_providers::Client(self.clone())
     }
-    pub fn security_rules(&self) -> security_rules::Client {
+    pub fn security_rules_client(&self) -> security_rules::Client {
         security_rules::Client(self.clone())
     }
-    pub fn service_association_links(&self) -> service_association_links::Client {
+    pub fn service_association_links_client(&self) -> service_association_links::Client {
         service_association_links::Client(self.clone())
     }
-    pub fn service_endpoint_policies(&self) -> service_endpoint_policies::Client {
+    pub fn service_endpoint_policies_client(&self) -> service_endpoint_policies::Client {
         service_endpoint_policies::Client(self.clone())
     }
-    pub fn service_endpoint_policy_definitions(&self) -> service_endpoint_policy_definitions::Client {
+    pub fn service_endpoint_policy_definitions_client(&self) -> service_endpoint_policy_definitions::Client {
         service_endpoint_policy_definitions::Client(self.clone())
     }
-    pub fn service_tag_information(&self) -> service_tag_information::Client {
+    pub fn service_tag_information_client(&self) -> service_tag_information::Client {
         service_tag_information::Client(self.clone())
     }
-    pub fn service_tags(&self) -> service_tags::Client {
+    pub fn service_tags_client(&self) -> service_tags::Client {
         service_tags::Client(self.clone())
     }
-    pub fn subnets(&self) -> subnets::Client {
+    pub fn subnets_client(&self) -> subnets::Client {
         subnets::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_appliance_sites(&self) -> virtual_appliance_sites::Client {
+    pub fn virtual_appliance_sites_client(&self) -> virtual_appliance_sites::Client {
         virtual_appliance_sites::Client(self.clone())
     }
-    pub fn virtual_appliance_skus(&self) -> virtual_appliance_skus::Client {
+    pub fn virtual_appliance_skus_client(&self) -> virtual_appliance_skus::Client {
         virtual_appliance_skus::Client(self.clone())
     }
-    pub fn virtual_hub_bgp_connection(&self) -> virtual_hub_bgp_connection::Client {
+    pub fn virtual_hub_bgp_connection_client(&self) -> virtual_hub_bgp_connection::Client {
         virtual_hub_bgp_connection::Client(self.clone())
     }
-    pub fn virtual_hub_bgp_connections(&self) -> virtual_hub_bgp_connections::Client {
+    pub fn virtual_hub_bgp_connections_client(&self) -> virtual_hub_bgp_connections::Client {
         virtual_hub_bgp_connections::Client(self.clone())
     }
-    pub fn virtual_hub_ip_configuration(&self) -> virtual_hub_ip_configuration::Client {
+    pub fn virtual_hub_ip_configuration_client(&self) -> virtual_hub_ip_configuration::Client {
         virtual_hub_ip_configuration::Client(self.clone())
     }
-    pub fn virtual_hub_route_table_v2s(&self) -> virtual_hub_route_table_v2s::Client {
+    pub fn virtual_hub_route_table_v2s_client(&self) -> virtual_hub_route_table_v2s::Client {
         virtual_hub_route_table_v2s::Client(self.clone())
     }
-    pub fn virtual_hubs(&self) -> virtual_hubs::Client {
+    pub fn virtual_hubs_client(&self) -> virtual_hubs::Client {
         virtual_hubs::Client(self.clone())
     }
-    pub fn virtual_network_gateway_connections(&self) -> virtual_network_gateway_connections::Client {
+    pub fn virtual_network_gateway_connections_client(&self) -> virtual_network_gateway_connections::Client {
         virtual_network_gateway_connections::Client(self.clone())
     }
-    pub fn virtual_network_gateway_nat_rules(&self) -> virtual_network_gateway_nat_rules::Client {
+    pub fn virtual_network_gateway_nat_rules_client(&self) -> virtual_network_gateway_nat_rules::Client {
         virtual_network_gateway_nat_rules::Client(self.clone())
     }
-    pub fn virtual_network_gateways(&self) -> virtual_network_gateways::Client {
+    pub fn virtual_network_gateways_client(&self) -> virtual_network_gateways::Client {
         virtual_network_gateways::Client(self.clone())
     }
-    pub fn virtual_network_peerings(&self) -> virtual_network_peerings::Client {
+    pub fn virtual_network_peerings_client(&self) -> virtual_network_peerings::Client {
         virtual_network_peerings::Client(self.clone())
     }
-    pub fn virtual_network_taps(&self) -> virtual_network_taps::Client {
+    pub fn virtual_network_taps_client(&self) -> virtual_network_taps::Client {
         virtual_network_taps::Client(self.clone())
     }
-    pub fn virtual_networks(&self) -> virtual_networks::Client {
+    pub fn virtual_networks_client(&self) -> virtual_networks::Client {
         virtual_networks::Client(self.clone())
     }
-    pub fn virtual_router_peerings(&self) -> virtual_router_peerings::Client {
+    pub fn virtual_router_peerings_client(&self) -> virtual_router_peerings::Client {
         virtual_router_peerings::Client(self.clone())
     }
-    pub fn virtual_routers(&self) -> virtual_routers::Client {
+    pub fn virtual_routers_client(&self) -> virtual_routers::Client {
         virtual_routers::Client(self.clone())
     }
-    pub fn virtual_wans(&self) -> virtual_wans::Client {
+    pub fn virtual_wans_client(&self) -> virtual_wans::Client {
         virtual_wans::Client(self.clone())
     }
-    pub fn vpn_connections(&self) -> vpn_connections::Client {
+    pub fn vpn_connections_client(&self) -> vpn_connections::Client {
         vpn_connections::Client(self.clone())
     }
-    pub fn vpn_gateways(&self) -> vpn_gateways::Client {
+    pub fn vpn_gateways_client(&self) -> vpn_gateways::Client {
         vpn_gateways::Client(self.clone())
     }
-    pub fn vpn_link_connections(&self) -> vpn_link_connections::Client {
+    pub fn vpn_link_connections_client(&self) -> vpn_link_connections::Client {
         vpn_link_connections::Client(self.clone())
     }
-    pub fn vpn_server_configurations(&self) -> vpn_server_configurations::Client {
+    pub fn vpn_server_configurations_client(&self) -> vpn_server_configurations::Client {
         vpn_server_configurations::Client(self.clone())
     }
-    pub fn vpn_server_configurations_associated_with_virtual_wan(&self) -> vpn_server_configurations_associated_with_virtual_wan::Client {
+    pub fn vpn_server_configurations_associated_with_virtual_wan_client(
+        &self,
+    ) -> vpn_server_configurations_associated_with_virtual_wan::Client {
         vpn_server_configurations_associated_with_virtual_wan::Client(self.clone())
     }
-    pub fn vpn_site_link_connections(&self) -> vpn_site_link_connections::Client {
+    pub fn vpn_site_link_connections_client(&self) -> vpn_site_link_connections::Client {
         vpn_site_link_connections::Client(self.clone())
     }
-    pub fn vpn_site_links(&self) -> vpn_site_links::Client {
+    pub fn vpn_site_links_client(&self) -> vpn_site_links::Client {
         vpn_site_links::Client(self.clone())
     }
-    pub fn vpn_sites(&self) -> vpn_sites::Client {
+    pub fn vpn_sites_client(&self) -> vpn_sites::Client {
         vpn_sites::Client(self.clone())
     }
-    pub fn vpn_sites_configuration(&self) -> vpn_sites_configuration::Client {
+    pub fn vpn_sites_configuration_client(&self) -> vpn_sites_configuration::Client {
         vpn_sites_configuration::Client(self.clone())
     }
-    pub fn web_application_firewall_policies(&self) -> web_application_firewall_policies::Client {
+    pub fn web_application_firewall_policies_client(&self) -> web_application_firewall_policies::Client {
         web_application_firewall_policies::Client(self.clone())
     }
-    pub fn web_categories(&self) -> web_categories::Client {
+    pub fn web_categories_client(&self) -> web_categories::Client {
         web_categories::Client(self.clone())
     }
 }

--- a/services/mgmt/network/src/package_2021_08/operations.rs
+++ b/services/mgmt/network/src/package_2021_08/operations.rs
@@ -74,346 +74,348 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_gateway_private_endpoint_connections(&self) -> application_gateway_private_endpoint_connections::Client {
+    pub fn application_gateway_private_endpoint_connections_client(&self) -> application_gateway_private_endpoint_connections::Client {
         application_gateway_private_endpoint_connections::Client(self.clone())
     }
-    pub fn application_gateway_private_link_resources(&self) -> application_gateway_private_link_resources::Client {
+    pub fn application_gateway_private_link_resources_client(&self) -> application_gateway_private_link_resources::Client {
         application_gateway_private_link_resources::Client(self.clone())
     }
-    pub fn application_gateways(&self) -> application_gateways::Client {
+    pub fn application_gateways_client(&self) -> application_gateways::Client {
         application_gateways::Client(self.clone())
     }
-    pub fn application_security_groups(&self) -> application_security_groups::Client {
+    pub fn application_security_groups_client(&self) -> application_security_groups::Client {
         application_security_groups::Client(self.clone())
     }
-    pub fn available_delegations(&self) -> available_delegations::Client {
+    pub fn available_delegations_client(&self) -> available_delegations::Client {
         available_delegations::Client(self.clone())
     }
-    pub fn available_endpoint_services(&self) -> available_endpoint_services::Client {
+    pub fn available_endpoint_services_client(&self) -> available_endpoint_services::Client {
         available_endpoint_services::Client(self.clone())
     }
-    pub fn available_private_endpoint_types(&self) -> available_private_endpoint_types::Client {
+    pub fn available_private_endpoint_types_client(&self) -> available_private_endpoint_types::Client {
         available_private_endpoint_types::Client(self.clone())
     }
-    pub fn available_resource_group_delegations(&self) -> available_resource_group_delegations::Client {
+    pub fn available_resource_group_delegations_client(&self) -> available_resource_group_delegations::Client {
         available_resource_group_delegations::Client(self.clone())
     }
-    pub fn available_service_aliases(&self) -> available_service_aliases::Client {
+    pub fn available_service_aliases_client(&self) -> available_service_aliases::Client {
         available_service_aliases::Client(self.clone())
     }
-    pub fn azure_firewall_fqdn_tags(&self) -> azure_firewall_fqdn_tags::Client {
+    pub fn azure_firewall_fqdn_tags_client(&self) -> azure_firewall_fqdn_tags::Client {
         azure_firewall_fqdn_tags::Client(self.clone())
     }
-    pub fn azure_firewalls(&self) -> azure_firewalls::Client {
+    pub fn azure_firewalls_client(&self) -> azure_firewalls::Client {
         azure_firewalls::Client(self.clone())
     }
-    pub fn bastion_hosts(&self) -> bastion_hosts::Client {
+    pub fn bastion_hosts_client(&self) -> bastion_hosts::Client {
         bastion_hosts::Client(self.clone())
     }
-    pub fn bgp_service_communities(&self) -> bgp_service_communities::Client {
+    pub fn bgp_service_communities_client(&self) -> bgp_service_communities::Client {
         bgp_service_communities::Client(self.clone())
     }
-    pub fn configuration_policy_groups(&self) -> configuration_policy_groups::Client {
+    pub fn configuration_policy_groups_client(&self) -> configuration_policy_groups::Client {
         configuration_policy_groups::Client(self.clone())
     }
-    pub fn connection_monitors(&self) -> connection_monitors::Client {
+    pub fn connection_monitors_client(&self) -> connection_monitors::Client {
         connection_monitors::Client(self.clone())
     }
-    pub fn custom_ip_prefixes(&self) -> custom_ip_prefixes::Client {
+    pub fn custom_ip_prefixes_client(&self) -> custom_ip_prefixes::Client {
         custom_ip_prefixes::Client(self.clone())
     }
-    pub fn ddos_custom_policies(&self) -> ddos_custom_policies::Client {
+    pub fn ddos_custom_policies_client(&self) -> ddos_custom_policies::Client {
         ddos_custom_policies::Client(self.clone())
     }
-    pub fn ddos_protection_plans(&self) -> ddos_protection_plans::Client {
+    pub fn ddos_protection_plans_client(&self) -> ddos_protection_plans::Client {
         ddos_protection_plans::Client(self.clone())
     }
-    pub fn default_security_rules(&self) -> default_security_rules::Client {
+    pub fn default_security_rules_client(&self) -> default_security_rules::Client {
         default_security_rules::Client(self.clone())
     }
-    pub fn dscp_configuration(&self) -> dscp_configuration::Client {
+    pub fn dscp_configuration_client(&self) -> dscp_configuration::Client {
         dscp_configuration::Client(self.clone())
     }
-    pub fn express_route_circuit_authorizations(&self) -> express_route_circuit_authorizations::Client {
+    pub fn express_route_circuit_authorizations_client(&self) -> express_route_circuit_authorizations::Client {
         express_route_circuit_authorizations::Client(self.clone())
     }
-    pub fn express_route_circuit_connections(&self) -> express_route_circuit_connections::Client {
+    pub fn express_route_circuit_connections_client(&self) -> express_route_circuit_connections::Client {
         express_route_circuit_connections::Client(self.clone())
     }
-    pub fn express_route_circuit_peerings(&self) -> express_route_circuit_peerings::Client {
+    pub fn express_route_circuit_peerings_client(&self) -> express_route_circuit_peerings::Client {
         express_route_circuit_peerings::Client(self.clone())
     }
-    pub fn express_route_circuits(&self) -> express_route_circuits::Client {
+    pub fn express_route_circuits_client(&self) -> express_route_circuits::Client {
         express_route_circuits::Client(self.clone())
     }
-    pub fn express_route_connections(&self) -> express_route_connections::Client {
+    pub fn express_route_connections_client(&self) -> express_route_connections::Client {
         express_route_connections::Client(self.clone())
     }
-    pub fn express_route_cross_connection_peerings(&self) -> express_route_cross_connection_peerings::Client {
+    pub fn express_route_cross_connection_peerings_client(&self) -> express_route_cross_connection_peerings::Client {
         express_route_cross_connection_peerings::Client(self.clone())
     }
-    pub fn express_route_cross_connections(&self) -> express_route_cross_connections::Client {
+    pub fn express_route_cross_connections_client(&self) -> express_route_cross_connections::Client {
         express_route_cross_connections::Client(self.clone())
     }
-    pub fn express_route_gateways(&self) -> express_route_gateways::Client {
+    pub fn express_route_gateways_client(&self) -> express_route_gateways::Client {
         express_route_gateways::Client(self.clone())
     }
-    pub fn express_route_links(&self) -> express_route_links::Client {
+    pub fn express_route_links_client(&self) -> express_route_links::Client {
         express_route_links::Client(self.clone())
     }
-    pub fn express_route_port_authorizations(&self) -> express_route_port_authorizations::Client {
+    pub fn express_route_port_authorizations_client(&self) -> express_route_port_authorizations::Client {
         express_route_port_authorizations::Client(self.clone())
     }
-    pub fn express_route_ports(&self) -> express_route_ports::Client {
+    pub fn express_route_ports_client(&self) -> express_route_ports::Client {
         express_route_ports::Client(self.clone())
     }
-    pub fn express_route_ports_locations(&self) -> express_route_ports_locations::Client {
+    pub fn express_route_ports_locations_client(&self) -> express_route_ports_locations::Client {
         express_route_ports_locations::Client(self.clone())
     }
-    pub fn express_route_service_providers(&self) -> express_route_service_providers::Client {
+    pub fn express_route_service_providers_client(&self) -> express_route_service_providers::Client {
         express_route_service_providers::Client(self.clone())
     }
-    pub fn firewall_policies(&self) -> firewall_policies::Client {
+    pub fn firewall_policies_client(&self) -> firewall_policies::Client {
         firewall_policies::Client(self.clone())
     }
-    pub fn firewall_policy_idps_signatures(&self) -> firewall_policy_idps_signatures::Client {
+    pub fn firewall_policy_idps_signatures_client(&self) -> firewall_policy_idps_signatures::Client {
         firewall_policy_idps_signatures::Client(self.clone())
     }
-    pub fn firewall_policy_idps_signatures_filter_values(&self) -> firewall_policy_idps_signatures_filter_values::Client {
+    pub fn firewall_policy_idps_signatures_filter_values_client(&self) -> firewall_policy_idps_signatures_filter_values::Client {
         firewall_policy_idps_signatures_filter_values::Client(self.clone())
     }
-    pub fn firewall_policy_idps_signatures_overrides(&self) -> firewall_policy_idps_signatures_overrides::Client {
+    pub fn firewall_policy_idps_signatures_overrides_client(&self) -> firewall_policy_idps_signatures_overrides::Client {
         firewall_policy_idps_signatures_overrides::Client(self.clone())
     }
-    pub fn firewall_policy_rule_collection_groups(&self) -> firewall_policy_rule_collection_groups::Client {
+    pub fn firewall_policy_rule_collection_groups_client(&self) -> firewall_policy_rule_collection_groups::Client {
         firewall_policy_rule_collection_groups::Client(self.clone())
     }
-    pub fn flow_logs(&self) -> flow_logs::Client {
+    pub fn flow_logs_client(&self) -> flow_logs::Client {
         flow_logs::Client(self.clone())
     }
-    pub fn hub_route_tables(&self) -> hub_route_tables::Client {
+    pub fn hub_route_tables_client(&self) -> hub_route_tables::Client {
         hub_route_tables::Client(self.clone())
     }
-    pub fn hub_virtual_network_connections(&self) -> hub_virtual_network_connections::Client {
+    pub fn hub_virtual_network_connections_client(&self) -> hub_virtual_network_connections::Client {
         hub_virtual_network_connections::Client(self.clone())
     }
-    pub fn inbound_nat_rules(&self) -> inbound_nat_rules::Client {
+    pub fn inbound_nat_rules_client(&self) -> inbound_nat_rules::Client {
         inbound_nat_rules::Client(self.clone())
     }
-    pub fn inbound_security_rule(&self) -> inbound_security_rule::Client {
+    pub fn inbound_security_rule_client(&self) -> inbound_security_rule::Client {
         inbound_security_rule::Client(self.clone())
     }
-    pub fn ip_allocations(&self) -> ip_allocations::Client {
+    pub fn ip_allocations_client(&self) -> ip_allocations::Client {
         ip_allocations::Client(self.clone())
     }
-    pub fn ip_groups(&self) -> ip_groups::Client {
+    pub fn ip_groups_client(&self) -> ip_groups::Client {
         ip_groups::Client(self.clone())
     }
-    pub fn load_balancer_backend_address_pools(&self) -> load_balancer_backend_address_pools::Client {
+    pub fn load_balancer_backend_address_pools_client(&self) -> load_balancer_backend_address_pools::Client {
         load_balancer_backend_address_pools::Client(self.clone())
     }
-    pub fn load_balancer_frontend_ip_configurations(&self) -> load_balancer_frontend_ip_configurations::Client {
+    pub fn load_balancer_frontend_ip_configurations_client(&self) -> load_balancer_frontend_ip_configurations::Client {
         load_balancer_frontend_ip_configurations::Client(self.clone())
     }
-    pub fn load_balancer_load_balancing_rules(&self) -> load_balancer_load_balancing_rules::Client {
+    pub fn load_balancer_load_balancing_rules_client(&self) -> load_balancer_load_balancing_rules::Client {
         load_balancer_load_balancing_rules::Client(self.clone())
     }
-    pub fn load_balancer_network_interfaces(&self) -> load_balancer_network_interfaces::Client {
+    pub fn load_balancer_network_interfaces_client(&self) -> load_balancer_network_interfaces::Client {
         load_balancer_network_interfaces::Client(self.clone())
     }
-    pub fn load_balancer_outbound_rules(&self) -> load_balancer_outbound_rules::Client {
+    pub fn load_balancer_outbound_rules_client(&self) -> load_balancer_outbound_rules::Client {
         load_balancer_outbound_rules::Client(self.clone())
     }
-    pub fn load_balancer_probes(&self) -> load_balancer_probes::Client {
+    pub fn load_balancer_probes_client(&self) -> load_balancer_probes::Client {
         load_balancer_probes::Client(self.clone())
     }
-    pub fn load_balancers(&self) -> load_balancers::Client {
+    pub fn load_balancers_client(&self) -> load_balancers::Client {
         load_balancers::Client(self.clone())
     }
-    pub fn local_network_gateways(&self) -> local_network_gateways::Client {
+    pub fn local_network_gateways_client(&self) -> local_network_gateways::Client {
         local_network_gateways::Client(self.clone())
     }
-    pub fn nat_gateways(&self) -> nat_gateways::Client {
+    pub fn nat_gateways_client(&self) -> nat_gateways::Client {
         nat_gateways::Client(self.clone())
     }
-    pub fn nat_rules(&self) -> nat_rules::Client {
+    pub fn nat_rules_client(&self) -> nat_rules::Client {
         nat_rules::Client(self.clone())
     }
-    pub fn network_interface_ip_configurations(&self) -> network_interface_ip_configurations::Client {
+    pub fn network_interface_ip_configurations_client(&self) -> network_interface_ip_configurations::Client {
         network_interface_ip_configurations::Client(self.clone())
     }
-    pub fn network_interface_load_balancers(&self) -> network_interface_load_balancers::Client {
+    pub fn network_interface_load_balancers_client(&self) -> network_interface_load_balancers::Client {
         network_interface_load_balancers::Client(self.clone())
     }
-    pub fn network_interface_tap_configurations(&self) -> network_interface_tap_configurations::Client {
+    pub fn network_interface_tap_configurations_client(&self) -> network_interface_tap_configurations::Client {
         network_interface_tap_configurations::Client(self.clone())
     }
-    pub fn network_interfaces(&self) -> network_interfaces::Client {
+    pub fn network_interfaces_client(&self) -> network_interfaces::Client {
         network_interfaces::Client(self.clone())
     }
-    pub fn network_profiles(&self) -> network_profiles::Client {
+    pub fn network_profiles_client(&self) -> network_profiles::Client {
         network_profiles::Client(self.clone())
     }
-    pub fn network_security_groups(&self) -> network_security_groups::Client {
+    pub fn network_security_groups_client(&self) -> network_security_groups::Client {
         network_security_groups::Client(self.clone())
     }
-    pub fn network_virtual_appliances(&self) -> network_virtual_appliances::Client {
+    pub fn network_virtual_appliances_client(&self) -> network_virtual_appliances::Client {
         network_virtual_appliances::Client(self.clone())
     }
-    pub fn network_watchers(&self) -> network_watchers::Client {
+    pub fn network_watchers_client(&self) -> network_watchers::Client {
         network_watchers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn p2s_vpn_gateways(&self) -> p2s_vpn_gateways::Client {
+    pub fn p2s_vpn_gateways_client(&self) -> p2s_vpn_gateways::Client {
         p2s_vpn_gateways::Client(self.clone())
     }
-    pub fn packet_captures(&self) -> packet_captures::Client {
+    pub fn packet_captures_client(&self) -> packet_captures::Client {
         packet_captures::Client(self.clone())
     }
-    pub fn peer_express_route_circuit_connections(&self) -> peer_express_route_circuit_connections::Client {
+    pub fn peer_express_route_circuit_connections_client(&self) -> peer_express_route_circuit_connections::Client {
         peer_express_route_circuit_connections::Client(self.clone())
     }
-    pub fn private_dns_zone_groups(&self) -> private_dns_zone_groups::Client {
+    pub fn private_dns_zone_groups_client(&self) -> private_dns_zone_groups::Client {
         private_dns_zone_groups::Client(self.clone())
     }
-    pub fn private_endpoints(&self) -> private_endpoints::Client {
+    pub fn private_endpoints_client(&self) -> private_endpoints::Client {
         private_endpoints::Client(self.clone())
     }
-    pub fn private_link_services(&self) -> private_link_services::Client {
+    pub fn private_link_services_client(&self) -> private_link_services::Client {
         private_link_services::Client(self.clone())
     }
-    pub fn public_ip_addresses(&self) -> public_ip_addresses::Client {
+    pub fn public_ip_addresses_client(&self) -> public_ip_addresses::Client {
         public_ip_addresses::Client(self.clone())
     }
-    pub fn public_ip_prefixes(&self) -> public_ip_prefixes::Client {
+    pub fn public_ip_prefixes_client(&self) -> public_ip_prefixes::Client {
         public_ip_prefixes::Client(self.clone())
     }
-    pub fn resource_navigation_links(&self) -> resource_navigation_links::Client {
+    pub fn resource_navigation_links_client(&self) -> resource_navigation_links::Client {
         resource_navigation_links::Client(self.clone())
     }
-    pub fn route_filter_rules(&self) -> route_filter_rules::Client {
+    pub fn route_filter_rules_client(&self) -> route_filter_rules::Client {
         route_filter_rules::Client(self.clone())
     }
-    pub fn route_filters(&self) -> route_filters::Client {
+    pub fn route_filters_client(&self) -> route_filters::Client {
         route_filters::Client(self.clone())
     }
-    pub fn route_tables(&self) -> route_tables::Client {
+    pub fn route_tables_client(&self) -> route_tables::Client {
         route_tables::Client(self.clone())
     }
-    pub fn routes(&self) -> routes::Client {
+    pub fn routes_client(&self) -> routes::Client {
         routes::Client(self.clone())
     }
-    pub fn routing_intent(&self) -> routing_intent::Client {
+    pub fn routing_intent_client(&self) -> routing_intent::Client {
         routing_intent::Client(self.clone())
     }
-    pub fn security_partner_providers(&self) -> security_partner_providers::Client {
+    pub fn security_partner_providers_client(&self) -> security_partner_providers::Client {
         security_partner_providers::Client(self.clone())
     }
-    pub fn security_rules(&self) -> security_rules::Client {
+    pub fn security_rules_client(&self) -> security_rules::Client {
         security_rules::Client(self.clone())
     }
-    pub fn service_association_links(&self) -> service_association_links::Client {
+    pub fn service_association_links_client(&self) -> service_association_links::Client {
         service_association_links::Client(self.clone())
     }
-    pub fn service_endpoint_policies(&self) -> service_endpoint_policies::Client {
+    pub fn service_endpoint_policies_client(&self) -> service_endpoint_policies::Client {
         service_endpoint_policies::Client(self.clone())
     }
-    pub fn service_endpoint_policy_definitions(&self) -> service_endpoint_policy_definitions::Client {
+    pub fn service_endpoint_policy_definitions_client(&self) -> service_endpoint_policy_definitions::Client {
         service_endpoint_policy_definitions::Client(self.clone())
     }
-    pub fn service_tag_information(&self) -> service_tag_information::Client {
+    pub fn service_tag_information_client(&self) -> service_tag_information::Client {
         service_tag_information::Client(self.clone())
     }
-    pub fn service_tags(&self) -> service_tags::Client {
+    pub fn service_tags_client(&self) -> service_tags::Client {
         service_tags::Client(self.clone())
     }
-    pub fn subnets(&self) -> subnets::Client {
+    pub fn subnets_client(&self) -> subnets::Client {
         subnets::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_appliance_sites(&self) -> virtual_appliance_sites::Client {
+    pub fn virtual_appliance_sites_client(&self) -> virtual_appliance_sites::Client {
         virtual_appliance_sites::Client(self.clone())
     }
-    pub fn virtual_appliance_skus(&self) -> virtual_appliance_skus::Client {
+    pub fn virtual_appliance_skus_client(&self) -> virtual_appliance_skus::Client {
         virtual_appliance_skus::Client(self.clone())
     }
-    pub fn virtual_hub_bgp_connection(&self) -> virtual_hub_bgp_connection::Client {
+    pub fn virtual_hub_bgp_connection_client(&self) -> virtual_hub_bgp_connection::Client {
         virtual_hub_bgp_connection::Client(self.clone())
     }
-    pub fn virtual_hub_bgp_connections(&self) -> virtual_hub_bgp_connections::Client {
+    pub fn virtual_hub_bgp_connections_client(&self) -> virtual_hub_bgp_connections::Client {
         virtual_hub_bgp_connections::Client(self.clone())
     }
-    pub fn virtual_hub_ip_configuration(&self) -> virtual_hub_ip_configuration::Client {
+    pub fn virtual_hub_ip_configuration_client(&self) -> virtual_hub_ip_configuration::Client {
         virtual_hub_ip_configuration::Client(self.clone())
     }
-    pub fn virtual_hub_route_table_v2s(&self) -> virtual_hub_route_table_v2s::Client {
+    pub fn virtual_hub_route_table_v2s_client(&self) -> virtual_hub_route_table_v2s::Client {
         virtual_hub_route_table_v2s::Client(self.clone())
     }
-    pub fn virtual_hubs(&self) -> virtual_hubs::Client {
+    pub fn virtual_hubs_client(&self) -> virtual_hubs::Client {
         virtual_hubs::Client(self.clone())
     }
-    pub fn virtual_network_gateway_connections(&self) -> virtual_network_gateway_connections::Client {
+    pub fn virtual_network_gateway_connections_client(&self) -> virtual_network_gateway_connections::Client {
         virtual_network_gateway_connections::Client(self.clone())
     }
-    pub fn virtual_network_gateway_nat_rules(&self) -> virtual_network_gateway_nat_rules::Client {
+    pub fn virtual_network_gateway_nat_rules_client(&self) -> virtual_network_gateway_nat_rules::Client {
         virtual_network_gateway_nat_rules::Client(self.clone())
     }
-    pub fn virtual_network_gateways(&self) -> virtual_network_gateways::Client {
+    pub fn virtual_network_gateways_client(&self) -> virtual_network_gateways::Client {
         virtual_network_gateways::Client(self.clone())
     }
-    pub fn virtual_network_peerings(&self) -> virtual_network_peerings::Client {
+    pub fn virtual_network_peerings_client(&self) -> virtual_network_peerings::Client {
         virtual_network_peerings::Client(self.clone())
     }
-    pub fn virtual_network_taps(&self) -> virtual_network_taps::Client {
+    pub fn virtual_network_taps_client(&self) -> virtual_network_taps::Client {
         virtual_network_taps::Client(self.clone())
     }
-    pub fn virtual_networks(&self) -> virtual_networks::Client {
+    pub fn virtual_networks_client(&self) -> virtual_networks::Client {
         virtual_networks::Client(self.clone())
     }
-    pub fn virtual_router_peerings(&self) -> virtual_router_peerings::Client {
+    pub fn virtual_router_peerings_client(&self) -> virtual_router_peerings::Client {
         virtual_router_peerings::Client(self.clone())
     }
-    pub fn virtual_routers(&self) -> virtual_routers::Client {
+    pub fn virtual_routers_client(&self) -> virtual_routers::Client {
         virtual_routers::Client(self.clone())
     }
-    pub fn virtual_wans(&self) -> virtual_wans::Client {
+    pub fn virtual_wans_client(&self) -> virtual_wans::Client {
         virtual_wans::Client(self.clone())
     }
-    pub fn vpn_connections(&self) -> vpn_connections::Client {
+    pub fn vpn_connections_client(&self) -> vpn_connections::Client {
         vpn_connections::Client(self.clone())
     }
-    pub fn vpn_gateways(&self) -> vpn_gateways::Client {
+    pub fn vpn_gateways_client(&self) -> vpn_gateways::Client {
         vpn_gateways::Client(self.clone())
     }
-    pub fn vpn_link_connections(&self) -> vpn_link_connections::Client {
+    pub fn vpn_link_connections_client(&self) -> vpn_link_connections::Client {
         vpn_link_connections::Client(self.clone())
     }
-    pub fn vpn_server_configurations(&self) -> vpn_server_configurations::Client {
+    pub fn vpn_server_configurations_client(&self) -> vpn_server_configurations::Client {
         vpn_server_configurations::Client(self.clone())
     }
-    pub fn vpn_server_configurations_associated_with_virtual_wan(&self) -> vpn_server_configurations_associated_with_virtual_wan::Client {
+    pub fn vpn_server_configurations_associated_with_virtual_wan_client(
+        &self,
+    ) -> vpn_server_configurations_associated_with_virtual_wan::Client {
         vpn_server_configurations_associated_with_virtual_wan::Client(self.clone())
     }
-    pub fn vpn_site_link_connections(&self) -> vpn_site_link_connections::Client {
+    pub fn vpn_site_link_connections_client(&self) -> vpn_site_link_connections::Client {
         vpn_site_link_connections::Client(self.clone())
     }
-    pub fn vpn_site_links(&self) -> vpn_site_links::Client {
+    pub fn vpn_site_links_client(&self) -> vpn_site_links::Client {
         vpn_site_links::Client(self.clone())
     }
-    pub fn vpn_sites(&self) -> vpn_sites::Client {
+    pub fn vpn_sites_client(&self) -> vpn_sites::Client {
         vpn_sites::Client(self.clone())
     }
-    pub fn vpn_sites_configuration(&self) -> vpn_sites_configuration::Client {
+    pub fn vpn_sites_configuration_client(&self) -> vpn_sites_configuration::Client {
         vpn_sites_configuration::Client(self.clone())
     }
-    pub fn web_application_firewall_policies(&self) -> web_application_firewall_policies::Client {
+    pub fn web_application_firewall_policies_client(&self) -> web_application_firewall_policies::Client {
         web_application_firewall_policies::Client(self.clone())
     }
-    pub fn web_categories(&self) -> web_categories::Client {
+    pub fn web_categories_client(&self) -> web_categories::Client {
         web_categories::Client(self.clone())
     }
 }

--- a/services/mgmt/networkfunction/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/networkfunction/src/package_2021_09_01_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_traffic_collectors(&self) -> azure_traffic_collectors::Client {
+    pub fn azure_traffic_collectors_client(&self) -> azure_traffic_collectors::Client {
         azure_traffic_collectors::Client(self.clone())
     }
-    pub fn azure_traffic_collectors_by_resource_group(&self) -> azure_traffic_collectors_by_resource_group::Client {
+    pub fn azure_traffic_collectors_by_resource_group_client(&self) -> azure_traffic_collectors_by_resource_group::Client {
         azure_traffic_collectors_by_resource_group::Client(self.clone())
     }
-    pub fn azure_traffic_collectors_by_subscription(&self) -> azure_traffic_collectors_by_subscription::Client {
+    pub fn azure_traffic_collectors_by_subscription_client(&self) -> azure_traffic_collectors_by_subscription::Client {
         azure_traffic_collectors_by_subscription::Client(self.clone())
     }
-    pub fn collector_policies(&self) -> collector_policies::Client {
+    pub fn collector_policies_client(&self) -> collector_policies::Client {
         collector_policies::Client(self.clone())
     }
-    pub fn network_function(&self) -> network_function::Client {
+    pub fn network_function_client(&self) -> network_function::Client {
         network_function::Client(self.clone())
     }
 }

--- a/services/mgmt/networkfunction/src/package_2022_05_01/operations.rs
+++ b/services/mgmt/networkfunction/src/package_2022_05_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_traffic_collectors(&self) -> azure_traffic_collectors::Client {
+    pub fn azure_traffic_collectors_client(&self) -> azure_traffic_collectors::Client {
         azure_traffic_collectors::Client(self.clone())
     }
-    pub fn azure_traffic_collectors_by_resource_group(&self) -> azure_traffic_collectors_by_resource_group::Client {
+    pub fn azure_traffic_collectors_by_resource_group_client(&self) -> azure_traffic_collectors_by_resource_group::Client {
         azure_traffic_collectors_by_resource_group::Client(self.clone())
     }
-    pub fn azure_traffic_collectors_by_subscription(&self) -> azure_traffic_collectors_by_subscription::Client {
+    pub fn azure_traffic_collectors_by_subscription_client(&self) -> azure_traffic_collectors_by_subscription::Client {
         azure_traffic_collectors_by_subscription::Client(self.clone())
     }
-    pub fn collector_policies(&self) -> collector_policies::Client {
+    pub fn collector_policies_client(&self) -> collector_policies::Client {
         collector_policies::Client(self.clone())
     }
-    pub fn network_function(&self) -> network_function::Client {
+    pub fn network_function_client(&self) -> network_function::Client {
         network_function::Client(self.clone())
     }
 }

--- a/services/mgmt/nginx/src/package_2021_05_01_preview/operations.rs
+++ b/services/mgmt/nginx/src/package_2021_05_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/notificationhubs/src/package_2014_09/operations.rs
+++ b/services/mgmt/notificationhubs/src/package_2014_09/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn notification_hubs(&self) -> notification_hubs::Client {
+    pub fn notification_hubs_client(&self) -> notification_hubs::Client {
         notification_hubs::Client(self.clone())
     }
 }

--- a/services/mgmt/notificationhubs/src/package_2016_03/operations.rs
+++ b/services/mgmt/notificationhubs/src/package_2016_03/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn notification_hubs(&self) -> notification_hubs::Client {
+    pub fn notification_hubs_client(&self) -> notification_hubs::Client {
         notification_hubs::Client(self.clone())
     }
 }

--- a/services/mgmt/notificationhubs/src/package_2017_04/operations.rs
+++ b/services/mgmt/notificationhubs/src/package_2017_04/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn notification_hubs(&self) -> notification_hubs::Client {
+    pub fn notification_hubs_client(&self) -> notification_hubs::Client {
         notification_hubs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/oep/src/package_2021_06_01_preview/operations.rs
+++ b/services/mgmt/oep/src/package_2021_06_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn energy_services(&self) -> energy_services::Client {
+    pub fn energy_services_client(&self) -> energy_services::Client {
         energy_services::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/oep/src/package_2022_04_04_preview/operations.rs
+++ b/services/mgmt/oep/src/package_2022_04_04_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn energy_services(&self) -> energy_services::Client {
+    pub fn energy_services_client(&self) -> energy_services::Client {
         energy_services::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/operationalinsights/src/package_2020_03_preview/operations.rs
+++ b/services/mgmt/operationalinsights/src/package_2020_03_preview/operations.rs
@@ -74,67 +74,67 @@ impl Client {
             pipeline,
         }
     }
-    pub fn available_service_tiers(&self) -> available_service_tiers::Client {
+    pub fn available_service_tiers_client(&self) -> available_service_tiers::Client {
         available_service_tiers::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_collector_logs(&self) -> data_collector_logs::Client {
+    pub fn data_collector_logs_client(&self) -> data_collector_logs::Client {
         data_collector_logs::Client(self.clone())
     }
-    pub fn data_exports(&self) -> data_exports::Client {
+    pub fn data_exports_client(&self) -> data_exports::Client {
         data_exports::Client(self.clone())
     }
-    pub fn data_sources(&self) -> data_sources::Client {
+    pub fn data_sources_client(&self) -> data_sources::Client {
         data_sources::Client(self.clone())
     }
-    pub fn deleted_workspaces(&self) -> deleted_workspaces::Client {
+    pub fn deleted_workspaces_client(&self) -> deleted_workspaces::Client {
         deleted_workspaces::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn intelligence_packs(&self) -> intelligence_packs::Client {
+    pub fn intelligence_packs_client(&self) -> intelligence_packs::Client {
         intelligence_packs::Client(self.clone())
     }
-    pub fn linked_services(&self) -> linked_services::Client {
+    pub fn linked_services_client(&self) -> linked_services::Client {
         linked_services::Client(self.clone())
     }
-    pub fn linked_storage_accounts(&self) -> linked_storage_accounts::Client {
+    pub fn linked_storage_accounts_client(&self) -> linked_storage_accounts::Client {
         linked_storage_accounts::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn saved_searches(&self) -> saved_searches::Client {
+    pub fn saved_searches_client(&self) -> saved_searches::Client {
         saved_searches::Client(self.clone())
     }
-    pub fn schema(&self) -> schema::Client {
+    pub fn schema_client(&self) -> schema::Client {
         schema::Client(self.clone())
     }
-    pub fn shared_keys(&self) -> shared_keys::Client {
+    pub fn shared_keys_client(&self) -> shared_keys::Client {
         shared_keys::Client(self.clone())
     }
-    pub fn storage_insight_configs(&self) -> storage_insight_configs::Client {
+    pub fn storage_insight_configs_client(&self) -> storage_insight_configs::Client {
         storage_insight_configs::Client(self.clone())
     }
-    pub fn tables(&self) -> tables::Client {
+    pub fn tables_client(&self) -> tables::Client {
         tables::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn workspace_purge(&self) -> workspace_purge::Client {
+    pub fn workspace_purge_client(&self) -> workspace_purge::Client {
         workspace_purge::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/operationalinsights/src/package_2020_08/operations.rs
+++ b/services/mgmt/operationalinsights/src/package_2020_08/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn available_service_tiers(&self) -> available_service_tiers::Client {
+    pub fn available_service_tiers_client(&self) -> available_service_tiers::Client {
         available_service_tiers::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_exports(&self) -> data_exports::Client {
+    pub fn data_exports_client(&self) -> data_exports::Client {
         data_exports::Client(self.clone())
     }
-    pub fn data_sources(&self) -> data_sources::Client {
+    pub fn data_sources_client(&self) -> data_sources::Client {
         data_sources::Client(self.clone())
     }
-    pub fn deleted_workspaces(&self) -> deleted_workspaces::Client {
+    pub fn deleted_workspaces_client(&self) -> deleted_workspaces::Client {
         deleted_workspaces::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn intelligence_packs(&self) -> intelligence_packs::Client {
+    pub fn intelligence_packs_client(&self) -> intelligence_packs::Client {
         intelligence_packs::Client(self.clone())
     }
-    pub fn linked_services(&self) -> linked_services::Client {
+    pub fn linked_services_client(&self) -> linked_services::Client {
         linked_services::Client(self.clone())
     }
-    pub fn linked_storage_accounts(&self) -> linked_storage_accounts::Client {
+    pub fn linked_storage_accounts_client(&self) -> linked_storage_accounts::Client {
         linked_storage_accounts::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn saved_searches(&self) -> saved_searches::Client {
+    pub fn saved_searches_client(&self) -> saved_searches::Client {
         saved_searches::Client(self.clone())
     }
-    pub fn schema(&self) -> schema::Client {
+    pub fn schema_client(&self) -> schema::Client {
         schema::Client(self.clone())
     }
-    pub fn shared_keys(&self) -> shared_keys::Client {
+    pub fn shared_keys_client(&self) -> shared_keys::Client {
         shared_keys::Client(self.clone())
     }
-    pub fn storage_insight_configs(&self) -> storage_insight_configs::Client {
+    pub fn storage_insight_configs_client(&self) -> storage_insight_configs::Client {
         storage_insight_configs::Client(self.clone())
     }
-    pub fn tables(&self) -> tables::Client {
+    pub fn tables_client(&self) -> tables::Client {
         tables::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn workspace_purge(&self) -> workspace_purge::Client {
+    pub fn workspace_purge_client(&self) -> workspace_purge::Client {
         workspace_purge::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/operationalinsights/src/package_2020_10/operations.rs
+++ b/services/mgmt/operationalinsights/src/package_2020_10/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn available_service_tiers(&self) -> available_service_tiers::Client {
+    pub fn available_service_tiers_client(&self) -> available_service_tiers::Client {
         available_service_tiers::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_exports(&self) -> data_exports::Client {
+    pub fn data_exports_client(&self) -> data_exports::Client {
         data_exports::Client(self.clone())
     }
-    pub fn data_sources(&self) -> data_sources::Client {
+    pub fn data_sources_client(&self) -> data_sources::Client {
         data_sources::Client(self.clone())
     }
-    pub fn deleted_workspaces(&self) -> deleted_workspaces::Client {
+    pub fn deleted_workspaces_client(&self) -> deleted_workspaces::Client {
         deleted_workspaces::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn intelligence_packs(&self) -> intelligence_packs::Client {
+    pub fn intelligence_packs_client(&self) -> intelligence_packs::Client {
         intelligence_packs::Client(self.clone())
     }
-    pub fn linked_services(&self) -> linked_services::Client {
+    pub fn linked_services_client(&self) -> linked_services::Client {
         linked_services::Client(self.clone())
     }
-    pub fn linked_storage_accounts(&self) -> linked_storage_accounts::Client {
+    pub fn linked_storage_accounts_client(&self) -> linked_storage_accounts::Client {
         linked_storage_accounts::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn saved_searches(&self) -> saved_searches::Client {
+    pub fn saved_searches_client(&self) -> saved_searches::Client {
         saved_searches::Client(self.clone())
     }
-    pub fn schema(&self) -> schema::Client {
+    pub fn schema_client(&self) -> schema::Client {
         schema::Client(self.clone())
     }
-    pub fn shared_keys(&self) -> shared_keys::Client {
+    pub fn shared_keys_client(&self) -> shared_keys::Client {
         shared_keys::Client(self.clone())
     }
-    pub fn storage_insight_configs(&self) -> storage_insight_configs::Client {
+    pub fn storage_insight_configs_client(&self) -> storage_insight_configs::Client {
         storage_insight_configs::Client(self.clone())
     }
-    pub fn tables(&self) -> tables::Client {
+    pub fn tables_client(&self) -> tables::Client {
         tables::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn workspace_purge(&self) -> workspace_purge::Client {
+    pub fn workspace_purge_client(&self) -> workspace_purge::Client {
         workspace_purge::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/operationalinsights/src/package_2021_06/operations.rs
+++ b/services/mgmt/operationalinsights/src/package_2021_06/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn available_service_tiers(&self) -> available_service_tiers::Client {
+    pub fn available_service_tiers_client(&self) -> available_service_tiers::Client {
         available_service_tiers::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_exports(&self) -> data_exports::Client {
+    pub fn data_exports_client(&self) -> data_exports::Client {
         data_exports::Client(self.clone())
     }
-    pub fn data_sources(&self) -> data_sources::Client {
+    pub fn data_sources_client(&self) -> data_sources::Client {
         data_sources::Client(self.clone())
     }
-    pub fn deleted_workspaces(&self) -> deleted_workspaces::Client {
+    pub fn deleted_workspaces_client(&self) -> deleted_workspaces::Client {
         deleted_workspaces::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn intelligence_packs(&self) -> intelligence_packs::Client {
+    pub fn intelligence_packs_client(&self) -> intelligence_packs::Client {
         intelligence_packs::Client(self.clone())
     }
-    pub fn linked_services(&self) -> linked_services::Client {
+    pub fn linked_services_client(&self) -> linked_services::Client {
         linked_services::Client(self.clone())
     }
-    pub fn linked_storage_accounts(&self) -> linked_storage_accounts::Client {
+    pub fn linked_storage_accounts_client(&self) -> linked_storage_accounts::Client {
         linked_storage_accounts::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn saved_searches(&self) -> saved_searches::Client {
+    pub fn saved_searches_client(&self) -> saved_searches::Client {
         saved_searches::Client(self.clone())
     }
-    pub fn schema(&self) -> schema::Client {
+    pub fn schema_client(&self) -> schema::Client {
         schema::Client(self.clone())
     }
-    pub fn shared_keys(&self) -> shared_keys::Client {
+    pub fn shared_keys_client(&self) -> shared_keys::Client {
         shared_keys::Client(self.clone())
     }
-    pub fn storage_insight_configs(&self) -> storage_insight_configs::Client {
+    pub fn storage_insight_configs_client(&self) -> storage_insight_configs::Client {
         storage_insight_configs::Client(self.clone())
     }
-    pub fn tables(&self) -> tables::Client {
+    pub fn tables_client(&self) -> tables::Client {
         tables::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn workspace_purge(&self) -> workspace_purge::Client {
+    pub fn workspace_purge_client(&self) -> workspace_purge::Client {
         workspace_purge::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/operationalinsights/src/package_2021_12_01_preview/operations.rs
+++ b/services/mgmt/operationalinsights/src/package_2021_12_01_preview/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn available_service_tiers(&self) -> available_service_tiers::Client {
+    pub fn available_service_tiers_client(&self) -> available_service_tiers::Client {
         available_service_tiers::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn data_exports(&self) -> data_exports::Client {
+    pub fn data_exports_client(&self) -> data_exports::Client {
         data_exports::Client(self.clone())
     }
-    pub fn data_sources(&self) -> data_sources::Client {
+    pub fn data_sources_client(&self) -> data_sources::Client {
         data_sources::Client(self.clone())
     }
-    pub fn deleted_workspaces(&self) -> deleted_workspaces::Client {
+    pub fn deleted_workspaces_client(&self) -> deleted_workspaces::Client {
         deleted_workspaces::Client(self.clone())
     }
-    pub fn gateways(&self) -> gateways::Client {
+    pub fn gateways_client(&self) -> gateways::Client {
         gateways::Client(self.clone())
     }
-    pub fn intelligence_packs(&self) -> intelligence_packs::Client {
+    pub fn intelligence_packs_client(&self) -> intelligence_packs::Client {
         intelligence_packs::Client(self.clone())
     }
-    pub fn linked_services(&self) -> linked_services::Client {
+    pub fn linked_services_client(&self) -> linked_services::Client {
         linked_services::Client(self.clone())
     }
-    pub fn linked_storage_accounts(&self) -> linked_storage_accounts::Client {
+    pub fn linked_storage_accounts_client(&self) -> linked_storage_accounts::Client {
         linked_storage_accounts::Client(self.clone())
     }
-    pub fn management_groups(&self) -> management_groups::Client {
+    pub fn management_groups_client(&self) -> management_groups::Client {
         management_groups::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn saved_searches(&self) -> saved_searches::Client {
+    pub fn saved_searches_client(&self) -> saved_searches::Client {
         saved_searches::Client(self.clone())
     }
-    pub fn schema(&self) -> schema::Client {
+    pub fn schema_client(&self) -> schema::Client {
         schema::Client(self.clone())
     }
-    pub fn shared_keys(&self) -> shared_keys::Client {
+    pub fn shared_keys_client(&self) -> shared_keys::Client {
         shared_keys::Client(self.clone())
     }
-    pub fn storage_insight_configs(&self) -> storage_insight_configs::Client {
+    pub fn storage_insight_configs_client(&self) -> storage_insight_configs::Client {
         storage_insight_configs::Client(self.clone())
     }
-    pub fn tables(&self) -> tables::Client {
+    pub fn tables_client(&self) -> tables::Client {
         tables::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn workspace_purge(&self) -> workspace_purge::Client {
+    pub fn workspace_purge_client(&self) -> workspace_purge::Client {
         workspace_purge::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/operationsmanagement/src/package_2015_11_preview/operations.rs
+++ b/services/mgmt/operationsmanagement/src/package_2015_11_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn management_associations(&self) -> management_associations::Client {
+    pub fn management_associations_client(&self) -> management_associations::Client {
         management_associations::Client(self.clone())
     }
-    pub fn management_configurations(&self) -> management_configurations::Client {
+    pub fn management_configurations_client(&self) -> management_configurations::Client {
         management_configurations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn solutions(&self) -> solutions::Client {
+    pub fn solutions_client(&self) -> solutions::Client {
         solutions::Client(self.clone())
     }
 }

--- a/services/mgmt/orbital/src/package_2021_04_04_preview/operations.rs
+++ b/services/mgmt/orbital/src/package_2021_04_04_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn available_ground_stations(&self) -> available_ground_stations::Client {
+    pub fn available_ground_stations_client(&self) -> available_ground_stations::Client {
         available_ground_stations::Client(self.clone())
     }
-    pub fn contact_profiles(&self) -> contact_profiles::Client {
+    pub fn contact_profiles_client(&self) -> contact_profiles::Client {
         contact_profiles::Client(self.clone())
     }
-    pub fn contacts(&self) -> contacts::Client {
+    pub fn contacts_client(&self) -> contacts::Client {
         contacts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn spacecrafts(&self) -> spacecrafts::Client {
+    pub fn spacecrafts_client(&self) -> spacecrafts::Client {
         spacecrafts::Client(self.clone())
     }
 }

--- a/services/mgmt/orbital/src/package_2022_03_01/operations.rs
+++ b/services/mgmt/orbital/src/package_2022_03_01/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn available_ground_stations(&self) -> available_ground_stations::Client {
+    pub fn available_ground_stations_client(&self) -> available_ground_stations::Client {
         available_ground_stations::Client(self.clone())
     }
-    pub fn contact_profiles(&self) -> contact_profiles::Client {
+    pub fn contact_profiles_client(&self) -> contact_profiles::Client {
         contact_profiles::Client(self.clone())
     }
-    pub fn contacts(&self) -> contacts::Client {
+    pub fn contacts_client(&self) -> contacts::Client {
         contacts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_results(&self) -> operations_results::Client {
+    pub fn operations_results_client(&self) -> operations_results::Client {
         operations_results::Client(self.clone())
     }
-    pub fn spacecrafts(&self) -> spacecrafts::Client {
+    pub fn spacecrafts_client(&self) -> spacecrafts::Client {
         spacecrafts::Client(self.clone())
     }
 }

--- a/services/mgmt/peering/src/package_2020_04_01/operations.rs
+++ b/services/mgmt/peering/src/package_2020_04_01/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn legacy_peerings(&self) -> legacy_peerings::Client {
+    pub fn legacy_peerings_client(&self) -> legacy_peerings::Client {
         legacy_peerings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn peer_asns(&self) -> peer_asns::Client {
+    pub fn peer_asns_client(&self) -> peer_asns::Client {
         peer_asns::Client(self.clone())
     }
-    pub fn peering_locations(&self) -> peering_locations::Client {
+    pub fn peering_locations_client(&self) -> peering_locations::Client {
         peering_locations::Client(self.clone())
     }
-    pub fn peering_service_countries(&self) -> peering_service_countries::Client {
+    pub fn peering_service_countries_client(&self) -> peering_service_countries::Client {
         peering_service_countries::Client(self.clone())
     }
-    pub fn peering_service_locations(&self) -> peering_service_locations::Client {
+    pub fn peering_service_locations_client(&self) -> peering_service_locations::Client {
         peering_service_locations::Client(self.clone())
     }
-    pub fn peering_service_providers(&self) -> peering_service_providers::Client {
+    pub fn peering_service_providers_client(&self) -> peering_service_providers::Client {
         peering_service_providers::Client(self.clone())
     }
-    pub fn peering_services(&self) -> peering_services::Client {
+    pub fn peering_services_client(&self) -> peering_services::Client {
         peering_services::Client(self.clone())
     }
-    pub fn peerings(&self) -> peerings::Client {
+    pub fn peerings_client(&self) -> peerings::Client {
         peerings::Client(self.clone())
     }
-    pub fn prefixes(&self) -> prefixes::Client {
+    pub fn prefixes_client(&self) -> prefixes::Client {
         prefixes::Client(self.clone())
     }
-    pub fn received_routes(&self) -> received_routes::Client {
+    pub fn received_routes_client(&self) -> received_routes::Client {
         received_routes::Client(self.clone())
     }
-    pub fn registered_asns(&self) -> registered_asns::Client {
+    pub fn registered_asns_client(&self) -> registered_asns::Client {
         registered_asns::Client(self.clone())
     }
-    pub fn registered_prefixes(&self) -> registered_prefixes::Client {
+    pub fn registered_prefixes_client(&self) -> registered_prefixes::Client {
         registered_prefixes::Client(self.clone())
     }
 }

--- a/services/mgmt/peering/src/package_2020_10_01/operations.rs
+++ b/services/mgmt/peering/src/package_2020_10_01/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cdn_peering_prefixes(&self) -> cdn_peering_prefixes::Client {
+    pub fn cdn_peering_prefixes_client(&self) -> cdn_peering_prefixes::Client {
         cdn_peering_prefixes::Client(self.clone())
     }
-    pub fn legacy_peerings(&self) -> legacy_peerings::Client {
+    pub fn legacy_peerings_client(&self) -> legacy_peerings::Client {
         legacy_peerings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn peer_asns(&self) -> peer_asns::Client {
+    pub fn peer_asns_client(&self) -> peer_asns::Client {
         peer_asns::Client(self.clone())
     }
-    pub fn peering_locations(&self) -> peering_locations::Client {
+    pub fn peering_locations_client(&self) -> peering_locations::Client {
         peering_locations::Client(self.clone())
     }
-    pub fn peering_service_countries(&self) -> peering_service_countries::Client {
+    pub fn peering_service_countries_client(&self) -> peering_service_countries::Client {
         peering_service_countries::Client(self.clone())
     }
-    pub fn peering_service_locations(&self) -> peering_service_locations::Client {
+    pub fn peering_service_locations_client(&self) -> peering_service_locations::Client {
         peering_service_locations::Client(self.clone())
     }
-    pub fn peering_service_providers(&self) -> peering_service_providers::Client {
+    pub fn peering_service_providers_client(&self) -> peering_service_providers::Client {
         peering_service_providers::Client(self.clone())
     }
-    pub fn peering_services(&self) -> peering_services::Client {
+    pub fn peering_services_client(&self) -> peering_services::Client {
         peering_services::Client(self.clone())
     }
-    pub fn peerings(&self) -> peerings::Client {
+    pub fn peerings_client(&self) -> peerings::Client {
         peerings::Client(self.clone())
     }
-    pub fn prefixes(&self) -> prefixes::Client {
+    pub fn prefixes_client(&self) -> prefixes::Client {
         prefixes::Client(self.clone())
     }
-    pub fn received_routes(&self) -> received_routes::Client {
+    pub fn received_routes_client(&self) -> received_routes::Client {
         received_routes::Client(self.clone())
     }
-    pub fn registered_asns(&self) -> registered_asns::Client {
+    pub fn registered_asns_client(&self) -> registered_asns::Client {
         registered_asns::Client(self.clone())
     }
-    pub fn registered_prefixes(&self) -> registered_prefixes::Client {
+    pub fn registered_prefixes_client(&self) -> registered_prefixes::Client {
         registered_prefixes::Client(self.clone())
     }
 }

--- a/services/mgmt/peering/src/package_2021_01_01/operations.rs
+++ b/services/mgmt/peering/src/package_2021_01_01/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cdn_peering_prefixes(&self) -> cdn_peering_prefixes::Client {
+    pub fn cdn_peering_prefixes_client(&self) -> cdn_peering_prefixes::Client {
         cdn_peering_prefixes::Client(self.clone())
     }
-    pub fn legacy_peerings(&self) -> legacy_peerings::Client {
+    pub fn legacy_peerings_client(&self) -> legacy_peerings::Client {
         legacy_peerings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn peer_asns(&self) -> peer_asns::Client {
+    pub fn peer_asns_client(&self) -> peer_asns::Client {
         peer_asns::Client(self.clone())
     }
-    pub fn peering_locations(&self) -> peering_locations::Client {
+    pub fn peering_locations_client(&self) -> peering_locations::Client {
         peering_locations::Client(self.clone())
     }
-    pub fn peering_service_countries(&self) -> peering_service_countries::Client {
+    pub fn peering_service_countries_client(&self) -> peering_service_countries::Client {
         peering_service_countries::Client(self.clone())
     }
-    pub fn peering_service_locations(&self) -> peering_service_locations::Client {
+    pub fn peering_service_locations_client(&self) -> peering_service_locations::Client {
         peering_service_locations::Client(self.clone())
     }
-    pub fn peering_service_providers(&self) -> peering_service_providers::Client {
+    pub fn peering_service_providers_client(&self) -> peering_service_providers::Client {
         peering_service_providers::Client(self.clone())
     }
-    pub fn peering_services(&self) -> peering_services::Client {
+    pub fn peering_services_client(&self) -> peering_services::Client {
         peering_services::Client(self.clone())
     }
-    pub fn peerings(&self) -> peerings::Client {
+    pub fn peerings_client(&self) -> peerings::Client {
         peerings::Client(self.clone())
     }
-    pub fn prefixes(&self) -> prefixes::Client {
+    pub fn prefixes_client(&self) -> prefixes::Client {
         prefixes::Client(self.clone())
     }
-    pub fn received_routes(&self) -> received_routes::Client {
+    pub fn received_routes_client(&self) -> received_routes::Client {
         received_routes::Client(self.clone())
     }
-    pub fn registered_asns(&self) -> registered_asns::Client {
+    pub fn registered_asns_client(&self) -> registered_asns::Client {
         registered_asns::Client(self.clone())
     }
-    pub fn registered_prefixes(&self) -> registered_prefixes::Client {
+    pub fn registered_prefixes_client(&self) -> registered_prefixes::Client {
         registered_prefixes::Client(self.clone())
     }
 }

--- a/services/mgmt/peering/src/package_2021_06_01/operations.rs
+++ b/services/mgmt/peering/src/package_2021_06_01/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cdn_peering_prefixes(&self) -> cdn_peering_prefixes::Client {
+    pub fn cdn_peering_prefixes_client(&self) -> cdn_peering_prefixes::Client {
         cdn_peering_prefixes::Client(self.clone())
     }
-    pub fn connection_monitor_tests(&self) -> connection_monitor_tests::Client {
+    pub fn connection_monitor_tests_client(&self) -> connection_monitor_tests::Client {
         connection_monitor_tests::Client(self.clone())
     }
-    pub fn legacy_peerings(&self) -> legacy_peerings::Client {
+    pub fn legacy_peerings_client(&self) -> legacy_peerings::Client {
         legacy_peerings::Client(self.clone())
     }
-    pub fn looking_glass(&self) -> looking_glass::Client {
+    pub fn looking_glass_client(&self) -> looking_glass::Client {
         looking_glass::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn peer_asns(&self) -> peer_asns::Client {
+    pub fn peer_asns_client(&self) -> peer_asns::Client {
         peer_asns::Client(self.clone())
     }
-    pub fn peering_locations(&self) -> peering_locations::Client {
+    pub fn peering_locations_client(&self) -> peering_locations::Client {
         peering_locations::Client(self.clone())
     }
-    pub fn peering_service_countries(&self) -> peering_service_countries::Client {
+    pub fn peering_service_countries_client(&self) -> peering_service_countries::Client {
         peering_service_countries::Client(self.clone())
     }
-    pub fn peering_service_locations(&self) -> peering_service_locations::Client {
+    pub fn peering_service_locations_client(&self) -> peering_service_locations::Client {
         peering_service_locations::Client(self.clone())
     }
-    pub fn peering_service_providers(&self) -> peering_service_providers::Client {
+    pub fn peering_service_providers_client(&self) -> peering_service_providers::Client {
         peering_service_providers::Client(self.clone())
     }
-    pub fn peering_services(&self) -> peering_services::Client {
+    pub fn peering_services_client(&self) -> peering_services::Client {
         peering_services::Client(self.clone())
     }
-    pub fn peerings(&self) -> peerings::Client {
+    pub fn peerings_client(&self) -> peerings::Client {
         peerings::Client(self.clone())
     }
-    pub fn prefixes(&self) -> prefixes::Client {
+    pub fn prefixes_client(&self) -> prefixes::Client {
         prefixes::Client(self.clone())
     }
-    pub fn received_routes(&self) -> received_routes::Client {
+    pub fn received_routes_client(&self) -> received_routes::Client {
         received_routes::Client(self.clone())
     }
-    pub fn registered_asns(&self) -> registered_asns::Client {
+    pub fn registered_asns_client(&self) -> registered_asns::Client {
         registered_asns::Client(self.clone())
     }
-    pub fn registered_prefixes(&self) -> registered_prefixes::Client {
+    pub fn registered_prefixes_client(&self) -> registered_prefixes::Client {
         registered_prefixes::Client(self.clone())
     }
 }

--- a/services/mgmt/peering/src/package_2022_01_01/operations.rs
+++ b/services/mgmt/peering/src/package_2022_01_01/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cdn_peering_prefixes(&self) -> cdn_peering_prefixes::Client {
+    pub fn cdn_peering_prefixes_client(&self) -> cdn_peering_prefixes::Client {
         cdn_peering_prefixes::Client(self.clone())
     }
-    pub fn connection_monitor_tests(&self) -> connection_monitor_tests::Client {
+    pub fn connection_monitor_tests_client(&self) -> connection_monitor_tests::Client {
         connection_monitor_tests::Client(self.clone())
     }
-    pub fn legacy_peerings(&self) -> legacy_peerings::Client {
+    pub fn legacy_peerings_client(&self) -> legacy_peerings::Client {
         legacy_peerings::Client(self.clone())
     }
-    pub fn looking_glass(&self) -> looking_glass::Client {
+    pub fn looking_glass_client(&self) -> looking_glass::Client {
         looking_glass::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn peer_asns(&self) -> peer_asns::Client {
+    pub fn peer_asns_client(&self) -> peer_asns::Client {
         peer_asns::Client(self.clone())
     }
-    pub fn peering_locations(&self) -> peering_locations::Client {
+    pub fn peering_locations_client(&self) -> peering_locations::Client {
         peering_locations::Client(self.clone())
     }
-    pub fn peering_service_countries(&self) -> peering_service_countries::Client {
+    pub fn peering_service_countries_client(&self) -> peering_service_countries::Client {
         peering_service_countries::Client(self.clone())
     }
-    pub fn peering_service_locations(&self) -> peering_service_locations::Client {
+    pub fn peering_service_locations_client(&self) -> peering_service_locations::Client {
         peering_service_locations::Client(self.clone())
     }
-    pub fn peering_service_providers(&self) -> peering_service_providers::Client {
+    pub fn peering_service_providers_client(&self) -> peering_service_providers::Client {
         peering_service_providers::Client(self.clone())
     }
-    pub fn peering_services(&self) -> peering_services::Client {
+    pub fn peering_services_client(&self) -> peering_services::Client {
         peering_services::Client(self.clone())
     }
-    pub fn peerings(&self) -> peerings::Client {
+    pub fn peerings_client(&self) -> peerings::Client {
         peerings::Client(self.clone())
     }
-    pub fn prefixes(&self) -> prefixes::Client {
+    pub fn prefixes_client(&self) -> prefixes::Client {
         prefixes::Client(self.clone())
     }
-    pub fn received_routes(&self) -> received_routes::Client {
+    pub fn received_routes_client(&self) -> received_routes::Client {
         received_routes::Client(self.clone())
     }
-    pub fn registered_asns(&self) -> registered_asns::Client {
+    pub fn registered_asns_client(&self) -> registered_asns::Client {
         registered_asns::Client(self.clone())
     }
-    pub fn registered_prefixes(&self) -> registered_prefixes::Client {
+    pub fn registered_prefixes_client(&self) -> registered_prefixes::Client {
         registered_prefixes::Client(self.clone())
     }
 }

--- a/services/mgmt/policyinsights/src/package_2020_07/operations.rs
+++ b/services/mgmt/policyinsights/src/package_2020_07/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policy_events(&self) -> policy_events::Client {
+    pub fn policy_events_client(&self) -> policy_events::Client {
         policy_events::Client(self.clone())
     }
-    pub fn policy_metadata(&self) -> policy_metadata::Client {
+    pub fn policy_metadata_client(&self) -> policy_metadata::Client {
         policy_metadata::Client(self.clone())
     }
-    pub fn policy_restrictions(&self) -> policy_restrictions::Client {
+    pub fn policy_restrictions_client(&self) -> policy_restrictions::Client {
         policy_restrictions::Client(self.clone())
     }
-    pub fn policy_states(&self) -> policy_states::Client {
+    pub fn policy_states_client(&self) -> policy_states::Client {
         policy_states::Client(self.clone())
     }
-    pub fn policy_tracked_resources(&self) -> policy_tracked_resources::Client {
+    pub fn policy_tracked_resources_client(&self) -> policy_tracked_resources::Client {
         policy_tracked_resources::Client(self.clone())
     }
-    pub fn remediations(&self) -> remediations::Client {
+    pub fn remediations_client(&self) -> remediations::Client {
         remediations::Client(self.clone())
     }
 }

--- a/services/mgmt/policyinsights/src/package_2020_07_preview/operations.rs
+++ b/services/mgmt/policyinsights/src/package_2020_07_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policy_events(&self) -> policy_events::Client {
+    pub fn policy_events_client(&self) -> policy_events::Client {
         policy_events::Client(self.clone())
     }
-    pub fn policy_metadata(&self) -> policy_metadata::Client {
+    pub fn policy_metadata_client(&self) -> policy_metadata::Client {
         policy_metadata::Client(self.clone())
     }
-    pub fn policy_restrictions(&self) -> policy_restrictions::Client {
+    pub fn policy_restrictions_client(&self) -> policy_restrictions::Client {
         policy_restrictions::Client(self.clone())
     }
-    pub fn policy_states(&self) -> policy_states::Client {
+    pub fn policy_states_client(&self) -> policy_states::Client {
         policy_states::Client(self.clone())
     }
-    pub fn policy_tracked_resources(&self) -> policy_tracked_resources::Client {
+    pub fn policy_tracked_resources_client(&self) -> policy_tracked_resources::Client {
         policy_tracked_resources::Client(self.clone())
     }
-    pub fn remediations(&self) -> remediations::Client {
+    pub fn remediations_client(&self) -> remediations::Client {
         remediations::Client(self.clone())
     }
 }

--- a/services/mgmt/policyinsights/src/package_2021_01/operations.rs
+++ b/services/mgmt/policyinsights/src/package_2021_01/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attestations(&self) -> attestations::Client {
+    pub fn attestations_client(&self) -> attestations::Client {
         attestations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policy_events(&self) -> policy_events::Client {
+    pub fn policy_events_client(&self) -> policy_events::Client {
         policy_events::Client(self.clone())
     }
-    pub fn policy_metadata(&self) -> policy_metadata::Client {
+    pub fn policy_metadata_client(&self) -> policy_metadata::Client {
         policy_metadata::Client(self.clone())
     }
-    pub fn policy_restrictions(&self) -> policy_restrictions::Client {
+    pub fn policy_restrictions_client(&self) -> policy_restrictions::Client {
         policy_restrictions::Client(self.clone())
     }
-    pub fn policy_states(&self) -> policy_states::Client {
+    pub fn policy_states_client(&self) -> policy_states::Client {
         policy_states::Client(self.clone())
     }
-    pub fn policy_tracked_resources(&self) -> policy_tracked_resources::Client {
+    pub fn policy_tracked_resources_client(&self) -> policy_tracked_resources::Client {
         policy_tracked_resources::Client(self.clone())
     }
-    pub fn remediations(&self) -> remediations::Client {
+    pub fn remediations_client(&self) -> remediations::Client {
         remediations::Client(self.clone())
     }
 }

--- a/services/mgmt/policyinsights/src/package_2021_10/operations.rs
+++ b/services/mgmt/policyinsights/src/package_2021_10/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attestations(&self) -> attestations::Client {
+    pub fn attestations_client(&self) -> attestations::Client {
         attestations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policy_events(&self) -> policy_events::Client {
+    pub fn policy_events_client(&self) -> policy_events::Client {
         policy_events::Client(self.clone())
     }
-    pub fn policy_metadata(&self) -> policy_metadata::Client {
+    pub fn policy_metadata_client(&self) -> policy_metadata::Client {
         policy_metadata::Client(self.clone())
     }
-    pub fn policy_restrictions(&self) -> policy_restrictions::Client {
+    pub fn policy_restrictions_client(&self) -> policy_restrictions::Client {
         policy_restrictions::Client(self.clone())
     }
-    pub fn policy_states(&self) -> policy_states::Client {
+    pub fn policy_states_client(&self) -> policy_states::Client {
         policy_states::Client(self.clone())
     }
-    pub fn policy_tracked_resources(&self) -> policy_tracked_resources::Client {
+    pub fn policy_tracked_resources_client(&self) -> policy_tracked_resources::Client {
         policy_tracked_resources::Client(self.clone())
     }
-    pub fn remediations(&self) -> remediations::Client {
+    pub fn remediations_client(&self) -> remediations::Client {
         remediations::Client(self.clone())
     }
 }

--- a/services/mgmt/policyinsights/src/package_2022_03/operations.rs
+++ b/services/mgmt/policyinsights/src/package_2022_03/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attestations(&self) -> attestations::Client {
+    pub fn attestations_client(&self) -> attestations::Client {
         attestations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn policy_events(&self) -> policy_events::Client {
+    pub fn policy_events_client(&self) -> policy_events::Client {
         policy_events::Client(self.clone())
     }
-    pub fn policy_metadata(&self) -> policy_metadata::Client {
+    pub fn policy_metadata_client(&self) -> policy_metadata::Client {
         policy_metadata::Client(self.clone())
     }
-    pub fn policy_restrictions(&self) -> policy_restrictions::Client {
+    pub fn policy_restrictions_client(&self) -> policy_restrictions::Client {
         policy_restrictions::Client(self.clone())
     }
-    pub fn policy_states(&self) -> policy_states::Client {
+    pub fn policy_states_client(&self) -> policy_states::Client {
         policy_states::Client(self.clone())
     }
-    pub fn policy_tracked_resources(&self) -> policy_tracked_resources::Client {
+    pub fn policy_tracked_resources_client(&self) -> policy_tracked_resources::Client {
         policy_tracked_resources::Client(self.clone())
     }
-    pub fn remediations(&self) -> remediations::Client {
+    pub fn remediations_client(&self) -> remediations::Client {
         remediations::Client(self.clone())
     }
 }

--- a/services/mgmt/portal/src/package_2015_08_01_preview/operations.rs
+++ b/services/mgmt/portal/src/package_2015_08_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dashboards(&self) -> dashboards::Client {
+    pub fn dashboards_client(&self) -> dashboards::Client {
         dashboards::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/portal/src/package_2018_10_01_preview/operations.rs
+++ b/services/mgmt/portal/src/package_2018_10_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dashboards(&self) -> dashboards::Client {
+    pub fn dashboards_client(&self) -> dashboards::Client {
         dashboards::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/portal/src/package_2019_01_01_preview/operations.rs
+++ b/services/mgmt/portal/src/package_2019_01_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dashboards(&self) -> dashboards::Client {
+    pub fn dashboards_client(&self) -> dashboards::Client {
         dashboards::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn tenant_configurations(&self) -> tenant_configurations::Client {
+    pub fn tenant_configurations_client(&self) -> tenant_configurations::Client {
         tenant_configurations::Client(self.clone())
     }
 }

--- a/services/mgmt/portal/src/package_2020_09_01_preview/operations.rs
+++ b/services/mgmt/portal/src/package_2020_09_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn dashboards(&self) -> dashboards::Client {
+    pub fn dashboards_client(&self) -> dashboards::Client {
         dashboards::Client(self.clone())
     }
-    pub fn list_tenant_configuration_violations(&self) -> list_tenant_configuration_violations::Client {
+    pub fn list_tenant_configuration_violations_client(&self) -> list_tenant_configuration_violations::Client {
         list_tenant_configuration_violations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn tenant_configurations(&self) -> tenant_configurations::Client {
+    pub fn tenant_configurations_client(&self) -> tenant_configurations::Client {
         tenant_configurations::Client(self.clone())
     }
 }

--- a/services/mgmt/postgresql/src/package_2021_04_10_privatepreview/operations.rs
+++ b/services/mgmt/postgresql/src/package_2021_04_10_privatepreview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn get_private_dns_zone_suffix(&self) -> get_private_dns_zone_suffix::Client {
+    pub fn get_private_dns_zone_suffix_client(&self) -> get_private_dns_zone_suffix::Client {
         get_private_dns_zone_suffix::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recoverable_servers(&self) -> recoverable_servers::Client {
+    pub fn recoverable_servers_client(&self) -> recoverable_servers::Client {
         recoverable_servers::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn virtual_network_subnet_usage(&self) -> virtual_network_subnet_usage::Client {
+    pub fn virtual_network_subnet_usage_client(&self) -> virtual_network_subnet_usage::Client {
         virtual_network_subnet_usage::Client(self.clone())
     }
 }

--- a/services/mgmt/postgresql/src/package_2021_06_15_privatepreview/operations.rs
+++ b/services/mgmt/postgresql/src/package_2021_06_15_privatepreview/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn migrations(&self) -> migrations::Client {
+    pub fn migrations_client(&self) -> migrations::Client {
         migrations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn virtual_network_subnet_usage(&self) -> virtual_network_subnet_usage::Client {
+    pub fn virtual_network_subnet_usage_client(&self) -> virtual_network_subnet_usage::Client {
         virtual_network_subnet_usage::Client(self.clone())
     }
 }

--- a/services/mgmt/postgresql/src/package_flexibleserver_2021_06/operations.rs
+++ b/services/mgmt/postgresql/src/package_flexibleserver_2021_06/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn get_private_dns_zone_suffix(&self) -> get_private_dns_zone_suffix::Client {
+    pub fn get_private_dns_zone_suffix_client(&self) -> get_private_dns_zone_suffix::Client {
         get_private_dns_zone_suffix::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn virtual_network_subnet_usage(&self) -> virtual_network_subnet_usage::Client {
+    pub fn virtual_network_subnet_usage_client(&self) -> virtual_network_subnet_usage::Client {
         virtual_network_subnet_usage::Client(self.clone())
     }
 }

--- a/services/mgmt/postgresql/src/package_flexibleserver_2021_06_preview/operations.rs
+++ b/services/mgmt/postgresql/src/package_flexibleserver_2021_06_preview/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn advisors(&self) -> advisors::Client {
+    pub fn advisors_client(&self) -> advisors::Client {
         advisors::Client(self.clone())
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn get_private_dns_zone_suffix(&self) -> get_private_dns_zone_suffix::Client {
+    pub fn get_private_dns_zone_suffix_client(&self) -> get_private_dns_zone_suffix::Client {
         get_private_dns_zone_suffix::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn query_performance_insight_data(&self) -> query_performance_insight_data::Client {
+    pub fn query_performance_insight_data_client(&self) -> query_performance_insight_data::Client {
         query_performance_insight_data::Client(self.clone())
     }
-    pub fn query_texts(&self) -> query_texts::Client {
+    pub fn query_texts_client(&self) -> query_texts::Client {
         query_texts::Client(self.clone())
     }
-    pub fn recommended_actions(&self) -> recommended_actions::Client {
+    pub fn recommended_actions_client(&self) -> recommended_actions::Client {
         recommended_actions::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn top_query_statistics(&self) -> top_query_statistics::Client {
+    pub fn top_query_statistics_client(&self) -> top_query_statistics::Client {
         top_query_statistics::Client(self.clone())
     }
-    pub fn virtual_network_subnet_usage(&self) -> virtual_network_subnet_usage::Client {
+    pub fn virtual_network_subnet_usage_client(&self) -> virtual_network_subnet_usage::Client {
         virtual_network_subnet_usage::Client(self.clone())
     }
-    pub fn wait_statistics(&self) -> wait_statistics::Client {
+    pub fn wait_statistics_client(&self) -> wait_statistics::Client {
         wait_statistics::Client(self.clone())
     }
 }

--- a/services/mgmt/postgresql/src/package_flexibleserver_2022_01_preview/operations.rs
+++ b/services/mgmt/postgresql/src/package_flexibleserver_2022_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn check_name_availability(&self) -> check_name_availability::Client {
+    pub fn check_name_availability_client(&self) -> check_name_availability::Client {
         check_name_availability::Client(self.clone())
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn get_private_dns_zone_suffix(&self) -> get_private_dns_zone_suffix::Client {
+    pub fn get_private_dns_zone_suffix_client(&self) -> get_private_dns_zone_suffix::Client {
         get_private_dns_zone_suffix::Client(self.clone())
     }
-    pub fn location_based_capabilities(&self) -> location_based_capabilities::Client {
+    pub fn location_based_capabilities_client(&self) -> location_based_capabilities::Client {
         location_based_capabilities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn virtual_network_subnet_usage(&self) -> virtual_network_subnet_usage::Client {
+    pub fn virtual_network_subnet_usage_client(&self) -> virtual_network_subnet_usage::Client {
         virtual_network_subnet_usage::Client(self.clone())
     }
 }

--- a/services/mgmt/postgresqlhsc/src/package_2020_10_05_privatepreview/operations.rs
+++ b/services/mgmt/postgresqlhsc/src/package_2020_10_05_privatepreview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn configurations(&self) -> configurations::Client {
+    pub fn configurations_client(&self) -> configurations::Client {
         configurations::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn server_groups(&self) -> server_groups::Client {
+    pub fn server_groups_client(&self) -> server_groups::Client {
         server_groups::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
 }

--- a/services/mgmt/powerbidedicated/src/package_2017_10_01/operations.rs
+++ b/services/mgmt/powerbidedicated/src/package_2017_10_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn capacities(&self) -> capacities::Client {
+    pub fn capacities_client(&self) -> capacities::Client {
         capacities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/powerbidedicated/src/package_2021_01_01/operations.rs
+++ b/services/mgmt/powerbidedicated/src/package_2021_01_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn auto_scale_v_cores(&self) -> auto_scale_v_cores::Client {
+    pub fn auto_scale_v_cores_client(&self) -> auto_scale_v_cores::Client {
         auto_scale_v_cores::Client(self.clone())
     }
-    pub fn capacities(&self) -> capacities::Client {
+    pub fn capacities_client(&self) -> capacities::Client {
         capacities::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/powerbiembedded/src/package_2016_01/operations.rs
+++ b/services/mgmt/powerbiembedded/src/package_2016_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn workspace_collections(&self) -> workspace_collections::Client {
+    pub fn workspace_collections_client(&self) -> workspace_collections::Client {
         workspace_collections::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/powerbiprivatelinks/src/package_2020_06_01/operations.rs
+++ b/services/mgmt/powerbiprivatelinks/src/package_2020_06_01/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn power_bi_resources(&self) -> power_bi_resources::Client {
+    pub fn power_bi_resources_client(&self) -> power_bi_resources::Client {
         power_bi_resources::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_service_resource_operation_results(&self) -> private_link_service_resource_operation_results::Client {
+    pub fn private_link_service_resource_operation_results_client(&self) -> private_link_service_resource_operation_results::Client {
         private_link_service_resource_operation_results::Client(self.clone())
     }
-    pub fn private_link_services(&self) -> private_link_services::Client {
+    pub fn private_link_services_client(&self) -> private_link_services::Client {
         private_link_services::Client(self.clone())
     }
-    pub fn private_link_services_for_power_bi(&self) -> private_link_services_for_power_bi::Client {
+    pub fn private_link_services_for_power_bi_client(&self) -> private_link_services_for_power_bi::Client {
         private_link_services_for_power_bi::Client(self.clone())
     }
 }

--- a/services/mgmt/powerplatform/src/package_2020_10_30_preview/operations.rs
+++ b/services/mgmt/powerplatform/src/package_2020_10_30_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn enterprise_policies(&self) -> enterprise_policies::Client {
+    pub fn enterprise_policies_client(&self) -> enterprise_policies::Client {
         enterprise_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/privatedns/src/package_2018_09/operations.rs
+++ b/services/mgmt/privatedns/src/package_2018_09/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn private_zones(&self) -> private_zones::Client {
+    pub fn private_zones_client(&self) -> private_zones::Client {
         private_zones::Client(self.clone())
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn virtual_network_links(&self) -> virtual_network_links::Client {
+    pub fn virtual_network_links_client(&self) -> virtual_network_links::Client {
         virtual_network_links::Client(self.clone())
     }
 }

--- a/services/mgmt/privatedns/src/package_2020_01/operations.rs
+++ b/services/mgmt/privatedns/src/package_2020_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn private_zones(&self) -> private_zones::Client {
+    pub fn private_zones_client(&self) -> private_zones::Client {
         private_zones::Client(self.clone())
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn virtual_network_links(&self) -> virtual_network_links::Client {
+    pub fn virtual_network_links_client(&self) -> virtual_network_links::Client {
         virtual_network_links::Client(self.clone())
     }
 }

--- a/services/mgmt/privatedns/src/package_2020_06/operations.rs
+++ b/services/mgmt/privatedns/src/package_2020_06/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn private_zones(&self) -> private_zones::Client {
+    pub fn private_zones_client(&self) -> private_zones::Client {
         private_zones::Client(self.clone())
     }
-    pub fn record_sets(&self) -> record_sets::Client {
+    pub fn record_sets_client(&self) -> record_sets::Client {
         record_sets::Client(self.clone())
     }
-    pub fn virtual_network_links(&self) -> virtual_network_links::Client {
+    pub fn virtual_network_links_client(&self) -> virtual_network_links::Client {
         virtual_network_links::Client(self.clone())
     }
 }

--- a/services/mgmt/providerhub/src/package_2020_11_20/operations.rs
+++ b/services/mgmt/providerhub/src/package_2020_11_20/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_rollouts(&self) -> custom_rollouts::Client {
+    pub fn custom_rollouts_client(&self) -> custom_rollouts::Client {
         custom_rollouts::Client(self.clone())
     }
-    pub fn default_rollouts(&self) -> default_rollouts::Client {
+    pub fn default_rollouts_client(&self) -> default_rollouts::Client {
         default_rollouts::Client(self.clone())
     }
-    pub fn notification_registrations(&self) -> notification_registrations::Client {
+    pub fn notification_registrations_client(&self) -> notification_registrations::Client {
         notification_registrations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_registrations(&self) -> provider_registrations::Client {
+    pub fn provider_registrations_client(&self) -> provider_registrations::Client {
         provider_registrations::Client(self.clone())
     }
-    pub fn resource_type_registrations(&self) -> resource_type_registrations::Client {
+    pub fn resource_type_registrations_client(&self) -> resource_type_registrations::Client {
         resource_type_registrations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
 }

--- a/services/mgmt/providerhub/src/package_2021_05_01_preview/operations.rs
+++ b/services/mgmt/providerhub/src/package_2021_05_01_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_rollouts(&self) -> custom_rollouts::Client {
+    pub fn custom_rollouts_client(&self) -> custom_rollouts::Client {
         custom_rollouts::Client(self.clone())
     }
-    pub fn default_rollouts(&self) -> default_rollouts::Client {
+    pub fn default_rollouts_client(&self) -> default_rollouts::Client {
         default_rollouts::Client(self.clone())
     }
-    pub fn notification_registrations(&self) -> notification_registrations::Client {
+    pub fn notification_registrations_client(&self) -> notification_registrations::Client {
         notification_registrations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_registrations(&self) -> provider_registrations::Client {
+    pub fn provider_registrations_client(&self) -> provider_registrations::Client {
         provider_registrations::Client(self.clone())
     }
-    pub fn resource_type_registrations(&self) -> resource_type_registrations::Client {
+    pub fn resource_type_registrations_client(&self) -> resource_type_registrations::Client {
         resource_type_registrations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
 }

--- a/services/mgmt/providerhub/src/package_2021_06_01_preview/operations.rs
+++ b/services/mgmt/providerhub/src/package_2021_06_01_preview/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_rollouts(&self) -> custom_rollouts::Client {
+    pub fn custom_rollouts_client(&self) -> custom_rollouts::Client {
         custom_rollouts::Client(self.clone())
     }
-    pub fn default_rollouts(&self) -> default_rollouts::Client {
+    pub fn default_rollouts_client(&self) -> default_rollouts::Client {
         default_rollouts::Client(self.clone())
     }
-    pub fn notification_registrations(&self) -> notification_registrations::Client {
+    pub fn notification_registrations_client(&self) -> notification_registrations::Client {
         notification_registrations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_registrations(&self) -> provider_registrations::Client {
+    pub fn provider_registrations_client(&self) -> provider_registrations::Client {
         provider_registrations::Client(self.clone())
     }
-    pub fn resource_actions(&self) -> resource_actions::Client {
+    pub fn resource_actions_client(&self) -> resource_actions::Client {
         resource_actions::Client(self.clone())
     }
-    pub fn resource_type_registrations(&self) -> resource_type_registrations::Client {
+    pub fn resource_type_registrations_client(&self) -> resource_type_registrations::Client {
         resource_type_registrations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
 }

--- a/services/mgmt/providerhub/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/providerhub/src/package_2021_09_01_preview/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_rollouts(&self) -> custom_rollouts::Client {
+    pub fn custom_rollouts_client(&self) -> custom_rollouts::Client {
         custom_rollouts::Client(self.clone())
     }
-    pub fn default_rollouts(&self) -> default_rollouts::Client {
+    pub fn default_rollouts_client(&self) -> default_rollouts::Client {
         default_rollouts::Client(self.clone())
     }
-    pub fn notification_registrations(&self) -> notification_registrations::Client {
+    pub fn notification_registrations_client(&self) -> notification_registrations::Client {
         notification_registrations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_registrations(&self) -> provider_registrations::Client {
+    pub fn provider_registrations_client(&self) -> provider_registrations::Client {
         provider_registrations::Client(self.clone())
     }
-    pub fn resource_actions(&self) -> resource_actions::Client {
+    pub fn resource_actions_client(&self) -> resource_actions::Client {
         resource_actions::Client(self.clone())
     }
-    pub fn resource_type_registrations(&self) -> resource_type_registrations::Client {
+    pub fn resource_type_registrations_client(&self) -> resource_type_registrations::Client {
         resource_type_registrations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
 }

--- a/services/mgmt/purview/src/package_2020_12_01_preview/operations.rs
+++ b/services/mgmt/purview/src/package_2020_12_01_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn default_accounts(&self) -> default_accounts::Client {
+    pub fn default_accounts_client(&self) -> default_accounts::Client {
         default_accounts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/purview/src/package_2021_07_01/operations.rs
+++ b/services/mgmt/purview/src/package_2021_07_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn default_accounts(&self) -> default_accounts::Client {
+    pub fn default_accounts_client(&self) -> default_accounts::Client {
         default_accounts::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/quantum/src/package_2019_11_04_preview/operations.rs
+++ b/services/mgmt/quantum/src/package_2019_11_04_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn offerings(&self) -> offerings::Client {
+    pub fn offerings_client(&self) -> offerings::Client {
         offerings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn workspace(&self) -> workspace::Client {
+    pub fn workspace_client(&self) -> workspace::Client {
         workspace::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/quantum/src/package_2022_01_10_preview/operations.rs
+++ b/services/mgmt/quantum/src/package_2022_01_10_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn offerings(&self) -> offerings::Client {
+    pub fn offerings_client(&self) -> offerings::Client {
         offerings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn workspace(&self) -> workspace::Client {
+    pub fn workspace_client(&self) -> workspace::Client {
         workspace::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/quota/src/package_2021_03_15/operations.rs
+++ b/services/mgmt/quota/src/package_2021_03_15/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn quota(&self) -> quota::Client {
+    pub fn quota_client(&self) -> quota::Client {
         quota::Client(self.clone())
     }
-    pub fn quota_request_status(&self) -> quota_request_status::Client {
+    pub fn quota_request_status_client(&self) -> quota_request_status::Client {
         quota_request_status::Client(self.clone())
     }
-    pub fn quota_resource_providers(&self) -> quota_resource_providers::Client {
+    pub fn quota_resource_providers_client(&self) -> quota_resource_providers::Client {
         quota_resource_providers::Client(self.clone())
     }
 }

--- a/services/mgmt/quota/src/package_2021_03_15_preview/operations.rs
+++ b/services/mgmt/quota/src/package_2021_03_15_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn quota(&self) -> quota::Client {
+    pub fn quota_client(&self) -> quota::Client {
         quota::Client(self.clone())
     }
-    pub fn quota_operation(&self) -> quota_operation::Client {
+    pub fn quota_operation_client(&self) -> quota_operation::Client {
         quota_operation::Client(self.clone())
     }
-    pub fn quota_request_status(&self) -> quota_request_status::Client {
+    pub fn quota_request_status_client(&self) -> quota_request_status::Client {
         quota_request_status::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/recommendationsservice/src/package_2022_02_01/operations.rs
+++ b/services/mgmt/recommendationsservice/src/package_2022_02_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn modeling(&self) -> modeling::Client {
+    pub fn modeling_client(&self) -> modeling::Client {
         modeling::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn service_endpoints(&self) -> service_endpoints::Client {
+    pub fn service_endpoints_client(&self) -> service_endpoints::Client {
         service_endpoints::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservices/src/package_2022_02/operations.rs
+++ b/services/mgmt/recoveryservices/src/package_2022_02/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recovery_services(&self) -> recovery_services::Client {
+    pub fn recovery_services_client(&self) -> recovery_services::Client {
         recovery_services::Client(self.clone())
     }
-    pub fn registered_identities(&self) -> registered_identities::Client {
+    pub fn registered_identities_client(&self) -> registered_identities::Client {
         registered_identities::Client(self.clone())
     }
-    pub fn replication_usages(&self) -> replication_usages::Client {
+    pub fn replication_usages_client(&self) -> replication_usages::Client {
         replication_usages::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn vault_certificates(&self) -> vault_certificates::Client {
+    pub fn vault_certificates_client(&self) -> vault_certificates::Client {
         vault_certificates::Client(self.clone())
     }
-    pub fn vault_extended_info(&self) -> vault_extended_info::Client {
+    pub fn vault_extended_info_client(&self) -> vault_extended_info::Client {
         vault_extended_info::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservices/src/package_2022_03/operations.rs
+++ b/services/mgmt/recoveryservices/src/package_2022_03/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recovery_services(&self) -> recovery_services::Client {
+    pub fn recovery_services_client(&self) -> recovery_services::Client {
         recovery_services::Client(self.clone())
     }
-    pub fn registered_identities(&self) -> registered_identities::Client {
+    pub fn registered_identities_client(&self) -> registered_identities::Client {
         registered_identities::Client(self.clone())
     }
-    pub fn replication_usages(&self) -> replication_usages::Client {
+    pub fn replication_usages_client(&self) -> replication_usages::Client {
         replication_usages::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn vault_certificates(&self) -> vault_certificates::Client {
+    pub fn vault_certificates_client(&self) -> vault_certificates::Client {
         vault_certificates::Client(self.clone())
     }
-    pub fn vault_extended_info(&self) -> vault_extended_info::Client {
+    pub fn vault_extended_info_client(&self) -> vault_extended_info::Client {
         vault_extended_info::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservices/src/package_2022_04/operations.rs
+++ b/services/mgmt/recoveryservices/src/package_2022_04/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recovery_services(&self) -> recovery_services::Client {
+    pub fn recovery_services_client(&self) -> recovery_services::Client {
         recovery_services::Client(self.clone())
     }
-    pub fn registered_identities(&self) -> registered_identities::Client {
+    pub fn registered_identities_client(&self) -> registered_identities::Client {
         registered_identities::Client(self.clone())
     }
-    pub fn replication_usages(&self) -> replication_usages::Client {
+    pub fn replication_usages_client(&self) -> replication_usages::Client {
         replication_usages::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn vault_certificates(&self) -> vault_certificates::Client {
+    pub fn vault_certificates_client(&self) -> vault_certificates::Client {
         vault_certificates::Client(self.clone())
     }
-    pub fn vault_extended_info(&self) -> vault_extended_info::Client {
+    pub fn vault_extended_info_client(&self) -> vault_extended_info::Client {
         vault_extended_info::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservices/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/recoveryservices/src/package_preview_2021_11/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recovery_services(&self) -> recovery_services::Client {
+    pub fn recovery_services_client(&self) -> recovery_services::Client {
         recovery_services::Client(self.clone())
     }
-    pub fn registered_identities(&self) -> registered_identities::Client {
+    pub fn registered_identities_client(&self) -> registered_identities::Client {
         registered_identities::Client(self.clone())
     }
-    pub fn replication_usages(&self) -> replication_usages::Client {
+    pub fn replication_usages_client(&self) -> replication_usages::Client {
         replication_usages::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn vault_certificates(&self) -> vault_certificates::Client {
+    pub fn vault_certificates_client(&self) -> vault_certificates::Client {
         vault_certificates::Client(self.clone())
     }
-    pub fn vault_extended_info(&self) -> vault_extended_info::Client {
+    pub fn vault_extended_info_client(&self) -> vault_extended_info::Client {
         vault_extended_info::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservices/src/package_preview_2022_01/operations.rs
+++ b/services/mgmt/recoveryservices/src/package_preview_2022_01/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recovery_services(&self) -> recovery_services::Client {
+    pub fn recovery_services_client(&self) -> recovery_services::Client {
         recovery_services::Client(self.clone())
     }
-    pub fn registered_identities(&self) -> registered_identities::Client {
+    pub fn registered_identities_client(&self) -> registered_identities::Client {
         registered_identities::Client(self.clone())
     }
-    pub fn replication_usages(&self) -> replication_usages::Client {
+    pub fn replication_usages_client(&self) -> replication_usages::Client {
         replication_usages::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn vault_certificates(&self) -> vault_certificates::Client {
+    pub fn vault_certificates_client(&self) -> vault_certificates::Client {
         vault_certificates::Client(self.clone())
     }
-    pub fn vault_extended_info(&self) -> vault_extended_info::Client {
+    pub fn vault_extended_info_client(&self) -> vault_extended_info::Client {
         vault_extended_info::Client(self.clone())
     }
-    pub fn vaults(&self) -> vaults::Client {
+    pub fn vaults_client(&self) -> vaults::Client {
         vaults::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicesbackup/src/package_2022_01/operations.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_2022_01/operations.rs
@@ -74,148 +74,148 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_engines(&self) -> backup_engines::Client {
+    pub fn backup_engines_client(&self) -> backup_engines::Client {
         backup_engines::Client(self.clone())
     }
-    pub fn backup_jobs(&self) -> backup_jobs::Client {
+    pub fn backup_jobs_client(&self) -> backup_jobs::Client {
         backup_jobs::Client(self.clone())
     }
-    pub fn backup_operation_results(&self) -> backup_operation_results::Client {
+    pub fn backup_operation_results_client(&self) -> backup_operation_results::Client {
         backup_operation_results::Client(self.clone())
     }
-    pub fn backup_operation_statuses(&self) -> backup_operation_statuses::Client {
+    pub fn backup_operation_statuses_client(&self) -> backup_operation_statuses::Client {
         backup_operation_statuses::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_protectable_items(&self) -> backup_protectable_items::Client {
+    pub fn backup_protectable_items_client(&self) -> backup_protectable_items::Client {
         backup_protectable_items::Client(self.clone())
     }
-    pub fn backup_protected_items(&self) -> backup_protected_items::Client {
+    pub fn backup_protected_items_client(&self) -> backup_protected_items::Client {
         backup_protected_items::Client(self.clone())
     }
-    pub fn backup_protection_containers(&self) -> backup_protection_containers::Client {
+    pub fn backup_protection_containers_client(&self) -> backup_protection_containers::Client {
         backup_protection_containers::Client(self.clone())
     }
-    pub fn backup_protection_intent(&self) -> backup_protection_intent::Client {
+    pub fn backup_protection_intent_client(&self) -> backup_protection_intent::Client {
         backup_protection_intent::Client(self.clone())
     }
-    pub fn backup_resource_encryption_configs(&self) -> backup_resource_encryption_configs::Client {
+    pub fn backup_resource_encryption_configs_client(&self) -> backup_resource_encryption_configs::Client {
         backup_resource_encryption_configs::Client(self.clone())
     }
-    pub fn backup_resource_storage_configs_non_crr(&self) -> backup_resource_storage_configs_non_crr::Client {
+    pub fn backup_resource_storage_configs_non_crr_client(&self) -> backup_resource_storage_configs_non_crr::Client {
         backup_resource_storage_configs_non_crr::Client(self.clone())
     }
-    pub fn backup_resource_vault_configs(&self) -> backup_resource_vault_configs::Client {
+    pub fn backup_resource_vault_configs_client(&self) -> backup_resource_vault_configs::Client {
         backup_resource_vault_configs::Client(self.clone())
     }
-    pub fn backup_status(&self) -> backup_status::Client {
+    pub fn backup_status_client(&self) -> backup_status::Client {
         backup_status::Client(self.clone())
     }
-    pub fn backup_usage_summaries(&self) -> backup_usage_summaries::Client {
+    pub fn backup_usage_summaries_client(&self) -> backup_usage_summaries::Client {
         backup_usage_summaries::Client(self.clone())
     }
-    pub fn backup_workload_items(&self) -> backup_workload_items::Client {
+    pub fn backup_workload_items_client(&self) -> backup_workload_items::Client {
         backup_workload_items::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn bms_prepare_data_move_operation_result(&self) -> bms_prepare_data_move_operation_result::Client {
+    pub fn bms_prepare_data_move_operation_result_client(&self) -> bms_prepare_data_move_operation_result::Client {
         bms_prepare_data_move_operation_result::Client(self.clone())
     }
-    pub fn export_jobs_operation_results(&self) -> export_jobs_operation_results::Client {
+    pub fn export_jobs_operation_results_client(&self) -> export_jobs_operation_results::Client {
         export_jobs_operation_results::Client(self.clone())
     }
-    pub fn feature_support(&self) -> feature_support::Client {
+    pub fn feature_support_client(&self) -> feature_support::Client {
         feature_support::Client(self.clone())
     }
-    pub fn item_level_recovery_connections(&self) -> item_level_recovery_connections::Client {
+    pub fn item_level_recovery_connections_client(&self) -> item_level_recovery_connections::Client {
         item_level_recovery_connections::Client(self.clone())
     }
-    pub fn job_cancellations(&self) -> job_cancellations::Client {
+    pub fn job_cancellations_client(&self) -> job_cancellations::Client {
         job_cancellations::Client(self.clone())
     }
-    pub fn job_details(&self) -> job_details::Client {
+    pub fn job_details_client(&self) -> job_details::Client {
         job_details::Client(self.clone())
     }
-    pub fn job_operation_results(&self) -> job_operation_results::Client {
+    pub fn job_operation_results_client(&self) -> job_operation_results::Client {
         job_operation_results::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint(&self) -> private_endpoint::Client {
+    pub fn private_endpoint_client(&self) -> private_endpoint::Client {
         private_endpoint::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn protectable_containers(&self) -> protectable_containers::Client {
+    pub fn protectable_containers_client(&self) -> protectable_containers::Client {
         protectable_containers::Client(self.clone())
     }
-    pub fn protected_item_operation_results(&self) -> protected_item_operation_results::Client {
+    pub fn protected_item_operation_results_client(&self) -> protected_item_operation_results::Client {
         protected_item_operation_results::Client(self.clone())
     }
-    pub fn protected_item_operation_statuses(&self) -> protected_item_operation_statuses::Client {
+    pub fn protected_item_operation_statuses_client(&self) -> protected_item_operation_statuses::Client {
         protected_item_operation_statuses::Client(self.clone())
     }
-    pub fn protected_items(&self) -> protected_items::Client {
+    pub fn protected_items_client(&self) -> protected_items::Client {
         protected_items::Client(self.clone())
     }
-    pub fn protection_container_operation_results(&self) -> protection_container_operation_results::Client {
+    pub fn protection_container_operation_results_client(&self) -> protection_container_operation_results::Client {
         protection_container_operation_results::Client(self.clone())
     }
-    pub fn protection_container_refresh_operation_results(&self) -> protection_container_refresh_operation_results::Client {
+    pub fn protection_container_refresh_operation_results_client(&self) -> protection_container_refresh_operation_results::Client {
         protection_container_refresh_operation_results::Client(self.clone())
     }
-    pub fn protection_containers(&self) -> protection_containers::Client {
+    pub fn protection_containers_client(&self) -> protection_containers::Client {
         protection_containers::Client(self.clone())
     }
-    pub fn protection_intent(&self) -> protection_intent::Client {
+    pub fn protection_intent_client(&self) -> protection_intent::Client {
         protection_intent::Client(self.clone())
     }
-    pub fn protection_policies(&self) -> protection_policies::Client {
+    pub fn protection_policies_client(&self) -> protection_policies::Client {
         protection_policies::Client(self.clone())
     }
-    pub fn protection_policy_operation_results(&self) -> protection_policy_operation_results::Client {
+    pub fn protection_policy_operation_results_client(&self) -> protection_policy_operation_results::Client {
         protection_policy_operation_results::Client(self.clone())
     }
-    pub fn protection_policy_operation_statuses(&self) -> protection_policy_operation_statuses::Client {
+    pub fn protection_policy_operation_statuses_client(&self) -> protection_policy_operation_statuses::Client {
         protection_policy_operation_statuses::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn recovery_points_recommended_for_move(&self) -> recovery_points_recommended_for_move::Client {
+    pub fn recovery_points_recommended_for_move_client(&self) -> recovery_points_recommended_for_move::Client {
         recovery_points_recommended_for_move::Client(self.clone())
     }
-    pub fn resource_guard_proxies(&self) -> resource_guard_proxies::Client {
+    pub fn resource_guard_proxies_client(&self) -> resource_guard_proxies::Client {
         resource_guard_proxies::Client(self.clone())
     }
-    pub fn resource_guard_proxy(&self) -> resource_guard_proxy::Client {
+    pub fn resource_guard_proxy_client(&self) -> resource_guard_proxy::Client {
         resource_guard_proxy::Client(self.clone())
     }
-    pub fn restores(&self) -> restores::Client {
+    pub fn restores_client(&self) -> restores::Client {
         restores::Client(self.clone())
     }
-    pub fn security_pi_ns(&self) -> security_pi_ns::Client {
+    pub fn security_pi_ns_client(&self) -> security_pi_ns::Client {
         security_pi_ns::Client(self.clone())
     }
-    pub fn validate_operation(&self) -> validate_operation::Client {
+    pub fn validate_operation_client(&self) -> validate_operation::Client {
         validate_operation::Client(self.clone())
     }
-    pub fn validate_operation_results(&self) -> validate_operation_results::Client {
+    pub fn validate_operation_results_client(&self) -> validate_operation_results::Client {
         validate_operation_results::Client(self.clone())
     }
-    pub fn validate_operation_statuses(&self) -> validate_operation_statuses::Client {
+    pub fn validate_operation_statuses_client(&self) -> validate_operation_statuses::Client {
         validate_operation_statuses::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicesbackup/src/package_2022_02/operations.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_2022_02/operations.rs
@@ -74,148 +74,148 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_engines(&self) -> backup_engines::Client {
+    pub fn backup_engines_client(&self) -> backup_engines::Client {
         backup_engines::Client(self.clone())
     }
-    pub fn backup_jobs(&self) -> backup_jobs::Client {
+    pub fn backup_jobs_client(&self) -> backup_jobs::Client {
         backup_jobs::Client(self.clone())
     }
-    pub fn backup_operation_results(&self) -> backup_operation_results::Client {
+    pub fn backup_operation_results_client(&self) -> backup_operation_results::Client {
         backup_operation_results::Client(self.clone())
     }
-    pub fn backup_operation_statuses(&self) -> backup_operation_statuses::Client {
+    pub fn backup_operation_statuses_client(&self) -> backup_operation_statuses::Client {
         backup_operation_statuses::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_protectable_items(&self) -> backup_protectable_items::Client {
+    pub fn backup_protectable_items_client(&self) -> backup_protectable_items::Client {
         backup_protectable_items::Client(self.clone())
     }
-    pub fn backup_protected_items(&self) -> backup_protected_items::Client {
+    pub fn backup_protected_items_client(&self) -> backup_protected_items::Client {
         backup_protected_items::Client(self.clone())
     }
-    pub fn backup_protection_containers(&self) -> backup_protection_containers::Client {
+    pub fn backup_protection_containers_client(&self) -> backup_protection_containers::Client {
         backup_protection_containers::Client(self.clone())
     }
-    pub fn backup_protection_intent(&self) -> backup_protection_intent::Client {
+    pub fn backup_protection_intent_client(&self) -> backup_protection_intent::Client {
         backup_protection_intent::Client(self.clone())
     }
-    pub fn backup_resource_encryption_configs(&self) -> backup_resource_encryption_configs::Client {
+    pub fn backup_resource_encryption_configs_client(&self) -> backup_resource_encryption_configs::Client {
         backup_resource_encryption_configs::Client(self.clone())
     }
-    pub fn backup_resource_storage_configs_non_crr(&self) -> backup_resource_storage_configs_non_crr::Client {
+    pub fn backup_resource_storage_configs_non_crr_client(&self) -> backup_resource_storage_configs_non_crr::Client {
         backup_resource_storage_configs_non_crr::Client(self.clone())
     }
-    pub fn backup_resource_vault_configs(&self) -> backup_resource_vault_configs::Client {
+    pub fn backup_resource_vault_configs_client(&self) -> backup_resource_vault_configs::Client {
         backup_resource_vault_configs::Client(self.clone())
     }
-    pub fn backup_status(&self) -> backup_status::Client {
+    pub fn backup_status_client(&self) -> backup_status::Client {
         backup_status::Client(self.clone())
     }
-    pub fn backup_usage_summaries(&self) -> backup_usage_summaries::Client {
+    pub fn backup_usage_summaries_client(&self) -> backup_usage_summaries::Client {
         backup_usage_summaries::Client(self.clone())
     }
-    pub fn backup_workload_items(&self) -> backup_workload_items::Client {
+    pub fn backup_workload_items_client(&self) -> backup_workload_items::Client {
         backup_workload_items::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn bms_prepare_data_move_operation_result(&self) -> bms_prepare_data_move_operation_result::Client {
+    pub fn bms_prepare_data_move_operation_result_client(&self) -> bms_prepare_data_move_operation_result::Client {
         bms_prepare_data_move_operation_result::Client(self.clone())
     }
-    pub fn export_jobs_operation_results(&self) -> export_jobs_operation_results::Client {
+    pub fn export_jobs_operation_results_client(&self) -> export_jobs_operation_results::Client {
         export_jobs_operation_results::Client(self.clone())
     }
-    pub fn feature_support(&self) -> feature_support::Client {
+    pub fn feature_support_client(&self) -> feature_support::Client {
         feature_support::Client(self.clone())
     }
-    pub fn item_level_recovery_connections(&self) -> item_level_recovery_connections::Client {
+    pub fn item_level_recovery_connections_client(&self) -> item_level_recovery_connections::Client {
         item_level_recovery_connections::Client(self.clone())
     }
-    pub fn job_cancellations(&self) -> job_cancellations::Client {
+    pub fn job_cancellations_client(&self) -> job_cancellations::Client {
         job_cancellations::Client(self.clone())
     }
-    pub fn job_details(&self) -> job_details::Client {
+    pub fn job_details_client(&self) -> job_details::Client {
         job_details::Client(self.clone())
     }
-    pub fn job_operation_results(&self) -> job_operation_results::Client {
+    pub fn job_operation_results_client(&self) -> job_operation_results::Client {
         job_operation_results::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint(&self) -> private_endpoint::Client {
+    pub fn private_endpoint_client(&self) -> private_endpoint::Client {
         private_endpoint::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn protectable_containers(&self) -> protectable_containers::Client {
+    pub fn protectable_containers_client(&self) -> protectable_containers::Client {
         protectable_containers::Client(self.clone())
     }
-    pub fn protected_item_operation_results(&self) -> protected_item_operation_results::Client {
+    pub fn protected_item_operation_results_client(&self) -> protected_item_operation_results::Client {
         protected_item_operation_results::Client(self.clone())
     }
-    pub fn protected_item_operation_statuses(&self) -> protected_item_operation_statuses::Client {
+    pub fn protected_item_operation_statuses_client(&self) -> protected_item_operation_statuses::Client {
         protected_item_operation_statuses::Client(self.clone())
     }
-    pub fn protected_items(&self) -> protected_items::Client {
+    pub fn protected_items_client(&self) -> protected_items::Client {
         protected_items::Client(self.clone())
     }
-    pub fn protection_container_operation_results(&self) -> protection_container_operation_results::Client {
+    pub fn protection_container_operation_results_client(&self) -> protection_container_operation_results::Client {
         protection_container_operation_results::Client(self.clone())
     }
-    pub fn protection_container_refresh_operation_results(&self) -> protection_container_refresh_operation_results::Client {
+    pub fn protection_container_refresh_operation_results_client(&self) -> protection_container_refresh_operation_results::Client {
         protection_container_refresh_operation_results::Client(self.clone())
     }
-    pub fn protection_containers(&self) -> protection_containers::Client {
+    pub fn protection_containers_client(&self) -> protection_containers::Client {
         protection_containers::Client(self.clone())
     }
-    pub fn protection_intent(&self) -> protection_intent::Client {
+    pub fn protection_intent_client(&self) -> protection_intent::Client {
         protection_intent::Client(self.clone())
     }
-    pub fn protection_policies(&self) -> protection_policies::Client {
+    pub fn protection_policies_client(&self) -> protection_policies::Client {
         protection_policies::Client(self.clone())
     }
-    pub fn protection_policy_operation_results(&self) -> protection_policy_operation_results::Client {
+    pub fn protection_policy_operation_results_client(&self) -> protection_policy_operation_results::Client {
         protection_policy_operation_results::Client(self.clone())
     }
-    pub fn protection_policy_operation_statuses(&self) -> protection_policy_operation_statuses::Client {
+    pub fn protection_policy_operation_statuses_client(&self) -> protection_policy_operation_statuses::Client {
         protection_policy_operation_statuses::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn recovery_points_recommended_for_move(&self) -> recovery_points_recommended_for_move::Client {
+    pub fn recovery_points_recommended_for_move_client(&self) -> recovery_points_recommended_for_move::Client {
         recovery_points_recommended_for_move::Client(self.clone())
     }
-    pub fn resource_guard_proxies(&self) -> resource_guard_proxies::Client {
+    pub fn resource_guard_proxies_client(&self) -> resource_guard_proxies::Client {
         resource_guard_proxies::Client(self.clone())
     }
-    pub fn resource_guard_proxy(&self) -> resource_guard_proxy::Client {
+    pub fn resource_guard_proxy_client(&self) -> resource_guard_proxy::Client {
         resource_guard_proxy::Client(self.clone())
     }
-    pub fn restores(&self) -> restores::Client {
+    pub fn restores_client(&self) -> restores::Client {
         restores::Client(self.clone())
     }
-    pub fn security_pi_ns(&self) -> security_pi_ns::Client {
+    pub fn security_pi_ns_client(&self) -> security_pi_ns::Client {
         security_pi_ns::Client(self.clone())
     }
-    pub fn validate_operation(&self) -> validate_operation::Client {
+    pub fn validate_operation_client(&self) -> validate_operation::Client {
         validate_operation::Client(self.clone())
     }
-    pub fn validate_operation_results(&self) -> validate_operation_results::Client {
+    pub fn validate_operation_results_client(&self) -> validate_operation_results::Client {
         validate_operation_results::Client(self.clone())
     }
-    pub fn validate_operation_statuses(&self) -> validate_operation_statuses::Client {
+    pub fn validate_operation_statuses_client(&self) -> validate_operation_statuses::Client {
         validate_operation_statuses::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicesbackup/src/package_2022_03/operations.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_2022_03/operations.rs
@@ -74,148 +74,148 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_engines(&self) -> backup_engines::Client {
+    pub fn backup_engines_client(&self) -> backup_engines::Client {
         backup_engines::Client(self.clone())
     }
-    pub fn backup_jobs(&self) -> backup_jobs::Client {
+    pub fn backup_jobs_client(&self) -> backup_jobs::Client {
         backup_jobs::Client(self.clone())
     }
-    pub fn backup_operation_results(&self) -> backup_operation_results::Client {
+    pub fn backup_operation_results_client(&self) -> backup_operation_results::Client {
         backup_operation_results::Client(self.clone())
     }
-    pub fn backup_operation_statuses(&self) -> backup_operation_statuses::Client {
+    pub fn backup_operation_statuses_client(&self) -> backup_operation_statuses::Client {
         backup_operation_statuses::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_protectable_items(&self) -> backup_protectable_items::Client {
+    pub fn backup_protectable_items_client(&self) -> backup_protectable_items::Client {
         backup_protectable_items::Client(self.clone())
     }
-    pub fn backup_protected_items(&self) -> backup_protected_items::Client {
+    pub fn backup_protected_items_client(&self) -> backup_protected_items::Client {
         backup_protected_items::Client(self.clone())
     }
-    pub fn backup_protection_containers(&self) -> backup_protection_containers::Client {
+    pub fn backup_protection_containers_client(&self) -> backup_protection_containers::Client {
         backup_protection_containers::Client(self.clone())
     }
-    pub fn backup_protection_intent(&self) -> backup_protection_intent::Client {
+    pub fn backup_protection_intent_client(&self) -> backup_protection_intent::Client {
         backup_protection_intent::Client(self.clone())
     }
-    pub fn backup_resource_encryption_configs(&self) -> backup_resource_encryption_configs::Client {
+    pub fn backup_resource_encryption_configs_client(&self) -> backup_resource_encryption_configs::Client {
         backup_resource_encryption_configs::Client(self.clone())
     }
-    pub fn backup_resource_storage_configs_non_crr(&self) -> backup_resource_storage_configs_non_crr::Client {
+    pub fn backup_resource_storage_configs_non_crr_client(&self) -> backup_resource_storage_configs_non_crr::Client {
         backup_resource_storage_configs_non_crr::Client(self.clone())
     }
-    pub fn backup_resource_vault_configs(&self) -> backup_resource_vault_configs::Client {
+    pub fn backup_resource_vault_configs_client(&self) -> backup_resource_vault_configs::Client {
         backup_resource_vault_configs::Client(self.clone())
     }
-    pub fn backup_status(&self) -> backup_status::Client {
+    pub fn backup_status_client(&self) -> backup_status::Client {
         backup_status::Client(self.clone())
     }
-    pub fn backup_usage_summaries(&self) -> backup_usage_summaries::Client {
+    pub fn backup_usage_summaries_client(&self) -> backup_usage_summaries::Client {
         backup_usage_summaries::Client(self.clone())
     }
-    pub fn backup_workload_items(&self) -> backup_workload_items::Client {
+    pub fn backup_workload_items_client(&self) -> backup_workload_items::Client {
         backup_workload_items::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn bms_prepare_data_move_operation_result(&self) -> bms_prepare_data_move_operation_result::Client {
+    pub fn bms_prepare_data_move_operation_result_client(&self) -> bms_prepare_data_move_operation_result::Client {
         bms_prepare_data_move_operation_result::Client(self.clone())
     }
-    pub fn export_jobs_operation_results(&self) -> export_jobs_operation_results::Client {
+    pub fn export_jobs_operation_results_client(&self) -> export_jobs_operation_results::Client {
         export_jobs_operation_results::Client(self.clone())
     }
-    pub fn feature_support(&self) -> feature_support::Client {
+    pub fn feature_support_client(&self) -> feature_support::Client {
         feature_support::Client(self.clone())
     }
-    pub fn item_level_recovery_connections(&self) -> item_level_recovery_connections::Client {
+    pub fn item_level_recovery_connections_client(&self) -> item_level_recovery_connections::Client {
         item_level_recovery_connections::Client(self.clone())
     }
-    pub fn job_cancellations(&self) -> job_cancellations::Client {
+    pub fn job_cancellations_client(&self) -> job_cancellations::Client {
         job_cancellations::Client(self.clone())
     }
-    pub fn job_details(&self) -> job_details::Client {
+    pub fn job_details_client(&self) -> job_details::Client {
         job_details::Client(self.clone())
     }
-    pub fn job_operation_results(&self) -> job_operation_results::Client {
+    pub fn job_operation_results_client(&self) -> job_operation_results::Client {
         job_operation_results::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint(&self) -> private_endpoint::Client {
+    pub fn private_endpoint_client(&self) -> private_endpoint::Client {
         private_endpoint::Client(self.clone())
     }
-    pub fn private_endpoint_connection(&self) -> private_endpoint_connection::Client {
+    pub fn private_endpoint_connection_client(&self) -> private_endpoint_connection::Client {
         private_endpoint_connection::Client(self.clone())
     }
-    pub fn protectable_containers(&self) -> protectable_containers::Client {
+    pub fn protectable_containers_client(&self) -> protectable_containers::Client {
         protectable_containers::Client(self.clone())
     }
-    pub fn protected_item_operation_results(&self) -> protected_item_operation_results::Client {
+    pub fn protected_item_operation_results_client(&self) -> protected_item_operation_results::Client {
         protected_item_operation_results::Client(self.clone())
     }
-    pub fn protected_item_operation_statuses(&self) -> protected_item_operation_statuses::Client {
+    pub fn protected_item_operation_statuses_client(&self) -> protected_item_operation_statuses::Client {
         protected_item_operation_statuses::Client(self.clone())
     }
-    pub fn protected_items(&self) -> protected_items::Client {
+    pub fn protected_items_client(&self) -> protected_items::Client {
         protected_items::Client(self.clone())
     }
-    pub fn protection_container_operation_results(&self) -> protection_container_operation_results::Client {
+    pub fn protection_container_operation_results_client(&self) -> protection_container_operation_results::Client {
         protection_container_operation_results::Client(self.clone())
     }
-    pub fn protection_container_refresh_operation_results(&self) -> protection_container_refresh_operation_results::Client {
+    pub fn protection_container_refresh_operation_results_client(&self) -> protection_container_refresh_operation_results::Client {
         protection_container_refresh_operation_results::Client(self.clone())
     }
-    pub fn protection_containers(&self) -> protection_containers::Client {
+    pub fn protection_containers_client(&self) -> protection_containers::Client {
         protection_containers::Client(self.clone())
     }
-    pub fn protection_intent(&self) -> protection_intent::Client {
+    pub fn protection_intent_client(&self) -> protection_intent::Client {
         protection_intent::Client(self.clone())
     }
-    pub fn protection_policies(&self) -> protection_policies::Client {
+    pub fn protection_policies_client(&self) -> protection_policies::Client {
         protection_policies::Client(self.clone())
     }
-    pub fn protection_policy_operation_results(&self) -> protection_policy_operation_results::Client {
+    pub fn protection_policy_operation_results_client(&self) -> protection_policy_operation_results::Client {
         protection_policy_operation_results::Client(self.clone())
     }
-    pub fn protection_policy_operation_statuses(&self) -> protection_policy_operation_statuses::Client {
+    pub fn protection_policy_operation_statuses_client(&self) -> protection_policy_operation_statuses::Client {
         protection_policy_operation_statuses::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn recovery_points_recommended_for_move(&self) -> recovery_points_recommended_for_move::Client {
+    pub fn recovery_points_recommended_for_move_client(&self) -> recovery_points_recommended_for_move::Client {
         recovery_points_recommended_for_move::Client(self.clone())
     }
-    pub fn resource_guard_proxies(&self) -> resource_guard_proxies::Client {
+    pub fn resource_guard_proxies_client(&self) -> resource_guard_proxies::Client {
         resource_guard_proxies::Client(self.clone())
     }
-    pub fn resource_guard_proxy(&self) -> resource_guard_proxy::Client {
+    pub fn resource_guard_proxy_client(&self) -> resource_guard_proxy::Client {
         resource_guard_proxy::Client(self.clone())
     }
-    pub fn restores(&self) -> restores::Client {
+    pub fn restores_client(&self) -> restores::Client {
         restores::Client(self.clone())
     }
-    pub fn security_pi_ns(&self) -> security_pi_ns::Client {
+    pub fn security_pi_ns_client(&self) -> security_pi_ns::Client {
         security_pi_ns::Client(self.clone())
     }
-    pub fn validate_operation(&self) -> validate_operation::Client {
+    pub fn validate_operation_client(&self) -> validate_operation::Client {
         validate_operation::Client(self.clone())
     }
-    pub fn validate_operation_results(&self) -> validate_operation_results::Client {
+    pub fn validate_operation_results_client(&self) -> validate_operation_results::Client {
         validate_operation_results::Client(self.clone())
     }
-    pub fn validate_operation_statuses(&self) -> validate_operation_statuses::Client {
+    pub fn validate_operation_statuses_client(&self) -> validate_operation_statuses::Client {
         validate_operation_statuses::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2018_12_20/operations.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2018_12_20/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn aad_properties(&self) -> aad_properties::Client {
+    pub fn aad_properties_client(&self) -> aad_properties::Client {
         aad_properties::Client(self.clone())
     }
-    pub fn backup_crr_job_details(&self) -> backup_crr_job_details::Client {
+    pub fn backup_crr_job_details_client(&self) -> backup_crr_job_details::Client {
         backup_crr_job_details::Client(self.clone())
     }
-    pub fn backup_crr_jobs(&self) -> backup_crr_jobs::Client {
+    pub fn backup_crr_jobs_client(&self) -> backup_crr_jobs::Client {
         backup_crr_jobs::Client(self.clone())
     }
-    pub fn backup_protected_items_crr(&self) -> backup_protected_items_crr::Client {
+    pub fn backup_protected_items_crr_client(&self) -> backup_protected_items_crr::Client {
         backup_protected_items_crr::Client(self.clone())
     }
-    pub fn backup_resource_storage_configs(&self) -> backup_resource_storage_configs::Client {
+    pub fn backup_resource_storage_configs_client(&self) -> backup_resource_storage_configs::Client {
         backup_resource_storage_configs::Client(self.clone())
     }
-    pub fn backup_usage_summaries_crr(&self) -> backup_usage_summaries_crr::Client {
+    pub fn backup_usage_summaries_crr_client(&self) -> backup_usage_summaries_crr::Client {
         backup_usage_summaries_crr::Client(self.clone())
     }
-    pub fn cross_region_restore(&self) -> cross_region_restore::Client {
+    pub fn cross_region_restore_client(&self) -> cross_region_restore::Client {
         cross_region_restore::Client(self.clone())
     }
-    pub fn crr_operation_results(&self) -> crr_operation_results::Client {
+    pub fn crr_operation_results_client(&self) -> crr_operation_results::Client {
         crr_operation_results::Client(self.clone())
     }
-    pub fn crr_operation_status(&self) -> crr_operation_status::Client {
+    pub fn crr_operation_status_client(&self) -> crr_operation_status::Client {
         crr_operation_status::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn recovery_points_crr(&self) -> recovery_points_crr::Client {
+    pub fn recovery_points_crr_client(&self) -> recovery_points_crr::Client {
         recovery_points_crr::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2021_11_15/operations.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2021_11_15/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn aad_properties(&self) -> aad_properties::Client {
+    pub fn aad_properties_client(&self) -> aad_properties::Client {
         aad_properties::Client(self.clone())
     }
-    pub fn backup_crr_job_details(&self) -> backup_crr_job_details::Client {
+    pub fn backup_crr_job_details_client(&self) -> backup_crr_job_details::Client {
         backup_crr_job_details::Client(self.clone())
     }
-    pub fn backup_crr_jobs(&self) -> backup_crr_jobs::Client {
+    pub fn backup_crr_jobs_client(&self) -> backup_crr_jobs::Client {
         backup_crr_jobs::Client(self.clone())
     }
-    pub fn backup_protected_items_crr(&self) -> backup_protected_items_crr::Client {
+    pub fn backup_protected_items_crr_client(&self) -> backup_protected_items_crr::Client {
         backup_protected_items_crr::Client(self.clone())
     }
-    pub fn backup_resource_storage_configs(&self) -> backup_resource_storage_configs::Client {
+    pub fn backup_resource_storage_configs_client(&self) -> backup_resource_storage_configs::Client {
         backup_resource_storage_configs::Client(self.clone())
     }
-    pub fn backup_usage_summaries_crr(&self) -> backup_usage_summaries_crr::Client {
+    pub fn backup_usage_summaries_crr_client(&self) -> backup_usage_summaries_crr::Client {
         backup_usage_summaries_crr::Client(self.clone())
     }
-    pub fn cross_region_restore(&self) -> cross_region_restore::Client {
+    pub fn cross_region_restore_client(&self) -> cross_region_restore::Client {
         cross_region_restore::Client(self.clone())
     }
-    pub fn crr_operation_results(&self) -> crr_operation_results::Client {
+    pub fn crr_operation_results_client(&self) -> crr_operation_results::Client {
         crr_operation_results::Client(self.clone())
     }
-    pub fn crr_operation_status(&self) -> crr_operation_status::Client {
+    pub fn crr_operation_status_client(&self) -> crr_operation_status::Client {
         crr_operation_status::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn recovery_points_crr(&self) -> recovery_points_crr::Client {
+    pub fn recovery_points_crr_client(&self) -> recovery_points_crr::Client {
         recovery_points_crr::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2021_11/operations.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2021_11/operations.rs
@@ -74,88 +74,88 @@ impl Client {
             pipeline,
         }
     }
-    pub fn migration_recovery_points(&self) -> migration_recovery_points::Client {
+    pub fn migration_recovery_points_client(&self) -> migration_recovery_points::Client {
         migration_recovery_points::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn replication_alert_settings(&self) -> replication_alert_settings::Client {
+    pub fn replication_alert_settings_client(&self) -> replication_alert_settings::Client {
         replication_alert_settings::Client(self.clone())
     }
-    pub fn replication_appliances(&self) -> replication_appliances::Client {
+    pub fn replication_appliances_client(&self) -> replication_appliances::Client {
         replication_appliances::Client(self.clone())
     }
-    pub fn replication_eligibility_results(&self) -> replication_eligibility_results::Client {
+    pub fn replication_eligibility_results_client(&self) -> replication_eligibility_results::Client {
         replication_eligibility_results::Client(self.clone())
     }
-    pub fn replication_events(&self) -> replication_events::Client {
+    pub fn replication_events_client(&self) -> replication_events::Client {
         replication_events::Client(self.clone())
     }
-    pub fn replication_fabrics(&self) -> replication_fabrics::Client {
+    pub fn replication_fabrics_client(&self) -> replication_fabrics::Client {
         replication_fabrics::Client(self.clone())
     }
-    pub fn replication_jobs(&self) -> replication_jobs::Client {
+    pub fn replication_jobs_client(&self) -> replication_jobs::Client {
         replication_jobs::Client(self.clone())
     }
-    pub fn replication_logical_networks(&self) -> replication_logical_networks::Client {
+    pub fn replication_logical_networks_client(&self) -> replication_logical_networks::Client {
         replication_logical_networks::Client(self.clone())
     }
-    pub fn replication_migration_items(&self) -> replication_migration_items::Client {
+    pub fn replication_migration_items_client(&self) -> replication_migration_items::Client {
         replication_migration_items::Client(self.clone())
     }
-    pub fn replication_network_mappings(&self) -> replication_network_mappings::Client {
+    pub fn replication_network_mappings_client(&self) -> replication_network_mappings::Client {
         replication_network_mappings::Client(self.clone())
     }
-    pub fn replication_networks(&self) -> replication_networks::Client {
+    pub fn replication_networks_client(&self) -> replication_networks::Client {
         replication_networks::Client(self.clone())
     }
-    pub fn replication_policies(&self) -> replication_policies::Client {
+    pub fn replication_policies_client(&self) -> replication_policies::Client {
         replication_policies::Client(self.clone())
     }
-    pub fn replication_protectable_items(&self) -> replication_protectable_items::Client {
+    pub fn replication_protectable_items_client(&self) -> replication_protectable_items::Client {
         replication_protectable_items::Client(self.clone())
     }
-    pub fn replication_protected_items(&self) -> replication_protected_items::Client {
+    pub fn replication_protected_items_client(&self) -> replication_protected_items::Client {
         replication_protected_items::Client(self.clone())
     }
-    pub fn replication_protection_container_mappings(&self) -> replication_protection_container_mappings::Client {
+    pub fn replication_protection_container_mappings_client(&self) -> replication_protection_container_mappings::Client {
         replication_protection_container_mappings::Client(self.clone())
     }
-    pub fn replication_protection_containers(&self) -> replication_protection_containers::Client {
+    pub fn replication_protection_containers_client(&self) -> replication_protection_containers::Client {
         replication_protection_containers::Client(self.clone())
     }
-    pub fn replication_protection_intents(&self) -> replication_protection_intents::Client {
+    pub fn replication_protection_intents_client(&self) -> replication_protection_intents::Client {
         replication_protection_intents::Client(self.clone())
     }
-    pub fn replication_recovery_plans(&self) -> replication_recovery_plans::Client {
+    pub fn replication_recovery_plans_client(&self) -> replication_recovery_plans::Client {
         replication_recovery_plans::Client(self.clone())
     }
-    pub fn replication_recovery_services_providers(&self) -> replication_recovery_services_providers::Client {
+    pub fn replication_recovery_services_providers_client(&self) -> replication_recovery_services_providers::Client {
         replication_recovery_services_providers::Client(self.clone())
     }
-    pub fn replication_storage_classification_mappings(&self) -> replication_storage_classification_mappings::Client {
+    pub fn replication_storage_classification_mappings_client(&self) -> replication_storage_classification_mappings::Client {
         replication_storage_classification_mappings::Client(self.clone())
     }
-    pub fn replication_storage_classifications(&self) -> replication_storage_classifications::Client {
+    pub fn replication_storage_classifications_client(&self) -> replication_storage_classifications::Client {
         replication_storage_classifications::Client(self.clone())
     }
-    pub fn replication_vault_health(&self) -> replication_vault_health::Client {
+    pub fn replication_vault_health_client(&self) -> replication_vault_health::Client {
         replication_vault_health::Client(self.clone())
     }
-    pub fn replication_vault_setting(&self) -> replication_vault_setting::Client {
+    pub fn replication_vault_setting_client(&self) -> replication_vault_setting::Client {
         replication_vault_setting::Client(self.clone())
     }
-    pub fn replicationv_centers(&self) -> replicationv_centers::Client {
+    pub fn replicationv_centers_client(&self) -> replicationv_centers::Client {
         replicationv_centers::Client(self.clone())
     }
-    pub fn supported_operating_systems(&self) -> supported_operating_systems::Client {
+    pub fn supported_operating_systems_client(&self) -> supported_operating_systems::Client {
         supported_operating_systems::Client(self.clone())
     }
-    pub fn target_compute_sizes(&self) -> target_compute_sizes::Client {
+    pub fn target_compute_sizes_client(&self) -> target_compute_sizes::Client {
         target_compute_sizes::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2021_12/operations.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2021_12/operations.rs
@@ -74,88 +74,88 @@ impl Client {
             pipeline,
         }
     }
-    pub fn migration_recovery_points(&self) -> migration_recovery_points::Client {
+    pub fn migration_recovery_points_client(&self) -> migration_recovery_points::Client {
         migration_recovery_points::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn replication_alert_settings(&self) -> replication_alert_settings::Client {
+    pub fn replication_alert_settings_client(&self) -> replication_alert_settings::Client {
         replication_alert_settings::Client(self.clone())
     }
-    pub fn replication_appliances(&self) -> replication_appliances::Client {
+    pub fn replication_appliances_client(&self) -> replication_appliances::Client {
         replication_appliances::Client(self.clone())
     }
-    pub fn replication_eligibility_results(&self) -> replication_eligibility_results::Client {
+    pub fn replication_eligibility_results_client(&self) -> replication_eligibility_results::Client {
         replication_eligibility_results::Client(self.clone())
     }
-    pub fn replication_events(&self) -> replication_events::Client {
+    pub fn replication_events_client(&self) -> replication_events::Client {
         replication_events::Client(self.clone())
     }
-    pub fn replication_fabrics(&self) -> replication_fabrics::Client {
+    pub fn replication_fabrics_client(&self) -> replication_fabrics::Client {
         replication_fabrics::Client(self.clone())
     }
-    pub fn replication_jobs(&self) -> replication_jobs::Client {
+    pub fn replication_jobs_client(&self) -> replication_jobs::Client {
         replication_jobs::Client(self.clone())
     }
-    pub fn replication_logical_networks(&self) -> replication_logical_networks::Client {
+    pub fn replication_logical_networks_client(&self) -> replication_logical_networks::Client {
         replication_logical_networks::Client(self.clone())
     }
-    pub fn replication_migration_items(&self) -> replication_migration_items::Client {
+    pub fn replication_migration_items_client(&self) -> replication_migration_items::Client {
         replication_migration_items::Client(self.clone())
     }
-    pub fn replication_network_mappings(&self) -> replication_network_mappings::Client {
+    pub fn replication_network_mappings_client(&self) -> replication_network_mappings::Client {
         replication_network_mappings::Client(self.clone())
     }
-    pub fn replication_networks(&self) -> replication_networks::Client {
+    pub fn replication_networks_client(&self) -> replication_networks::Client {
         replication_networks::Client(self.clone())
     }
-    pub fn replication_policies(&self) -> replication_policies::Client {
+    pub fn replication_policies_client(&self) -> replication_policies::Client {
         replication_policies::Client(self.clone())
     }
-    pub fn replication_protectable_items(&self) -> replication_protectable_items::Client {
+    pub fn replication_protectable_items_client(&self) -> replication_protectable_items::Client {
         replication_protectable_items::Client(self.clone())
     }
-    pub fn replication_protected_items(&self) -> replication_protected_items::Client {
+    pub fn replication_protected_items_client(&self) -> replication_protected_items::Client {
         replication_protected_items::Client(self.clone())
     }
-    pub fn replication_protection_container_mappings(&self) -> replication_protection_container_mappings::Client {
+    pub fn replication_protection_container_mappings_client(&self) -> replication_protection_container_mappings::Client {
         replication_protection_container_mappings::Client(self.clone())
     }
-    pub fn replication_protection_containers(&self) -> replication_protection_containers::Client {
+    pub fn replication_protection_containers_client(&self) -> replication_protection_containers::Client {
         replication_protection_containers::Client(self.clone())
     }
-    pub fn replication_protection_intents(&self) -> replication_protection_intents::Client {
+    pub fn replication_protection_intents_client(&self) -> replication_protection_intents::Client {
         replication_protection_intents::Client(self.clone())
     }
-    pub fn replication_recovery_plans(&self) -> replication_recovery_plans::Client {
+    pub fn replication_recovery_plans_client(&self) -> replication_recovery_plans::Client {
         replication_recovery_plans::Client(self.clone())
     }
-    pub fn replication_recovery_services_providers(&self) -> replication_recovery_services_providers::Client {
+    pub fn replication_recovery_services_providers_client(&self) -> replication_recovery_services_providers::Client {
         replication_recovery_services_providers::Client(self.clone())
     }
-    pub fn replication_storage_classification_mappings(&self) -> replication_storage_classification_mappings::Client {
+    pub fn replication_storage_classification_mappings_client(&self) -> replication_storage_classification_mappings::Client {
         replication_storage_classification_mappings::Client(self.clone())
     }
-    pub fn replication_storage_classifications(&self) -> replication_storage_classifications::Client {
+    pub fn replication_storage_classifications_client(&self) -> replication_storage_classifications::Client {
         replication_storage_classifications::Client(self.clone())
     }
-    pub fn replication_vault_health(&self) -> replication_vault_health::Client {
+    pub fn replication_vault_health_client(&self) -> replication_vault_health::Client {
         replication_vault_health::Client(self.clone())
     }
-    pub fn replication_vault_setting(&self) -> replication_vault_setting::Client {
+    pub fn replication_vault_setting_client(&self) -> replication_vault_setting::Client {
         replication_vault_setting::Client(self.clone())
     }
-    pub fn replicationv_centers(&self) -> replicationv_centers::Client {
+    pub fn replicationv_centers_client(&self) -> replicationv_centers::Client {
         replicationv_centers::Client(self.clone())
     }
-    pub fn supported_operating_systems(&self) -> supported_operating_systems::Client {
+    pub fn supported_operating_systems_client(&self) -> supported_operating_systems::Client {
         supported_operating_systems::Client(self.clone())
     }
-    pub fn target_compute_sizes(&self) -> target_compute_sizes::Client {
+    pub fn target_compute_sizes_client(&self) -> target_compute_sizes::Client {
         target_compute_sizes::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2022_01/operations.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2022_01/operations.rs
@@ -74,88 +74,88 @@ impl Client {
             pipeline,
         }
     }
-    pub fn migration_recovery_points(&self) -> migration_recovery_points::Client {
+    pub fn migration_recovery_points_client(&self) -> migration_recovery_points::Client {
         migration_recovery_points::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn replication_alert_settings(&self) -> replication_alert_settings::Client {
+    pub fn replication_alert_settings_client(&self) -> replication_alert_settings::Client {
         replication_alert_settings::Client(self.clone())
     }
-    pub fn replication_appliances(&self) -> replication_appliances::Client {
+    pub fn replication_appliances_client(&self) -> replication_appliances::Client {
         replication_appliances::Client(self.clone())
     }
-    pub fn replication_eligibility_results(&self) -> replication_eligibility_results::Client {
+    pub fn replication_eligibility_results_client(&self) -> replication_eligibility_results::Client {
         replication_eligibility_results::Client(self.clone())
     }
-    pub fn replication_events(&self) -> replication_events::Client {
+    pub fn replication_events_client(&self) -> replication_events::Client {
         replication_events::Client(self.clone())
     }
-    pub fn replication_fabrics(&self) -> replication_fabrics::Client {
+    pub fn replication_fabrics_client(&self) -> replication_fabrics::Client {
         replication_fabrics::Client(self.clone())
     }
-    pub fn replication_jobs(&self) -> replication_jobs::Client {
+    pub fn replication_jobs_client(&self) -> replication_jobs::Client {
         replication_jobs::Client(self.clone())
     }
-    pub fn replication_logical_networks(&self) -> replication_logical_networks::Client {
+    pub fn replication_logical_networks_client(&self) -> replication_logical_networks::Client {
         replication_logical_networks::Client(self.clone())
     }
-    pub fn replication_migration_items(&self) -> replication_migration_items::Client {
+    pub fn replication_migration_items_client(&self) -> replication_migration_items::Client {
         replication_migration_items::Client(self.clone())
     }
-    pub fn replication_network_mappings(&self) -> replication_network_mappings::Client {
+    pub fn replication_network_mappings_client(&self) -> replication_network_mappings::Client {
         replication_network_mappings::Client(self.clone())
     }
-    pub fn replication_networks(&self) -> replication_networks::Client {
+    pub fn replication_networks_client(&self) -> replication_networks::Client {
         replication_networks::Client(self.clone())
     }
-    pub fn replication_policies(&self) -> replication_policies::Client {
+    pub fn replication_policies_client(&self) -> replication_policies::Client {
         replication_policies::Client(self.clone())
     }
-    pub fn replication_protectable_items(&self) -> replication_protectable_items::Client {
+    pub fn replication_protectable_items_client(&self) -> replication_protectable_items::Client {
         replication_protectable_items::Client(self.clone())
     }
-    pub fn replication_protected_items(&self) -> replication_protected_items::Client {
+    pub fn replication_protected_items_client(&self) -> replication_protected_items::Client {
         replication_protected_items::Client(self.clone())
     }
-    pub fn replication_protection_container_mappings(&self) -> replication_protection_container_mappings::Client {
+    pub fn replication_protection_container_mappings_client(&self) -> replication_protection_container_mappings::Client {
         replication_protection_container_mappings::Client(self.clone())
     }
-    pub fn replication_protection_containers(&self) -> replication_protection_containers::Client {
+    pub fn replication_protection_containers_client(&self) -> replication_protection_containers::Client {
         replication_protection_containers::Client(self.clone())
     }
-    pub fn replication_protection_intents(&self) -> replication_protection_intents::Client {
+    pub fn replication_protection_intents_client(&self) -> replication_protection_intents::Client {
         replication_protection_intents::Client(self.clone())
     }
-    pub fn replication_recovery_plans(&self) -> replication_recovery_plans::Client {
+    pub fn replication_recovery_plans_client(&self) -> replication_recovery_plans::Client {
         replication_recovery_plans::Client(self.clone())
     }
-    pub fn replication_recovery_services_providers(&self) -> replication_recovery_services_providers::Client {
+    pub fn replication_recovery_services_providers_client(&self) -> replication_recovery_services_providers::Client {
         replication_recovery_services_providers::Client(self.clone())
     }
-    pub fn replication_storage_classification_mappings(&self) -> replication_storage_classification_mappings::Client {
+    pub fn replication_storage_classification_mappings_client(&self) -> replication_storage_classification_mappings::Client {
         replication_storage_classification_mappings::Client(self.clone())
     }
-    pub fn replication_storage_classifications(&self) -> replication_storage_classifications::Client {
+    pub fn replication_storage_classifications_client(&self) -> replication_storage_classifications::Client {
         replication_storage_classifications::Client(self.clone())
     }
-    pub fn replication_vault_health(&self) -> replication_vault_health::Client {
+    pub fn replication_vault_health_client(&self) -> replication_vault_health::Client {
         replication_vault_health::Client(self.clone())
     }
-    pub fn replication_vault_setting(&self) -> replication_vault_setting::Client {
+    pub fn replication_vault_setting_client(&self) -> replication_vault_setting::Client {
         replication_vault_setting::Client(self.clone())
     }
-    pub fn replicationv_centers(&self) -> replicationv_centers::Client {
+    pub fn replicationv_centers_client(&self) -> replicationv_centers::Client {
         replicationv_centers::Client(self.clone())
     }
-    pub fn supported_operating_systems(&self) -> supported_operating_systems::Client {
+    pub fn supported_operating_systems_client(&self) -> supported_operating_systems::Client {
         supported_operating_systems::Client(self.clone())
     }
-    pub fn target_compute_sizes(&self) -> target_compute_sizes::Client {
+    pub fn target_compute_sizes_client(&self) -> target_compute_sizes::Client {
         target_compute_sizes::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2022_02/operations.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2022_02/operations.rs
@@ -74,88 +74,88 @@ impl Client {
             pipeline,
         }
     }
-    pub fn migration_recovery_points(&self) -> migration_recovery_points::Client {
+    pub fn migration_recovery_points_client(&self) -> migration_recovery_points::Client {
         migration_recovery_points::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn replication_alert_settings(&self) -> replication_alert_settings::Client {
+    pub fn replication_alert_settings_client(&self) -> replication_alert_settings::Client {
         replication_alert_settings::Client(self.clone())
     }
-    pub fn replication_appliances(&self) -> replication_appliances::Client {
+    pub fn replication_appliances_client(&self) -> replication_appliances::Client {
         replication_appliances::Client(self.clone())
     }
-    pub fn replication_eligibility_results(&self) -> replication_eligibility_results::Client {
+    pub fn replication_eligibility_results_client(&self) -> replication_eligibility_results::Client {
         replication_eligibility_results::Client(self.clone())
     }
-    pub fn replication_events(&self) -> replication_events::Client {
+    pub fn replication_events_client(&self) -> replication_events::Client {
         replication_events::Client(self.clone())
     }
-    pub fn replication_fabrics(&self) -> replication_fabrics::Client {
+    pub fn replication_fabrics_client(&self) -> replication_fabrics::Client {
         replication_fabrics::Client(self.clone())
     }
-    pub fn replication_jobs(&self) -> replication_jobs::Client {
+    pub fn replication_jobs_client(&self) -> replication_jobs::Client {
         replication_jobs::Client(self.clone())
     }
-    pub fn replication_logical_networks(&self) -> replication_logical_networks::Client {
+    pub fn replication_logical_networks_client(&self) -> replication_logical_networks::Client {
         replication_logical_networks::Client(self.clone())
     }
-    pub fn replication_migration_items(&self) -> replication_migration_items::Client {
+    pub fn replication_migration_items_client(&self) -> replication_migration_items::Client {
         replication_migration_items::Client(self.clone())
     }
-    pub fn replication_network_mappings(&self) -> replication_network_mappings::Client {
+    pub fn replication_network_mappings_client(&self) -> replication_network_mappings::Client {
         replication_network_mappings::Client(self.clone())
     }
-    pub fn replication_networks(&self) -> replication_networks::Client {
+    pub fn replication_networks_client(&self) -> replication_networks::Client {
         replication_networks::Client(self.clone())
     }
-    pub fn replication_policies(&self) -> replication_policies::Client {
+    pub fn replication_policies_client(&self) -> replication_policies::Client {
         replication_policies::Client(self.clone())
     }
-    pub fn replication_protectable_items(&self) -> replication_protectable_items::Client {
+    pub fn replication_protectable_items_client(&self) -> replication_protectable_items::Client {
         replication_protectable_items::Client(self.clone())
     }
-    pub fn replication_protected_items(&self) -> replication_protected_items::Client {
+    pub fn replication_protected_items_client(&self) -> replication_protected_items::Client {
         replication_protected_items::Client(self.clone())
     }
-    pub fn replication_protection_container_mappings(&self) -> replication_protection_container_mappings::Client {
+    pub fn replication_protection_container_mappings_client(&self) -> replication_protection_container_mappings::Client {
         replication_protection_container_mappings::Client(self.clone())
     }
-    pub fn replication_protection_containers(&self) -> replication_protection_containers::Client {
+    pub fn replication_protection_containers_client(&self) -> replication_protection_containers::Client {
         replication_protection_containers::Client(self.clone())
     }
-    pub fn replication_protection_intents(&self) -> replication_protection_intents::Client {
+    pub fn replication_protection_intents_client(&self) -> replication_protection_intents::Client {
         replication_protection_intents::Client(self.clone())
     }
-    pub fn replication_recovery_plans(&self) -> replication_recovery_plans::Client {
+    pub fn replication_recovery_plans_client(&self) -> replication_recovery_plans::Client {
         replication_recovery_plans::Client(self.clone())
     }
-    pub fn replication_recovery_services_providers(&self) -> replication_recovery_services_providers::Client {
+    pub fn replication_recovery_services_providers_client(&self) -> replication_recovery_services_providers::Client {
         replication_recovery_services_providers::Client(self.clone())
     }
-    pub fn replication_storage_classification_mappings(&self) -> replication_storage_classification_mappings::Client {
+    pub fn replication_storage_classification_mappings_client(&self) -> replication_storage_classification_mappings::Client {
         replication_storage_classification_mappings::Client(self.clone())
     }
-    pub fn replication_storage_classifications(&self) -> replication_storage_classifications::Client {
+    pub fn replication_storage_classifications_client(&self) -> replication_storage_classifications::Client {
         replication_storage_classifications::Client(self.clone())
     }
-    pub fn replication_vault_health(&self) -> replication_vault_health::Client {
+    pub fn replication_vault_health_client(&self) -> replication_vault_health::Client {
         replication_vault_health::Client(self.clone())
     }
-    pub fn replication_vault_setting(&self) -> replication_vault_setting::Client {
+    pub fn replication_vault_setting_client(&self) -> replication_vault_setting::Client {
         replication_vault_setting::Client(self.clone())
     }
-    pub fn replicationv_centers(&self) -> replicationv_centers::Client {
+    pub fn replicationv_centers_client(&self) -> replicationv_centers::Client {
         replicationv_centers::Client(self.clone())
     }
-    pub fn supported_operating_systems(&self) -> supported_operating_systems::Client {
+    pub fn supported_operating_systems_client(&self) -> supported_operating_systems::Client {
         supported_operating_systems::Client(self.clone())
     }
-    pub fn target_compute_sizes(&self) -> target_compute_sizes::Client {
+    pub fn target_compute_sizes_client(&self) -> target_compute_sizes::Client {
         target_compute_sizes::Client(self.clone())
     }
 }

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2022_03/operations.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2022_03/operations.rs
@@ -74,88 +74,88 @@ impl Client {
             pipeline,
         }
     }
-    pub fn migration_recovery_points(&self) -> migration_recovery_points::Client {
+    pub fn migration_recovery_points_client(&self) -> migration_recovery_points::Client {
         migration_recovery_points::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn recovery_points(&self) -> recovery_points::Client {
+    pub fn recovery_points_client(&self) -> recovery_points::Client {
         recovery_points::Client(self.clone())
     }
-    pub fn replication_alert_settings(&self) -> replication_alert_settings::Client {
+    pub fn replication_alert_settings_client(&self) -> replication_alert_settings::Client {
         replication_alert_settings::Client(self.clone())
     }
-    pub fn replication_appliances(&self) -> replication_appliances::Client {
+    pub fn replication_appliances_client(&self) -> replication_appliances::Client {
         replication_appliances::Client(self.clone())
     }
-    pub fn replication_eligibility_results(&self) -> replication_eligibility_results::Client {
+    pub fn replication_eligibility_results_client(&self) -> replication_eligibility_results::Client {
         replication_eligibility_results::Client(self.clone())
     }
-    pub fn replication_events(&self) -> replication_events::Client {
+    pub fn replication_events_client(&self) -> replication_events::Client {
         replication_events::Client(self.clone())
     }
-    pub fn replication_fabrics(&self) -> replication_fabrics::Client {
+    pub fn replication_fabrics_client(&self) -> replication_fabrics::Client {
         replication_fabrics::Client(self.clone())
     }
-    pub fn replication_jobs(&self) -> replication_jobs::Client {
+    pub fn replication_jobs_client(&self) -> replication_jobs::Client {
         replication_jobs::Client(self.clone())
     }
-    pub fn replication_logical_networks(&self) -> replication_logical_networks::Client {
+    pub fn replication_logical_networks_client(&self) -> replication_logical_networks::Client {
         replication_logical_networks::Client(self.clone())
     }
-    pub fn replication_migration_items(&self) -> replication_migration_items::Client {
+    pub fn replication_migration_items_client(&self) -> replication_migration_items::Client {
         replication_migration_items::Client(self.clone())
     }
-    pub fn replication_network_mappings(&self) -> replication_network_mappings::Client {
+    pub fn replication_network_mappings_client(&self) -> replication_network_mappings::Client {
         replication_network_mappings::Client(self.clone())
     }
-    pub fn replication_networks(&self) -> replication_networks::Client {
+    pub fn replication_networks_client(&self) -> replication_networks::Client {
         replication_networks::Client(self.clone())
     }
-    pub fn replication_policies(&self) -> replication_policies::Client {
+    pub fn replication_policies_client(&self) -> replication_policies::Client {
         replication_policies::Client(self.clone())
     }
-    pub fn replication_protectable_items(&self) -> replication_protectable_items::Client {
+    pub fn replication_protectable_items_client(&self) -> replication_protectable_items::Client {
         replication_protectable_items::Client(self.clone())
     }
-    pub fn replication_protected_items(&self) -> replication_protected_items::Client {
+    pub fn replication_protected_items_client(&self) -> replication_protected_items::Client {
         replication_protected_items::Client(self.clone())
     }
-    pub fn replication_protection_container_mappings(&self) -> replication_protection_container_mappings::Client {
+    pub fn replication_protection_container_mappings_client(&self) -> replication_protection_container_mappings::Client {
         replication_protection_container_mappings::Client(self.clone())
     }
-    pub fn replication_protection_containers(&self) -> replication_protection_containers::Client {
+    pub fn replication_protection_containers_client(&self) -> replication_protection_containers::Client {
         replication_protection_containers::Client(self.clone())
     }
-    pub fn replication_protection_intents(&self) -> replication_protection_intents::Client {
+    pub fn replication_protection_intents_client(&self) -> replication_protection_intents::Client {
         replication_protection_intents::Client(self.clone())
     }
-    pub fn replication_recovery_plans(&self) -> replication_recovery_plans::Client {
+    pub fn replication_recovery_plans_client(&self) -> replication_recovery_plans::Client {
         replication_recovery_plans::Client(self.clone())
     }
-    pub fn replication_recovery_services_providers(&self) -> replication_recovery_services_providers::Client {
+    pub fn replication_recovery_services_providers_client(&self) -> replication_recovery_services_providers::Client {
         replication_recovery_services_providers::Client(self.clone())
     }
-    pub fn replication_storage_classification_mappings(&self) -> replication_storage_classification_mappings::Client {
+    pub fn replication_storage_classification_mappings_client(&self) -> replication_storage_classification_mappings::Client {
         replication_storage_classification_mappings::Client(self.clone())
     }
-    pub fn replication_storage_classifications(&self) -> replication_storage_classifications::Client {
+    pub fn replication_storage_classifications_client(&self) -> replication_storage_classifications::Client {
         replication_storage_classifications::Client(self.clone())
     }
-    pub fn replication_vault_health(&self) -> replication_vault_health::Client {
+    pub fn replication_vault_health_client(&self) -> replication_vault_health::Client {
         replication_vault_health::Client(self.clone())
     }
-    pub fn replication_vault_setting(&self) -> replication_vault_setting::Client {
+    pub fn replication_vault_setting_client(&self) -> replication_vault_setting::Client {
         replication_vault_setting::Client(self.clone())
     }
-    pub fn replicationv_centers(&self) -> replicationv_centers::Client {
+    pub fn replicationv_centers_client(&self) -> replicationv_centers::Client {
         replicationv_centers::Client(self.clone())
     }
-    pub fn supported_operating_systems(&self) -> supported_operating_systems::Client {
+    pub fn supported_operating_systems_client(&self) -> supported_operating_systems::Client {
         supported_operating_systems::Client(self.clone())
     }
-    pub fn target_compute_sizes(&self) -> target_compute_sizes::Client {
+    pub fn target_compute_sizes_client(&self) -> target_compute_sizes::Client {
         target_compute_sizes::Client(self.clone())
     }
 }

--- a/services/mgmt/redhatopenshift/src/package_2020_04_30/operations.rs
+++ b/services/mgmt/redhatopenshift/src/package_2020_04_30/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn open_shift_clusters(&self) -> open_shift_clusters::Client {
+    pub fn open_shift_clusters_client(&self) -> open_shift_clusters::Client {
         open_shift_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/redhatopenshift/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/redhatopenshift/src/package_2021_09_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn open_shift_clusters(&self) -> open_shift_clusters::Client {
+    pub fn open_shift_clusters_client(&self) -> open_shift_clusters::Client {
         open_shift_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/redhatopenshift/src/package_2022_04_01/operations.rs
+++ b/services/mgmt/redhatopenshift/src/package_2022_04_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn open_shift_clusters(&self) -> open_shift_clusters::Client {
+    pub fn open_shift_clusters_client(&self) -> open_shift_clusters::Client {
         open_shift_clusters::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/redis/src/package_2018_03/operations.rs
+++ b/services/mgmt/redis/src/package_2018_03/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn linked_server(&self) -> linked_server::Client {
+    pub fn linked_server_client(&self) -> linked_server::Client {
         linked_server::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn patch_schedules(&self) -> patch_schedules::Client {
+    pub fn patch_schedules_client(&self) -> patch_schedules::Client {
         patch_schedules::Client(self.clone())
     }
-    pub fn redis(&self) -> redis::Client {
+    pub fn redis_client(&self) -> redis::Client {
         redis::Client(self.clone())
     }
 }

--- a/services/mgmt/redis/src/package_2019_07_preview/operations.rs
+++ b/services/mgmt/redis/src/package_2019_07_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn linked_server(&self) -> linked_server::Client {
+    pub fn linked_server_client(&self) -> linked_server::Client {
         linked_server::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn patch_schedules(&self) -> patch_schedules::Client {
+    pub fn patch_schedules_client(&self) -> patch_schedules::Client {
         patch_schedules::Client(self.clone())
     }
-    pub fn redis(&self) -> redis::Client {
+    pub fn redis_client(&self) -> redis::Client {
         redis::Client(self.clone())
     }
 }

--- a/services/mgmt/redis/src/package_2020_06/operations.rs
+++ b/services/mgmt/redis/src/package_2020_06/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn linked_server(&self) -> linked_server::Client {
+    pub fn linked_server_client(&self) -> linked_server::Client {
         linked_server::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn patch_schedules(&self) -> patch_schedules::Client {
+    pub fn patch_schedules_client(&self) -> patch_schedules::Client {
         patch_schedules::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis(&self) -> redis::Client {
+    pub fn redis_client(&self) -> redis::Client {
         redis::Client(self.clone())
     }
 }

--- a/services/mgmt/redis/src/package_2020_12/operations.rs
+++ b/services/mgmt/redis/src/package_2020_12/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn linked_server(&self) -> linked_server::Client {
+    pub fn linked_server_client(&self) -> linked_server::Client {
         linked_server::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn patch_schedules(&self) -> patch_schedules::Client {
+    pub fn patch_schedules_client(&self) -> patch_schedules::Client {
         patch_schedules::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis(&self) -> redis::Client {
+    pub fn redis_client(&self) -> redis::Client {
         redis::Client(self.clone())
     }
 }

--- a/services/mgmt/redis/src/package_2021_06/operations.rs
+++ b/services/mgmt/redis/src/package_2021_06/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn async_operation_status(&self) -> async_operation_status::Client {
+    pub fn async_operation_status_client(&self) -> async_operation_status::Client {
         async_operation_status::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn linked_server(&self) -> linked_server::Client {
+    pub fn linked_server_client(&self) -> linked_server::Client {
         linked_server::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn patch_schedules(&self) -> patch_schedules::Client {
+    pub fn patch_schedules_client(&self) -> patch_schedules::Client {
         patch_schedules::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis(&self) -> redis::Client {
+    pub fn redis_client(&self) -> redis::Client {
         redis::Client(self.clone())
     }
 }

--- a/services/mgmt/redisenterprise/src/package_2020_10_01_preview/operations.rs
+++ b/services/mgmt/redisenterprise/src/package_2020_10_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn get(&self) -> get::Client {
+    pub fn get_client(&self) -> get::Client {
         get::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis_enterprise(&self) -> redis_enterprise::Client {
+    pub fn redis_enterprise_client(&self) -> redis_enterprise::Client {
         redis_enterprise::Client(self.clone())
     }
 }

--- a/services/mgmt/redisenterprise/src/package_2021_03/operations.rs
+++ b/services/mgmt/redisenterprise/src/package_2021_03/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis_enterprise(&self) -> redis_enterprise::Client {
+    pub fn redis_enterprise_client(&self) -> redis_enterprise::Client {
         redis_enterprise::Client(self.clone())
     }
 }

--- a/services/mgmt/redisenterprise/src/package_2021_08/operations.rs
+++ b/services/mgmt/redisenterprise/src/package_2021_08/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis_enterprise(&self) -> redis_enterprise::Client {
+    pub fn redis_enterprise_client(&self) -> redis_enterprise::Client {
         redis_enterprise::Client(self.clone())
     }
 }

--- a/services/mgmt/redisenterprise/src/package_2022_01/operations.rs
+++ b/services/mgmt/redisenterprise/src/package_2022_01/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis_enterprise(&self) -> redis_enterprise::Client {
+    pub fn redis_enterprise_client(&self) -> redis_enterprise::Client {
         redis_enterprise::Client(self.clone())
     }
 }

--- a/services/mgmt/redisenterprise/src/package_preview_2021_02/operations.rs
+++ b/services/mgmt/redisenterprise/src/package_preview_2021_02/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn operations_status(&self) -> operations_status::Client {
+    pub fn operations_status_client(&self) -> operations_status::Client {
         operations_status::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn redis_enterprise(&self) -> redis_enterprise::Client {
+    pub fn redis_enterprise_client(&self) -> redis_enterprise::Client {
         redis_enterprise::Client(self.clone())
     }
 }

--- a/services/mgmt/relay/src/package_2016_07/operations.rs
+++ b/services/mgmt/relay/src/package_2016_07/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hybrid_connections(&self) -> hybrid_connections::Client {
+    pub fn hybrid_connections_client(&self) -> hybrid_connections::Client {
         hybrid_connections::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn wcf_relays(&self) -> wcf_relays::Client {
+    pub fn wcf_relays_client(&self) -> wcf_relays::Client {
         wcf_relays::Client(self.clone())
     }
 }

--- a/services/mgmt/relay/src/package_2017_04/operations.rs
+++ b/services/mgmt/relay/src/package_2017_04/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hybrid_connections(&self) -> hybrid_connections::Client {
+    pub fn hybrid_connections_client(&self) -> hybrid_connections::Client {
         hybrid_connections::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn wcf_relays(&self) -> wcf_relays::Client {
+    pub fn wcf_relays_client(&self) -> wcf_relays::Client {
         wcf_relays::Client(self.clone())
     }
 }

--- a/services/mgmt/relay/src/package_2018_01_preview/operations.rs
+++ b/services/mgmt/relay/src/package_2018_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operation_status_private_endpoint_connections(&self) -> operation_status_private_endpoint_connections::Client {
+    pub fn operation_status_private_endpoint_connections_client(&self) -> operation_status_private_endpoint_connections::Client {
         operation_status_private_endpoint_connections::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
 }

--- a/services/mgmt/relay/src/package_2021_11_01/operations.rs
+++ b/services/mgmt/relay/src/package_2021_11_01/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hybrid_connections(&self) -> hybrid_connections::Client {
+    pub fn hybrid_connections_client(&self) -> hybrid_connections::Client {
         hybrid_connections::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn wcf_relays(&self) -> wcf_relays::Client {
+    pub fn wcf_relays_client(&self) -> wcf_relays::Client {
         wcf_relays::Client(self.clone())
     }
 }

--- a/services/mgmt/reservations/src/package_2020_11_preview/operations.rs
+++ b/services/mgmt/reservations/src/package_2020_11_preview/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn auto_quota_increase(&self) -> auto_quota_increase::Client {
+    pub fn auto_quota_increase_client(&self) -> auto_quota_increase::Client {
         auto_quota_increase::Client(self.clone())
     }
-    pub fn calculate_exchange(&self) -> calculate_exchange::Client {
+    pub fn calculate_exchange_client(&self) -> calculate_exchange::Client {
         calculate_exchange::Client(self.clone())
     }
-    pub fn exchange(&self) -> exchange::Client {
+    pub fn exchange_client(&self) -> exchange::Client {
         exchange::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn quota(&self) -> quota::Client {
+    pub fn quota_client(&self) -> quota::Client {
         quota::Client(self.clone())
     }
-    pub fn quota_request_status(&self) -> quota_request_status::Client {
+    pub fn quota_request_status_client(&self) -> quota_request_status::Client {
         quota_request_status::Client(self.clone())
     }
-    pub fn reservation(&self) -> reservation::Client {
+    pub fn reservation_client(&self) -> reservation::Client {
         reservation::Client(self.clone())
     }
-    pub fn reservation_order(&self) -> reservation_order::Client {
+    pub fn reservation_order_client(&self) -> reservation_order::Client {
         reservation_order::Client(self.clone())
     }
 }

--- a/services/mgmt/reservations/src/package_2021_07_01/operations.rs
+++ b/services/mgmt/reservations/src/package_2021_07_01/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn calculate_exchange(&self) -> calculate_exchange::Client {
+    pub fn calculate_exchange_client(&self) -> calculate_exchange::Client {
         calculate_exchange::Client(self.clone())
     }
-    pub fn exchange(&self) -> exchange::Client {
+    pub fn exchange_client(&self) -> exchange::Client {
         exchange::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn quota(&self) -> quota::Client {
+    pub fn quota_client(&self) -> quota::Client {
         quota::Client(self.clone())
     }
-    pub fn quota_request_status(&self) -> quota_request_status::Client {
+    pub fn quota_request_status_client(&self) -> quota_request_status::Client {
         quota_request_status::Client(self.clone())
     }
-    pub fn reservation(&self) -> reservation::Client {
+    pub fn reservation_client(&self) -> reservation::Client {
         reservation::Client(self.clone())
     }
-    pub fn reservation_order(&self) -> reservation_order::Client {
+    pub fn reservation_order_client(&self) -> reservation_order::Client {
         reservation_order::Client(self.clone())
     }
 }

--- a/services/mgmt/reservations/src/package_2022_03/operations.rs
+++ b/services/mgmt/reservations/src/package_2022_03/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn calculate_exchange(&self) -> calculate_exchange::Client {
+    pub fn calculate_exchange_client(&self) -> calculate_exchange::Client {
         calculate_exchange::Client(self.clone())
     }
-    pub fn exchange(&self) -> exchange::Client {
+    pub fn exchange_client(&self) -> exchange::Client {
         exchange::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn quota(&self) -> quota::Client {
+    pub fn quota_client(&self) -> quota::Client {
         quota::Client(self.clone())
     }
-    pub fn quota_request_status(&self) -> quota_request_status::Client {
+    pub fn quota_request_status_client(&self) -> quota_request_status::Client {
         quota_request_status::Client(self.clone())
     }
-    pub fn reservation(&self) -> reservation::Client {
+    pub fn reservation_client(&self) -> reservation::Client {
         reservation::Client(self.clone())
     }
-    pub fn reservation_order(&self) -> reservation_order::Client {
+    pub fn reservation_order_client(&self) -> reservation_order::Client {
         reservation_order::Client(self.clone())
     }
 }

--- a/services/mgmt/reservations/src/package_preview_2019_04/operations.rs
+++ b/services/mgmt/reservations/src/package_preview_2019_04/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn reservation(&self) -> reservation::Client {
+    pub fn reservation_client(&self) -> reservation::Client {
         reservation::Client(self.clone())
     }
-    pub fn reservation_order(&self) -> reservation_order::Client {
+    pub fn reservation_order_client(&self) -> reservation_order::Client {
         reservation_order::Client(self.clone())
     }
 }

--- a/services/mgmt/reservations/src/package_preview_2019_07_19/operations.rs
+++ b/services/mgmt/reservations/src/package_preview_2019_07_19/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn auto_quota_increase(&self) -> auto_quota_increase::Client {
+    pub fn auto_quota_increase_client(&self) -> auto_quota_increase::Client {
         auto_quota_increase::Client(self.clone())
     }
-    pub fn operation(&self) -> operation::Client {
+    pub fn operation_client(&self) -> operation::Client {
         operation::Client(self.clone())
     }
-    pub fn quota(&self) -> quota::Client {
+    pub fn quota_client(&self) -> quota::Client {
         quota::Client(self.clone())
     }
-    pub fn quota_request_status(&self) -> quota_request_status::Client {
+    pub fn quota_request_status_client(&self) -> quota_request_status::Client {
         quota_request_status::Client(self.clone())
     }
-    pub fn reservation(&self) -> reservation::Client {
+    pub fn reservation_client(&self) -> reservation::Client {
         reservation::Client(self.clone())
     }
-    pub fn reservation_order(&self) -> reservation_order::Client {
+    pub fn reservation_order_client(&self) -> reservation_order::Client {
         reservation_order::Client(self.clone())
     }
 }

--- a/services/mgmt/resourceconnector/src/package_2021_10_31_preview/operations.rs
+++ b/services/mgmt/resourceconnector/src/package_2021_10_31_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn appliances(&self) -> appliances::Client {
+    pub fn appliances_client(&self) -> appliances::Client {
         appliances::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcegraph/src/package_2021_03/operations.rs
+++ b/services/mgmt/resourcegraph/src/package_2021_03/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcegraph/src/package_preview_2020_04/operations.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2020_04/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcegraph/src/package_preview_2020_09/operations.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2020_09/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcegraph/src/package_preview_2021_03/operations.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2021_03/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcegraph/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2021_06/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcehealth/src/package_2017_07/operations.rs
+++ b/services/mgmt/resourcehealth/src/package_2017_07/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_statuses(&self) -> availability_statuses::Client {
+    pub fn availability_statuses_client(&self) -> availability_statuses::Client {
         availability_statuses::Client(self.clone())
     }
-    pub fn child_availability_statuses(&self) -> child_availability_statuses::Client {
+    pub fn child_availability_statuses_client(&self) -> child_availability_statuses::Client {
         child_availability_statuses::Client(self.clone())
     }
-    pub fn child_resources(&self) -> child_resources::Client {
+    pub fn child_resources_client(&self) -> child_resources::Client {
         child_resources::Client(self.clone())
     }
-    pub fn emerging_issues(&self) -> emerging_issues::Client {
+    pub fn emerging_issues_client(&self) -> emerging_issues::Client {
         emerging_issues::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcehealth/src/package_2018_07_01/operations.rs
+++ b/services/mgmt/resourcehealth/src/package_2018_07_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_statuses(&self) -> availability_statuses::Client {
+    pub fn availability_statuses_client(&self) -> availability_statuses::Client {
         availability_statuses::Client(self.clone())
     }
-    pub fn emerging_issues(&self) -> emerging_issues::Client {
+    pub fn emerging_issues_client(&self) -> emerging_issues::Client {
         emerging_issues::Client(self.clone())
     }
-    pub fn events(&self) -> events::Client {
+    pub fn events_client(&self) -> events::Client {
         events::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcehealth/src/package_2018_08_preview/operations.rs
+++ b/services/mgmt/resourcehealth/src/package_2018_08_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_statuses(&self) -> availability_statuses::Client {
+    pub fn availability_statuses_client(&self) -> availability_statuses::Client {
         availability_statuses::Client(self.clone())
     }
-    pub fn emerging_issues(&self) -> emerging_issues::Client {
+    pub fn emerging_issues_client(&self) -> emerging_issues::Client {
         emerging_issues::Client(self.clone())
     }
-    pub fn events(&self) -> events::Client {
+    pub fn events_client(&self) -> events::Client {
         events::Client(self.clone())
     }
-    pub fn impacted_resources(&self) -> impacted_resources::Client {
+    pub fn impacted_resources_client(&self) -> impacted_resources::Client {
         impacted_resources::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcehealth/src/package_2020_05_01/operations.rs
+++ b/services/mgmt/resourcehealth/src/package_2020_05_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_statuses(&self) -> availability_statuses::Client {
+    pub fn availability_statuses_client(&self) -> availability_statuses::Client {
         availability_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcehealth/src/package_2020_05_01_preview/operations.rs
+++ b/services/mgmt/resourcehealth/src/package_2020_05_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_statuses(&self) -> availability_statuses::Client {
+    pub fn availability_statuses_client(&self) -> availability_statuses::Client {
         availability_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcemover/src/package_2019_10_01_preview/operations.rs
+++ b/services/mgmt/resourcemover/src/package_2019_10_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn move_collections(&self) -> move_collections::Client {
+    pub fn move_collections_client(&self) -> move_collections::Client {
         move_collections::Client(self.clone())
     }
-    pub fn move_resources(&self) -> move_resources::Client {
+    pub fn move_resources_client(&self) -> move_resources::Client {
         move_resources::Client(self.clone())
     }
-    pub fn operations_discovery(&self) -> operations_discovery::Client {
+    pub fn operations_discovery_client(&self) -> operations_discovery::Client {
         operations_discovery::Client(self.clone())
     }
-    pub fn unresolved_dependencies(&self) -> unresolved_dependencies::Client {
+    pub fn unresolved_dependencies_client(&self) -> unresolved_dependencies::Client {
         unresolved_dependencies::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcemover/src/package_2021_01_01/operations.rs
+++ b/services/mgmt/resourcemover/src/package_2021_01_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn move_collections(&self) -> move_collections::Client {
+    pub fn move_collections_client(&self) -> move_collections::Client {
         move_collections::Client(self.clone())
     }
-    pub fn move_resources(&self) -> move_resources::Client {
+    pub fn move_resources_client(&self) -> move_resources::Client {
         move_resources::Client(self.clone())
     }
-    pub fn operations_discovery(&self) -> operations_discovery::Client {
+    pub fn operations_discovery_client(&self) -> operations_discovery::Client {
         operations_discovery::Client(self.clone())
     }
-    pub fn unresolved_dependencies(&self) -> unresolved_dependencies::Client {
+    pub fn unresolved_dependencies_client(&self) -> unresolved_dependencies::Client {
         unresolved_dependencies::Client(self.clone())
     }
 }

--- a/services/mgmt/resourcemover/src/package_2021_08_01/operations.rs
+++ b/services/mgmt/resourcemover/src/package_2021_08_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn move_collections(&self) -> move_collections::Client {
+    pub fn move_collections_client(&self) -> move_collections::Client {
         move_collections::Client(self.clone())
     }
-    pub fn move_resources(&self) -> move_resources::Client {
+    pub fn move_resources_client(&self) -> move_resources::Client {
         move_resources::Client(self.clone())
     }
-    pub fn operations_discovery(&self) -> operations_discovery::Client {
+    pub fn operations_discovery_client(&self) -> operations_discovery::Client {
         operations_discovery::Client(self.clone())
     }
-    pub fn unresolved_dependencies(&self) -> unresolved_dependencies::Client {
+    pub fn unresolved_dependencies_client(&self) -> unresolved_dependencies::Client {
         unresolved_dependencies::Client(self.clone())
     }
 }

--- a/services/mgmt/resources/examples/group_create.rs
+++ b/services/mgmt/resources/examples/group_create.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         tags: None,
     };
     let group_created = client
-        .resource_groups()
+        .resource_groups_client()
         .create_or_update(resource_group_name, group, subscription_id)
         .into_future()
         .await?;

--- a/services/mgmt/resources/src/package_features_2021_07/operations.rs
+++ b/services/mgmt/resources/src/package_features_2021_07/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn features(&self) -> features::Client {
+    pub fn features_client(&self) -> features::Client {
         features::Client(self.clone())
     }
-    pub fn subscription_feature_registrations(&self) -> subscription_feature_registrations::Client {
+    pub fn subscription_feature_registrations_client(&self) -> subscription_feature_registrations::Client {
         subscription_feature_registrations::Client(self.clone())
     }
 }

--- a/services/mgmt/resources/src/package_locks_2020_05/operations.rs
+++ b/services/mgmt/resources/src/package_locks_2020_05/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn authorization_operations(&self) -> authorization_operations::Client {
+    pub fn authorization_operations_client(&self) -> authorization_operations::Client {
         authorization_operations::Client(self.clone())
     }
-    pub fn management_locks(&self) -> management_locks::Client {
+    pub fn management_locks_client(&self) -> management_locks::Client {
         management_locks::Client(self.clone())
     }
 }

--- a/services/mgmt/resources/src/package_policy_2021_06/operations.rs
+++ b/services/mgmt/resources/src/package_policy_2021_06/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_policy_manifests(&self) -> data_policy_manifests::Client {
+    pub fn data_policy_manifests_client(&self) -> data_policy_manifests::Client {
         data_policy_manifests::Client(self.clone())
     }
-    pub fn policy_assignments(&self) -> policy_assignments::Client {
+    pub fn policy_assignments_client(&self) -> policy_assignments::Client {
         policy_assignments::Client(self.clone())
     }
-    pub fn policy_definitions(&self) -> policy_definitions::Client {
+    pub fn policy_definitions_client(&self) -> policy_definitions::Client {
         policy_definitions::Client(self.clone())
     }
-    pub fn policy_exemptions(&self) -> policy_exemptions::Client {
+    pub fn policy_exemptions_client(&self) -> policy_exemptions::Client {
         policy_exemptions::Client(self.clone())
     }
-    pub fn policy_set_definitions(&self) -> policy_set_definitions::Client {
+    pub fn policy_set_definitions_client(&self) -> policy_set_definitions::Client {
         policy_set_definitions::Client(self.clone())
     }
 }

--- a/services/mgmt/resources/src/package_resources_2021_04/operations.rs
+++ b/services/mgmt/resources/src/package_resources_2021_04/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn deployment_operations(&self) -> deployment_operations::Client {
+    pub fn deployment_operations_client(&self) -> deployment_operations::Client {
         deployment_operations::Client(self.clone())
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn provider_resource_types(&self) -> provider_resource_types::Client {
+    pub fn provider_resource_types_client(&self) -> provider_resource_types::Client {
         provider_resource_types::Client(self.clone())
     }
-    pub fn providers(&self) -> providers::Client {
+    pub fn providers_client(&self) -> providers::Client {
         providers::Client(self.clone())
     }
-    pub fn resource_groups(&self) -> resource_groups::Client {
+    pub fn resource_groups_client(&self) -> resource_groups::Client {
         resource_groups::Client(self.clone())
     }
-    pub fn resources(&self) -> resources::Client {
+    pub fn resources_client(&self) -> resources::Client {
         resources::Client(self.clone())
     }
-    pub fn tags(&self) -> tags::Client {
+    pub fn tags_client(&self) -> tags::Client {
         tags::Client(self.clone())
     }
 }

--- a/services/mgmt/resources/src/package_subscriptions_2021_01/operations.rs
+++ b/services/mgmt/resources/src/package_subscriptions_2021_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn tenants(&self) -> tenants::Client {
+    pub fn tenants_client(&self) -> tenants::Client {
         tenants::Client(self.clone())
     }
 }

--- a/services/mgmt/saas/src/package_2018_03_01_beta/operations.rs
+++ b/services/mgmt/saas/src/package_2018_03_01_beta/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn saa_s(&self) -> saa_s::Client {
+    pub fn saa_s_client(&self) -> saa_s::Client {
         saa_s::Client(self.clone())
     }
-    pub fn saa_s_operation(&self) -> saa_s_operation::Client {
+    pub fn saa_s_operation_client(&self) -> saa_s_operation::Client {
         saa_s_operation::Client(self.clone())
     }
-    pub fn saas_resources(&self) -> saas_resources::Client {
+    pub fn saas_resources_client(&self) -> saas_resources::Client {
         saas_resources::Client(self.clone())
     }
-    pub fn saas_subscription_level(&self) -> saas_subscription_level::Client {
+    pub fn saas_subscription_level_client(&self) -> saas_subscription_level::Client {
         saas_subscription_level::Client(self.clone())
     }
 }

--- a/services/mgmt/scheduler/src/package_2014_08_preview/operations.rs
+++ b/services/mgmt/scheduler/src/package_2014_08_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn job_collections(&self) -> job_collections::Client {
+    pub fn job_collections_client(&self) -> job_collections::Client {
         job_collections::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
 }

--- a/services/mgmt/scheduler/src/package_2016_01/operations.rs
+++ b/services/mgmt/scheduler/src/package_2016_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn job_collections(&self) -> job_collections::Client {
+    pub fn job_collections_client(&self) -> job_collections::Client {
         job_collections::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
 }

--- a/services/mgmt/scheduler/src/package_2016_03/operations.rs
+++ b/services/mgmt/scheduler/src/package_2016_03/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn job_collections(&self) -> job_collections::Client {
+    pub fn job_collections_client(&self) -> job_collections::Client {
         job_collections::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
 }

--- a/services/mgmt/scvmm/src/package_2020_06_05_preview/operations.rs
+++ b/services/mgmt/scvmm/src/package_2020_06_05_preview/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_sets(&self) -> availability_sets::Client {
+    pub fn availability_sets_client(&self) -> availability_sets::Client {
         availability_sets::Client(self.clone())
     }
-    pub fn clouds(&self) -> clouds::Client {
+    pub fn clouds_client(&self) -> clouds::Client {
         clouds::Client(self.clone())
     }
-    pub fn inventory_items(&self) -> inventory_items::Client {
+    pub fn inventory_items_client(&self) -> inventory_items::Client {
         inventory_items::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn virtual_machine_templates(&self) -> virtual_machine_templates::Client {
+    pub fn virtual_machine_templates_client(&self) -> virtual_machine_templates::Client {
         virtual_machine_templates::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
-    pub fn virtual_networks(&self) -> virtual_networks::Client {
+    pub fn virtual_networks_client(&self) -> virtual_networks::Client {
         virtual_networks::Client(self.clone())
     }
-    pub fn vmm_servers(&self) -> vmm_servers::Client {
+    pub fn vmm_servers_client(&self) -> vmm_servers::Client {
         vmm_servers::Client(self.clone())
     }
 }

--- a/services/mgmt/search/src/package_2019_10_preview/operations.rs
+++ b/services/mgmt/search/src/package_2019_10_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn admin_keys(&self) -> admin_keys::Client {
+    pub fn admin_keys_client(&self) -> admin_keys::Client {
         admin_keys::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_keys(&self) -> query_keys::Client {
+    pub fn query_keys_client(&self) -> query_keys::Client {
         query_keys::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/search/src/package_2020_03/operations.rs
+++ b/services/mgmt/search/src/package_2020_03/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn admin_keys(&self) -> admin_keys::Client {
+    pub fn admin_keys_client(&self) -> admin_keys::Client {
         admin_keys::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_keys(&self) -> query_keys::Client {
+    pub fn query_keys_client(&self) -> query_keys::Client {
         query_keys::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/search/src/package_2020_08/operations.rs
+++ b/services/mgmt/search/src/package_2020_08/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn admin_keys(&self) -> admin_keys::Client {
+    pub fn admin_keys_client(&self) -> admin_keys::Client {
         admin_keys::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_keys(&self) -> query_keys::Client {
+    pub fn query_keys_client(&self) -> query_keys::Client {
         query_keys::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn shared_private_link_resources(&self) -> shared_private_link_resources::Client {
+    pub fn shared_private_link_resources_client(&self) -> shared_private_link_resources::Client {
         shared_private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/search/src/package_2020_08_preview/operations.rs
+++ b/services/mgmt/search/src/package_2020_08_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn admin_keys(&self) -> admin_keys::Client {
+    pub fn admin_keys_client(&self) -> admin_keys::Client {
         admin_keys::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_keys(&self) -> query_keys::Client {
+    pub fn query_keys_client(&self) -> query_keys::Client {
         query_keys::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn shared_private_link_resources(&self) -> shared_private_link_resources::Client {
+    pub fn shared_private_link_resources_client(&self) -> shared_private_link_resources::Client {
         shared_private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/search/src/package_2021_04_preview/operations.rs
+++ b/services/mgmt/search/src/package_2021_04_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn admin_keys(&self) -> admin_keys::Client {
+    pub fn admin_keys_client(&self) -> admin_keys::Client {
         admin_keys::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn query_keys(&self) -> query_keys::Client {
+    pub fn query_keys_client(&self) -> query_keys::Client {
         query_keys::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn shared_private_link_resources(&self) -> shared_private_link_resources::Client {
+    pub fn shared_private_link_resources_client(&self) -> shared_private_link_resources::Client {
         shared_private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/security/src/package_composite_v3/operations.rs
+++ b/services/mgmt/security/src/package_composite_v3/operations.rs
@@ -74,151 +74,151 @@ impl Client {
             pipeline,
         }
     }
-    pub fn adaptive_application_controls(&self) -> adaptive_application_controls::Client {
+    pub fn adaptive_application_controls_client(&self) -> adaptive_application_controls::Client {
         adaptive_application_controls::Client(self.clone())
     }
-    pub fn adaptive_network_hardenings(&self) -> adaptive_network_hardenings::Client {
+    pub fn adaptive_network_hardenings_client(&self) -> adaptive_network_hardenings::Client {
         adaptive_network_hardenings::Client(self.clone())
     }
-    pub fn advanced_threat_protection(&self) -> advanced_threat_protection::Client {
+    pub fn advanced_threat_protection_client(&self) -> advanced_threat_protection::Client {
         advanced_threat_protection::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn alerts_suppression_rules(&self) -> alerts_suppression_rules::Client {
+    pub fn alerts_suppression_rules_client(&self) -> alerts_suppression_rules::Client {
         alerts_suppression_rules::Client(self.clone())
     }
-    pub fn allowed_connections(&self) -> allowed_connections::Client {
+    pub fn allowed_connections_client(&self) -> allowed_connections::Client {
         allowed_connections::Client(self.clone())
     }
-    pub fn assessments(&self) -> assessments::Client {
+    pub fn assessments_client(&self) -> assessments::Client {
         assessments::Client(self.clone())
     }
-    pub fn assessments_metadata(&self) -> assessments_metadata::Client {
+    pub fn assessments_metadata_client(&self) -> assessments_metadata::Client {
         assessments_metadata::Client(self.clone())
     }
-    pub fn auto_provisioning_settings(&self) -> auto_provisioning_settings::Client {
+    pub fn auto_provisioning_settings_client(&self) -> auto_provisioning_settings::Client {
         auto_provisioning_settings::Client(self.clone())
     }
-    pub fn automations(&self) -> automations::Client {
+    pub fn automations_client(&self) -> automations::Client {
         automations::Client(self.clone())
     }
-    pub fn compliance_results(&self) -> compliance_results::Client {
+    pub fn compliance_results_client(&self) -> compliance_results::Client {
         compliance_results::Client(self.clone())
     }
-    pub fn compliances(&self) -> compliances::Client {
+    pub fn compliances_client(&self) -> compliances::Client {
         compliances::Client(self.clone())
     }
-    pub fn connectors(&self) -> connectors::Client {
+    pub fn connectors_client(&self) -> connectors::Client {
         connectors::Client(self.clone())
     }
-    pub fn custom_assessment_automations(&self) -> custom_assessment_automations::Client {
+    pub fn custom_assessment_automations_client(&self) -> custom_assessment_automations::Client {
         custom_assessment_automations::Client(self.clone())
     }
-    pub fn custom_entity_store_assignments(&self) -> custom_entity_store_assignments::Client {
+    pub fn custom_entity_store_assignments_client(&self) -> custom_entity_store_assignments::Client {
         custom_entity_store_assignments::Client(self.clone())
     }
-    pub fn device_security_groups(&self) -> device_security_groups::Client {
+    pub fn device_security_groups_client(&self) -> device_security_groups::Client {
         device_security_groups::Client(self.clone())
     }
-    pub fn discovered_security_solutions(&self) -> discovered_security_solutions::Client {
+    pub fn discovered_security_solutions_client(&self) -> discovered_security_solutions::Client {
         discovered_security_solutions::Client(self.clone())
     }
-    pub fn external_security_solutions(&self) -> external_security_solutions::Client {
+    pub fn external_security_solutions_client(&self) -> external_security_solutions::Client {
         external_security_solutions::Client(self.clone())
     }
-    pub fn information_protection_policies(&self) -> information_protection_policies::Client {
+    pub fn information_protection_policies_client(&self) -> information_protection_policies::Client {
         information_protection_policies::Client(self.clone())
     }
-    pub fn ingestion_settings(&self) -> ingestion_settings::Client {
+    pub fn ingestion_settings_client(&self) -> ingestion_settings::Client {
         ingestion_settings::Client(self.clone())
     }
-    pub fn iot_security_solution(&self) -> iot_security_solution::Client {
+    pub fn iot_security_solution_client(&self) -> iot_security_solution::Client {
         iot_security_solution::Client(self.clone())
     }
-    pub fn iot_security_solution_analytics(&self) -> iot_security_solution_analytics::Client {
+    pub fn iot_security_solution_analytics_client(&self) -> iot_security_solution_analytics::Client {
         iot_security_solution_analytics::Client(self.clone())
     }
-    pub fn iot_security_solutions_analytics_aggregated_alert(&self) -> iot_security_solutions_analytics_aggregated_alert::Client {
+    pub fn iot_security_solutions_analytics_aggregated_alert_client(&self) -> iot_security_solutions_analytics_aggregated_alert::Client {
         iot_security_solutions_analytics_aggregated_alert::Client(self.clone())
     }
-    pub fn iot_security_solutions_analytics_recommendation(&self) -> iot_security_solutions_analytics_recommendation::Client {
+    pub fn iot_security_solutions_analytics_recommendation_client(&self) -> iot_security_solutions_analytics_recommendation::Client {
         iot_security_solutions_analytics_recommendation::Client(self.clone())
     }
-    pub fn jit_network_access_policies(&self) -> jit_network_access_policies::Client {
+    pub fn jit_network_access_policies_client(&self) -> jit_network_access_policies::Client {
         jit_network_access_policies::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn mde_onboardings(&self) -> mde_onboardings::Client {
+    pub fn mde_onboardings_client(&self) -> mde_onboardings::Client {
         mde_onboardings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pricings(&self) -> pricings::Client {
+    pub fn pricings_client(&self) -> pricings::Client {
         pricings::Client(self.clone())
     }
-    pub fn regulatory_compliance_assessments(&self) -> regulatory_compliance_assessments::Client {
+    pub fn regulatory_compliance_assessments_client(&self) -> regulatory_compliance_assessments::Client {
         regulatory_compliance_assessments::Client(self.clone())
     }
-    pub fn regulatory_compliance_controls(&self) -> regulatory_compliance_controls::Client {
+    pub fn regulatory_compliance_controls_client(&self) -> regulatory_compliance_controls::Client {
         regulatory_compliance_controls::Client(self.clone())
     }
-    pub fn regulatory_compliance_standards(&self) -> regulatory_compliance_standards::Client {
+    pub fn regulatory_compliance_standards_client(&self) -> regulatory_compliance_standards::Client {
         regulatory_compliance_standards::Client(self.clone())
     }
-    pub fn secure_score_control_definitions(&self) -> secure_score_control_definitions::Client {
+    pub fn secure_score_control_definitions_client(&self) -> secure_score_control_definitions::Client {
         secure_score_control_definitions::Client(self.clone())
     }
-    pub fn secure_score_controls(&self) -> secure_score_controls::Client {
+    pub fn secure_score_controls_client(&self) -> secure_score_controls::Client {
         secure_score_controls::Client(self.clone())
     }
-    pub fn secure_scores(&self) -> secure_scores::Client {
+    pub fn secure_scores_client(&self) -> secure_scores::Client {
         secure_scores::Client(self.clone())
     }
-    pub fn security_connectors(&self) -> security_connectors::Client {
+    pub fn security_connectors_client(&self) -> security_connectors::Client {
         security_connectors::Client(self.clone())
     }
-    pub fn security_contacts(&self) -> security_contacts::Client {
+    pub fn security_contacts_client(&self) -> security_contacts::Client {
         security_contacts::Client(self.clone())
     }
-    pub fn security_solutions(&self) -> security_solutions::Client {
+    pub fn security_solutions_client(&self) -> security_solutions::Client {
         security_solutions::Client(self.clone())
     }
-    pub fn security_solutions_reference_data(&self) -> security_solutions_reference_data::Client {
+    pub fn security_solutions_reference_data_client(&self) -> security_solutions_reference_data::Client {
         security_solutions_reference_data::Client(self.clone())
     }
-    pub fn server_vulnerability_assessment(&self) -> server_vulnerability_assessment::Client {
+    pub fn server_vulnerability_assessment_client(&self) -> server_vulnerability_assessment::Client {
         server_vulnerability_assessment::Client(self.clone())
     }
-    pub fn settings(&self) -> settings::Client {
+    pub fn settings_client(&self) -> settings::Client {
         settings::Client(self.clone())
     }
-    pub fn software_inventories(&self) -> software_inventories::Client {
+    pub fn software_inventories_client(&self) -> software_inventories::Client {
         software_inventories::Client(self.clone())
     }
-    pub fn sql_vulnerability_assessment_baseline_rules(&self) -> sql_vulnerability_assessment_baseline_rules::Client {
+    pub fn sql_vulnerability_assessment_baseline_rules_client(&self) -> sql_vulnerability_assessment_baseline_rules::Client {
         sql_vulnerability_assessment_baseline_rules::Client(self.clone())
     }
-    pub fn sql_vulnerability_assessment_scan_results(&self) -> sql_vulnerability_assessment_scan_results::Client {
+    pub fn sql_vulnerability_assessment_scan_results_client(&self) -> sql_vulnerability_assessment_scan_results::Client {
         sql_vulnerability_assessment_scan_results::Client(self.clone())
     }
-    pub fn sql_vulnerability_assessment_scans(&self) -> sql_vulnerability_assessment_scans::Client {
+    pub fn sql_vulnerability_assessment_scans_client(&self) -> sql_vulnerability_assessment_scans::Client {
         sql_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn sub_assessments(&self) -> sub_assessments::Client {
+    pub fn sub_assessments_client(&self) -> sub_assessments::Client {
         sub_assessments::Client(self.clone())
     }
-    pub fn tasks(&self) -> tasks::Client {
+    pub fn tasks_client(&self) -> tasks::Client {
         tasks::Client(self.clone())
     }
-    pub fn topology(&self) -> topology::Client {
+    pub fn topology_client(&self) -> topology::Client {
         topology::Client(self.clone())
     }
-    pub fn workspace_settings(&self) -> workspace_settings::Client {
+    pub fn workspace_settings_client(&self) -> workspace_settings::Client {
         workspace_settings::Client(self.clone())
     }
 }

--- a/services/mgmt/security/src/package_preview_2021_07/operations.rs
+++ b/services/mgmt/security/src/package_preview_2021_07/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn custom_assessment_automations(&self) -> custom_assessment_automations::Client {
+    pub fn custom_assessment_automations_client(&self) -> custom_assessment_automations::Client {
         custom_assessment_automations::Client(self.clone())
     }
-    pub fn custom_entity_store_assignments(&self) -> custom_entity_store_assignments::Client {
+    pub fn custom_entity_store_assignments_client(&self) -> custom_entity_store_assignments::Client {
         custom_entity_store_assignments::Client(self.clone())
     }
 }

--- a/services/mgmt/security/src/package_preview_2021_08/operations.rs
+++ b/services/mgmt/security/src/package_preview_2021_08/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn assignments(&self) -> assignments::Client {
+    pub fn assignments_client(&self) -> assignments::Client {
         assignments::Client(self.clone())
     }
-    pub fn standards(&self) -> standards::Client {
+    pub fn standards_client(&self) -> standards::Client {
         standards::Client(self.clone())
     }
 }

--- a/services/mgmt/security/src/package_preview_2021_10/operations.rs
+++ b/services/mgmt/security/src/package_preview_2021_10/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn mde_onboardings(&self) -> mde_onboardings::Client {
+    pub fn mde_onboardings_client(&self) -> mde_onboardings::Client {
         mde_onboardings::Client(self.clone())
     }
 }

--- a/services/mgmt/security/src/package_preview_2021_12/operations.rs
+++ b/services/mgmt/security/src/package_preview_2021_12/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn security_connectors(&self) -> security_connectors::Client {
+    pub fn security_connectors_client(&self) -> security_connectors::Client {
         security_connectors::Client(self.clone())
     }
 }

--- a/services/mgmt/securityandcompliance/src/package_2021_01_11/operations.rs
+++ b/services/mgmt/securityandcompliance/src/package_2021_01_11/operations.rs
@@ -74,58 +74,60 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections_adt_api(&self) -> private_endpoint_connections_adt_api::Client {
+    pub fn private_endpoint_connections_adt_api_client(&self) -> private_endpoint_connections_adt_api::Client {
         private_endpoint_connections_adt_api::Client(self.clone())
     }
-    pub fn private_endpoint_connections_comp(&self) -> private_endpoint_connections_comp::Client {
+    pub fn private_endpoint_connections_comp_client(&self) -> private_endpoint_connections_comp::Client {
         private_endpoint_connections_comp::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_edm(&self) -> private_endpoint_connections_for_edm::Client {
+    pub fn private_endpoint_connections_for_edm_client(&self) -> private_endpoint_connections_for_edm::Client {
         private_endpoint_connections_for_edm::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_scc_powershell(&self) -> private_endpoint_connections_for_scc_powershell::Client {
+    pub fn private_endpoint_connections_for_scc_powershell_client(&self) -> private_endpoint_connections_for_scc_powershell::Client {
         private_endpoint_connections_for_scc_powershell::Client(self.clone())
     }
-    pub fn private_endpoint_connections_sec(&self) -> private_endpoint_connections_sec::Client {
+    pub fn private_endpoint_connections_sec_client(&self) -> private_endpoint_connections_sec::Client {
         private_endpoint_connections_sec::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_resources_adt_api(&self) -> private_link_resources_adt_api::Client {
+    pub fn private_link_resources_adt_api_client(&self) -> private_link_resources_adt_api::Client {
         private_link_resources_adt_api::Client(self.clone())
     }
-    pub fn private_link_resources_comp(&self) -> private_link_resources_comp::Client {
+    pub fn private_link_resources_comp_client(&self) -> private_link_resources_comp::Client {
         private_link_resources_comp::Client(self.clone())
     }
-    pub fn private_link_resources_for_scc_powershell(&self) -> private_link_resources_for_scc_powershell::Client {
+    pub fn private_link_resources_for_scc_powershell_client(&self) -> private_link_resources_for_scc_powershell::Client {
         private_link_resources_for_scc_powershell::Client(self.clone())
     }
-    pub fn private_link_resources_sec(&self) -> private_link_resources_sec::Client {
+    pub fn private_link_resources_sec_client(&self) -> private_link_resources_sec::Client {
         private_link_resources_sec::Client(self.clone())
     }
-    pub fn private_link_services_for_edm_upload(&self) -> private_link_services_for_edm_upload::Client {
+    pub fn private_link_services_for_edm_upload_client(&self) -> private_link_services_for_edm_upload::Client {
         private_link_services_for_edm_upload::Client(self.clone())
     }
-    pub fn private_link_services_for_m365_compliance_center(&self) -> private_link_services_for_m365_compliance_center::Client {
+    pub fn private_link_services_for_m365_compliance_center_client(&self) -> private_link_services_for_m365_compliance_center::Client {
         private_link_services_for_m365_compliance_center::Client(self.clone())
     }
-    pub fn private_link_services_for_m365_security_center(&self) -> private_link_services_for_m365_security_center::Client {
+    pub fn private_link_services_for_m365_security_center_client(&self) -> private_link_services_for_m365_security_center::Client {
         private_link_services_for_m365_security_center::Client(self.clone())
     }
-    pub fn private_link_services_for_o365_management_activity_api(&self) -> private_link_services_for_o365_management_activity_api::Client {
+    pub fn private_link_services_for_o365_management_activity_api_client(
+        &self,
+    ) -> private_link_services_for_o365_management_activity_api::Client {
         private_link_services_for_o365_management_activity_api::Client(self.clone())
     }
-    pub fn private_link_services_for_scc_powershell(&self) -> private_link_services_for_scc_powershell::Client {
+    pub fn private_link_services_for_scc_powershell_client(&self) -> private_link_services_for_scc_powershell::Client {
         private_link_services_for_scc_powershell::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/securityandcompliance/src/package_2021_03_08/operations.rs
+++ b/services/mgmt/securityandcompliance/src/package_2021_03_08/operations.rs
@@ -74,67 +74,69 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections_adt_api(&self) -> private_endpoint_connections_adt_api::Client {
+    pub fn private_endpoint_connections_adt_api_client(&self) -> private_endpoint_connections_adt_api::Client {
         private_endpoint_connections_adt_api::Client(self.clone())
     }
-    pub fn private_endpoint_connections_comp(&self) -> private_endpoint_connections_comp::Client {
+    pub fn private_endpoint_connections_comp_client(&self) -> private_endpoint_connections_comp::Client {
         private_endpoint_connections_comp::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_edm(&self) -> private_endpoint_connections_for_edm::Client {
+    pub fn private_endpoint_connections_for_edm_client(&self) -> private_endpoint_connections_for_edm::Client {
         private_endpoint_connections_for_edm::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_mip_policy_sync(&self) -> private_endpoint_connections_for_mip_policy_sync::Client {
+    pub fn private_endpoint_connections_for_mip_policy_sync_client(&self) -> private_endpoint_connections_for_mip_policy_sync::Client {
         private_endpoint_connections_for_mip_policy_sync::Client(self.clone())
     }
-    pub fn private_endpoint_connections_for_scc_powershell(&self) -> private_endpoint_connections_for_scc_powershell::Client {
+    pub fn private_endpoint_connections_for_scc_powershell_client(&self) -> private_endpoint_connections_for_scc_powershell::Client {
         private_endpoint_connections_for_scc_powershell::Client(self.clone())
     }
-    pub fn private_endpoint_connections_sec(&self) -> private_endpoint_connections_sec::Client {
+    pub fn private_endpoint_connections_sec_client(&self) -> private_endpoint_connections_sec::Client {
         private_endpoint_connections_sec::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn private_link_resources_adt_api(&self) -> private_link_resources_adt_api::Client {
+    pub fn private_link_resources_adt_api_client(&self) -> private_link_resources_adt_api::Client {
         private_link_resources_adt_api::Client(self.clone())
     }
-    pub fn private_link_resources_comp(&self) -> private_link_resources_comp::Client {
+    pub fn private_link_resources_comp_client(&self) -> private_link_resources_comp::Client {
         private_link_resources_comp::Client(self.clone())
     }
-    pub fn private_link_resources_for_mip_policy_sync(&self) -> private_link_resources_for_mip_policy_sync::Client {
+    pub fn private_link_resources_for_mip_policy_sync_client(&self) -> private_link_resources_for_mip_policy_sync::Client {
         private_link_resources_for_mip_policy_sync::Client(self.clone())
     }
-    pub fn private_link_resources_for_scc_powershell(&self) -> private_link_resources_for_scc_powershell::Client {
+    pub fn private_link_resources_for_scc_powershell_client(&self) -> private_link_resources_for_scc_powershell::Client {
         private_link_resources_for_scc_powershell::Client(self.clone())
     }
-    pub fn private_link_resources_sec(&self) -> private_link_resources_sec::Client {
+    pub fn private_link_resources_sec_client(&self) -> private_link_resources_sec::Client {
         private_link_resources_sec::Client(self.clone())
     }
-    pub fn private_link_services_for_edm_upload(&self) -> private_link_services_for_edm_upload::Client {
+    pub fn private_link_services_for_edm_upload_client(&self) -> private_link_services_for_edm_upload::Client {
         private_link_services_for_edm_upload::Client(self.clone())
     }
-    pub fn private_link_services_for_m365_compliance_center(&self) -> private_link_services_for_m365_compliance_center::Client {
+    pub fn private_link_services_for_m365_compliance_center_client(&self) -> private_link_services_for_m365_compliance_center::Client {
         private_link_services_for_m365_compliance_center::Client(self.clone())
     }
-    pub fn private_link_services_for_m365_security_center(&self) -> private_link_services_for_m365_security_center::Client {
+    pub fn private_link_services_for_m365_security_center_client(&self) -> private_link_services_for_m365_security_center::Client {
         private_link_services_for_m365_security_center::Client(self.clone())
     }
-    pub fn private_link_services_for_mip_policy_sync(&self) -> private_link_services_for_mip_policy_sync::Client {
+    pub fn private_link_services_for_mip_policy_sync_client(&self) -> private_link_services_for_mip_policy_sync::Client {
         private_link_services_for_mip_policy_sync::Client(self.clone())
     }
-    pub fn private_link_services_for_o365_management_activity_api(&self) -> private_link_services_for_o365_management_activity_api::Client {
+    pub fn private_link_services_for_o365_management_activity_api_client(
+        &self,
+    ) -> private_link_services_for_o365_management_activity_api::Client {
         private_link_services_for_o365_management_activity_api::Client(self.clone())
     }
-    pub fn private_link_services_for_scc_powershell(&self) -> private_link_services_for_scc_powershell::Client {
+    pub fn private_link_services_for_scc_powershell_client(&self) -> private_link_services_for_scc_powershell::Client {
         private_link_services_for_scc_powershell::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/securityinsights/src/package_preview_2021_10/operations.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2021_10/operations.rs
@@ -74,100 +74,100 @@ impl Client {
             pipeline,
         }
     }
-    pub fn actions(&self) -> actions::Client {
+    pub fn actions_client(&self) -> actions::Client {
         actions::Client(self.clone())
     }
-    pub fn alert_rule_templates(&self) -> alert_rule_templates::Client {
+    pub fn alert_rule_templates_client(&self) -> alert_rule_templates::Client {
         alert_rule_templates::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn automation_rules(&self) -> automation_rules::Client {
+    pub fn automation_rules_client(&self) -> automation_rules::Client {
         automation_rules::Client(self.clone())
     }
-    pub fn bookmark(&self) -> bookmark::Client {
+    pub fn bookmark_client(&self) -> bookmark::Client {
         bookmark::Client(self.clone())
     }
-    pub fn bookmark_relations(&self) -> bookmark_relations::Client {
+    pub fn bookmark_relations_client(&self) -> bookmark_relations::Client {
         bookmark_relations::Client(self.clone())
     }
-    pub fn bookmarks(&self) -> bookmarks::Client {
+    pub fn bookmarks_client(&self) -> bookmarks::Client {
         bookmarks::Client(self.clone())
     }
-    pub fn data_connectors(&self) -> data_connectors::Client {
+    pub fn data_connectors_client(&self) -> data_connectors::Client {
         data_connectors::Client(self.clone())
     }
-    pub fn data_connectors_check_requirements(&self) -> data_connectors_check_requirements::Client {
+    pub fn data_connectors_check_requirements_client(&self) -> data_connectors_check_requirements::Client {
         data_connectors_check_requirements::Client(self.clone())
     }
-    pub fn domain_whois(&self) -> domain_whois::Client {
+    pub fn domain_whois_client(&self) -> domain_whois::Client {
         domain_whois::Client(self.clone())
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn entities_get_timeline(&self) -> entities_get_timeline::Client {
+    pub fn entities_get_timeline_client(&self) -> entities_get_timeline::Client {
         entities_get_timeline::Client(self.clone())
     }
-    pub fn entities_relations(&self) -> entities_relations::Client {
+    pub fn entities_relations_client(&self) -> entities_relations::Client {
         entities_relations::Client(self.clone())
     }
-    pub fn entity_queries(&self) -> entity_queries::Client {
+    pub fn entity_queries_client(&self) -> entity_queries::Client {
         entity_queries::Client(self.clone())
     }
-    pub fn entity_query_templates(&self) -> entity_query_templates::Client {
+    pub fn entity_query_templates_client(&self) -> entity_query_templates::Client {
         entity_query_templates::Client(self.clone())
     }
-    pub fn entity_relations(&self) -> entity_relations::Client {
+    pub fn entity_relations_client(&self) -> entity_relations::Client {
         entity_relations::Client(self.clone())
     }
-    pub fn incident_comments(&self) -> incident_comments::Client {
+    pub fn incident_comments_client(&self) -> incident_comments::Client {
         incident_comments::Client(self.clone())
     }
-    pub fn incident_relations(&self) -> incident_relations::Client {
+    pub fn incident_relations_client(&self) -> incident_relations::Client {
         incident_relations::Client(self.clone())
     }
-    pub fn incidents(&self) -> incidents::Client {
+    pub fn incidents_client(&self) -> incidents::Client {
         incidents::Client(self.clone())
     }
-    pub fn ip_geodata(&self) -> ip_geodata::Client {
+    pub fn ip_geodata_client(&self) -> ip_geodata::Client {
         ip_geodata::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn office_consents(&self) -> office_consents::Client {
+    pub fn office_consents_client(&self) -> office_consents::Client {
         office_consents::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn product_settings(&self) -> product_settings::Client {
+    pub fn product_settings_client(&self) -> product_settings::Client {
         product_settings::Client(self.clone())
     }
-    pub fn sentinel_onboarding_states(&self) -> sentinel_onboarding_states::Client {
+    pub fn sentinel_onboarding_states_client(&self) -> sentinel_onboarding_states::Client {
         sentinel_onboarding_states::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_controls(&self) -> source_controls::Client {
+    pub fn source_controls_client(&self) -> source_controls::Client {
         source_controls::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator(&self) -> threat_intelligence_indicator::Client {
+    pub fn threat_intelligence_indicator_client(&self) -> threat_intelligence_indicator::Client {
         threat_intelligence_indicator::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator_metrics(&self) -> threat_intelligence_indicator_metrics::Client {
+    pub fn threat_intelligence_indicator_metrics_client(&self) -> threat_intelligence_indicator_metrics::Client {
         threat_intelligence_indicator_metrics::Client(self.clone())
     }
-    pub fn threat_intelligence_indicators(&self) -> threat_intelligence_indicators::Client {
+    pub fn threat_intelligence_indicators_client(&self) -> threat_intelligence_indicators::Client {
         threat_intelligence_indicators::Client(self.clone())
     }
-    pub fn watchlist_items(&self) -> watchlist_items::Client {
+    pub fn watchlist_items_client(&self) -> watchlist_items::Client {
         watchlist_items::Client(self.clone())
     }
-    pub fn watchlists(&self) -> watchlists::Client {
+    pub fn watchlists_client(&self) -> watchlists::Client {
         watchlists::Client(self.clone())
     }
 }

--- a/services/mgmt/securityinsights/src/package_preview_2022_01/operations.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_01/operations.rs
@@ -74,100 +74,100 @@ impl Client {
             pipeline,
         }
     }
-    pub fn actions(&self) -> actions::Client {
+    pub fn actions_client(&self) -> actions::Client {
         actions::Client(self.clone())
     }
-    pub fn alert_rule_templates(&self) -> alert_rule_templates::Client {
+    pub fn alert_rule_templates_client(&self) -> alert_rule_templates::Client {
         alert_rule_templates::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn automation_rules(&self) -> automation_rules::Client {
+    pub fn automation_rules_client(&self) -> automation_rules::Client {
         automation_rules::Client(self.clone())
     }
-    pub fn bookmark(&self) -> bookmark::Client {
+    pub fn bookmark_client(&self) -> bookmark::Client {
         bookmark::Client(self.clone())
     }
-    pub fn bookmark_relations(&self) -> bookmark_relations::Client {
+    pub fn bookmark_relations_client(&self) -> bookmark_relations::Client {
         bookmark_relations::Client(self.clone())
     }
-    pub fn bookmarks(&self) -> bookmarks::Client {
+    pub fn bookmarks_client(&self) -> bookmarks::Client {
         bookmarks::Client(self.clone())
     }
-    pub fn data_connectors(&self) -> data_connectors::Client {
+    pub fn data_connectors_client(&self) -> data_connectors::Client {
         data_connectors::Client(self.clone())
     }
-    pub fn data_connectors_check_requirements(&self) -> data_connectors_check_requirements::Client {
+    pub fn data_connectors_check_requirements_client(&self) -> data_connectors_check_requirements::Client {
         data_connectors_check_requirements::Client(self.clone())
     }
-    pub fn domain_whois(&self) -> domain_whois::Client {
+    pub fn domain_whois_client(&self) -> domain_whois::Client {
         domain_whois::Client(self.clone())
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn entities_get_timeline(&self) -> entities_get_timeline::Client {
+    pub fn entities_get_timeline_client(&self) -> entities_get_timeline::Client {
         entities_get_timeline::Client(self.clone())
     }
-    pub fn entities_relations(&self) -> entities_relations::Client {
+    pub fn entities_relations_client(&self) -> entities_relations::Client {
         entities_relations::Client(self.clone())
     }
-    pub fn entity_queries(&self) -> entity_queries::Client {
+    pub fn entity_queries_client(&self) -> entity_queries::Client {
         entity_queries::Client(self.clone())
     }
-    pub fn entity_query_templates(&self) -> entity_query_templates::Client {
+    pub fn entity_query_templates_client(&self) -> entity_query_templates::Client {
         entity_query_templates::Client(self.clone())
     }
-    pub fn entity_relations(&self) -> entity_relations::Client {
+    pub fn entity_relations_client(&self) -> entity_relations::Client {
         entity_relations::Client(self.clone())
     }
-    pub fn incident_comments(&self) -> incident_comments::Client {
+    pub fn incident_comments_client(&self) -> incident_comments::Client {
         incident_comments::Client(self.clone())
     }
-    pub fn incident_relations(&self) -> incident_relations::Client {
+    pub fn incident_relations_client(&self) -> incident_relations::Client {
         incident_relations::Client(self.clone())
     }
-    pub fn incidents(&self) -> incidents::Client {
+    pub fn incidents_client(&self) -> incidents::Client {
         incidents::Client(self.clone())
     }
-    pub fn ip_geodata(&self) -> ip_geodata::Client {
+    pub fn ip_geodata_client(&self) -> ip_geodata::Client {
         ip_geodata::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn office_consents(&self) -> office_consents::Client {
+    pub fn office_consents_client(&self) -> office_consents::Client {
         office_consents::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn product_settings(&self) -> product_settings::Client {
+    pub fn product_settings_client(&self) -> product_settings::Client {
         product_settings::Client(self.clone())
     }
-    pub fn sentinel_onboarding_states(&self) -> sentinel_onboarding_states::Client {
+    pub fn sentinel_onboarding_states_client(&self) -> sentinel_onboarding_states::Client {
         sentinel_onboarding_states::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_controls(&self) -> source_controls::Client {
+    pub fn source_controls_client(&self) -> source_controls::Client {
         source_controls::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator(&self) -> threat_intelligence_indicator::Client {
+    pub fn threat_intelligence_indicator_client(&self) -> threat_intelligence_indicator::Client {
         threat_intelligence_indicator::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator_metrics(&self) -> threat_intelligence_indicator_metrics::Client {
+    pub fn threat_intelligence_indicator_metrics_client(&self) -> threat_intelligence_indicator_metrics::Client {
         threat_intelligence_indicator_metrics::Client(self.clone())
     }
-    pub fn threat_intelligence_indicators(&self) -> threat_intelligence_indicators::Client {
+    pub fn threat_intelligence_indicators_client(&self) -> threat_intelligence_indicators::Client {
         threat_intelligence_indicators::Client(self.clone())
     }
-    pub fn watchlist_items(&self) -> watchlist_items::Client {
+    pub fn watchlist_items_client(&self) -> watchlist_items::Client {
         watchlist_items::Client(self.clone())
     }
-    pub fn watchlists(&self) -> watchlists::Client {
+    pub fn watchlists_client(&self) -> watchlists::Client {
         watchlists::Client(self.clone())
     }
 }

--- a/services/mgmt/securityinsights/src/package_preview_2022_04/operations.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_04/operations.rs
@@ -74,100 +74,100 @@ impl Client {
             pipeline,
         }
     }
-    pub fn actions(&self) -> actions::Client {
+    pub fn actions_client(&self) -> actions::Client {
         actions::Client(self.clone())
     }
-    pub fn alert_rule_templates(&self) -> alert_rule_templates::Client {
+    pub fn alert_rule_templates_client(&self) -> alert_rule_templates::Client {
         alert_rule_templates::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn automation_rules(&self) -> automation_rules::Client {
+    pub fn automation_rules_client(&self) -> automation_rules::Client {
         automation_rules::Client(self.clone())
     }
-    pub fn bookmark(&self) -> bookmark::Client {
+    pub fn bookmark_client(&self) -> bookmark::Client {
         bookmark::Client(self.clone())
     }
-    pub fn bookmark_relations(&self) -> bookmark_relations::Client {
+    pub fn bookmark_relations_client(&self) -> bookmark_relations::Client {
         bookmark_relations::Client(self.clone())
     }
-    pub fn bookmarks(&self) -> bookmarks::Client {
+    pub fn bookmarks_client(&self) -> bookmarks::Client {
         bookmarks::Client(self.clone())
     }
-    pub fn data_connectors(&self) -> data_connectors::Client {
+    pub fn data_connectors_client(&self) -> data_connectors::Client {
         data_connectors::Client(self.clone())
     }
-    pub fn data_connectors_check_requirements(&self) -> data_connectors_check_requirements::Client {
+    pub fn data_connectors_check_requirements_client(&self) -> data_connectors_check_requirements::Client {
         data_connectors_check_requirements::Client(self.clone())
     }
-    pub fn domain_whois(&self) -> domain_whois::Client {
+    pub fn domain_whois_client(&self) -> domain_whois::Client {
         domain_whois::Client(self.clone())
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn entities_get_timeline(&self) -> entities_get_timeline::Client {
+    pub fn entities_get_timeline_client(&self) -> entities_get_timeline::Client {
         entities_get_timeline::Client(self.clone())
     }
-    pub fn entities_relations(&self) -> entities_relations::Client {
+    pub fn entities_relations_client(&self) -> entities_relations::Client {
         entities_relations::Client(self.clone())
     }
-    pub fn entity_queries(&self) -> entity_queries::Client {
+    pub fn entity_queries_client(&self) -> entity_queries::Client {
         entity_queries::Client(self.clone())
     }
-    pub fn entity_query_templates(&self) -> entity_query_templates::Client {
+    pub fn entity_query_templates_client(&self) -> entity_query_templates::Client {
         entity_query_templates::Client(self.clone())
     }
-    pub fn entity_relations(&self) -> entity_relations::Client {
+    pub fn entity_relations_client(&self) -> entity_relations::Client {
         entity_relations::Client(self.clone())
     }
-    pub fn incident_comments(&self) -> incident_comments::Client {
+    pub fn incident_comments_client(&self) -> incident_comments::Client {
         incident_comments::Client(self.clone())
     }
-    pub fn incident_relations(&self) -> incident_relations::Client {
+    pub fn incident_relations_client(&self) -> incident_relations::Client {
         incident_relations::Client(self.clone())
     }
-    pub fn incidents(&self) -> incidents::Client {
+    pub fn incidents_client(&self) -> incidents::Client {
         incidents::Client(self.clone())
     }
-    pub fn ip_geodata(&self) -> ip_geodata::Client {
+    pub fn ip_geodata_client(&self) -> ip_geodata::Client {
         ip_geodata::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn office_consents(&self) -> office_consents::Client {
+    pub fn office_consents_client(&self) -> office_consents::Client {
         office_consents::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn product_settings(&self) -> product_settings::Client {
+    pub fn product_settings_client(&self) -> product_settings::Client {
         product_settings::Client(self.clone())
     }
-    pub fn sentinel_onboarding_states(&self) -> sentinel_onboarding_states::Client {
+    pub fn sentinel_onboarding_states_client(&self) -> sentinel_onboarding_states::Client {
         sentinel_onboarding_states::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_controls(&self) -> source_controls::Client {
+    pub fn source_controls_client(&self) -> source_controls::Client {
         source_controls::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator(&self) -> threat_intelligence_indicator::Client {
+    pub fn threat_intelligence_indicator_client(&self) -> threat_intelligence_indicator::Client {
         threat_intelligence_indicator::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator_metrics(&self) -> threat_intelligence_indicator_metrics::Client {
+    pub fn threat_intelligence_indicator_metrics_client(&self) -> threat_intelligence_indicator_metrics::Client {
         threat_intelligence_indicator_metrics::Client(self.clone())
     }
-    pub fn threat_intelligence_indicators(&self) -> threat_intelligence_indicators::Client {
+    pub fn threat_intelligence_indicators_client(&self) -> threat_intelligence_indicators::Client {
         threat_intelligence_indicators::Client(self.clone())
     }
-    pub fn watchlist_items(&self) -> watchlist_items::Client {
+    pub fn watchlist_items_client(&self) -> watchlist_items::Client {
         watchlist_items::Client(self.clone())
     }
-    pub fn watchlists(&self) -> watchlists::Client {
+    pub fn watchlists_client(&self) -> watchlists::Client {
         watchlists::Client(self.clone())
     }
 }

--- a/services/mgmt/securityinsights/src/package_preview_2022_05/operations.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_05/operations.rs
@@ -74,103 +74,103 @@ impl Client {
             pipeline,
         }
     }
-    pub fn actions(&self) -> actions::Client {
+    pub fn actions_client(&self) -> actions::Client {
         actions::Client(self.clone())
     }
-    pub fn alert_rule_templates(&self) -> alert_rule_templates::Client {
+    pub fn alert_rule_templates_client(&self) -> alert_rule_templates::Client {
         alert_rule_templates::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn automation_rules(&self) -> automation_rules::Client {
+    pub fn automation_rules_client(&self) -> automation_rules::Client {
         automation_rules::Client(self.clone())
     }
-    pub fn bookmark(&self) -> bookmark::Client {
+    pub fn bookmark_client(&self) -> bookmark::Client {
         bookmark::Client(self.clone())
     }
-    pub fn bookmark_relations(&self) -> bookmark_relations::Client {
+    pub fn bookmark_relations_client(&self) -> bookmark_relations::Client {
         bookmark_relations::Client(self.clone())
     }
-    pub fn bookmarks(&self) -> bookmarks::Client {
+    pub fn bookmarks_client(&self) -> bookmarks::Client {
         bookmarks::Client(self.clone())
     }
-    pub fn data_connectors(&self) -> data_connectors::Client {
+    pub fn data_connectors_client(&self) -> data_connectors::Client {
         data_connectors::Client(self.clone())
     }
-    pub fn data_connectors_check_requirements(&self) -> data_connectors_check_requirements::Client {
+    pub fn data_connectors_check_requirements_client(&self) -> data_connectors_check_requirements::Client {
         data_connectors_check_requirements::Client(self.clone())
     }
-    pub fn domain_whois(&self) -> domain_whois::Client {
+    pub fn domain_whois_client(&self) -> domain_whois::Client {
         domain_whois::Client(self.clone())
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn entities_get_timeline(&self) -> entities_get_timeline::Client {
+    pub fn entities_get_timeline_client(&self) -> entities_get_timeline::Client {
         entities_get_timeline::Client(self.clone())
     }
-    pub fn entities_relations(&self) -> entities_relations::Client {
+    pub fn entities_relations_client(&self) -> entities_relations::Client {
         entities_relations::Client(self.clone())
     }
-    pub fn entity_queries(&self) -> entity_queries::Client {
+    pub fn entity_queries_client(&self) -> entity_queries::Client {
         entity_queries::Client(self.clone())
     }
-    pub fn entity_query_templates(&self) -> entity_query_templates::Client {
+    pub fn entity_query_templates_client(&self) -> entity_query_templates::Client {
         entity_query_templates::Client(self.clone())
     }
-    pub fn entity_relations(&self) -> entity_relations::Client {
+    pub fn entity_relations_client(&self) -> entity_relations::Client {
         entity_relations::Client(self.clone())
     }
-    pub fn incident_comments(&self) -> incident_comments::Client {
+    pub fn incident_comments_client(&self) -> incident_comments::Client {
         incident_comments::Client(self.clone())
     }
-    pub fn incident_relations(&self) -> incident_relations::Client {
+    pub fn incident_relations_client(&self) -> incident_relations::Client {
         incident_relations::Client(self.clone())
     }
-    pub fn incidents(&self) -> incidents::Client {
+    pub fn incidents_client(&self) -> incidents::Client {
         incidents::Client(self.clone())
     }
-    pub fn ip_geodata(&self) -> ip_geodata::Client {
+    pub fn ip_geodata_client(&self) -> ip_geodata::Client {
         ip_geodata::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn office_consents(&self) -> office_consents::Client {
+    pub fn office_consents_client(&self) -> office_consents::Client {
         office_consents::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn product_settings(&self) -> product_settings::Client {
+    pub fn product_settings_client(&self) -> product_settings::Client {
         product_settings::Client(self.clone())
     }
-    pub fn security_ml_analytics_settings(&self) -> security_ml_analytics_settings::Client {
+    pub fn security_ml_analytics_settings_client(&self) -> security_ml_analytics_settings::Client {
         security_ml_analytics_settings::Client(self.clone())
     }
-    pub fn sentinel_onboarding_states(&self) -> sentinel_onboarding_states::Client {
+    pub fn sentinel_onboarding_states_client(&self) -> sentinel_onboarding_states::Client {
         sentinel_onboarding_states::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_controls(&self) -> source_controls::Client {
+    pub fn source_controls_client(&self) -> source_controls::Client {
         source_controls::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator(&self) -> threat_intelligence_indicator::Client {
+    pub fn threat_intelligence_indicator_client(&self) -> threat_intelligence_indicator::Client {
         threat_intelligence_indicator::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator_metrics(&self) -> threat_intelligence_indicator_metrics::Client {
+    pub fn threat_intelligence_indicator_metrics_client(&self) -> threat_intelligence_indicator_metrics::Client {
         threat_intelligence_indicator_metrics::Client(self.clone())
     }
-    pub fn threat_intelligence_indicators(&self) -> threat_intelligence_indicators::Client {
+    pub fn threat_intelligence_indicators_client(&self) -> threat_intelligence_indicators::Client {
         threat_intelligence_indicators::Client(self.clone())
     }
-    pub fn watchlist_items(&self) -> watchlist_items::Client {
+    pub fn watchlist_items_client(&self) -> watchlist_items::Client {
         watchlist_items::Client(self.clone())
     }
-    pub fn watchlists(&self) -> watchlists::Client {
+    pub fn watchlists_client(&self) -> watchlists::Client {
         watchlists::Client(self.clone())
     }
 }

--- a/services/mgmt/securityinsights/src/package_preview_2022_06/operations.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_06/operations.rs
@@ -74,103 +74,103 @@ impl Client {
             pipeline,
         }
     }
-    pub fn actions(&self) -> actions::Client {
+    pub fn actions_client(&self) -> actions::Client {
         actions::Client(self.clone())
     }
-    pub fn alert_rule_templates(&self) -> alert_rule_templates::Client {
+    pub fn alert_rule_templates_client(&self) -> alert_rule_templates::Client {
         alert_rule_templates::Client(self.clone())
     }
-    pub fn alert_rules(&self) -> alert_rules::Client {
+    pub fn alert_rules_client(&self) -> alert_rules::Client {
         alert_rules::Client(self.clone())
     }
-    pub fn automation_rules(&self) -> automation_rules::Client {
+    pub fn automation_rules_client(&self) -> automation_rules::Client {
         automation_rules::Client(self.clone())
     }
-    pub fn bookmark(&self) -> bookmark::Client {
+    pub fn bookmark_client(&self) -> bookmark::Client {
         bookmark::Client(self.clone())
     }
-    pub fn bookmark_relations(&self) -> bookmark_relations::Client {
+    pub fn bookmark_relations_client(&self) -> bookmark_relations::Client {
         bookmark_relations::Client(self.clone())
     }
-    pub fn bookmarks(&self) -> bookmarks::Client {
+    pub fn bookmarks_client(&self) -> bookmarks::Client {
         bookmarks::Client(self.clone())
     }
-    pub fn data_connectors(&self) -> data_connectors::Client {
+    pub fn data_connectors_client(&self) -> data_connectors::Client {
         data_connectors::Client(self.clone())
     }
-    pub fn data_connectors_check_requirements(&self) -> data_connectors_check_requirements::Client {
+    pub fn data_connectors_check_requirements_client(&self) -> data_connectors_check_requirements::Client {
         data_connectors_check_requirements::Client(self.clone())
     }
-    pub fn domain_whois(&self) -> domain_whois::Client {
+    pub fn domain_whois_client(&self) -> domain_whois::Client {
         domain_whois::Client(self.clone())
     }
-    pub fn entities(&self) -> entities::Client {
+    pub fn entities_client(&self) -> entities::Client {
         entities::Client(self.clone())
     }
-    pub fn entities_get_timeline(&self) -> entities_get_timeline::Client {
+    pub fn entities_get_timeline_client(&self) -> entities_get_timeline::Client {
         entities_get_timeline::Client(self.clone())
     }
-    pub fn entities_relations(&self) -> entities_relations::Client {
+    pub fn entities_relations_client(&self) -> entities_relations::Client {
         entities_relations::Client(self.clone())
     }
-    pub fn entity_queries(&self) -> entity_queries::Client {
+    pub fn entity_queries_client(&self) -> entity_queries::Client {
         entity_queries::Client(self.clone())
     }
-    pub fn entity_query_templates(&self) -> entity_query_templates::Client {
+    pub fn entity_query_templates_client(&self) -> entity_query_templates::Client {
         entity_query_templates::Client(self.clone())
     }
-    pub fn entity_relations(&self) -> entity_relations::Client {
+    pub fn entity_relations_client(&self) -> entity_relations::Client {
         entity_relations::Client(self.clone())
     }
-    pub fn incident_comments(&self) -> incident_comments::Client {
+    pub fn incident_comments_client(&self) -> incident_comments::Client {
         incident_comments::Client(self.clone())
     }
-    pub fn incident_relations(&self) -> incident_relations::Client {
+    pub fn incident_relations_client(&self) -> incident_relations::Client {
         incident_relations::Client(self.clone())
     }
-    pub fn incidents(&self) -> incidents::Client {
+    pub fn incidents_client(&self) -> incidents::Client {
         incidents::Client(self.clone())
     }
-    pub fn ip_geodata(&self) -> ip_geodata::Client {
+    pub fn ip_geodata_client(&self) -> ip_geodata::Client {
         ip_geodata::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn office_consents(&self) -> office_consents::Client {
+    pub fn office_consents_client(&self) -> office_consents::Client {
         office_consents::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn product_settings(&self) -> product_settings::Client {
+    pub fn product_settings_client(&self) -> product_settings::Client {
         product_settings::Client(self.clone())
     }
-    pub fn security_ml_analytics_settings(&self) -> security_ml_analytics_settings::Client {
+    pub fn security_ml_analytics_settings_client(&self) -> security_ml_analytics_settings::Client {
         security_ml_analytics_settings::Client(self.clone())
     }
-    pub fn sentinel_onboarding_states(&self) -> sentinel_onboarding_states::Client {
+    pub fn sentinel_onboarding_states_client(&self) -> sentinel_onboarding_states::Client {
         sentinel_onboarding_states::Client(self.clone())
     }
-    pub fn source_control(&self) -> source_control::Client {
+    pub fn source_control_client(&self) -> source_control::Client {
         source_control::Client(self.clone())
     }
-    pub fn source_controls(&self) -> source_controls::Client {
+    pub fn source_controls_client(&self) -> source_controls::Client {
         source_controls::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator(&self) -> threat_intelligence_indicator::Client {
+    pub fn threat_intelligence_indicator_client(&self) -> threat_intelligence_indicator::Client {
         threat_intelligence_indicator::Client(self.clone())
     }
-    pub fn threat_intelligence_indicator_metrics(&self) -> threat_intelligence_indicator_metrics::Client {
+    pub fn threat_intelligence_indicator_metrics_client(&self) -> threat_intelligence_indicator_metrics::Client {
         threat_intelligence_indicator_metrics::Client(self.clone())
     }
-    pub fn threat_intelligence_indicators(&self) -> threat_intelligence_indicators::Client {
+    pub fn threat_intelligence_indicators_client(&self) -> threat_intelligence_indicators::Client {
         threat_intelligence_indicators::Client(self.clone())
     }
-    pub fn watchlist_items(&self) -> watchlist_items::Client {
+    pub fn watchlist_items_client(&self) -> watchlist_items::Client {
         watchlist_items::Client(self.clone())
     }
-    pub fn watchlists(&self) -> watchlists::Client {
+    pub fn watchlists_client(&self) -> watchlists::Client {
         watchlists::Client(self.clone())
     }
 }

--- a/services/mgmt/serialconsole/src/package_2018_05/operations.rs
+++ b/services/mgmt/serialconsole/src/package_2018_05/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn serial_ports(&self) -> serial_ports::Client {
+    pub fn serial_ports_client(&self) -> serial_ports::Client {
         serial_ports::Client(self.clone())
     }
 }

--- a/services/mgmt/servicebus/src/package_2018_01_preview/operations.rs
+++ b/services/mgmt/servicebus/src/package_2018_01_preview/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn event_hubs(&self) -> event_hubs::Client {
+    pub fn event_hubs_client(&self) -> event_hubs::Client {
         event_hubs::Client(self.clone())
     }
-    pub fn migration_configs(&self) -> migration_configs::Client {
+    pub fn migration_configs_client(&self) -> migration_configs::Client {
         migration_configs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn premium_messaging_regions(&self) -> premium_messaging_regions::Client {
+    pub fn premium_messaging_regions_client(&self) -> premium_messaging_regions::Client {
         premium_messaging_regions::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queues(&self) -> queues::Client {
+    pub fn queues_client(&self) -> queues::Client {
         queues::Client(self.clone())
     }
-    pub fn regions(&self) -> regions::Client {
+    pub fn regions_client(&self) -> regions::Client {
         regions::Client(self.clone())
     }
-    pub fn rules(&self) -> rules::Client {
+    pub fn rules_client(&self) -> rules::Client {
         rules::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn topics(&self) -> topics::Client {
+    pub fn topics_client(&self) -> topics::Client {
         topics::Client(self.clone())
     }
 }

--- a/services/mgmt/servicebus/src/package_2021_01_preview/operations.rs
+++ b/services/mgmt/servicebus/src/package_2021_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn migration_configs(&self) -> migration_configs::Client {
+    pub fn migration_configs_client(&self) -> migration_configs::Client {
         migration_configs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queues(&self) -> queues::Client {
+    pub fn queues_client(&self) -> queues::Client {
         queues::Client(self.clone())
     }
-    pub fn rules(&self) -> rules::Client {
+    pub fn rules_client(&self) -> rules::Client {
         rules::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn topics(&self) -> topics::Client {
+    pub fn topics_client(&self) -> topics::Client {
         topics::Client(self.clone())
     }
 }

--- a/services/mgmt/servicebus/src/package_2021_06_preview/operations.rs
+++ b/services/mgmt/servicebus/src/package_2021_06_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn migration_configs(&self) -> migration_configs::Client {
+    pub fn migration_configs_client(&self) -> migration_configs::Client {
         migration_configs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queues(&self) -> queues::Client {
+    pub fn queues_client(&self) -> queues::Client {
         queues::Client(self.clone())
     }
-    pub fn rules(&self) -> rules::Client {
+    pub fn rules_client(&self) -> rules::Client {
         rules::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn topics(&self) -> topics::Client {
+    pub fn topics_client(&self) -> topics::Client {
         topics::Client(self.clone())
     }
 }

--- a/services/mgmt/servicebus/src/package_2021_11/operations.rs
+++ b/services/mgmt/servicebus/src/package_2021_11/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn migration_configs(&self) -> migration_configs::Client {
+    pub fn migration_configs_client(&self) -> migration_configs::Client {
         migration_configs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queues(&self) -> queues::Client {
+    pub fn queues_client(&self) -> queues::Client {
         queues::Client(self.clone())
     }
-    pub fn rules(&self) -> rules::Client {
+    pub fn rules_client(&self) -> rules::Client {
         rules::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn topics(&self) -> topics::Client {
+    pub fn topics_client(&self) -> topics::Client {
         topics::Client(self.clone())
     }
 }

--- a/services/mgmt/servicebus/src/package_2022_01_preview/operations.rs
+++ b/services/mgmt/servicebus/src/package_2022_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disaster_recovery_configs(&self) -> disaster_recovery_configs::Client {
+    pub fn disaster_recovery_configs_client(&self) -> disaster_recovery_configs::Client {
         disaster_recovery_configs::Client(self.clone())
     }
-    pub fn migration_configs(&self) -> migration_configs::Client {
+    pub fn migration_configs_client(&self) -> migration_configs::Client {
         migration_configs::Client(self.clone())
     }
-    pub fn namespaces(&self) -> namespaces::Client {
+    pub fn namespaces_client(&self) -> namespaces::Client {
         namespaces::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queues(&self) -> queues::Client {
+    pub fn queues_client(&self) -> queues::Client {
         queues::Client(self.clone())
     }
-    pub fn rules(&self) -> rules::Client {
+    pub fn rules_client(&self) -> rules::Client {
         rules::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn topics(&self) -> topics::Client {
+    pub fn topics_client(&self) -> topics::Client {
         topics::Client(self.clone())
     }
 }

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2021_07_preview/operations.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2021_07_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_type_versions(&self) -> application_type_versions::Client {
+    pub fn application_type_versions_client(&self) -> application_type_versions::Client {
         application_type_versions::Client(self.clone())
     }
-    pub fn application_types(&self) -> application_types::Client {
+    pub fn application_types_client(&self) -> application_types::Client {
         application_types::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn managed_cluster_version(&self) -> managed_cluster_version::Client {
+    pub fn managed_cluster_version_client(&self) -> managed_cluster_version::Client {
         managed_cluster_version::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn node_type_skus(&self) -> node_type_skus::Client {
+    pub fn node_type_skus_client(&self) -> node_type_skus::Client {
         node_type_skus::Client(self.clone())
     }
-    pub fn node_types(&self) -> node_types::Client {
+    pub fn node_types_client(&self) -> node_types::Client {
         node_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2021_09_privatepreview/operations.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2021_09_privatepreview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_type_versions(&self) -> application_type_versions::Client {
+    pub fn application_type_versions_client(&self) -> application_type_versions::Client {
         application_type_versions::Client(self.clone())
     }
-    pub fn application_types(&self) -> application_types::Client {
+    pub fn application_types_client(&self) -> application_types::Client {
         application_types::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn managed_cluster_version(&self) -> managed_cluster_version::Client {
+    pub fn managed_cluster_version_client(&self) -> managed_cluster_version::Client {
         managed_cluster_version::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn managed_unsupported_vm_sizes(&self) -> managed_unsupported_vm_sizes::Client {
+    pub fn managed_unsupported_vm_sizes_client(&self) -> managed_unsupported_vm_sizes::Client {
         managed_unsupported_vm_sizes::Client(self.clone())
     }
-    pub fn node_type_skus(&self) -> node_type_skus::Client {
+    pub fn node_type_skus_client(&self) -> node_type_skus::Client {
         node_type_skus::Client(self.clone())
     }
-    pub fn node_types(&self) -> node_types::Client {
+    pub fn node_types_client(&self) -> node_types::Client {
         node_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2021_11_preview/operations.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2021_11_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_type_versions(&self) -> application_type_versions::Client {
+    pub fn application_type_versions_client(&self) -> application_type_versions::Client {
         application_type_versions::Client(self.clone())
     }
-    pub fn application_types(&self) -> application_types::Client {
+    pub fn application_types_client(&self) -> application_types::Client {
         application_types::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn managed_cluster_version(&self) -> managed_cluster_version::Client {
+    pub fn managed_cluster_version_client(&self) -> managed_cluster_version::Client {
         managed_cluster_version::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn managed_unsupported_vm_sizes(&self) -> managed_unsupported_vm_sizes::Client {
+    pub fn managed_unsupported_vm_sizes_client(&self) -> managed_unsupported_vm_sizes::Client {
         managed_unsupported_vm_sizes::Client(self.clone())
     }
-    pub fn node_type_skus(&self) -> node_type_skus::Client {
+    pub fn node_type_skus_client(&self) -> node_type_skus::Client {
         node_type_skus::Client(self.clone())
     }
-    pub fn node_types(&self) -> node_types::Client {
+    pub fn node_types_client(&self) -> node_types::Client {
         node_types::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2022_01/operations.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2022_01/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_type_versions(&self) -> application_type_versions::Client {
+    pub fn application_type_versions_client(&self) -> application_type_versions::Client {
         application_type_versions::Client(self.clone())
     }
-    pub fn application_types(&self) -> application_types::Client {
+    pub fn application_types_client(&self) -> application_types::Client {
         application_types::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn managed_cluster_version(&self) -> managed_cluster_version::Client {
+    pub fn managed_cluster_version_client(&self) -> managed_cluster_version::Client {
         managed_cluster_version::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn managed_unsupported_vm_sizes(&self) -> managed_unsupported_vm_sizes::Client {
+    pub fn managed_unsupported_vm_sizes_client(&self) -> managed_unsupported_vm_sizes::Client {
         managed_unsupported_vm_sizes::Client(self.clone())
     }
-    pub fn node_type_skus(&self) -> node_type_skus::Client {
+    pub fn node_type_skus_client(&self) -> node_type_skus::Client {
         node_type_skus::Client(self.clone())
     }
-    pub fn node_types(&self) -> node_types::Client {
+    pub fn node_types_client(&self) -> node_types::Client {
         node_types::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2022_02_preview/operations.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2022_02_preview/operations.rs
@@ -74,43 +74,43 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_type_versions(&self) -> application_type_versions::Client {
+    pub fn application_type_versions_client(&self) -> application_type_versions::Client {
         application_type_versions::Client(self.clone())
     }
-    pub fn application_types(&self) -> application_types::Client {
+    pub fn application_types_client(&self) -> application_types::Client {
         application_types::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn managed_az_resiliency_status(&self) -> managed_az_resiliency_status::Client {
+    pub fn managed_az_resiliency_status_client(&self) -> managed_az_resiliency_status::Client {
         managed_az_resiliency_status::Client(self.clone())
     }
-    pub fn managed_cluster_version(&self) -> managed_cluster_version::Client {
+    pub fn managed_cluster_version_client(&self) -> managed_cluster_version::Client {
         managed_cluster_version::Client(self.clone())
     }
-    pub fn managed_clusters(&self) -> managed_clusters::Client {
+    pub fn managed_clusters_client(&self) -> managed_clusters::Client {
         managed_clusters::Client(self.clone())
     }
-    pub fn managed_unsupported_vm_sizes(&self) -> managed_unsupported_vm_sizes::Client {
+    pub fn managed_unsupported_vm_sizes_client(&self) -> managed_unsupported_vm_sizes::Client {
         managed_unsupported_vm_sizes::Client(self.clone())
     }
-    pub fn node_type_skus(&self) -> node_type_skus::Client {
+    pub fn node_type_skus_client(&self) -> node_type_skus::Client {
         node_type_skus::Client(self.clone())
     }
-    pub fn node_types(&self) -> node_types::Client {
+    pub fn node_types_client(&self) -> node_types::Client {
         node_types::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/servicefabricmesh/src/package_2018_07_01_preview/operations.rs
+++ b/services/mgmt/servicefabricmesh/src/package_2018_07_01_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn code_package(&self) -> code_package::Client {
+    pub fn code_package_client(&self) -> code_package::Client {
         code_package::Client(self.clone())
     }
-    pub fn network(&self) -> network::Client {
+    pub fn network_client(&self) -> network::Client {
         network::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn replica(&self) -> replica::Client {
+    pub fn replica_client(&self) -> replica::Client {
         replica::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn volume(&self) -> volume::Client {
+    pub fn volume_client(&self) -> volume::Client {
         volume::Client(self.clone())
     }
 }

--- a/services/mgmt/servicefabricmesh/src/package_2018_09_01_preview/operations.rs
+++ b/services/mgmt/servicefabricmesh/src/package_2018_09_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn code_package(&self) -> code_package::Client {
+    pub fn code_package_client(&self) -> code_package::Client {
         code_package::Client(self.clone())
     }
-    pub fn gateway(&self) -> gateway::Client {
+    pub fn gateway_client(&self) -> gateway::Client {
         gateway::Client(self.clone())
     }
-    pub fn network(&self) -> network::Client {
+    pub fn network_client(&self) -> network::Client {
         network::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn secret(&self) -> secret::Client {
+    pub fn secret_client(&self) -> secret::Client {
         secret::Client(self.clone())
     }
-    pub fn secret_value(&self) -> secret_value::Client {
+    pub fn secret_value_client(&self) -> secret_value::Client {
         secret_value::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn service_replica(&self) -> service_replica::Client {
+    pub fn service_replica_client(&self) -> service_replica::Client {
         service_replica::Client(self.clone())
     }
-    pub fn volume(&self) -> volume::Client {
+    pub fn volume_client(&self) -> volume::Client {
         volume::Client(self.clone())
     }
 }

--- a/services/mgmt/servicelinker/src/package_2021_11_01_preview/operations.rs
+++ b/services/mgmt/servicelinker/src/package_2021_11_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn linker(&self) -> linker::Client {
+    pub fn linker_client(&self) -> linker::Client {
         linker::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/servicelinker/src/package_2022_01_01_preview/operations.rs
+++ b/services/mgmt/servicelinker/src/package_2022_01_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn linker(&self) -> linker::Client {
+    pub fn linker_client(&self) -> linker::Client {
         linker::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/servicelinker/src/package_2022_05_01/operations.rs
+++ b/services/mgmt/servicelinker/src/package_2022_05_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn linker(&self) -> linker::Client {
+    pub fn linker_client(&self) -> linker::Client {
         linker::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/servicemap/src/package_2015_11_preview/operations.rs
+++ b/services/mgmt/servicemap/src/package_2015_11_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn client_groups(&self) -> client_groups::Client {
+    pub fn client_groups_client(&self) -> client_groups::Client {
         client_groups::Client(self.clone())
     }
-    pub fn machine_groups(&self) -> machine_groups::Client {
+    pub fn machine_groups_client(&self) -> machine_groups::Client {
         machine_groups::Client(self.clone())
     }
-    pub fn machines(&self) -> machines::Client {
+    pub fn machines_client(&self) -> machines::Client {
         machines::Client(self.clone())
     }
-    pub fn maps(&self) -> maps::Client {
+    pub fn maps_client(&self) -> maps::Client {
         maps::Client(self.clone())
     }
-    pub fn ports(&self) -> ports::Client {
+    pub fn ports_client(&self) -> ports::Client {
         ports::Client(self.clone())
     }
-    pub fn processes(&self) -> processes::Client {
+    pub fn processes_client(&self) -> processes::Client {
         processes::Client(self.clone())
     }
-    pub fn summaries(&self) -> summaries::Client {
+    pub fn summaries_client(&self) -> summaries::Client {
         summaries::Client(self.clone())
     }
 }

--- a/services/mgmt/signalr/src/package_2021_04_01_preview/operations.rs
+++ b/services/mgmt/signalr/src/package_2021_04_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn signal_r(&self) -> signal_r::Client {
+    pub fn signal_r_client(&self) -> signal_r::Client {
         signal_r::Client(self.clone())
     }
-    pub fn signal_r_private_endpoint_connections(&self) -> signal_r_private_endpoint_connections::Client {
+    pub fn signal_r_private_endpoint_connections_client(&self) -> signal_r_private_endpoint_connections::Client {
         signal_r_private_endpoint_connections::Client(self.clone())
     }
-    pub fn signal_r_private_link_resources(&self) -> signal_r_private_link_resources::Client {
+    pub fn signal_r_private_link_resources_client(&self) -> signal_r_private_link_resources::Client {
         signal_r_private_link_resources::Client(self.clone())
     }
-    pub fn signal_r_shared_private_link_resources(&self) -> signal_r_shared_private_link_resources::Client {
+    pub fn signal_r_shared_private_link_resources_client(&self) -> signal_r_shared_private_link_resources::Client {
         signal_r_shared_private_link_resources::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/signalr/src/package_2021_06_01_preview/operations.rs
+++ b/services/mgmt/signalr/src/package_2021_06_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn signal_r(&self) -> signal_r::Client {
+    pub fn signal_r_client(&self) -> signal_r::Client {
         signal_r::Client(self.clone())
     }
-    pub fn signal_r_private_endpoint_connections(&self) -> signal_r_private_endpoint_connections::Client {
+    pub fn signal_r_private_endpoint_connections_client(&self) -> signal_r_private_endpoint_connections::Client {
         signal_r_private_endpoint_connections::Client(self.clone())
     }
-    pub fn signal_r_private_link_resources(&self) -> signal_r_private_link_resources::Client {
+    pub fn signal_r_private_link_resources_client(&self) -> signal_r_private_link_resources::Client {
         signal_r_private_link_resources::Client(self.clone())
     }
-    pub fn signal_r_shared_private_link_resources(&self) -> signal_r_shared_private_link_resources::Client {
+    pub fn signal_r_shared_private_link_resources_client(&self) -> signal_r_shared_private_link_resources::Client {
         signal_r_shared_private_link_resources::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/signalr/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/signalr/src/package_2021_09_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn signal_r(&self) -> signal_r::Client {
+    pub fn signal_r_client(&self) -> signal_r::Client {
         signal_r::Client(self.clone())
     }
-    pub fn signal_r_private_endpoint_connections(&self) -> signal_r_private_endpoint_connections::Client {
+    pub fn signal_r_private_endpoint_connections_client(&self) -> signal_r_private_endpoint_connections::Client {
         signal_r_private_endpoint_connections::Client(self.clone())
     }
-    pub fn signal_r_private_link_resources(&self) -> signal_r_private_link_resources::Client {
+    pub fn signal_r_private_link_resources_client(&self) -> signal_r_private_link_resources::Client {
         signal_r_private_link_resources::Client(self.clone())
     }
-    pub fn signal_r_shared_private_link_resources(&self) -> signal_r_shared_private_link_resources::Client {
+    pub fn signal_r_shared_private_link_resources_client(&self) -> signal_r_shared_private_link_resources::Client {
         signal_r_shared_private_link_resources::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/signalr/src/package_2021_10_01/operations.rs
+++ b/services/mgmt/signalr/src/package_2021_10_01/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn signal_r(&self) -> signal_r::Client {
+    pub fn signal_r_client(&self) -> signal_r::Client {
         signal_r::Client(self.clone())
     }
-    pub fn signal_r_private_endpoint_connections(&self) -> signal_r_private_endpoint_connections::Client {
+    pub fn signal_r_private_endpoint_connections_client(&self) -> signal_r_private_endpoint_connections::Client {
         signal_r_private_endpoint_connections::Client(self.clone())
     }
-    pub fn signal_r_private_link_resources(&self) -> signal_r_private_link_resources::Client {
+    pub fn signal_r_private_link_resources_client(&self) -> signal_r_private_link_resources::Client {
         signal_r_private_link_resources::Client(self.clone())
     }
-    pub fn signal_r_shared_private_link_resources(&self) -> signal_r_shared_private_link_resources::Client {
+    pub fn signal_r_shared_private_link_resources_client(&self) -> signal_r_shared_private_link_resources::Client {
         signal_r_shared_private_link_resources::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/signalr/src/package_2022_02_01/operations.rs
+++ b/services/mgmt/signalr/src/package_2022_02_01/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn signal_r(&self) -> signal_r::Client {
+    pub fn signal_r_client(&self) -> signal_r::Client {
         signal_r::Client(self.clone())
     }
-    pub fn signal_r_custom_certificates(&self) -> signal_r_custom_certificates::Client {
+    pub fn signal_r_custom_certificates_client(&self) -> signal_r_custom_certificates::Client {
         signal_r_custom_certificates::Client(self.clone())
     }
-    pub fn signal_r_custom_domains(&self) -> signal_r_custom_domains::Client {
+    pub fn signal_r_custom_domains_client(&self) -> signal_r_custom_domains::Client {
         signal_r_custom_domains::Client(self.clone())
     }
-    pub fn signal_r_private_endpoint_connections(&self) -> signal_r_private_endpoint_connections::Client {
+    pub fn signal_r_private_endpoint_connections_client(&self) -> signal_r_private_endpoint_connections::Client {
         signal_r_private_endpoint_connections::Client(self.clone())
     }
-    pub fn signal_r_private_link_resources(&self) -> signal_r_private_link_resources::Client {
+    pub fn signal_r_private_link_resources_client(&self) -> signal_r_private_link_resources::Client {
         signal_r_private_link_resources::Client(self.clone())
     }
-    pub fn signal_r_shared_private_link_resources(&self) -> signal_r_shared_private_link_resources::Client {
+    pub fn signal_r_shared_private_link_resources_client(&self) -> signal_r_shared_private_link_resources::Client {
         signal_r_shared_private_link_resources::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/softwareplan/src/package_2019_06_01_preview/operations.rs
+++ b/services/mgmt/softwareplan/src/package_2019_06_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hybrid_use_benefit(&self) -> hybrid_use_benefit::Client {
+    pub fn hybrid_use_benefit_client(&self) -> hybrid_use_benefit::Client {
         hybrid_use_benefit::Client(self.clone())
     }
-    pub fn hybrid_use_benefit_revision(&self) -> hybrid_use_benefit_revision::Client {
+    pub fn hybrid_use_benefit_revision_client(&self) -> hybrid_use_benefit_revision::Client {
         hybrid_use_benefit_revision::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn software_plan(&self) -> software_plan::Client {
+    pub fn software_plan_client(&self) -> software_plan::Client {
         software_plan::Client(self.clone())
     }
 }

--- a/services/mgmt/softwareplan/src/package_2019_12_01/operations.rs
+++ b/services/mgmt/softwareplan/src/package_2019_12_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hybrid_use_benefit(&self) -> hybrid_use_benefit::Client {
+    pub fn hybrid_use_benefit_client(&self) -> hybrid_use_benefit::Client {
         hybrid_use_benefit::Client(self.clone())
     }
-    pub fn hybrid_use_benefit_revision(&self) -> hybrid_use_benefit_revision::Client {
+    pub fn hybrid_use_benefit_revision_client(&self) -> hybrid_use_benefit_revision::Client {
         hybrid_use_benefit_revision::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn software_plan(&self) -> software_plan::Client {
+    pub fn software_plan_client(&self) -> software_plan::Client {
         software_plan::Client(self.clone())
     }
 }

--- a/services/mgmt/solutions/src/package_managedapplications_2021_07/operations.rs
+++ b/services/mgmt/solutions/src/package_managedapplications_2021_07/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn application_definitions(&self) -> application_definitions::Client {
+    pub fn application_definitions_client(&self) -> application_definitions::Client {
         application_definitions::Client(self.clone())
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn jit_requests(&self) -> jit_requests::Client {
+    pub fn jit_requests_client(&self) -> jit_requests::Client {
         jit_requests::Client(self.clone())
     }
 }

--- a/services/mgmt/sql/src/package_composite_v2/operations.rs
+++ b/services/mgmt/sql/src/package_composite_v2/operations.rs
@@ -74,284 +74,284 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_long_term_retention_policies(&self) -> backup_long_term_retention_policies::Client {
+    pub fn backup_long_term_retention_policies_client(&self) -> backup_long_term_retention_policies::Client {
         backup_long_term_retention_policies::Client(self.clone())
     }
-    pub fn backup_short_term_retention_policies(&self) -> backup_short_term_retention_policies::Client {
+    pub fn backup_short_term_retention_policies_client(&self) -> backup_short_term_retention_policies::Client {
         backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn capabilities(&self) -> capabilities::Client {
+    pub fn capabilities_client(&self) -> capabilities::Client {
         capabilities::Client(self.clone())
     }
-    pub fn data_masking_policies(&self) -> data_masking_policies::Client {
+    pub fn data_masking_policies_client(&self) -> data_masking_policies::Client {
         data_masking_policies::Client(self.clone())
     }
-    pub fn data_masking_rules(&self) -> data_masking_rules::Client {
+    pub fn data_masking_rules_client(&self) -> data_masking_rules::Client {
         data_masking_rules::Client(self.clone())
     }
-    pub fn database_automatic_tuning(&self) -> database_automatic_tuning::Client {
+    pub fn database_automatic_tuning_client(&self) -> database_automatic_tuning::Client {
         database_automatic_tuning::Client(self.clone())
     }
-    pub fn database_blob_auditing_policies(&self) -> database_blob_auditing_policies::Client {
+    pub fn database_blob_auditing_policies_client(&self) -> database_blob_auditing_policies::Client {
         database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn database_operations(&self) -> database_operations::Client {
+    pub fn database_operations_client(&self) -> database_operations::Client {
         database_operations::Client(self.clone())
     }
-    pub fn database_threat_detection_policies(&self) -> database_threat_detection_policies::Client {
+    pub fn database_threat_detection_policies_client(&self) -> database_threat_detection_policies::Client {
         database_threat_detection_policies::Client(self.clone())
     }
-    pub fn database_usages(&self) -> database_usages::Client {
+    pub fn database_usages_client(&self) -> database_usages::Client {
         database_usages::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_rule_baselines(&self) -> database_vulnerability_assessment_rule_baselines::Client {
+    pub fn database_vulnerability_assessment_rule_baselines_client(&self) -> database_vulnerability_assessment_rule_baselines::Client {
         database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_scans(&self) -> database_vulnerability_assessment_scans::Client {
+    pub fn database_vulnerability_assessment_scans_client(&self) -> database_vulnerability_assessment_scans::Client {
         database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn database_vulnerability_assessments(&self) -> database_vulnerability_assessments::Client {
+    pub fn database_vulnerability_assessments_client(&self) -> database_vulnerability_assessments::Client {
         database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn elastic_pool_activities(&self) -> elastic_pool_activities::Client {
+    pub fn elastic_pool_activities_client(&self) -> elastic_pool_activities::Client {
         elastic_pool_activities::Client(self.clone())
     }
-    pub fn elastic_pool_database_activities(&self) -> elastic_pool_database_activities::Client {
+    pub fn elastic_pool_database_activities_client(&self) -> elastic_pool_database_activities::Client {
         elastic_pool_database_activities::Client(self.clone())
     }
-    pub fn elastic_pool_operations(&self) -> elastic_pool_operations::Client {
+    pub fn elastic_pool_operations_client(&self) -> elastic_pool_operations::Client {
         elastic_pool_operations::Client(self.clone())
     }
-    pub fn elastic_pools(&self) -> elastic_pools::Client {
+    pub fn elastic_pools_client(&self) -> elastic_pools::Client {
         elastic_pools::Client(self.clone())
     }
-    pub fn encryption_protectors(&self) -> encryption_protectors::Client {
+    pub fn encryption_protectors_client(&self) -> encryption_protectors::Client {
         encryption_protectors::Client(self.clone())
     }
-    pub fn extended_database_blob_auditing_policies(&self) -> extended_database_blob_auditing_policies::Client {
+    pub fn extended_database_blob_auditing_policies_client(&self) -> extended_database_blob_auditing_policies::Client {
         extended_database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn extended_server_blob_auditing_policies(&self) -> extended_server_blob_auditing_policies::Client {
+    pub fn extended_server_blob_auditing_policies_client(&self) -> extended_server_blob_auditing_policies::Client {
         extended_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn failover_groups(&self) -> failover_groups::Client {
+    pub fn failover_groups_client(&self) -> failover_groups::Client {
         failover_groups::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn geo_backup_policies(&self) -> geo_backup_policies::Client {
+    pub fn geo_backup_policies_client(&self) -> geo_backup_policies::Client {
         geo_backup_policies::Client(self.clone())
     }
-    pub fn instance_failover_groups(&self) -> instance_failover_groups::Client {
+    pub fn instance_failover_groups_client(&self) -> instance_failover_groups::Client {
         instance_failover_groups::Client(self.clone())
     }
-    pub fn instance_pools(&self) -> instance_pools::Client {
+    pub fn instance_pools_client(&self) -> instance_pools::Client {
         instance_pools::Client(self.clone())
     }
-    pub fn job_agents(&self) -> job_agents::Client {
+    pub fn job_agents_client(&self) -> job_agents::Client {
         job_agents::Client(self.clone())
     }
-    pub fn job_credentials(&self) -> job_credentials::Client {
+    pub fn job_credentials_client(&self) -> job_credentials::Client {
         job_credentials::Client(self.clone())
     }
-    pub fn job_executions(&self) -> job_executions::Client {
+    pub fn job_executions_client(&self) -> job_executions::Client {
         job_executions::Client(self.clone())
     }
-    pub fn job_step_executions(&self) -> job_step_executions::Client {
+    pub fn job_step_executions_client(&self) -> job_step_executions::Client {
         job_step_executions::Client(self.clone())
     }
-    pub fn job_steps(&self) -> job_steps::Client {
+    pub fn job_steps_client(&self) -> job_steps::Client {
         job_steps::Client(self.clone())
     }
-    pub fn job_target_executions(&self) -> job_target_executions::Client {
+    pub fn job_target_executions_client(&self) -> job_target_executions::Client {
         job_target_executions::Client(self.clone())
     }
-    pub fn job_target_groups(&self) -> job_target_groups::Client {
+    pub fn job_target_groups_client(&self) -> job_target_groups::Client {
         job_target_groups::Client(self.clone())
     }
-    pub fn job_versions(&self) -> job_versions::Client {
+    pub fn job_versions_client(&self) -> job_versions::Client {
         job_versions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn long_term_retention_backups(&self) -> long_term_retention_backups::Client {
+    pub fn long_term_retention_backups_client(&self) -> long_term_retention_backups::Client {
         long_term_retention_backups::Client(self.clone())
     }
-    pub fn long_term_retention_managed_instance_backups(&self) -> long_term_retention_managed_instance_backups::Client {
+    pub fn long_term_retention_managed_instance_backups_client(&self) -> long_term_retention_managed_instance_backups::Client {
         long_term_retention_managed_instance_backups::Client(self.clone())
     }
-    pub fn managed_backup_short_term_retention_policies(&self) -> managed_backup_short_term_retention_policies::Client {
+    pub fn managed_backup_short_term_retention_policies_client(&self) -> managed_backup_short_term_retention_policies::Client {
         managed_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_database_security_alert_policies(&self) -> managed_database_security_alert_policies::Client {
+    pub fn managed_database_security_alert_policies_client(&self) -> managed_database_security_alert_policies::Client {
         managed_database_security_alert_policies::Client(self.clone())
     }
-    pub fn managed_database_sensitivity_labels(&self) -> managed_database_sensitivity_labels::Client {
+    pub fn managed_database_sensitivity_labels_client(&self) -> managed_database_sensitivity_labels::Client {
         managed_database_sensitivity_labels::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_rule_baselines(
+    pub fn managed_database_vulnerability_assessment_rule_baselines_client(
         &self,
     ) -> managed_database_vulnerability_assessment_rule_baselines::Client {
         managed_database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_scans(&self) -> managed_database_vulnerability_assessment_scans::Client {
+    pub fn managed_database_vulnerability_assessment_scans_client(&self) -> managed_database_vulnerability_assessment_scans::Client {
         managed_database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessments(&self) -> managed_database_vulnerability_assessments::Client {
+    pub fn managed_database_vulnerability_assessments_client(&self) -> managed_database_vulnerability_assessments::Client {
         managed_database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_databases(&self) -> managed_databases::Client {
+    pub fn managed_databases_client(&self) -> managed_databases::Client {
         managed_databases::Client(self.clone())
     }
-    pub fn managed_instance_administrators(&self) -> managed_instance_administrators::Client {
+    pub fn managed_instance_administrators_client(&self) -> managed_instance_administrators::Client {
         managed_instance_administrators::Client(self.clone())
     }
-    pub fn managed_instance_azure_ad_only_authentications(&self) -> managed_instance_azure_ad_only_authentications::Client {
+    pub fn managed_instance_azure_ad_only_authentications_client(&self) -> managed_instance_azure_ad_only_authentications::Client {
         managed_instance_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn managed_instance_encryption_protectors(&self) -> managed_instance_encryption_protectors::Client {
+    pub fn managed_instance_encryption_protectors_client(&self) -> managed_instance_encryption_protectors::Client {
         managed_instance_encryption_protectors::Client(self.clone())
     }
-    pub fn managed_instance_keys(&self) -> managed_instance_keys::Client {
+    pub fn managed_instance_keys_client(&self) -> managed_instance_keys::Client {
         managed_instance_keys::Client(self.clone())
     }
-    pub fn managed_instance_long_term_retention_policies(&self) -> managed_instance_long_term_retention_policies::Client {
+    pub fn managed_instance_long_term_retention_policies_client(&self) -> managed_instance_long_term_retention_policies::Client {
         managed_instance_long_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_instance_tde_certificates(&self) -> managed_instance_tde_certificates::Client {
+    pub fn managed_instance_tde_certificates_client(&self) -> managed_instance_tde_certificates::Client {
         managed_instance_tde_certificates::Client(self.clone())
     }
-    pub fn managed_instance_vulnerability_assessments(&self) -> managed_instance_vulnerability_assessments::Client {
+    pub fn managed_instance_vulnerability_assessments_client(&self) -> managed_instance_vulnerability_assessments::Client {
         managed_instance_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_instances(&self) -> managed_instances::Client {
+    pub fn managed_instances_client(&self) -> managed_instances::Client {
         managed_instances::Client(self.clone())
     }
-    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies(
+    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies_client(
         &self,
     ) -> managed_restorable_dropped_database_backup_short_term_retention_policies::Client {
         managed_restorable_dropped_database_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_server_security_alert_policies(&self) -> managed_server_security_alert_policies::Client {
+    pub fn managed_server_security_alert_policies_client(&self) -> managed_server_security_alert_policies::Client {
         managed_server_security_alert_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recommended_elastic_pools(&self) -> recommended_elastic_pools::Client {
+    pub fn recommended_elastic_pools_client(&self) -> recommended_elastic_pools::Client {
         recommended_elastic_pools::Client(self.clone())
     }
-    pub fn recoverable_databases(&self) -> recoverable_databases::Client {
+    pub fn recoverable_databases_client(&self) -> recoverable_databases::Client {
         recoverable_databases::Client(self.clone())
     }
-    pub fn recoverable_managed_databases(&self) -> recoverable_managed_databases::Client {
+    pub fn recoverable_managed_databases_client(&self) -> recoverable_managed_databases::Client {
         recoverable_managed_databases::Client(self.clone())
     }
-    pub fn replication_links(&self) -> replication_links::Client {
+    pub fn replication_links_client(&self) -> replication_links::Client {
         replication_links::Client(self.clone())
     }
-    pub fn restorable_dropped_databases(&self) -> restorable_dropped_databases::Client {
+    pub fn restorable_dropped_databases_client(&self) -> restorable_dropped_databases::Client {
         restorable_dropped_databases::Client(self.clone())
     }
-    pub fn restorable_dropped_managed_databases(&self) -> restorable_dropped_managed_databases::Client {
+    pub fn restorable_dropped_managed_databases_client(&self) -> restorable_dropped_managed_databases::Client {
         restorable_dropped_managed_databases::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn sensitivity_labels(&self) -> sensitivity_labels::Client {
+    pub fn sensitivity_labels_client(&self) -> sensitivity_labels::Client {
         sensitivity_labels::Client(self.clone())
     }
-    pub fn server_automatic_tuning(&self) -> server_automatic_tuning::Client {
+    pub fn server_automatic_tuning_client(&self) -> server_automatic_tuning::Client {
         server_automatic_tuning::Client(self.clone())
     }
-    pub fn server_azure_ad_administrators(&self) -> server_azure_ad_administrators::Client {
+    pub fn server_azure_ad_administrators_client(&self) -> server_azure_ad_administrators::Client {
         server_azure_ad_administrators::Client(self.clone())
     }
-    pub fn server_azure_ad_only_authentications(&self) -> server_azure_ad_only_authentications::Client {
+    pub fn server_azure_ad_only_authentications_client(&self) -> server_azure_ad_only_authentications::Client {
         server_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn server_blob_auditing_policies(&self) -> server_blob_auditing_policies::Client {
+    pub fn server_blob_auditing_policies_client(&self) -> server_blob_auditing_policies::Client {
         server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn server_communication_links(&self) -> server_communication_links::Client {
+    pub fn server_communication_links_client(&self) -> server_communication_links::Client {
         server_communication_links::Client(self.clone())
     }
-    pub fn server_connection_policies(&self) -> server_connection_policies::Client {
+    pub fn server_connection_policies_client(&self) -> server_connection_policies::Client {
         server_connection_policies::Client(self.clone())
     }
-    pub fn server_dns_aliases(&self) -> server_dns_aliases::Client {
+    pub fn server_dns_aliases_client(&self) -> server_dns_aliases::Client {
         server_dns_aliases::Client(self.clone())
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn server_trust_groups(&self) -> server_trust_groups::Client {
+    pub fn server_trust_groups_client(&self) -> server_trust_groups::Client {
         server_trust_groups::Client(self.clone())
     }
-    pub fn server_usages(&self) -> server_usages::Client {
+    pub fn server_usages_client(&self) -> server_usages::Client {
         server_usages::Client(self.clone())
     }
-    pub fn server_vulnerability_assessments(&self) -> server_vulnerability_assessments::Client {
+    pub fn server_vulnerability_assessments_client(&self) -> server_vulnerability_assessments::Client {
         server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn service_objectives(&self) -> service_objectives::Client {
+    pub fn service_objectives_client(&self) -> service_objectives::Client {
         service_objectives::Client(self.clone())
     }
-    pub fn service_tier_advisors(&self) -> service_tier_advisors::Client {
+    pub fn service_tier_advisors_client(&self) -> service_tier_advisors::Client {
         service_tier_advisors::Client(self.clone())
     }
-    pub fn subscription_usages(&self) -> subscription_usages::Client {
+    pub fn subscription_usages_client(&self) -> subscription_usages::Client {
         subscription_usages::Client(self.clone())
     }
-    pub fn sync_agents(&self) -> sync_agents::Client {
+    pub fn sync_agents_client(&self) -> sync_agents::Client {
         sync_agents::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn sync_members(&self) -> sync_members::Client {
+    pub fn sync_members_client(&self) -> sync_members::Client {
         sync_members::Client(self.clone())
     }
-    pub fn tde_certificates(&self) -> tde_certificates::Client {
+    pub fn tde_certificates_client(&self) -> tde_certificates::Client {
         tde_certificates::Client(self.clone())
     }
-    pub fn transparent_data_encryption_activities(&self) -> transparent_data_encryption_activities::Client {
+    pub fn transparent_data_encryption_activities_client(&self) -> transparent_data_encryption_activities::Client {
         transparent_data_encryption_activities::Client(self.clone())
     }
-    pub fn transparent_data_encryptions(&self) -> transparent_data_encryptions::Client {
+    pub fn transparent_data_encryptions_client(&self) -> transparent_data_encryptions::Client {
         transparent_data_encryptions::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_clusters(&self) -> virtual_clusters::Client {
+    pub fn virtual_clusters_client(&self) -> virtual_clusters::Client {
         virtual_clusters::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn workload_classifiers(&self) -> workload_classifiers::Client {
+    pub fn workload_classifiers_client(&self) -> workload_classifiers::Client {
         workload_classifiers::Client(self.clone())
     }
-    pub fn workload_groups(&self) -> workload_groups::Client {
+    pub fn workload_groups_client(&self) -> workload_groups::Client {
         workload_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/sql/src/package_composite_v3/operations.rs
+++ b/services/mgmt/sql/src/package_composite_v3/operations.rs
@@ -74,290 +74,290 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_long_term_retention_policies(&self) -> backup_long_term_retention_policies::Client {
+    pub fn backup_long_term_retention_policies_client(&self) -> backup_long_term_retention_policies::Client {
         backup_long_term_retention_policies::Client(self.clone())
     }
-    pub fn backup_short_term_retention_policies(&self) -> backup_short_term_retention_policies::Client {
+    pub fn backup_short_term_retention_policies_client(&self) -> backup_short_term_retention_policies::Client {
         backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn capabilities(&self) -> capabilities::Client {
+    pub fn capabilities_client(&self) -> capabilities::Client {
         capabilities::Client(self.clone())
     }
-    pub fn data_masking_policies(&self) -> data_masking_policies::Client {
+    pub fn data_masking_policies_client(&self) -> data_masking_policies::Client {
         data_masking_policies::Client(self.clone())
     }
-    pub fn data_masking_rules(&self) -> data_masking_rules::Client {
+    pub fn data_masking_rules_client(&self) -> data_masking_rules::Client {
         data_masking_rules::Client(self.clone())
     }
-    pub fn database_automatic_tuning(&self) -> database_automatic_tuning::Client {
+    pub fn database_automatic_tuning_client(&self) -> database_automatic_tuning::Client {
         database_automatic_tuning::Client(self.clone())
     }
-    pub fn database_blob_auditing_policies(&self) -> database_blob_auditing_policies::Client {
+    pub fn database_blob_auditing_policies_client(&self) -> database_blob_auditing_policies::Client {
         database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn database_operations(&self) -> database_operations::Client {
+    pub fn database_operations_client(&self) -> database_operations::Client {
         database_operations::Client(self.clone())
     }
-    pub fn database_threat_detection_policies(&self) -> database_threat_detection_policies::Client {
+    pub fn database_threat_detection_policies_client(&self) -> database_threat_detection_policies::Client {
         database_threat_detection_policies::Client(self.clone())
     }
-    pub fn database_usages(&self) -> database_usages::Client {
+    pub fn database_usages_client(&self) -> database_usages::Client {
         database_usages::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_rule_baselines(&self) -> database_vulnerability_assessment_rule_baselines::Client {
+    pub fn database_vulnerability_assessment_rule_baselines_client(&self) -> database_vulnerability_assessment_rule_baselines::Client {
         database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_scans(&self) -> database_vulnerability_assessment_scans::Client {
+    pub fn database_vulnerability_assessment_scans_client(&self) -> database_vulnerability_assessment_scans::Client {
         database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn database_vulnerability_assessments(&self) -> database_vulnerability_assessments::Client {
+    pub fn database_vulnerability_assessments_client(&self) -> database_vulnerability_assessments::Client {
         database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn elastic_pool_activities(&self) -> elastic_pool_activities::Client {
+    pub fn elastic_pool_activities_client(&self) -> elastic_pool_activities::Client {
         elastic_pool_activities::Client(self.clone())
     }
-    pub fn elastic_pool_database_activities(&self) -> elastic_pool_database_activities::Client {
+    pub fn elastic_pool_database_activities_client(&self) -> elastic_pool_database_activities::Client {
         elastic_pool_database_activities::Client(self.clone())
     }
-    pub fn elastic_pool_operations(&self) -> elastic_pool_operations::Client {
+    pub fn elastic_pool_operations_client(&self) -> elastic_pool_operations::Client {
         elastic_pool_operations::Client(self.clone())
     }
-    pub fn elastic_pools(&self) -> elastic_pools::Client {
+    pub fn elastic_pools_client(&self) -> elastic_pools::Client {
         elastic_pools::Client(self.clone())
     }
-    pub fn encryption_protectors(&self) -> encryption_protectors::Client {
+    pub fn encryption_protectors_client(&self) -> encryption_protectors::Client {
         encryption_protectors::Client(self.clone())
     }
-    pub fn extended_database_blob_auditing_policies(&self) -> extended_database_blob_auditing_policies::Client {
+    pub fn extended_database_blob_auditing_policies_client(&self) -> extended_database_blob_auditing_policies::Client {
         extended_database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn extended_server_blob_auditing_policies(&self) -> extended_server_blob_auditing_policies::Client {
+    pub fn extended_server_blob_auditing_policies_client(&self) -> extended_server_blob_auditing_policies::Client {
         extended_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn failover_groups(&self) -> failover_groups::Client {
+    pub fn failover_groups_client(&self) -> failover_groups::Client {
         failover_groups::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn geo_backup_policies(&self) -> geo_backup_policies::Client {
+    pub fn geo_backup_policies_client(&self) -> geo_backup_policies::Client {
         geo_backup_policies::Client(self.clone())
     }
-    pub fn import_export(&self) -> import_export::Client {
+    pub fn import_export_client(&self) -> import_export::Client {
         import_export::Client(self.clone())
     }
-    pub fn instance_failover_groups(&self) -> instance_failover_groups::Client {
+    pub fn instance_failover_groups_client(&self) -> instance_failover_groups::Client {
         instance_failover_groups::Client(self.clone())
     }
-    pub fn instance_pools(&self) -> instance_pools::Client {
+    pub fn instance_pools_client(&self) -> instance_pools::Client {
         instance_pools::Client(self.clone())
     }
-    pub fn job_agents(&self) -> job_agents::Client {
+    pub fn job_agents_client(&self) -> job_agents::Client {
         job_agents::Client(self.clone())
     }
-    pub fn job_credentials(&self) -> job_credentials::Client {
+    pub fn job_credentials_client(&self) -> job_credentials::Client {
         job_credentials::Client(self.clone())
     }
-    pub fn job_executions(&self) -> job_executions::Client {
+    pub fn job_executions_client(&self) -> job_executions::Client {
         job_executions::Client(self.clone())
     }
-    pub fn job_step_executions(&self) -> job_step_executions::Client {
+    pub fn job_step_executions_client(&self) -> job_step_executions::Client {
         job_step_executions::Client(self.clone())
     }
-    pub fn job_steps(&self) -> job_steps::Client {
+    pub fn job_steps_client(&self) -> job_steps::Client {
         job_steps::Client(self.clone())
     }
-    pub fn job_target_executions(&self) -> job_target_executions::Client {
+    pub fn job_target_executions_client(&self) -> job_target_executions::Client {
         job_target_executions::Client(self.clone())
     }
-    pub fn job_target_groups(&self) -> job_target_groups::Client {
+    pub fn job_target_groups_client(&self) -> job_target_groups::Client {
         job_target_groups::Client(self.clone())
     }
-    pub fn job_versions(&self) -> job_versions::Client {
+    pub fn job_versions_client(&self) -> job_versions::Client {
         job_versions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn long_term_retention_backups(&self) -> long_term_retention_backups::Client {
+    pub fn long_term_retention_backups_client(&self) -> long_term_retention_backups::Client {
         long_term_retention_backups::Client(self.clone())
     }
-    pub fn long_term_retention_managed_instance_backups(&self) -> long_term_retention_managed_instance_backups::Client {
+    pub fn long_term_retention_managed_instance_backups_client(&self) -> long_term_retention_managed_instance_backups::Client {
         long_term_retention_managed_instance_backups::Client(self.clone())
     }
-    pub fn managed_backup_short_term_retention_policies(&self) -> managed_backup_short_term_retention_policies::Client {
+    pub fn managed_backup_short_term_retention_policies_client(&self) -> managed_backup_short_term_retention_policies::Client {
         managed_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_database_security_alert_policies(&self) -> managed_database_security_alert_policies::Client {
+    pub fn managed_database_security_alert_policies_client(&self) -> managed_database_security_alert_policies::Client {
         managed_database_security_alert_policies::Client(self.clone())
     }
-    pub fn managed_database_sensitivity_labels(&self) -> managed_database_sensitivity_labels::Client {
+    pub fn managed_database_sensitivity_labels_client(&self) -> managed_database_sensitivity_labels::Client {
         managed_database_sensitivity_labels::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_rule_baselines(
+    pub fn managed_database_vulnerability_assessment_rule_baselines_client(
         &self,
     ) -> managed_database_vulnerability_assessment_rule_baselines::Client {
         managed_database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_scans(&self) -> managed_database_vulnerability_assessment_scans::Client {
+    pub fn managed_database_vulnerability_assessment_scans_client(&self) -> managed_database_vulnerability_assessment_scans::Client {
         managed_database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessments(&self) -> managed_database_vulnerability_assessments::Client {
+    pub fn managed_database_vulnerability_assessments_client(&self) -> managed_database_vulnerability_assessments::Client {
         managed_database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_databases(&self) -> managed_databases::Client {
+    pub fn managed_databases_client(&self) -> managed_databases::Client {
         managed_databases::Client(self.clone())
     }
-    pub fn managed_instance_administrators(&self) -> managed_instance_administrators::Client {
+    pub fn managed_instance_administrators_client(&self) -> managed_instance_administrators::Client {
         managed_instance_administrators::Client(self.clone())
     }
-    pub fn managed_instance_azure_ad_only_authentications(&self) -> managed_instance_azure_ad_only_authentications::Client {
+    pub fn managed_instance_azure_ad_only_authentications_client(&self) -> managed_instance_azure_ad_only_authentications::Client {
         managed_instance_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn managed_instance_encryption_protectors(&self) -> managed_instance_encryption_protectors::Client {
+    pub fn managed_instance_encryption_protectors_client(&self) -> managed_instance_encryption_protectors::Client {
         managed_instance_encryption_protectors::Client(self.clone())
     }
-    pub fn managed_instance_keys(&self) -> managed_instance_keys::Client {
+    pub fn managed_instance_keys_client(&self) -> managed_instance_keys::Client {
         managed_instance_keys::Client(self.clone())
     }
-    pub fn managed_instance_long_term_retention_policies(&self) -> managed_instance_long_term_retention_policies::Client {
+    pub fn managed_instance_long_term_retention_policies_client(&self) -> managed_instance_long_term_retention_policies::Client {
         managed_instance_long_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_instance_operations(&self) -> managed_instance_operations::Client {
+    pub fn managed_instance_operations_client(&self) -> managed_instance_operations::Client {
         managed_instance_operations::Client(self.clone())
     }
-    pub fn managed_instance_tde_certificates(&self) -> managed_instance_tde_certificates::Client {
+    pub fn managed_instance_tde_certificates_client(&self) -> managed_instance_tde_certificates::Client {
         managed_instance_tde_certificates::Client(self.clone())
     }
-    pub fn managed_instance_vulnerability_assessments(&self) -> managed_instance_vulnerability_assessments::Client {
+    pub fn managed_instance_vulnerability_assessments_client(&self) -> managed_instance_vulnerability_assessments::Client {
         managed_instance_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_instances(&self) -> managed_instances::Client {
+    pub fn managed_instances_client(&self) -> managed_instances::Client {
         managed_instances::Client(self.clone())
     }
-    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies(
+    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies_client(
         &self,
     ) -> managed_restorable_dropped_database_backup_short_term_retention_policies::Client {
         managed_restorable_dropped_database_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_server_security_alert_policies(&self) -> managed_server_security_alert_policies::Client {
+    pub fn managed_server_security_alert_policies_client(&self) -> managed_server_security_alert_policies::Client {
         managed_server_security_alert_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recommended_elastic_pools(&self) -> recommended_elastic_pools::Client {
+    pub fn recommended_elastic_pools_client(&self) -> recommended_elastic_pools::Client {
         recommended_elastic_pools::Client(self.clone())
     }
-    pub fn recoverable_databases(&self) -> recoverable_databases::Client {
+    pub fn recoverable_databases_client(&self) -> recoverable_databases::Client {
         recoverable_databases::Client(self.clone())
     }
-    pub fn recoverable_managed_databases(&self) -> recoverable_managed_databases::Client {
+    pub fn recoverable_managed_databases_client(&self) -> recoverable_managed_databases::Client {
         recoverable_managed_databases::Client(self.clone())
     }
-    pub fn replication_links(&self) -> replication_links::Client {
+    pub fn replication_links_client(&self) -> replication_links::Client {
         replication_links::Client(self.clone())
     }
-    pub fn restorable_dropped_databases(&self) -> restorable_dropped_databases::Client {
+    pub fn restorable_dropped_databases_client(&self) -> restorable_dropped_databases::Client {
         restorable_dropped_databases::Client(self.clone())
     }
-    pub fn restorable_dropped_managed_databases(&self) -> restorable_dropped_managed_databases::Client {
+    pub fn restorable_dropped_managed_databases_client(&self) -> restorable_dropped_managed_databases::Client {
         restorable_dropped_managed_databases::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn sensitivity_labels(&self) -> sensitivity_labels::Client {
+    pub fn sensitivity_labels_client(&self) -> sensitivity_labels::Client {
         sensitivity_labels::Client(self.clone())
     }
-    pub fn server_automatic_tuning(&self) -> server_automatic_tuning::Client {
+    pub fn server_automatic_tuning_client(&self) -> server_automatic_tuning::Client {
         server_automatic_tuning::Client(self.clone())
     }
-    pub fn server_azure_ad_administrators(&self) -> server_azure_ad_administrators::Client {
+    pub fn server_azure_ad_administrators_client(&self) -> server_azure_ad_administrators::Client {
         server_azure_ad_administrators::Client(self.clone())
     }
-    pub fn server_azure_ad_only_authentications(&self) -> server_azure_ad_only_authentications::Client {
+    pub fn server_azure_ad_only_authentications_client(&self) -> server_azure_ad_only_authentications::Client {
         server_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn server_blob_auditing_policies(&self) -> server_blob_auditing_policies::Client {
+    pub fn server_blob_auditing_policies_client(&self) -> server_blob_auditing_policies::Client {
         server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn server_communication_links(&self) -> server_communication_links::Client {
+    pub fn server_communication_links_client(&self) -> server_communication_links::Client {
         server_communication_links::Client(self.clone())
     }
-    pub fn server_connection_policies(&self) -> server_connection_policies::Client {
+    pub fn server_connection_policies_client(&self) -> server_connection_policies::Client {
         server_connection_policies::Client(self.clone())
     }
-    pub fn server_dns_aliases(&self) -> server_dns_aliases::Client {
+    pub fn server_dns_aliases_client(&self) -> server_dns_aliases::Client {
         server_dns_aliases::Client(self.clone())
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn server_trust_groups(&self) -> server_trust_groups::Client {
+    pub fn server_trust_groups_client(&self) -> server_trust_groups::Client {
         server_trust_groups::Client(self.clone())
     }
-    pub fn server_usages(&self) -> server_usages::Client {
+    pub fn server_usages_client(&self) -> server_usages::Client {
         server_usages::Client(self.clone())
     }
-    pub fn server_vulnerability_assessments(&self) -> server_vulnerability_assessments::Client {
+    pub fn server_vulnerability_assessments_client(&self) -> server_vulnerability_assessments::Client {
         server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn service_objectives(&self) -> service_objectives::Client {
+    pub fn service_objectives_client(&self) -> service_objectives::Client {
         service_objectives::Client(self.clone())
     }
-    pub fn service_tier_advisors(&self) -> service_tier_advisors::Client {
+    pub fn service_tier_advisors_client(&self) -> service_tier_advisors::Client {
         service_tier_advisors::Client(self.clone())
     }
-    pub fn subscription_usages(&self) -> subscription_usages::Client {
+    pub fn subscription_usages_client(&self) -> subscription_usages::Client {
         subscription_usages::Client(self.clone())
     }
-    pub fn sync_agents(&self) -> sync_agents::Client {
+    pub fn sync_agents_client(&self) -> sync_agents::Client {
         sync_agents::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn sync_members(&self) -> sync_members::Client {
+    pub fn sync_members_client(&self) -> sync_members::Client {
         sync_members::Client(self.clone())
     }
-    pub fn tde_certificates(&self) -> tde_certificates::Client {
+    pub fn tde_certificates_client(&self) -> tde_certificates::Client {
         tde_certificates::Client(self.clone())
     }
-    pub fn transparent_data_encryption_activities(&self) -> transparent_data_encryption_activities::Client {
+    pub fn transparent_data_encryption_activities_client(&self) -> transparent_data_encryption_activities::Client {
         transparent_data_encryption_activities::Client(self.clone())
     }
-    pub fn transparent_data_encryptions(&self) -> transparent_data_encryptions::Client {
+    pub fn transparent_data_encryptions_client(&self) -> transparent_data_encryptions::Client {
         transparent_data_encryptions::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_clusters(&self) -> virtual_clusters::Client {
+    pub fn virtual_clusters_client(&self) -> virtual_clusters::Client {
         virtual_clusters::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn workload_classifiers(&self) -> workload_classifiers::Client {
+    pub fn workload_classifiers_client(&self) -> workload_classifiers::Client {
         workload_classifiers::Client(self.clone())
     }
-    pub fn workload_groups(&self) -> workload_groups::Client {
+    pub fn workload_groups_client(&self) -> workload_groups::Client {
         workload_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/sql/src/package_composite_v4/operations.rs
+++ b/services/mgmt/sql/src/package_composite_v4/operations.rs
@@ -74,296 +74,296 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_short_term_retention_policies(&self) -> backup_short_term_retention_policies::Client {
+    pub fn backup_short_term_retention_policies_client(&self) -> backup_short_term_retention_policies::Client {
         backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn capabilities(&self) -> capabilities::Client {
+    pub fn capabilities_client(&self) -> capabilities::Client {
         capabilities::Client(self.clone())
     }
-    pub fn data_masking_policies(&self) -> data_masking_policies::Client {
+    pub fn data_masking_policies_client(&self) -> data_masking_policies::Client {
         data_masking_policies::Client(self.clone())
     }
-    pub fn data_masking_rules(&self) -> data_masking_rules::Client {
+    pub fn data_masking_rules_client(&self) -> data_masking_rules::Client {
         data_masking_rules::Client(self.clone())
     }
-    pub fn database_automatic_tuning(&self) -> database_automatic_tuning::Client {
+    pub fn database_automatic_tuning_client(&self) -> database_automatic_tuning::Client {
         database_automatic_tuning::Client(self.clone())
     }
-    pub fn database_blob_auditing_policies(&self) -> database_blob_auditing_policies::Client {
+    pub fn database_blob_auditing_policies_client(&self) -> database_blob_auditing_policies::Client {
         database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn database_operations(&self) -> database_operations::Client {
+    pub fn database_operations_client(&self) -> database_operations::Client {
         database_operations::Client(self.clone())
     }
-    pub fn database_threat_detection_policies(&self) -> database_threat_detection_policies::Client {
+    pub fn database_threat_detection_policies_client(&self) -> database_threat_detection_policies::Client {
         database_threat_detection_policies::Client(self.clone())
     }
-    pub fn database_usages(&self) -> database_usages::Client {
+    pub fn database_usages_client(&self) -> database_usages::Client {
         database_usages::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_rule_baselines(&self) -> database_vulnerability_assessment_rule_baselines::Client {
+    pub fn database_vulnerability_assessment_rule_baselines_client(&self) -> database_vulnerability_assessment_rule_baselines::Client {
         database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_scans(&self) -> database_vulnerability_assessment_scans::Client {
+    pub fn database_vulnerability_assessment_scans_client(&self) -> database_vulnerability_assessment_scans::Client {
         database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn database_vulnerability_assessments(&self) -> database_vulnerability_assessments::Client {
+    pub fn database_vulnerability_assessments_client(&self) -> database_vulnerability_assessments::Client {
         database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn elastic_pool_activities(&self) -> elastic_pool_activities::Client {
+    pub fn elastic_pool_activities_client(&self) -> elastic_pool_activities::Client {
         elastic_pool_activities::Client(self.clone())
     }
-    pub fn elastic_pool_database_activities(&self) -> elastic_pool_database_activities::Client {
+    pub fn elastic_pool_database_activities_client(&self) -> elastic_pool_database_activities::Client {
         elastic_pool_database_activities::Client(self.clone())
     }
-    pub fn elastic_pool_operations(&self) -> elastic_pool_operations::Client {
+    pub fn elastic_pool_operations_client(&self) -> elastic_pool_operations::Client {
         elastic_pool_operations::Client(self.clone())
     }
-    pub fn elastic_pools(&self) -> elastic_pools::Client {
+    pub fn elastic_pools_client(&self) -> elastic_pools::Client {
         elastic_pools::Client(self.clone())
     }
-    pub fn encryption_protectors(&self) -> encryption_protectors::Client {
+    pub fn encryption_protectors_client(&self) -> encryption_protectors::Client {
         encryption_protectors::Client(self.clone())
     }
-    pub fn extended_database_blob_auditing_policies(&self) -> extended_database_blob_auditing_policies::Client {
+    pub fn extended_database_blob_auditing_policies_client(&self) -> extended_database_blob_auditing_policies::Client {
         extended_database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn extended_server_blob_auditing_policies(&self) -> extended_server_blob_auditing_policies::Client {
+    pub fn extended_server_blob_auditing_policies_client(&self) -> extended_server_blob_auditing_policies::Client {
         extended_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn failover_groups(&self) -> failover_groups::Client {
+    pub fn failover_groups_client(&self) -> failover_groups::Client {
         failover_groups::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn geo_backup_policies(&self) -> geo_backup_policies::Client {
+    pub fn geo_backup_policies_client(&self) -> geo_backup_policies::Client {
         geo_backup_policies::Client(self.clone())
     }
-    pub fn import_export(&self) -> import_export::Client {
+    pub fn import_export_client(&self) -> import_export::Client {
         import_export::Client(self.clone())
     }
-    pub fn instance_failover_groups(&self) -> instance_failover_groups::Client {
+    pub fn instance_failover_groups_client(&self) -> instance_failover_groups::Client {
         instance_failover_groups::Client(self.clone())
     }
-    pub fn instance_pools(&self) -> instance_pools::Client {
+    pub fn instance_pools_client(&self) -> instance_pools::Client {
         instance_pools::Client(self.clone())
     }
-    pub fn job_agents(&self) -> job_agents::Client {
+    pub fn job_agents_client(&self) -> job_agents::Client {
         job_agents::Client(self.clone())
     }
-    pub fn job_credentials(&self) -> job_credentials::Client {
+    pub fn job_credentials_client(&self) -> job_credentials::Client {
         job_credentials::Client(self.clone())
     }
-    pub fn job_executions(&self) -> job_executions::Client {
+    pub fn job_executions_client(&self) -> job_executions::Client {
         job_executions::Client(self.clone())
     }
-    pub fn job_step_executions(&self) -> job_step_executions::Client {
+    pub fn job_step_executions_client(&self) -> job_step_executions::Client {
         job_step_executions::Client(self.clone())
     }
-    pub fn job_steps(&self) -> job_steps::Client {
+    pub fn job_steps_client(&self) -> job_steps::Client {
         job_steps::Client(self.clone())
     }
-    pub fn job_target_executions(&self) -> job_target_executions::Client {
+    pub fn job_target_executions_client(&self) -> job_target_executions::Client {
         job_target_executions::Client(self.clone())
     }
-    pub fn job_target_groups(&self) -> job_target_groups::Client {
+    pub fn job_target_groups_client(&self) -> job_target_groups::Client {
         job_target_groups::Client(self.clone())
     }
-    pub fn job_versions(&self) -> job_versions::Client {
+    pub fn job_versions_client(&self) -> job_versions::Client {
         job_versions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn long_term_retention_backups(&self) -> long_term_retention_backups::Client {
+    pub fn long_term_retention_backups_client(&self) -> long_term_retention_backups::Client {
         long_term_retention_backups::Client(self.clone())
     }
-    pub fn long_term_retention_managed_instance_backups(&self) -> long_term_retention_managed_instance_backups::Client {
+    pub fn long_term_retention_managed_instance_backups_client(&self) -> long_term_retention_managed_instance_backups::Client {
         long_term_retention_managed_instance_backups::Client(self.clone())
     }
-    pub fn long_term_retention_policies(&self) -> long_term_retention_policies::Client {
+    pub fn long_term_retention_policies_client(&self) -> long_term_retention_policies::Client {
         long_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_backup_short_term_retention_policies(&self) -> managed_backup_short_term_retention_policies::Client {
+    pub fn managed_backup_short_term_retention_policies_client(&self) -> managed_backup_short_term_retention_policies::Client {
         managed_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_database_restore_details(&self) -> managed_database_restore_details::Client {
+    pub fn managed_database_restore_details_client(&self) -> managed_database_restore_details::Client {
         managed_database_restore_details::Client(self.clone())
     }
-    pub fn managed_database_security_alert_policies(&self) -> managed_database_security_alert_policies::Client {
+    pub fn managed_database_security_alert_policies_client(&self) -> managed_database_security_alert_policies::Client {
         managed_database_security_alert_policies::Client(self.clone())
     }
-    pub fn managed_database_sensitivity_labels(&self) -> managed_database_sensitivity_labels::Client {
+    pub fn managed_database_sensitivity_labels_client(&self) -> managed_database_sensitivity_labels::Client {
         managed_database_sensitivity_labels::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_rule_baselines(
+    pub fn managed_database_vulnerability_assessment_rule_baselines_client(
         &self,
     ) -> managed_database_vulnerability_assessment_rule_baselines::Client {
         managed_database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_scans(&self) -> managed_database_vulnerability_assessment_scans::Client {
+    pub fn managed_database_vulnerability_assessment_scans_client(&self) -> managed_database_vulnerability_assessment_scans::Client {
         managed_database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessments(&self) -> managed_database_vulnerability_assessments::Client {
+    pub fn managed_database_vulnerability_assessments_client(&self) -> managed_database_vulnerability_assessments::Client {
         managed_database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_databases(&self) -> managed_databases::Client {
+    pub fn managed_databases_client(&self) -> managed_databases::Client {
         managed_databases::Client(self.clone())
     }
-    pub fn managed_instance_administrators(&self) -> managed_instance_administrators::Client {
+    pub fn managed_instance_administrators_client(&self) -> managed_instance_administrators::Client {
         managed_instance_administrators::Client(self.clone())
     }
-    pub fn managed_instance_azure_ad_only_authentications(&self) -> managed_instance_azure_ad_only_authentications::Client {
+    pub fn managed_instance_azure_ad_only_authentications_client(&self) -> managed_instance_azure_ad_only_authentications::Client {
         managed_instance_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn managed_instance_encryption_protectors(&self) -> managed_instance_encryption_protectors::Client {
+    pub fn managed_instance_encryption_protectors_client(&self) -> managed_instance_encryption_protectors::Client {
         managed_instance_encryption_protectors::Client(self.clone())
     }
-    pub fn managed_instance_keys(&self) -> managed_instance_keys::Client {
+    pub fn managed_instance_keys_client(&self) -> managed_instance_keys::Client {
         managed_instance_keys::Client(self.clone())
     }
-    pub fn managed_instance_long_term_retention_policies(&self) -> managed_instance_long_term_retention_policies::Client {
+    pub fn managed_instance_long_term_retention_policies_client(&self) -> managed_instance_long_term_retention_policies::Client {
         managed_instance_long_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_instance_operations(&self) -> managed_instance_operations::Client {
+    pub fn managed_instance_operations_client(&self) -> managed_instance_operations::Client {
         managed_instance_operations::Client(self.clone())
     }
-    pub fn managed_instance_tde_certificates(&self) -> managed_instance_tde_certificates::Client {
+    pub fn managed_instance_tde_certificates_client(&self) -> managed_instance_tde_certificates::Client {
         managed_instance_tde_certificates::Client(self.clone())
     }
-    pub fn managed_instance_vulnerability_assessments(&self) -> managed_instance_vulnerability_assessments::Client {
+    pub fn managed_instance_vulnerability_assessments_client(&self) -> managed_instance_vulnerability_assessments::Client {
         managed_instance_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_instances(&self) -> managed_instances::Client {
+    pub fn managed_instances_client(&self) -> managed_instances::Client {
         managed_instances::Client(self.clone())
     }
-    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies(
+    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies_client(
         &self,
     ) -> managed_restorable_dropped_database_backup_short_term_retention_policies::Client {
         managed_restorable_dropped_database_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_server_security_alert_policies(&self) -> managed_server_security_alert_policies::Client {
+    pub fn managed_server_security_alert_policies_client(&self) -> managed_server_security_alert_policies::Client {
         managed_server_security_alert_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recommended_elastic_pools(&self) -> recommended_elastic_pools::Client {
+    pub fn recommended_elastic_pools_client(&self) -> recommended_elastic_pools::Client {
         recommended_elastic_pools::Client(self.clone())
     }
-    pub fn recoverable_databases(&self) -> recoverable_databases::Client {
+    pub fn recoverable_databases_client(&self) -> recoverable_databases::Client {
         recoverable_databases::Client(self.clone())
     }
-    pub fn recoverable_managed_databases(&self) -> recoverable_managed_databases::Client {
+    pub fn recoverable_managed_databases_client(&self) -> recoverable_managed_databases::Client {
         recoverable_managed_databases::Client(self.clone())
     }
-    pub fn replication_links(&self) -> replication_links::Client {
+    pub fn replication_links_client(&self) -> replication_links::Client {
         replication_links::Client(self.clone())
     }
-    pub fn restorable_dropped_databases(&self) -> restorable_dropped_databases::Client {
+    pub fn restorable_dropped_databases_client(&self) -> restorable_dropped_databases::Client {
         restorable_dropped_databases::Client(self.clone())
     }
-    pub fn restorable_dropped_managed_databases(&self) -> restorable_dropped_managed_databases::Client {
+    pub fn restorable_dropped_managed_databases_client(&self) -> restorable_dropped_managed_databases::Client {
         restorable_dropped_managed_databases::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn sensitivity_labels(&self) -> sensitivity_labels::Client {
+    pub fn sensitivity_labels_client(&self) -> sensitivity_labels::Client {
         sensitivity_labels::Client(self.clone())
     }
-    pub fn server_automatic_tuning(&self) -> server_automatic_tuning::Client {
+    pub fn server_automatic_tuning_client(&self) -> server_automatic_tuning::Client {
         server_automatic_tuning::Client(self.clone())
     }
-    pub fn server_azure_ad_administrators(&self) -> server_azure_ad_administrators::Client {
+    pub fn server_azure_ad_administrators_client(&self) -> server_azure_ad_administrators::Client {
         server_azure_ad_administrators::Client(self.clone())
     }
-    pub fn server_azure_ad_only_authentications(&self) -> server_azure_ad_only_authentications::Client {
+    pub fn server_azure_ad_only_authentications_client(&self) -> server_azure_ad_only_authentications::Client {
         server_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn server_blob_auditing_policies(&self) -> server_blob_auditing_policies::Client {
+    pub fn server_blob_auditing_policies_client(&self) -> server_blob_auditing_policies::Client {
         server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn server_communication_links(&self) -> server_communication_links::Client {
+    pub fn server_communication_links_client(&self) -> server_communication_links::Client {
         server_communication_links::Client(self.clone())
     }
-    pub fn server_connection_policies(&self) -> server_connection_policies::Client {
+    pub fn server_connection_policies_client(&self) -> server_connection_policies::Client {
         server_connection_policies::Client(self.clone())
     }
-    pub fn server_dev_ops_audit_settings(&self) -> server_dev_ops_audit_settings::Client {
+    pub fn server_dev_ops_audit_settings_client(&self) -> server_dev_ops_audit_settings::Client {
         server_dev_ops_audit_settings::Client(self.clone())
     }
-    pub fn server_dns_aliases(&self) -> server_dns_aliases::Client {
+    pub fn server_dns_aliases_client(&self) -> server_dns_aliases::Client {
         server_dns_aliases::Client(self.clone())
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn server_trust_groups(&self) -> server_trust_groups::Client {
+    pub fn server_trust_groups_client(&self) -> server_trust_groups::Client {
         server_trust_groups::Client(self.clone())
     }
-    pub fn server_usages(&self) -> server_usages::Client {
+    pub fn server_usages_client(&self) -> server_usages::Client {
         server_usages::Client(self.clone())
     }
-    pub fn server_vulnerability_assessments(&self) -> server_vulnerability_assessments::Client {
+    pub fn server_vulnerability_assessments_client(&self) -> server_vulnerability_assessments::Client {
         server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn service_objectives(&self) -> service_objectives::Client {
+    pub fn service_objectives_client(&self) -> service_objectives::Client {
         service_objectives::Client(self.clone())
     }
-    pub fn service_tier_advisors(&self) -> service_tier_advisors::Client {
+    pub fn service_tier_advisors_client(&self) -> service_tier_advisors::Client {
         service_tier_advisors::Client(self.clone())
     }
-    pub fn subscription_usages(&self) -> subscription_usages::Client {
+    pub fn subscription_usages_client(&self) -> subscription_usages::Client {
         subscription_usages::Client(self.clone())
     }
-    pub fn sync_agents(&self) -> sync_agents::Client {
+    pub fn sync_agents_client(&self) -> sync_agents::Client {
         sync_agents::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn sync_members(&self) -> sync_members::Client {
+    pub fn sync_members_client(&self) -> sync_members::Client {
         sync_members::Client(self.clone())
     }
-    pub fn tde_certificates(&self) -> tde_certificates::Client {
+    pub fn tde_certificates_client(&self) -> tde_certificates::Client {
         tde_certificates::Client(self.clone())
     }
-    pub fn transparent_data_encryption_activities(&self) -> transparent_data_encryption_activities::Client {
+    pub fn transparent_data_encryption_activities_client(&self) -> transparent_data_encryption_activities::Client {
         transparent_data_encryption_activities::Client(self.clone())
     }
-    pub fn transparent_data_encryptions(&self) -> transparent_data_encryptions::Client {
+    pub fn transparent_data_encryptions_client(&self) -> transparent_data_encryptions::Client {
         transparent_data_encryptions::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_clusters(&self) -> virtual_clusters::Client {
+    pub fn virtual_clusters_client(&self) -> virtual_clusters::Client {
         virtual_clusters::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn workload_classifiers(&self) -> workload_classifiers::Client {
+    pub fn workload_classifiers_client(&self) -> workload_classifiers::Client {
         workload_classifiers::Client(self.clone())
     }
-    pub fn workload_groups(&self) -> workload_groups::Client {
+    pub fn workload_groups_client(&self) -> workload_groups::Client {
         workload_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/sql/src/package_composite_v5/operations.rs
+++ b/services/mgmt/sql/src/package_composite_v5/operations.rs
@@ -74,380 +74,380 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_short_term_retention_policies(&self) -> backup_short_term_retention_policies::Client {
+    pub fn backup_short_term_retention_policies_client(&self) -> backup_short_term_retention_policies::Client {
         backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn capabilities(&self) -> capabilities::Client {
+    pub fn capabilities_client(&self) -> capabilities::Client {
         capabilities::Client(self.clone())
     }
-    pub fn data_masking_policies(&self) -> data_masking_policies::Client {
+    pub fn data_masking_policies_client(&self) -> data_masking_policies::Client {
         data_masking_policies::Client(self.clone())
     }
-    pub fn data_masking_rules(&self) -> data_masking_rules::Client {
+    pub fn data_masking_rules_client(&self) -> data_masking_rules::Client {
         data_masking_rules::Client(self.clone())
     }
-    pub fn data_warehouse_user_activities(&self) -> data_warehouse_user_activities::Client {
+    pub fn data_warehouse_user_activities_client(&self) -> data_warehouse_user_activities::Client {
         data_warehouse_user_activities::Client(self.clone())
     }
-    pub fn database_advanced_threat_protection_settings(&self) -> database_advanced_threat_protection_settings::Client {
+    pub fn database_advanced_threat_protection_settings_client(&self) -> database_advanced_threat_protection_settings::Client {
         database_advanced_threat_protection_settings::Client(self.clone())
     }
-    pub fn database_advisors(&self) -> database_advisors::Client {
+    pub fn database_advisors_client(&self) -> database_advisors::Client {
         database_advisors::Client(self.clone())
     }
-    pub fn database_automatic_tuning(&self) -> database_automatic_tuning::Client {
+    pub fn database_automatic_tuning_client(&self) -> database_automatic_tuning::Client {
         database_automatic_tuning::Client(self.clone())
     }
-    pub fn database_blob_auditing_policies(&self) -> database_blob_auditing_policies::Client {
+    pub fn database_blob_auditing_policies_client(&self) -> database_blob_auditing_policies::Client {
         database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn database_columns(&self) -> database_columns::Client {
+    pub fn database_columns_client(&self) -> database_columns::Client {
         database_columns::Client(self.clone())
     }
-    pub fn database_extensions(&self) -> database_extensions::Client {
+    pub fn database_extensions_client(&self) -> database_extensions::Client {
         database_extensions::Client(self.clone())
     }
-    pub fn database_operations(&self) -> database_operations::Client {
+    pub fn database_operations_client(&self) -> database_operations::Client {
         database_operations::Client(self.clone())
     }
-    pub fn database_recommended_actions(&self) -> database_recommended_actions::Client {
+    pub fn database_recommended_actions_client(&self) -> database_recommended_actions::Client {
         database_recommended_actions::Client(self.clone())
     }
-    pub fn database_schemas(&self) -> database_schemas::Client {
+    pub fn database_schemas_client(&self) -> database_schemas::Client {
         database_schemas::Client(self.clone())
     }
-    pub fn database_security_alert_policies(&self) -> database_security_alert_policies::Client {
+    pub fn database_security_alert_policies_client(&self) -> database_security_alert_policies::Client {
         database_security_alert_policies::Client(self.clone())
     }
-    pub fn database_tables(&self) -> database_tables::Client {
+    pub fn database_tables_client(&self) -> database_tables::Client {
         database_tables::Client(self.clone())
     }
-    pub fn database_usages(&self) -> database_usages::Client {
+    pub fn database_usages_client(&self) -> database_usages::Client {
         database_usages::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_rule_baselines(&self) -> database_vulnerability_assessment_rule_baselines::Client {
+    pub fn database_vulnerability_assessment_rule_baselines_client(&self) -> database_vulnerability_assessment_rule_baselines::Client {
         database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_scans(&self) -> database_vulnerability_assessment_scans::Client {
+    pub fn database_vulnerability_assessment_scans_client(&self) -> database_vulnerability_assessment_scans::Client {
         database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn database_vulnerability_assessments(&self) -> database_vulnerability_assessments::Client {
+    pub fn database_vulnerability_assessments_client(&self) -> database_vulnerability_assessments::Client {
         database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn deleted_servers(&self) -> deleted_servers::Client {
+    pub fn deleted_servers_client(&self) -> deleted_servers::Client {
         deleted_servers::Client(self.clone())
     }
-    pub fn distributed_availability_groups(&self) -> distributed_availability_groups::Client {
+    pub fn distributed_availability_groups_client(&self) -> distributed_availability_groups::Client {
         distributed_availability_groups::Client(self.clone())
     }
-    pub fn elastic_pool_activities(&self) -> elastic_pool_activities::Client {
+    pub fn elastic_pool_activities_client(&self) -> elastic_pool_activities::Client {
         elastic_pool_activities::Client(self.clone())
     }
-    pub fn elastic_pool_database_activities(&self) -> elastic_pool_database_activities::Client {
+    pub fn elastic_pool_database_activities_client(&self) -> elastic_pool_database_activities::Client {
         elastic_pool_database_activities::Client(self.clone())
     }
-    pub fn elastic_pool_operations(&self) -> elastic_pool_operations::Client {
+    pub fn elastic_pool_operations_client(&self) -> elastic_pool_operations::Client {
         elastic_pool_operations::Client(self.clone())
     }
-    pub fn elastic_pools(&self) -> elastic_pools::Client {
+    pub fn elastic_pools_client(&self) -> elastic_pools::Client {
         elastic_pools::Client(self.clone())
     }
-    pub fn encryption_protectors(&self) -> encryption_protectors::Client {
+    pub fn encryption_protectors_client(&self) -> encryption_protectors::Client {
         encryption_protectors::Client(self.clone())
     }
-    pub fn endpoint_certificates(&self) -> endpoint_certificates::Client {
+    pub fn endpoint_certificates_client(&self) -> endpoint_certificates::Client {
         endpoint_certificates::Client(self.clone())
     }
-    pub fn extended_database_blob_auditing_policies(&self) -> extended_database_blob_auditing_policies::Client {
+    pub fn extended_database_blob_auditing_policies_client(&self) -> extended_database_blob_auditing_policies::Client {
         extended_database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn extended_server_blob_auditing_policies(&self) -> extended_server_blob_auditing_policies::Client {
+    pub fn extended_server_blob_auditing_policies_client(&self) -> extended_server_blob_auditing_policies::Client {
         extended_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn failover_groups(&self) -> failover_groups::Client {
+    pub fn failover_groups_client(&self) -> failover_groups::Client {
         failover_groups::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn geo_backup_policies(&self) -> geo_backup_policies::Client {
+    pub fn geo_backup_policies_client(&self) -> geo_backup_policies::Client {
         geo_backup_policies::Client(self.clone())
     }
-    pub fn i_pv6_firewall_rules(&self) -> i_pv6_firewall_rules::Client {
+    pub fn i_pv6_firewall_rules_client(&self) -> i_pv6_firewall_rules::Client {
         i_pv6_firewall_rules::Client(self.clone())
     }
-    pub fn instance_failover_groups(&self) -> instance_failover_groups::Client {
+    pub fn instance_failover_groups_client(&self) -> instance_failover_groups::Client {
         instance_failover_groups::Client(self.clone())
     }
-    pub fn instance_pools(&self) -> instance_pools::Client {
+    pub fn instance_pools_client(&self) -> instance_pools::Client {
         instance_pools::Client(self.clone())
     }
-    pub fn job_agents(&self) -> job_agents::Client {
+    pub fn job_agents_client(&self) -> job_agents::Client {
         job_agents::Client(self.clone())
     }
-    pub fn job_credentials(&self) -> job_credentials::Client {
+    pub fn job_credentials_client(&self) -> job_credentials::Client {
         job_credentials::Client(self.clone())
     }
-    pub fn job_executions(&self) -> job_executions::Client {
+    pub fn job_executions_client(&self) -> job_executions::Client {
         job_executions::Client(self.clone())
     }
-    pub fn job_step_executions(&self) -> job_step_executions::Client {
+    pub fn job_step_executions_client(&self) -> job_step_executions::Client {
         job_step_executions::Client(self.clone())
     }
-    pub fn job_steps(&self) -> job_steps::Client {
+    pub fn job_steps_client(&self) -> job_steps::Client {
         job_steps::Client(self.clone())
     }
-    pub fn job_target_executions(&self) -> job_target_executions::Client {
+    pub fn job_target_executions_client(&self) -> job_target_executions::Client {
         job_target_executions::Client(self.clone())
     }
-    pub fn job_target_groups(&self) -> job_target_groups::Client {
+    pub fn job_target_groups_client(&self) -> job_target_groups::Client {
         job_target_groups::Client(self.clone())
     }
-    pub fn job_versions(&self) -> job_versions::Client {
+    pub fn job_versions_client(&self) -> job_versions::Client {
         job_versions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn ledger_digest_uploads(&self) -> ledger_digest_uploads::Client {
+    pub fn ledger_digest_uploads_client(&self) -> ledger_digest_uploads::Client {
         ledger_digest_uploads::Client(self.clone())
     }
-    pub fn long_term_retention_backups(&self) -> long_term_retention_backups::Client {
+    pub fn long_term_retention_backups_client(&self) -> long_term_retention_backups::Client {
         long_term_retention_backups::Client(self.clone())
     }
-    pub fn long_term_retention_managed_instance_backups(&self) -> long_term_retention_managed_instance_backups::Client {
+    pub fn long_term_retention_managed_instance_backups_client(&self) -> long_term_retention_managed_instance_backups::Client {
         long_term_retention_managed_instance_backups::Client(self.clone())
     }
-    pub fn long_term_retention_policies(&self) -> long_term_retention_policies::Client {
+    pub fn long_term_retention_policies_client(&self) -> long_term_retention_policies::Client {
         long_term_retention_policies::Client(self.clone())
     }
-    pub fn maintenance_window_options(&self) -> maintenance_window_options::Client {
+    pub fn maintenance_window_options_client(&self) -> maintenance_window_options::Client {
         maintenance_window_options::Client(self.clone())
     }
-    pub fn maintenance_windows(&self) -> maintenance_windows::Client {
+    pub fn maintenance_windows_client(&self) -> maintenance_windows::Client {
         maintenance_windows::Client(self.clone())
     }
-    pub fn managed_backup_short_term_retention_policies(&self) -> managed_backup_short_term_retention_policies::Client {
+    pub fn managed_backup_short_term_retention_policies_client(&self) -> managed_backup_short_term_retention_policies::Client {
         managed_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_database_columns(&self) -> managed_database_columns::Client {
+    pub fn managed_database_columns_client(&self) -> managed_database_columns::Client {
         managed_database_columns::Client(self.clone())
     }
-    pub fn managed_database_queries(&self) -> managed_database_queries::Client {
+    pub fn managed_database_queries_client(&self) -> managed_database_queries::Client {
         managed_database_queries::Client(self.clone())
     }
-    pub fn managed_database_recommended_sensitivity_labels(&self) -> managed_database_recommended_sensitivity_labels::Client {
+    pub fn managed_database_recommended_sensitivity_labels_client(&self) -> managed_database_recommended_sensitivity_labels::Client {
         managed_database_recommended_sensitivity_labels::Client(self.clone())
     }
-    pub fn managed_database_restore_details(&self) -> managed_database_restore_details::Client {
+    pub fn managed_database_restore_details_client(&self) -> managed_database_restore_details::Client {
         managed_database_restore_details::Client(self.clone())
     }
-    pub fn managed_database_schemas(&self) -> managed_database_schemas::Client {
+    pub fn managed_database_schemas_client(&self) -> managed_database_schemas::Client {
         managed_database_schemas::Client(self.clone())
     }
-    pub fn managed_database_security_alert_policies(&self) -> managed_database_security_alert_policies::Client {
+    pub fn managed_database_security_alert_policies_client(&self) -> managed_database_security_alert_policies::Client {
         managed_database_security_alert_policies::Client(self.clone())
     }
-    pub fn managed_database_security_events(&self) -> managed_database_security_events::Client {
+    pub fn managed_database_security_events_client(&self) -> managed_database_security_events::Client {
         managed_database_security_events::Client(self.clone())
     }
-    pub fn managed_database_sensitivity_labels(&self) -> managed_database_sensitivity_labels::Client {
+    pub fn managed_database_sensitivity_labels_client(&self) -> managed_database_sensitivity_labels::Client {
         managed_database_sensitivity_labels::Client(self.clone())
     }
-    pub fn managed_database_tables(&self) -> managed_database_tables::Client {
+    pub fn managed_database_tables_client(&self) -> managed_database_tables::Client {
         managed_database_tables::Client(self.clone())
     }
-    pub fn managed_database_transparent_data_encryption(&self) -> managed_database_transparent_data_encryption::Client {
+    pub fn managed_database_transparent_data_encryption_client(&self) -> managed_database_transparent_data_encryption::Client {
         managed_database_transparent_data_encryption::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_rule_baselines(
+    pub fn managed_database_vulnerability_assessment_rule_baselines_client(
         &self,
     ) -> managed_database_vulnerability_assessment_rule_baselines::Client {
         managed_database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_scans(&self) -> managed_database_vulnerability_assessment_scans::Client {
+    pub fn managed_database_vulnerability_assessment_scans_client(&self) -> managed_database_vulnerability_assessment_scans::Client {
         managed_database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessments(&self) -> managed_database_vulnerability_assessments::Client {
+    pub fn managed_database_vulnerability_assessments_client(&self) -> managed_database_vulnerability_assessments::Client {
         managed_database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_databases(&self) -> managed_databases::Client {
+    pub fn managed_databases_client(&self) -> managed_databases::Client {
         managed_databases::Client(self.clone())
     }
-    pub fn managed_instance_administrators(&self) -> managed_instance_administrators::Client {
+    pub fn managed_instance_administrators_client(&self) -> managed_instance_administrators::Client {
         managed_instance_administrators::Client(self.clone())
     }
-    pub fn managed_instance_azure_ad_only_authentications(&self) -> managed_instance_azure_ad_only_authentications::Client {
+    pub fn managed_instance_azure_ad_only_authentications_client(&self) -> managed_instance_azure_ad_only_authentications::Client {
         managed_instance_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn managed_instance_encryption_protectors(&self) -> managed_instance_encryption_protectors::Client {
+    pub fn managed_instance_encryption_protectors_client(&self) -> managed_instance_encryption_protectors::Client {
         managed_instance_encryption_protectors::Client(self.clone())
     }
-    pub fn managed_instance_keys(&self) -> managed_instance_keys::Client {
+    pub fn managed_instance_keys_client(&self) -> managed_instance_keys::Client {
         managed_instance_keys::Client(self.clone())
     }
-    pub fn managed_instance_long_term_retention_policies(&self) -> managed_instance_long_term_retention_policies::Client {
+    pub fn managed_instance_long_term_retention_policies_client(&self) -> managed_instance_long_term_retention_policies::Client {
         managed_instance_long_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_instance_operations(&self) -> managed_instance_operations::Client {
+    pub fn managed_instance_operations_client(&self) -> managed_instance_operations::Client {
         managed_instance_operations::Client(self.clone())
     }
-    pub fn managed_instance_private_endpoint_connections(&self) -> managed_instance_private_endpoint_connections::Client {
+    pub fn managed_instance_private_endpoint_connections_client(&self) -> managed_instance_private_endpoint_connections::Client {
         managed_instance_private_endpoint_connections::Client(self.clone())
     }
-    pub fn managed_instance_private_link_resources(&self) -> managed_instance_private_link_resources::Client {
+    pub fn managed_instance_private_link_resources_client(&self) -> managed_instance_private_link_resources::Client {
         managed_instance_private_link_resources::Client(self.clone())
     }
-    pub fn managed_instance_tde_certificates(&self) -> managed_instance_tde_certificates::Client {
+    pub fn managed_instance_tde_certificates_client(&self) -> managed_instance_tde_certificates::Client {
         managed_instance_tde_certificates::Client(self.clone())
     }
-    pub fn managed_instance_vulnerability_assessments(&self) -> managed_instance_vulnerability_assessments::Client {
+    pub fn managed_instance_vulnerability_assessments_client(&self) -> managed_instance_vulnerability_assessments::Client {
         managed_instance_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_instances(&self) -> managed_instances::Client {
+    pub fn managed_instances_client(&self) -> managed_instances::Client {
         managed_instances::Client(self.clone())
     }
-    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies(
+    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies_client(
         &self,
     ) -> managed_restorable_dropped_database_backup_short_term_retention_policies::Client {
         managed_restorable_dropped_database_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_server_security_alert_policies(&self) -> managed_server_security_alert_policies::Client {
+    pub fn managed_server_security_alert_policies_client(&self) -> managed_server_security_alert_policies::Client {
         managed_server_security_alert_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn outbound_firewall_rules(&self) -> outbound_firewall_rules::Client {
+    pub fn outbound_firewall_rules_client(&self) -> outbound_firewall_rules::Client {
         outbound_firewall_rules::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recommended_sensitivity_labels(&self) -> recommended_sensitivity_labels::Client {
+    pub fn recommended_sensitivity_labels_client(&self) -> recommended_sensitivity_labels::Client {
         recommended_sensitivity_labels::Client(self.clone())
     }
-    pub fn recoverable_databases(&self) -> recoverable_databases::Client {
+    pub fn recoverable_databases_client(&self) -> recoverable_databases::Client {
         recoverable_databases::Client(self.clone())
     }
-    pub fn recoverable_managed_databases(&self) -> recoverable_managed_databases::Client {
+    pub fn recoverable_managed_databases_client(&self) -> recoverable_managed_databases::Client {
         recoverable_managed_databases::Client(self.clone())
     }
-    pub fn replication_links(&self) -> replication_links::Client {
+    pub fn replication_links_client(&self) -> replication_links::Client {
         replication_links::Client(self.clone())
     }
-    pub fn restorable_dropped_databases(&self) -> restorable_dropped_databases::Client {
+    pub fn restorable_dropped_databases_client(&self) -> restorable_dropped_databases::Client {
         restorable_dropped_databases::Client(self.clone())
     }
-    pub fn restorable_dropped_managed_databases(&self) -> restorable_dropped_managed_databases::Client {
+    pub fn restorable_dropped_managed_databases_client(&self) -> restorable_dropped_managed_databases::Client {
         restorable_dropped_managed_databases::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn sensitivity_labels(&self) -> sensitivity_labels::Client {
+    pub fn sensitivity_labels_client(&self) -> sensitivity_labels::Client {
         sensitivity_labels::Client(self.clone())
     }
-    pub fn server_advanced_threat_protection_settings(&self) -> server_advanced_threat_protection_settings::Client {
+    pub fn server_advanced_threat_protection_settings_client(&self) -> server_advanced_threat_protection_settings::Client {
         server_advanced_threat_protection_settings::Client(self.clone())
     }
-    pub fn server_advisors(&self) -> server_advisors::Client {
+    pub fn server_advisors_client(&self) -> server_advisors::Client {
         server_advisors::Client(self.clone())
     }
-    pub fn server_automatic_tuning(&self) -> server_automatic_tuning::Client {
+    pub fn server_automatic_tuning_client(&self) -> server_automatic_tuning::Client {
         server_automatic_tuning::Client(self.clone())
     }
-    pub fn server_azure_ad_administrators(&self) -> server_azure_ad_administrators::Client {
+    pub fn server_azure_ad_administrators_client(&self) -> server_azure_ad_administrators::Client {
         server_azure_ad_administrators::Client(self.clone())
     }
-    pub fn server_azure_ad_only_authentications(&self) -> server_azure_ad_only_authentications::Client {
+    pub fn server_azure_ad_only_authentications_client(&self) -> server_azure_ad_only_authentications::Client {
         server_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn server_blob_auditing_policies(&self) -> server_blob_auditing_policies::Client {
+    pub fn server_blob_auditing_policies_client(&self) -> server_blob_auditing_policies::Client {
         server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn server_communication_links(&self) -> server_communication_links::Client {
+    pub fn server_communication_links_client(&self) -> server_communication_links::Client {
         server_communication_links::Client(self.clone())
     }
-    pub fn server_connection_policies(&self) -> server_connection_policies::Client {
+    pub fn server_connection_policies_client(&self) -> server_connection_policies::Client {
         server_connection_policies::Client(self.clone())
     }
-    pub fn server_dev_ops_audit_settings(&self) -> server_dev_ops_audit_settings::Client {
+    pub fn server_dev_ops_audit_settings_client(&self) -> server_dev_ops_audit_settings::Client {
         server_dev_ops_audit_settings::Client(self.clone())
     }
-    pub fn server_dns_aliases(&self) -> server_dns_aliases::Client {
+    pub fn server_dns_aliases_client(&self) -> server_dns_aliases::Client {
         server_dns_aliases::Client(self.clone())
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
-    pub fn server_operations(&self) -> server_operations::Client {
+    pub fn server_operations_client(&self) -> server_operations::Client {
         server_operations::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn server_trust_certificates(&self) -> server_trust_certificates::Client {
+    pub fn server_trust_certificates_client(&self) -> server_trust_certificates::Client {
         server_trust_certificates::Client(self.clone())
     }
-    pub fn server_trust_groups(&self) -> server_trust_groups::Client {
+    pub fn server_trust_groups_client(&self) -> server_trust_groups::Client {
         server_trust_groups::Client(self.clone())
     }
-    pub fn server_usages(&self) -> server_usages::Client {
+    pub fn server_usages_client(&self) -> server_usages::Client {
         server_usages::Client(self.clone())
     }
-    pub fn server_vulnerability_assessments(&self) -> server_vulnerability_assessments::Client {
+    pub fn server_vulnerability_assessments_client(&self) -> server_vulnerability_assessments::Client {
         server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn service_objectives(&self) -> service_objectives::Client {
+    pub fn service_objectives_client(&self) -> service_objectives::Client {
         service_objectives::Client(self.clone())
     }
-    pub fn sql_agent(&self) -> sql_agent::Client {
+    pub fn sql_agent_client(&self) -> sql_agent::Client {
         sql_agent::Client(self.clone())
     }
-    pub fn subscription_usages(&self) -> subscription_usages::Client {
+    pub fn subscription_usages_client(&self) -> subscription_usages::Client {
         subscription_usages::Client(self.clone())
     }
-    pub fn sync_agents(&self) -> sync_agents::Client {
+    pub fn sync_agents_client(&self) -> sync_agents::Client {
         sync_agents::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn sync_members(&self) -> sync_members::Client {
+    pub fn sync_members_client(&self) -> sync_members::Client {
         sync_members::Client(self.clone())
     }
-    pub fn tde_certificates(&self) -> tde_certificates::Client {
+    pub fn tde_certificates_client(&self) -> tde_certificates::Client {
         tde_certificates::Client(self.clone())
     }
-    pub fn time_zones(&self) -> time_zones::Client {
+    pub fn time_zones_client(&self) -> time_zones::Client {
         time_zones::Client(self.clone())
     }
-    pub fn transparent_data_encryptions(&self) -> transparent_data_encryptions::Client {
+    pub fn transparent_data_encryptions_client(&self) -> transparent_data_encryptions::Client {
         transparent_data_encryptions::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_clusters(&self) -> virtual_clusters::Client {
+    pub fn virtual_clusters_client(&self) -> virtual_clusters::Client {
         virtual_clusters::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn workload_classifiers(&self) -> workload_classifiers::Client {
+    pub fn workload_classifiers_client(&self) -> workload_classifiers::Client {
         workload_classifiers::Client(self.clone())
     }
-    pub fn workload_groups(&self) -> workload_groups::Client {
+    pub fn workload_groups_client(&self) -> workload_groups::Client {
         workload_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/sql/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/sql/src/package_preview_2021_11/operations.rs
@@ -74,356 +74,356 @@ impl Client {
             pipeline,
         }
     }
-    pub fn backup_short_term_retention_policies(&self) -> backup_short_term_retention_policies::Client {
+    pub fn backup_short_term_retention_policies_client(&self) -> backup_short_term_retention_policies::Client {
         backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn capabilities(&self) -> capabilities::Client {
+    pub fn capabilities_client(&self) -> capabilities::Client {
         capabilities::Client(self.clone())
     }
-    pub fn data_warehouse_user_activities(&self) -> data_warehouse_user_activities::Client {
+    pub fn data_warehouse_user_activities_client(&self) -> data_warehouse_user_activities::Client {
         data_warehouse_user_activities::Client(self.clone())
     }
-    pub fn database_advanced_threat_protection_settings(&self) -> database_advanced_threat_protection_settings::Client {
+    pub fn database_advanced_threat_protection_settings_client(&self) -> database_advanced_threat_protection_settings::Client {
         database_advanced_threat_protection_settings::Client(self.clone())
     }
-    pub fn database_advisors(&self) -> database_advisors::Client {
+    pub fn database_advisors_client(&self) -> database_advisors::Client {
         database_advisors::Client(self.clone())
     }
-    pub fn database_automatic_tuning(&self) -> database_automatic_tuning::Client {
+    pub fn database_automatic_tuning_client(&self) -> database_automatic_tuning::Client {
         database_automatic_tuning::Client(self.clone())
     }
-    pub fn database_blob_auditing_policies(&self) -> database_blob_auditing_policies::Client {
+    pub fn database_blob_auditing_policies_client(&self) -> database_blob_auditing_policies::Client {
         database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn database_columns(&self) -> database_columns::Client {
+    pub fn database_columns_client(&self) -> database_columns::Client {
         database_columns::Client(self.clone())
     }
-    pub fn database_extensions(&self) -> database_extensions::Client {
+    pub fn database_extensions_client(&self) -> database_extensions::Client {
         database_extensions::Client(self.clone())
     }
-    pub fn database_operations(&self) -> database_operations::Client {
+    pub fn database_operations_client(&self) -> database_operations::Client {
         database_operations::Client(self.clone())
     }
-    pub fn database_recommended_actions(&self) -> database_recommended_actions::Client {
+    pub fn database_recommended_actions_client(&self) -> database_recommended_actions::Client {
         database_recommended_actions::Client(self.clone())
     }
-    pub fn database_schemas(&self) -> database_schemas::Client {
+    pub fn database_schemas_client(&self) -> database_schemas::Client {
         database_schemas::Client(self.clone())
     }
-    pub fn database_security_alert_policies(&self) -> database_security_alert_policies::Client {
+    pub fn database_security_alert_policies_client(&self) -> database_security_alert_policies::Client {
         database_security_alert_policies::Client(self.clone())
     }
-    pub fn database_tables(&self) -> database_tables::Client {
+    pub fn database_tables_client(&self) -> database_tables::Client {
         database_tables::Client(self.clone())
     }
-    pub fn database_usages(&self) -> database_usages::Client {
+    pub fn database_usages_client(&self) -> database_usages::Client {
         database_usages::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_rule_baselines(&self) -> database_vulnerability_assessment_rule_baselines::Client {
+    pub fn database_vulnerability_assessment_rule_baselines_client(&self) -> database_vulnerability_assessment_rule_baselines::Client {
         database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn database_vulnerability_assessment_scans(&self) -> database_vulnerability_assessment_scans::Client {
+    pub fn database_vulnerability_assessment_scans_client(&self) -> database_vulnerability_assessment_scans::Client {
         database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn database_vulnerability_assessments(&self) -> database_vulnerability_assessments::Client {
+    pub fn database_vulnerability_assessments_client(&self) -> database_vulnerability_assessments::Client {
         database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn deleted_servers(&self) -> deleted_servers::Client {
+    pub fn deleted_servers_client(&self) -> deleted_servers::Client {
         deleted_servers::Client(self.clone())
     }
-    pub fn distributed_availability_groups(&self) -> distributed_availability_groups::Client {
+    pub fn distributed_availability_groups_client(&self) -> distributed_availability_groups::Client {
         distributed_availability_groups::Client(self.clone())
     }
-    pub fn elastic_pool_operations(&self) -> elastic_pool_operations::Client {
+    pub fn elastic_pool_operations_client(&self) -> elastic_pool_operations::Client {
         elastic_pool_operations::Client(self.clone())
     }
-    pub fn elastic_pools(&self) -> elastic_pools::Client {
+    pub fn elastic_pools_client(&self) -> elastic_pools::Client {
         elastic_pools::Client(self.clone())
     }
-    pub fn encryption_protectors(&self) -> encryption_protectors::Client {
+    pub fn encryption_protectors_client(&self) -> encryption_protectors::Client {
         encryption_protectors::Client(self.clone())
     }
-    pub fn endpoint_certificates(&self) -> endpoint_certificates::Client {
+    pub fn endpoint_certificates_client(&self) -> endpoint_certificates::Client {
         endpoint_certificates::Client(self.clone())
     }
-    pub fn extended_database_blob_auditing_policies(&self) -> extended_database_blob_auditing_policies::Client {
+    pub fn extended_database_blob_auditing_policies_client(&self) -> extended_database_blob_auditing_policies::Client {
         extended_database_blob_auditing_policies::Client(self.clone())
     }
-    pub fn extended_server_blob_auditing_policies(&self) -> extended_server_blob_auditing_policies::Client {
+    pub fn extended_server_blob_auditing_policies_client(&self) -> extended_server_blob_auditing_policies::Client {
         extended_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn failover_groups(&self) -> failover_groups::Client {
+    pub fn failover_groups_client(&self) -> failover_groups::Client {
         failover_groups::Client(self.clone())
     }
-    pub fn firewall_rules(&self) -> firewall_rules::Client {
+    pub fn firewall_rules_client(&self) -> firewall_rules::Client {
         firewall_rules::Client(self.clone())
     }
-    pub fn i_pv6_firewall_rules(&self) -> i_pv6_firewall_rules::Client {
+    pub fn i_pv6_firewall_rules_client(&self) -> i_pv6_firewall_rules::Client {
         i_pv6_firewall_rules::Client(self.clone())
     }
-    pub fn instance_failover_groups(&self) -> instance_failover_groups::Client {
+    pub fn instance_failover_groups_client(&self) -> instance_failover_groups::Client {
         instance_failover_groups::Client(self.clone())
     }
-    pub fn instance_pools(&self) -> instance_pools::Client {
+    pub fn instance_pools_client(&self) -> instance_pools::Client {
         instance_pools::Client(self.clone())
     }
-    pub fn job_agents(&self) -> job_agents::Client {
+    pub fn job_agents_client(&self) -> job_agents::Client {
         job_agents::Client(self.clone())
     }
-    pub fn job_credentials(&self) -> job_credentials::Client {
+    pub fn job_credentials_client(&self) -> job_credentials::Client {
         job_credentials::Client(self.clone())
     }
-    pub fn job_executions(&self) -> job_executions::Client {
+    pub fn job_executions_client(&self) -> job_executions::Client {
         job_executions::Client(self.clone())
     }
-    pub fn job_step_executions(&self) -> job_step_executions::Client {
+    pub fn job_step_executions_client(&self) -> job_step_executions::Client {
         job_step_executions::Client(self.clone())
     }
-    pub fn job_steps(&self) -> job_steps::Client {
+    pub fn job_steps_client(&self) -> job_steps::Client {
         job_steps::Client(self.clone())
     }
-    pub fn job_target_executions(&self) -> job_target_executions::Client {
+    pub fn job_target_executions_client(&self) -> job_target_executions::Client {
         job_target_executions::Client(self.clone())
     }
-    pub fn job_target_groups(&self) -> job_target_groups::Client {
+    pub fn job_target_groups_client(&self) -> job_target_groups::Client {
         job_target_groups::Client(self.clone())
     }
-    pub fn job_versions(&self) -> job_versions::Client {
+    pub fn job_versions_client(&self) -> job_versions::Client {
         job_versions::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn ledger_digest_uploads(&self) -> ledger_digest_uploads::Client {
+    pub fn ledger_digest_uploads_client(&self) -> ledger_digest_uploads::Client {
         ledger_digest_uploads::Client(self.clone())
     }
-    pub fn long_term_retention_backups(&self) -> long_term_retention_backups::Client {
+    pub fn long_term_retention_backups_client(&self) -> long_term_retention_backups::Client {
         long_term_retention_backups::Client(self.clone())
     }
-    pub fn long_term_retention_managed_instance_backups(&self) -> long_term_retention_managed_instance_backups::Client {
+    pub fn long_term_retention_managed_instance_backups_client(&self) -> long_term_retention_managed_instance_backups::Client {
         long_term_retention_managed_instance_backups::Client(self.clone())
     }
-    pub fn long_term_retention_policies(&self) -> long_term_retention_policies::Client {
+    pub fn long_term_retention_policies_client(&self) -> long_term_retention_policies::Client {
         long_term_retention_policies::Client(self.clone())
     }
-    pub fn maintenance_window_options(&self) -> maintenance_window_options::Client {
+    pub fn maintenance_window_options_client(&self) -> maintenance_window_options::Client {
         maintenance_window_options::Client(self.clone())
     }
-    pub fn maintenance_windows(&self) -> maintenance_windows::Client {
+    pub fn maintenance_windows_client(&self) -> maintenance_windows::Client {
         maintenance_windows::Client(self.clone())
     }
-    pub fn managed_backup_short_term_retention_policies(&self) -> managed_backup_short_term_retention_policies::Client {
+    pub fn managed_backup_short_term_retention_policies_client(&self) -> managed_backup_short_term_retention_policies::Client {
         managed_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_database_columns(&self) -> managed_database_columns::Client {
+    pub fn managed_database_columns_client(&self) -> managed_database_columns::Client {
         managed_database_columns::Client(self.clone())
     }
-    pub fn managed_database_queries(&self) -> managed_database_queries::Client {
+    pub fn managed_database_queries_client(&self) -> managed_database_queries::Client {
         managed_database_queries::Client(self.clone())
     }
-    pub fn managed_database_recommended_sensitivity_labels(&self) -> managed_database_recommended_sensitivity_labels::Client {
+    pub fn managed_database_recommended_sensitivity_labels_client(&self) -> managed_database_recommended_sensitivity_labels::Client {
         managed_database_recommended_sensitivity_labels::Client(self.clone())
     }
-    pub fn managed_database_restore_details(&self) -> managed_database_restore_details::Client {
+    pub fn managed_database_restore_details_client(&self) -> managed_database_restore_details::Client {
         managed_database_restore_details::Client(self.clone())
     }
-    pub fn managed_database_schemas(&self) -> managed_database_schemas::Client {
+    pub fn managed_database_schemas_client(&self) -> managed_database_schemas::Client {
         managed_database_schemas::Client(self.clone())
     }
-    pub fn managed_database_security_alert_policies(&self) -> managed_database_security_alert_policies::Client {
+    pub fn managed_database_security_alert_policies_client(&self) -> managed_database_security_alert_policies::Client {
         managed_database_security_alert_policies::Client(self.clone())
     }
-    pub fn managed_database_security_events(&self) -> managed_database_security_events::Client {
+    pub fn managed_database_security_events_client(&self) -> managed_database_security_events::Client {
         managed_database_security_events::Client(self.clone())
     }
-    pub fn managed_database_sensitivity_labels(&self) -> managed_database_sensitivity_labels::Client {
+    pub fn managed_database_sensitivity_labels_client(&self) -> managed_database_sensitivity_labels::Client {
         managed_database_sensitivity_labels::Client(self.clone())
     }
-    pub fn managed_database_tables(&self) -> managed_database_tables::Client {
+    pub fn managed_database_tables_client(&self) -> managed_database_tables::Client {
         managed_database_tables::Client(self.clone())
     }
-    pub fn managed_database_transparent_data_encryption(&self) -> managed_database_transparent_data_encryption::Client {
+    pub fn managed_database_transparent_data_encryption_client(&self) -> managed_database_transparent_data_encryption::Client {
         managed_database_transparent_data_encryption::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_rule_baselines(
+    pub fn managed_database_vulnerability_assessment_rule_baselines_client(
         &self,
     ) -> managed_database_vulnerability_assessment_rule_baselines::Client {
         managed_database_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessment_scans(&self) -> managed_database_vulnerability_assessment_scans::Client {
+    pub fn managed_database_vulnerability_assessment_scans_client(&self) -> managed_database_vulnerability_assessment_scans::Client {
         managed_database_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn managed_database_vulnerability_assessments(&self) -> managed_database_vulnerability_assessments::Client {
+    pub fn managed_database_vulnerability_assessments_client(&self) -> managed_database_vulnerability_assessments::Client {
         managed_database_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_databases(&self) -> managed_databases::Client {
+    pub fn managed_databases_client(&self) -> managed_databases::Client {
         managed_databases::Client(self.clone())
     }
-    pub fn managed_instance_administrators(&self) -> managed_instance_administrators::Client {
+    pub fn managed_instance_administrators_client(&self) -> managed_instance_administrators::Client {
         managed_instance_administrators::Client(self.clone())
     }
-    pub fn managed_instance_azure_ad_only_authentications(&self) -> managed_instance_azure_ad_only_authentications::Client {
+    pub fn managed_instance_azure_ad_only_authentications_client(&self) -> managed_instance_azure_ad_only_authentications::Client {
         managed_instance_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn managed_instance_encryption_protectors(&self) -> managed_instance_encryption_protectors::Client {
+    pub fn managed_instance_encryption_protectors_client(&self) -> managed_instance_encryption_protectors::Client {
         managed_instance_encryption_protectors::Client(self.clone())
     }
-    pub fn managed_instance_keys(&self) -> managed_instance_keys::Client {
+    pub fn managed_instance_keys_client(&self) -> managed_instance_keys::Client {
         managed_instance_keys::Client(self.clone())
     }
-    pub fn managed_instance_long_term_retention_policies(&self) -> managed_instance_long_term_retention_policies::Client {
+    pub fn managed_instance_long_term_retention_policies_client(&self) -> managed_instance_long_term_retention_policies::Client {
         managed_instance_long_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_instance_operations(&self) -> managed_instance_operations::Client {
+    pub fn managed_instance_operations_client(&self) -> managed_instance_operations::Client {
         managed_instance_operations::Client(self.clone())
     }
-    pub fn managed_instance_private_endpoint_connections(&self) -> managed_instance_private_endpoint_connections::Client {
+    pub fn managed_instance_private_endpoint_connections_client(&self) -> managed_instance_private_endpoint_connections::Client {
         managed_instance_private_endpoint_connections::Client(self.clone())
     }
-    pub fn managed_instance_private_link_resources(&self) -> managed_instance_private_link_resources::Client {
+    pub fn managed_instance_private_link_resources_client(&self) -> managed_instance_private_link_resources::Client {
         managed_instance_private_link_resources::Client(self.clone())
     }
-    pub fn managed_instance_tde_certificates(&self) -> managed_instance_tde_certificates::Client {
+    pub fn managed_instance_tde_certificates_client(&self) -> managed_instance_tde_certificates::Client {
         managed_instance_tde_certificates::Client(self.clone())
     }
-    pub fn managed_instance_vulnerability_assessments(&self) -> managed_instance_vulnerability_assessments::Client {
+    pub fn managed_instance_vulnerability_assessments_client(&self) -> managed_instance_vulnerability_assessments::Client {
         managed_instance_vulnerability_assessments::Client(self.clone())
     }
-    pub fn managed_instances(&self) -> managed_instances::Client {
+    pub fn managed_instances_client(&self) -> managed_instances::Client {
         managed_instances::Client(self.clone())
     }
-    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies(
+    pub fn managed_restorable_dropped_database_backup_short_term_retention_policies_client(
         &self,
     ) -> managed_restorable_dropped_database_backup_short_term_retention_policies::Client {
         managed_restorable_dropped_database_backup_short_term_retention_policies::Client(self.clone())
     }
-    pub fn managed_server_dns_aliases(&self) -> managed_server_dns_aliases::Client {
+    pub fn managed_server_dns_aliases_client(&self) -> managed_server_dns_aliases::Client {
         managed_server_dns_aliases::Client(self.clone())
     }
-    pub fn managed_server_security_alert_policies(&self) -> managed_server_security_alert_policies::Client {
+    pub fn managed_server_security_alert_policies_client(&self) -> managed_server_security_alert_policies::Client {
         managed_server_security_alert_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn outbound_firewall_rules(&self) -> outbound_firewall_rules::Client {
+    pub fn outbound_firewall_rules_client(&self) -> outbound_firewall_rules::Client {
         outbound_firewall_rules::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn recommended_sensitivity_labels(&self) -> recommended_sensitivity_labels::Client {
+    pub fn recommended_sensitivity_labels_client(&self) -> recommended_sensitivity_labels::Client {
         recommended_sensitivity_labels::Client(self.clone())
     }
-    pub fn recoverable_managed_databases(&self) -> recoverable_managed_databases::Client {
+    pub fn recoverable_managed_databases_client(&self) -> recoverable_managed_databases::Client {
         recoverable_managed_databases::Client(self.clone())
     }
-    pub fn replication_links(&self) -> replication_links::Client {
+    pub fn replication_links_client(&self) -> replication_links::Client {
         replication_links::Client(self.clone())
     }
-    pub fn restorable_dropped_databases(&self) -> restorable_dropped_databases::Client {
+    pub fn restorable_dropped_databases_client(&self) -> restorable_dropped_databases::Client {
         restorable_dropped_databases::Client(self.clone())
     }
-    pub fn restorable_dropped_managed_databases(&self) -> restorable_dropped_managed_databases::Client {
+    pub fn restorable_dropped_managed_databases_client(&self) -> restorable_dropped_managed_databases::Client {
         restorable_dropped_managed_databases::Client(self.clone())
     }
-    pub fn restore_points(&self) -> restore_points::Client {
+    pub fn restore_points_client(&self) -> restore_points::Client {
         restore_points::Client(self.clone())
     }
-    pub fn sensitivity_labels(&self) -> sensitivity_labels::Client {
+    pub fn sensitivity_labels_client(&self) -> sensitivity_labels::Client {
         sensitivity_labels::Client(self.clone())
     }
-    pub fn server_advanced_threat_protection_settings(&self) -> server_advanced_threat_protection_settings::Client {
+    pub fn server_advanced_threat_protection_settings_client(&self) -> server_advanced_threat_protection_settings::Client {
         server_advanced_threat_protection_settings::Client(self.clone())
     }
-    pub fn server_advisors(&self) -> server_advisors::Client {
+    pub fn server_advisors_client(&self) -> server_advisors::Client {
         server_advisors::Client(self.clone())
     }
-    pub fn server_automatic_tuning(&self) -> server_automatic_tuning::Client {
+    pub fn server_automatic_tuning_client(&self) -> server_automatic_tuning::Client {
         server_automatic_tuning::Client(self.clone())
     }
-    pub fn server_azure_ad_administrators(&self) -> server_azure_ad_administrators::Client {
+    pub fn server_azure_ad_administrators_client(&self) -> server_azure_ad_administrators::Client {
         server_azure_ad_administrators::Client(self.clone())
     }
-    pub fn server_azure_ad_only_authentications(&self) -> server_azure_ad_only_authentications::Client {
+    pub fn server_azure_ad_only_authentications_client(&self) -> server_azure_ad_only_authentications::Client {
         server_azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn server_blob_auditing_policies(&self) -> server_blob_auditing_policies::Client {
+    pub fn server_blob_auditing_policies_client(&self) -> server_blob_auditing_policies::Client {
         server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn server_connection_policies(&self) -> server_connection_policies::Client {
+    pub fn server_connection_policies_client(&self) -> server_connection_policies::Client {
         server_connection_policies::Client(self.clone())
     }
-    pub fn server_dev_ops_audit_settings(&self) -> server_dev_ops_audit_settings::Client {
+    pub fn server_dev_ops_audit_settings_client(&self) -> server_dev_ops_audit_settings::Client {
         server_dev_ops_audit_settings::Client(self.clone())
     }
-    pub fn server_dns_aliases(&self) -> server_dns_aliases::Client {
+    pub fn server_dns_aliases_client(&self) -> server_dns_aliases::Client {
         server_dns_aliases::Client(self.clone())
     }
-    pub fn server_keys(&self) -> server_keys::Client {
+    pub fn server_keys_client(&self) -> server_keys::Client {
         server_keys::Client(self.clone())
     }
-    pub fn server_operations(&self) -> server_operations::Client {
+    pub fn server_operations_client(&self) -> server_operations::Client {
         server_operations::Client(self.clone())
     }
-    pub fn server_security_alert_policies(&self) -> server_security_alert_policies::Client {
+    pub fn server_security_alert_policies_client(&self) -> server_security_alert_policies::Client {
         server_security_alert_policies::Client(self.clone())
     }
-    pub fn server_trust_certificates(&self) -> server_trust_certificates::Client {
+    pub fn server_trust_certificates_client(&self) -> server_trust_certificates::Client {
         server_trust_certificates::Client(self.clone())
     }
-    pub fn server_trust_groups(&self) -> server_trust_groups::Client {
+    pub fn server_trust_groups_client(&self) -> server_trust_groups::Client {
         server_trust_groups::Client(self.clone())
     }
-    pub fn server_vulnerability_assessments(&self) -> server_vulnerability_assessments::Client {
+    pub fn server_vulnerability_assessments_client(&self) -> server_vulnerability_assessments::Client {
         server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn servers(&self) -> servers::Client {
+    pub fn servers_client(&self) -> servers::Client {
         servers::Client(self.clone())
     }
-    pub fn sql_agent(&self) -> sql_agent::Client {
+    pub fn sql_agent_client(&self) -> sql_agent::Client {
         sql_agent::Client(self.clone())
     }
-    pub fn subscription_usages(&self) -> subscription_usages::Client {
+    pub fn subscription_usages_client(&self) -> subscription_usages::Client {
         subscription_usages::Client(self.clone())
     }
-    pub fn sync_agents(&self) -> sync_agents::Client {
+    pub fn sync_agents_client(&self) -> sync_agents::Client {
         sync_agents::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn sync_members(&self) -> sync_members::Client {
+    pub fn sync_members_client(&self) -> sync_members::Client {
         sync_members::Client(self.clone())
     }
-    pub fn tde_certificates(&self) -> tde_certificates::Client {
+    pub fn tde_certificates_client(&self) -> tde_certificates::Client {
         tde_certificates::Client(self.clone())
     }
-    pub fn time_zones(&self) -> time_zones::Client {
+    pub fn time_zones_client(&self) -> time_zones::Client {
         time_zones::Client(self.clone())
     }
-    pub fn transparent_data_encryptions(&self) -> transparent_data_encryptions::Client {
+    pub fn transparent_data_encryptions_client(&self) -> transparent_data_encryptions::Client {
         transparent_data_encryptions::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_clusters(&self) -> virtual_clusters::Client {
+    pub fn virtual_clusters_client(&self) -> virtual_clusters::Client {
         virtual_clusters::Client(self.clone())
     }
-    pub fn virtual_network_rules(&self) -> virtual_network_rules::Client {
+    pub fn virtual_network_rules_client(&self) -> virtual_network_rules::Client {
         virtual_network_rules::Client(self.clone())
     }
-    pub fn workload_classifiers(&self) -> workload_classifiers::Client {
+    pub fn workload_classifiers_client(&self) -> workload_classifiers::Client {
         workload_classifiers::Client(self.clone())
     }
-    pub fn workload_groups(&self) -> workload_groups::Client {
+    pub fn workload_groups_client(&self) -> workload_groups::Client {
         workload_groups::Client(self.clone())
     }
 }

--- a/services/mgmt/sqlvirtualmachine/src/package_2017_03_01_preview/operations.rs
+++ b/services/mgmt/sqlvirtualmachine/src/package_2017_03_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_group_listeners(&self) -> availability_group_listeners::Client {
+    pub fn availability_group_listeners_client(&self) -> availability_group_listeners::Client {
         availability_group_listeners::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn sql_virtual_machine_groups(&self) -> sql_virtual_machine_groups::Client {
+    pub fn sql_virtual_machine_groups_client(&self) -> sql_virtual_machine_groups::Client {
         sql_virtual_machine_groups::Client(self.clone())
     }
-    pub fn sql_virtual_machines(&self) -> sql_virtual_machines::Client {
+    pub fn sql_virtual_machines_client(&self) -> sql_virtual_machines::Client {
         sql_virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/sqlvirtualmachine/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/sqlvirtualmachine/src/package_preview_2021_11/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn availability_group_listeners(&self) -> availability_group_listeners::Client {
+    pub fn availability_group_listeners_client(&self) -> availability_group_listeners::Client {
         availability_group_listeners::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn sql_virtual_machine_groups(&self) -> sql_virtual_machine_groups::Client {
+    pub fn sql_virtual_machine_groups_client(&self) -> sql_virtual_machine_groups::Client {
         sql_virtual_machine_groups::Client(self.clone())
     }
-    pub fn sql_virtual_machines(&self) -> sql_virtual_machines::Client {
+    pub fn sql_virtual_machines_client(&self) -> sql_virtual_machines::Client {
         sql_virtual_machines::Client(self.clone())
     }
 }

--- a/services/mgmt/stack/src/package_2016_01/operations.rs
+++ b/services/mgmt/stack/src/package_2016_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn products(&self) -> products::Client {
+    pub fn products_client(&self) -> products::Client {
         products::Client(self.clone())
     }
-    pub fn registrations(&self) -> registrations::Client {
+    pub fn registrations_client(&self) -> registrations::Client {
         registrations::Client(self.clone())
     }
 }

--- a/services/mgmt/stack/src/package_2017_06_01/operations.rs
+++ b/services/mgmt/stack/src/package_2017_06_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cloud_manifest_file(&self) -> cloud_manifest_file::Client {
+    pub fn cloud_manifest_file_client(&self) -> cloud_manifest_file::Client {
         cloud_manifest_file::Client(self.clone())
     }
-    pub fn customer_subscriptions(&self) -> customer_subscriptions::Client {
+    pub fn customer_subscriptions_client(&self) -> customer_subscriptions::Client {
         customer_subscriptions::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn products(&self) -> products::Client {
+    pub fn products_client(&self) -> products::Client {
         products::Client(self.clone())
     }
-    pub fn registrations(&self) -> registrations::Client {
+    pub fn registrations_client(&self) -> registrations::Client {
         registrations::Client(self.clone())
     }
 }

--- a/services/mgmt/stack/src/package_preview_2020_06/operations.rs
+++ b/services/mgmt/stack/src/package_preview_2020_06/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cloud_manifest_file(&self) -> cloud_manifest_file::Client {
+    pub fn cloud_manifest_file_client(&self) -> cloud_manifest_file::Client {
         cloud_manifest_file::Client(self.clone())
     }
-    pub fn customer_subscriptions(&self) -> customer_subscriptions::Client {
+    pub fn customer_subscriptions_client(&self) -> customer_subscriptions::Client {
         customer_subscriptions::Client(self.clone())
     }
-    pub fn linked_subscriptions(&self) -> linked_subscriptions::Client {
+    pub fn linked_subscriptions_client(&self) -> linked_subscriptions::Client {
         linked_subscriptions::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn products(&self) -> products::Client {
+    pub fn products_client(&self) -> products::Client {
         products::Client(self.clone())
     }
-    pub fn registrations(&self) -> registrations::Client {
+    pub fn registrations_client(&self) -> registrations::Client {
         registrations::Client(self.clone())
     }
 }

--- a/services/mgmt/storage/examples/storage_account_list.rs
+++ b/services/mgmt/storage/examples/storage_account_list.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = azure_mgmt_storage::ClientBuilder::new(credential).build();
 
     let mut count = 0;
-    let mut stream = client.storage_accounts().list(subscription_id).into_stream();
+    let mut stream = client.storage_accounts_client().list(subscription_id).into_stream();
     while let Some(accounts) = stream.next().await {
         let accounts = accounts?;
         count += accounts.value.len();

--- a/services/mgmt/storage/examples/storage_containers_list.rs
+++ b/services/mgmt/storage/examples/storage_containers_list.rs
@@ -20,7 +20,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let group = std::env::args().nth(1).expect("please specify resource group");
     let account = std::env::args().nth(2).expect("please specify account");
 
-    let mut stream = client.blob_containers().list(&group, &account, &subscription_id).into_stream();
+    let mut stream = client
+        .blob_containers_client()
+        .list(&group, &account, &subscription_id)
+        .into_stream();
     let mut count = 0;
     while let Some(x) = stream.next().await {
         let x = x?;

--- a/services/mgmt/storage/src/package_2021_04/operations.rs
+++ b/services/mgmt/storage/src/package_2021_04/operations.rs
@@ -74,61 +74,61 @@ impl Client {
             pipeline,
         }
     }
-    pub fn blob_containers(&self) -> blob_containers::Client {
+    pub fn blob_containers_client(&self) -> blob_containers::Client {
         blob_containers::Client(self.clone())
     }
-    pub fn blob_inventory_policies(&self) -> blob_inventory_policies::Client {
+    pub fn blob_inventory_policies_client(&self) -> blob_inventory_policies::Client {
         blob_inventory_policies::Client(self.clone())
     }
-    pub fn blob_services(&self) -> blob_services::Client {
+    pub fn blob_services_client(&self) -> blob_services::Client {
         blob_services::Client(self.clone())
     }
-    pub fn deleted_accounts(&self) -> deleted_accounts::Client {
+    pub fn deleted_accounts_client(&self) -> deleted_accounts::Client {
         deleted_accounts::Client(self.clone())
     }
-    pub fn encryption_scopes(&self) -> encryption_scopes::Client {
+    pub fn encryption_scopes_client(&self) -> encryption_scopes::Client {
         encryption_scopes::Client(self.clone())
     }
-    pub fn file_services(&self) -> file_services::Client {
+    pub fn file_services_client(&self) -> file_services::Client {
         file_services::Client(self.clone())
     }
-    pub fn file_shares(&self) -> file_shares::Client {
+    pub fn file_shares_client(&self) -> file_shares::Client {
         file_shares::Client(self.clone())
     }
-    pub fn management_policies(&self) -> management_policies::Client {
+    pub fn management_policies_client(&self) -> management_policies::Client {
         management_policies::Client(self.clone())
     }
-    pub fn object_replication_policies(&self) -> object_replication_policies::Client {
+    pub fn object_replication_policies_client(&self) -> object_replication_policies::Client {
         object_replication_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queue(&self) -> queue::Client {
+    pub fn queue_client(&self) -> queue::Client {
         queue::Client(self.clone())
     }
-    pub fn queue_services(&self) -> queue_services::Client {
+    pub fn queue_services_client(&self) -> queue_services::Client {
         queue_services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn table(&self) -> table::Client {
+    pub fn table_client(&self) -> table::Client {
         table::Client(self.clone())
     }
-    pub fn table_services(&self) -> table_services::Client {
+    pub fn table_services_client(&self) -> table_services::Client {
         table_services::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/storage/src/package_2021_06/operations.rs
+++ b/services/mgmt/storage/src/package_2021_06/operations.rs
@@ -74,61 +74,61 @@ impl Client {
             pipeline,
         }
     }
-    pub fn blob_containers(&self) -> blob_containers::Client {
+    pub fn blob_containers_client(&self) -> blob_containers::Client {
         blob_containers::Client(self.clone())
     }
-    pub fn blob_inventory_policies(&self) -> blob_inventory_policies::Client {
+    pub fn blob_inventory_policies_client(&self) -> blob_inventory_policies::Client {
         blob_inventory_policies::Client(self.clone())
     }
-    pub fn blob_services(&self) -> blob_services::Client {
+    pub fn blob_services_client(&self) -> blob_services::Client {
         blob_services::Client(self.clone())
     }
-    pub fn deleted_accounts(&self) -> deleted_accounts::Client {
+    pub fn deleted_accounts_client(&self) -> deleted_accounts::Client {
         deleted_accounts::Client(self.clone())
     }
-    pub fn encryption_scopes(&self) -> encryption_scopes::Client {
+    pub fn encryption_scopes_client(&self) -> encryption_scopes::Client {
         encryption_scopes::Client(self.clone())
     }
-    pub fn file_services(&self) -> file_services::Client {
+    pub fn file_services_client(&self) -> file_services::Client {
         file_services::Client(self.clone())
     }
-    pub fn file_shares(&self) -> file_shares::Client {
+    pub fn file_shares_client(&self) -> file_shares::Client {
         file_shares::Client(self.clone())
     }
-    pub fn management_policies(&self) -> management_policies::Client {
+    pub fn management_policies_client(&self) -> management_policies::Client {
         management_policies::Client(self.clone())
     }
-    pub fn object_replication_policies(&self) -> object_replication_policies::Client {
+    pub fn object_replication_policies_client(&self) -> object_replication_policies::Client {
         object_replication_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queue(&self) -> queue::Client {
+    pub fn queue_client(&self) -> queue::Client {
         queue::Client(self.clone())
     }
-    pub fn queue_services(&self) -> queue_services::Client {
+    pub fn queue_services_client(&self) -> queue_services::Client {
         queue_services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn table(&self) -> table::Client {
+    pub fn table_client(&self) -> table::Client {
         table::Client(self.clone())
     }
-    pub fn table_services(&self) -> table_services::Client {
+    pub fn table_services_client(&self) -> table_services::Client {
         table_services::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/storage/src/package_2021_08/operations.rs
+++ b/services/mgmt/storage/src/package_2021_08/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn blob_containers(&self) -> blob_containers::Client {
+    pub fn blob_containers_client(&self) -> blob_containers::Client {
         blob_containers::Client(self.clone())
     }
-    pub fn blob_inventory_policies(&self) -> blob_inventory_policies::Client {
+    pub fn blob_inventory_policies_client(&self) -> blob_inventory_policies::Client {
         blob_inventory_policies::Client(self.clone())
     }
-    pub fn blob_services(&self) -> blob_services::Client {
+    pub fn blob_services_client(&self) -> blob_services::Client {
         blob_services::Client(self.clone())
     }
-    pub fn deleted_accounts(&self) -> deleted_accounts::Client {
+    pub fn deleted_accounts_client(&self) -> deleted_accounts::Client {
         deleted_accounts::Client(self.clone())
     }
-    pub fn encryption_scopes(&self) -> encryption_scopes::Client {
+    pub fn encryption_scopes_client(&self) -> encryption_scopes::Client {
         encryption_scopes::Client(self.clone())
     }
-    pub fn file_services(&self) -> file_services::Client {
+    pub fn file_services_client(&self) -> file_services::Client {
         file_services::Client(self.clone())
     }
-    pub fn file_shares(&self) -> file_shares::Client {
+    pub fn file_shares_client(&self) -> file_shares::Client {
         file_shares::Client(self.clone())
     }
-    pub fn local_users(&self) -> local_users::Client {
+    pub fn local_users_client(&self) -> local_users::Client {
         local_users::Client(self.clone())
     }
-    pub fn management_policies(&self) -> management_policies::Client {
+    pub fn management_policies_client(&self) -> management_policies::Client {
         management_policies::Client(self.clone())
     }
-    pub fn object_replication_policies(&self) -> object_replication_policies::Client {
+    pub fn object_replication_policies_client(&self) -> object_replication_policies::Client {
         object_replication_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queue(&self) -> queue::Client {
+    pub fn queue_client(&self) -> queue::Client {
         queue::Client(self.clone())
     }
-    pub fn queue_services(&self) -> queue_services::Client {
+    pub fn queue_services_client(&self) -> queue_services::Client {
         queue_services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn table(&self) -> table::Client {
+    pub fn table_client(&self) -> table::Client {
         table::Client(self.clone())
     }
-    pub fn table_services(&self) -> table_services::Client {
+    pub fn table_services_client(&self) -> table_services::Client {
         table_services::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/storage/src/package_2021_09/operations.rs
+++ b/services/mgmt/storage/src/package_2021_09/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn blob_containers(&self) -> blob_containers::Client {
+    pub fn blob_containers_client(&self) -> blob_containers::Client {
         blob_containers::Client(self.clone())
     }
-    pub fn blob_inventory_policies(&self) -> blob_inventory_policies::Client {
+    pub fn blob_inventory_policies_client(&self) -> blob_inventory_policies::Client {
         blob_inventory_policies::Client(self.clone())
     }
-    pub fn blob_services(&self) -> blob_services::Client {
+    pub fn blob_services_client(&self) -> blob_services::Client {
         blob_services::Client(self.clone())
     }
-    pub fn deleted_accounts(&self) -> deleted_accounts::Client {
+    pub fn deleted_accounts_client(&self) -> deleted_accounts::Client {
         deleted_accounts::Client(self.clone())
     }
-    pub fn encryption_scopes(&self) -> encryption_scopes::Client {
+    pub fn encryption_scopes_client(&self) -> encryption_scopes::Client {
         encryption_scopes::Client(self.clone())
     }
-    pub fn file_services(&self) -> file_services::Client {
+    pub fn file_services_client(&self) -> file_services::Client {
         file_services::Client(self.clone())
     }
-    pub fn file_shares(&self) -> file_shares::Client {
+    pub fn file_shares_client(&self) -> file_shares::Client {
         file_shares::Client(self.clone())
     }
-    pub fn local_users(&self) -> local_users::Client {
+    pub fn local_users_client(&self) -> local_users::Client {
         local_users::Client(self.clone())
     }
-    pub fn management_policies(&self) -> management_policies::Client {
+    pub fn management_policies_client(&self) -> management_policies::Client {
         management_policies::Client(self.clone())
     }
-    pub fn object_replication_policies(&self) -> object_replication_policies::Client {
+    pub fn object_replication_policies_client(&self) -> object_replication_policies::Client {
         object_replication_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn queue(&self) -> queue::Client {
+    pub fn queue_client(&self) -> queue::Client {
         queue::Client(self.clone())
     }
-    pub fn queue_services(&self) -> queue_services::Client {
+    pub fn queue_services_client(&self) -> queue_services::Client {
         queue_services::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn table(&self) -> table::Client {
+    pub fn table_client(&self) -> table::Client {
         table::Client(self.clone())
     }
-    pub fn table_services(&self) -> table_services::Client {
+    pub fn table_services_client(&self) -> table_services::Client {
         table_services::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/storage/src/profile_hybrid_2020_09_01/operations.rs
+++ b/services/mgmt/storage/src/profile_hybrid_2020_09_01/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn blob_inventory_policies(&self) -> blob_inventory_policies::Client {
+    pub fn blob_inventory_policies_client(&self) -> blob_inventory_policies::Client {
         blob_inventory_policies::Client(self.clone())
     }
-    pub fn encryption_scopes(&self) -> encryption_scopes::Client {
+    pub fn encryption_scopes_client(&self) -> encryption_scopes::Client {
         encryption_scopes::Client(self.clone())
     }
-    pub fn management_policies(&self) -> management_policies::Client {
+    pub fn management_policies_client(&self) -> management_policies::Client {
         management_policies::Client(self.clone())
     }
-    pub fn object_replication_policies(&self) -> object_replication_policies::Client {
+    pub fn object_replication_policies_client(&self) -> object_replication_policies::Client {
         object_replication_policies::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_accounts(&self) -> storage_accounts::Client {
+    pub fn storage_accounts_client(&self) -> storage_accounts::Client {
         storage_accounts::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
 }

--- a/services/mgmt/storagecache/src/package_2021_03/operations.rs
+++ b/services/mgmt/storagecache/src/package_2021_03/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn asc_operations(&self) -> asc_operations::Client {
+    pub fn asc_operations_client(&self) -> asc_operations::Client {
         asc_operations::Client(self.clone())
     }
-    pub fn caches(&self) -> caches::Client {
+    pub fn caches_client(&self) -> caches::Client {
         caches::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_targets(&self) -> storage_targets::Client {
+    pub fn storage_targets_client(&self) -> storage_targets::Client {
         storage_targets::Client(self.clone())
     }
-    pub fn usage_models(&self) -> usage_models::Client {
+    pub fn usage_models_client(&self) -> usage_models::Client {
         usage_models::Client(self.clone())
     }
 }

--- a/services/mgmt/storagecache/src/package_2021_05/operations.rs
+++ b/services/mgmt/storagecache/src/package_2021_05/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn asc_operations(&self) -> asc_operations::Client {
+    pub fn asc_operations_client(&self) -> asc_operations::Client {
         asc_operations::Client(self.clone())
     }
-    pub fn caches(&self) -> caches::Client {
+    pub fn caches_client(&self) -> caches::Client {
         caches::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_target(&self) -> storage_target::Client {
+    pub fn storage_target_client(&self) -> storage_target::Client {
         storage_target::Client(self.clone())
     }
-    pub fn storage_targets(&self) -> storage_targets::Client {
+    pub fn storage_targets_client(&self) -> storage_targets::Client {
         storage_targets::Client(self.clone())
     }
-    pub fn usage_models(&self) -> usage_models::Client {
+    pub fn usage_models_client(&self) -> usage_models::Client {
         usage_models::Client(self.clone())
     }
 }

--- a/services/mgmt/storagecache/src/package_2021_09/operations.rs
+++ b/services/mgmt/storagecache/src/package_2021_09/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn asc_operations(&self) -> asc_operations::Client {
+    pub fn asc_operations_client(&self) -> asc_operations::Client {
         asc_operations::Client(self.clone())
     }
-    pub fn caches(&self) -> caches::Client {
+    pub fn caches_client(&self) -> caches::Client {
         caches::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_target(&self) -> storage_target::Client {
+    pub fn storage_target_client(&self) -> storage_target::Client {
         storage_target::Client(self.clone())
     }
-    pub fn storage_targets(&self) -> storage_targets::Client {
+    pub fn storage_targets_client(&self) -> storage_targets::Client {
         storage_targets::Client(self.clone())
     }
-    pub fn usage_models(&self) -> usage_models::Client {
+    pub fn usage_models_client(&self) -> usage_models::Client {
         usage_models::Client(self.clone())
     }
 }

--- a/services/mgmt/storagecache/src/package_2022_01/operations.rs
+++ b/services/mgmt/storagecache/src/package_2022_01/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn asc_operations(&self) -> asc_operations::Client {
+    pub fn asc_operations_client(&self) -> asc_operations::Client {
         asc_operations::Client(self.clone())
     }
-    pub fn asc_usages(&self) -> asc_usages::Client {
+    pub fn asc_usages_client(&self) -> asc_usages::Client {
         asc_usages::Client(self.clone())
     }
-    pub fn caches(&self) -> caches::Client {
+    pub fn caches_client(&self) -> caches::Client {
         caches::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_target(&self) -> storage_target::Client {
+    pub fn storage_target_client(&self) -> storage_target::Client {
         storage_target::Client(self.clone())
     }
-    pub fn storage_targets(&self) -> storage_targets::Client {
+    pub fn storage_targets_client(&self) -> storage_targets::Client {
         storage_targets::Client(self.clone())
     }
-    pub fn usage_models(&self) -> usage_models::Client {
+    pub fn usage_models_client(&self) -> usage_models::Client {
         usage_models::Client(self.clone())
     }
 }

--- a/services/mgmt/storagecache/src/package_2022_05/operations.rs
+++ b/services/mgmt/storagecache/src/package_2022_05/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn asc_operations(&self) -> asc_operations::Client {
+    pub fn asc_operations_client(&self) -> asc_operations::Client {
         asc_operations::Client(self.clone())
     }
-    pub fn asc_usages(&self) -> asc_usages::Client {
+    pub fn asc_usages_client(&self) -> asc_usages::Client {
         asc_usages::Client(self.clone())
     }
-    pub fn caches(&self) -> caches::Client {
+    pub fn caches_client(&self) -> caches::Client {
         caches::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn storage_target(&self) -> storage_target::Client {
+    pub fn storage_target_client(&self) -> storage_target::Client {
         storage_target::Client(self.clone())
     }
-    pub fn storage_targets(&self) -> storage_targets::Client {
+    pub fn storage_targets_client(&self) -> storage_targets::Client {
         storage_targets::Client(self.clone())
     }
-    pub fn usage_models(&self) -> usage_models::Client {
+    pub fn usage_models_client(&self) -> usage_models::Client {
         usage_models::Client(self.clone())
     }
 }

--- a/services/mgmt/storageimportexport/src/package_2016_11/operations.rs
+++ b/services/mgmt/storageimportexport/src/package_2016_11/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bit_locker_keys(&self) -> bit_locker_keys::Client {
+    pub fn bit_locker_keys_client(&self) -> bit_locker_keys::Client {
         bit_locker_keys::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/storageimportexport/src/package_2020_08/operations.rs
+++ b/services/mgmt/storageimportexport/src/package_2020_08/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bit_locker_keys(&self) -> bit_locker_keys::Client {
+    pub fn bit_locker_keys_client(&self) -> bit_locker_keys::Client {
         bit_locker_keys::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/storageimportexport/src/package_preview_2021_01/operations.rs
+++ b/services/mgmt/storageimportexport/src/package_preview_2021_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn bit_locker_keys(&self) -> bit_locker_keys::Client {
+    pub fn bit_locker_keys_client(&self) -> bit_locker_keys::Client {
         bit_locker_keys::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/storagepool/src/package_2020_03_15_preview/operations.rs
+++ b/services/mgmt/storagepool/src/package_2020_03_15_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disk_pools(&self) -> disk_pools::Client {
+    pub fn disk_pools_client(&self) -> disk_pools::Client {
         disk_pools::Client(self.clone())
     }
-    pub fn iscsi_targets(&self) -> iscsi_targets::Client {
+    pub fn iscsi_targets_client(&self) -> iscsi_targets::Client {
         iscsi_targets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/storagepool/src/package_2021_04_01_preview/operations.rs
+++ b/services/mgmt/storagepool/src/package_2021_04_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disk_pool_zones(&self) -> disk_pool_zones::Client {
+    pub fn disk_pool_zones_client(&self) -> disk_pool_zones::Client {
         disk_pool_zones::Client(self.clone())
     }
-    pub fn disk_pools(&self) -> disk_pools::Client {
+    pub fn disk_pools_client(&self) -> disk_pools::Client {
         disk_pools::Client(self.clone())
     }
-    pub fn iscsi_targets(&self) -> iscsi_targets::Client {
+    pub fn iscsi_targets_client(&self) -> iscsi_targets::Client {
         iscsi_targets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/storagepool/src/package_2021_08_01/operations.rs
+++ b/services/mgmt/storagepool/src/package_2021_08_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn disk_pool_zones(&self) -> disk_pool_zones::Client {
+    pub fn disk_pool_zones_client(&self) -> disk_pool_zones::Client {
         disk_pool_zones::Client(self.clone())
     }
-    pub fn disk_pools(&self) -> disk_pools::Client {
+    pub fn disk_pools_client(&self) -> disk_pools::Client {
         disk_pools::Client(self.clone())
     }
-    pub fn iscsi_targets(&self) -> iscsi_targets::Client {
+    pub fn iscsi_targets_client(&self) -> iscsi_targets::Client {
         iscsi_targets::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn resource_skus(&self) -> resource_skus::Client {
+    pub fn resource_skus_client(&self) -> resource_skus::Client {
         resource_skus::Client(self.clone())
     }
 }

--- a/services/mgmt/storagesync/src/package_2019_03_01/operations.rs
+++ b/services/mgmt/storagesync/src/package_2019_03_01/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cloud_endpoints(&self) -> cloud_endpoints::Client {
+    pub fn cloud_endpoints_client(&self) -> cloud_endpoints::Client {
         cloud_endpoints::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn registered_servers(&self) -> registered_servers::Client {
+    pub fn registered_servers_client(&self) -> registered_servers::Client {
         registered_servers::Client(self.clone())
     }
-    pub fn server_endpoints(&self) -> server_endpoints::Client {
+    pub fn server_endpoints_client(&self) -> server_endpoints::Client {
         server_endpoints::Client(self.clone())
     }
-    pub fn storage_sync_services(&self) -> storage_sync_services::Client {
+    pub fn storage_sync_services_client(&self) -> storage_sync_services::Client {
         storage_sync_services::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn workflows(&self) -> workflows::Client {
+    pub fn workflows_client(&self) -> workflows::Client {
         workflows::Client(self.clone())
     }
 }

--- a/services/mgmt/storagesync/src/package_2019_06_01/operations.rs
+++ b/services/mgmt/storagesync/src/package_2019_06_01/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cloud_endpoints(&self) -> cloud_endpoints::Client {
+    pub fn cloud_endpoints_client(&self) -> cloud_endpoints::Client {
         cloud_endpoints::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn registered_servers(&self) -> registered_servers::Client {
+    pub fn registered_servers_client(&self) -> registered_servers::Client {
         registered_servers::Client(self.clone())
     }
-    pub fn server_endpoints(&self) -> server_endpoints::Client {
+    pub fn server_endpoints_client(&self) -> server_endpoints::Client {
         server_endpoints::Client(self.clone())
     }
-    pub fn storage_sync_services(&self) -> storage_sync_services::Client {
+    pub fn storage_sync_services_client(&self) -> storage_sync_services::Client {
         storage_sync_services::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn workflows(&self) -> workflows::Client {
+    pub fn workflows_client(&self) -> workflows::Client {
         workflows::Client(self.clone())
     }
 }

--- a/services/mgmt/storagesync/src/package_2019_10_01/operations.rs
+++ b/services/mgmt/storagesync/src/package_2019_10_01/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cloud_endpoints(&self) -> cloud_endpoints::Client {
+    pub fn cloud_endpoints_client(&self) -> cloud_endpoints::Client {
         cloud_endpoints::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn registered_servers(&self) -> registered_servers::Client {
+    pub fn registered_servers_client(&self) -> registered_servers::Client {
         registered_servers::Client(self.clone())
     }
-    pub fn server_endpoints(&self) -> server_endpoints::Client {
+    pub fn server_endpoints_client(&self) -> server_endpoints::Client {
         server_endpoints::Client(self.clone())
     }
-    pub fn storage_sync_services(&self) -> storage_sync_services::Client {
+    pub fn storage_sync_services_client(&self) -> storage_sync_services::Client {
         storage_sync_services::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn workflows(&self) -> workflows::Client {
+    pub fn workflows_client(&self) -> workflows::Client {
         workflows::Client(self.clone())
     }
 }

--- a/services/mgmt/storagesync/src/package_2020_03_01/operations.rs
+++ b/services/mgmt/storagesync/src/package_2020_03_01/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cloud_endpoints(&self) -> cloud_endpoints::Client {
+    pub fn cloud_endpoints_client(&self) -> cloud_endpoints::Client {
         cloud_endpoints::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn registered_servers(&self) -> registered_servers::Client {
+    pub fn registered_servers_client(&self) -> registered_servers::Client {
         registered_servers::Client(self.clone())
     }
-    pub fn server_endpoints(&self) -> server_endpoints::Client {
+    pub fn server_endpoints_client(&self) -> server_endpoints::Client {
         server_endpoints::Client(self.clone())
     }
-    pub fn storage_sync_services(&self) -> storage_sync_services::Client {
+    pub fn storage_sync_services_client(&self) -> storage_sync_services::Client {
         storage_sync_services::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn workflows(&self) -> workflows::Client {
+    pub fn workflows_client(&self) -> workflows::Client {
         workflows::Client(self.clone())
     }
 }

--- a/services/mgmt/storagesync/src/package_2020_09_01/operations.rs
+++ b/services/mgmt/storagesync/src/package_2020_09_01/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn cloud_endpoints(&self) -> cloud_endpoints::Client {
+    pub fn cloud_endpoints_client(&self) -> cloud_endpoints::Client {
         cloud_endpoints::Client(self.clone())
     }
-    pub fn operation_status(&self) -> operation_status::Client {
+    pub fn operation_status_client(&self) -> operation_status::Client {
         operation_status::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn registered_servers(&self) -> registered_servers::Client {
+    pub fn registered_servers_client(&self) -> registered_servers::Client {
         registered_servers::Client(self.clone())
     }
-    pub fn server_endpoints(&self) -> server_endpoints::Client {
+    pub fn server_endpoints_client(&self) -> server_endpoints::Client {
         server_endpoints::Client(self.clone())
     }
-    pub fn storage_sync_services(&self) -> storage_sync_services::Client {
+    pub fn storage_sync_services_client(&self) -> storage_sync_services::Client {
         storage_sync_services::Client(self.clone())
     }
-    pub fn sync_groups(&self) -> sync_groups::Client {
+    pub fn sync_groups_client(&self) -> sync_groups::Client {
         sync_groups::Client(self.clone())
     }
-    pub fn workflows(&self) -> workflows::Client {
+    pub fn workflows_client(&self) -> workflows::Client {
         workflows::Client(self.clone())
     }
 }

--- a/services/mgmt/storsimple1200series/src/package_2016_10/operations.rs
+++ b/services/mgmt/storsimple1200series/src/package_2016_10/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_control_records(&self) -> access_control_records::Client {
+    pub fn access_control_records_client(&self) -> access_control_records::Client {
         access_control_records::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn available_provider_operations(&self) -> available_provider_operations::Client {
+    pub fn available_provider_operations_client(&self) -> available_provider_operations::Client {
         available_provider_operations::Client(self.clone())
     }
-    pub fn backup_schedule_groups(&self) -> backup_schedule_groups::Client {
+    pub fn backup_schedule_groups_client(&self) -> backup_schedule_groups::Client {
         backup_schedule_groups::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn chap_settings(&self) -> chap_settings::Client {
+    pub fn chap_settings_client(&self) -> chap_settings::Client {
         chap_settings::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn file_servers(&self) -> file_servers::Client {
+    pub fn file_servers_client(&self) -> file_servers::Client {
         file_servers::Client(self.clone())
     }
-    pub fn file_shares(&self) -> file_shares::Client {
+    pub fn file_shares_client(&self) -> file_shares::Client {
         file_shares::Client(self.clone())
     }
-    pub fn iscsi_disks(&self) -> iscsi_disks::Client {
+    pub fn iscsi_disks_client(&self) -> iscsi_disks::Client {
         iscsi_disks::Client(self.clone())
     }
-    pub fn iscsi_servers(&self) -> iscsi_servers::Client {
+    pub fn iscsi_servers_client(&self) -> iscsi_servers::Client {
         iscsi_servers::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn managers(&self) -> managers::Client {
+    pub fn managers_client(&self) -> managers::Client {
         managers::Client(self.clone())
     }
-    pub fn storage_account_credentials(&self) -> storage_account_credentials::Client {
+    pub fn storage_account_credentials_client(&self) -> storage_account_credentials::Client {
         storage_account_credentials::Client(self.clone())
     }
-    pub fn storage_domains(&self) -> storage_domains::Client {
+    pub fn storage_domains_client(&self) -> storage_domains::Client {
         storage_domains::Client(self.clone())
     }
 }

--- a/services/mgmt/storsimple8000series/src/package_2017_06/operations.rs
+++ b/services/mgmt/storsimple8000series/src/package_2017_06/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_control_records(&self) -> access_control_records::Client {
+    pub fn access_control_records_client(&self) -> access_control_records::Client {
         access_control_records::Client(self.clone())
     }
-    pub fn alerts(&self) -> alerts::Client {
+    pub fn alerts_client(&self) -> alerts::Client {
         alerts::Client(self.clone())
     }
-    pub fn backup_policies(&self) -> backup_policies::Client {
+    pub fn backup_policies_client(&self) -> backup_policies::Client {
         backup_policies::Client(self.clone())
     }
-    pub fn backup_schedules(&self) -> backup_schedules::Client {
+    pub fn backup_schedules_client(&self) -> backup_schedules::Client {
         backup_schedules::Client(self.clone())
     }
-    pub fn backups(&self) -> backups::Client {
+    pub fn backups_client(&self) -> backups::Client {
         backups::Client(self.clone())
     }
-    pub fn bandwidth_settings(&self) -> bandwidth_settings::Client {
+    pub fn bandwidth_settings_client(&self) -> bandwidth_settings::Client {
         bandwidth_settings::Client(self.clone())
     }
-    pub fn cloud_appliances(&self) -> cloud_appliances::Client {
+    pub fn cloud_appliances_client(&self) -> cloud_appliances::Client {
         cloud_appliances::Client(self.clone())
     }
-    pub fn device_settings(&self) -> device_settings::Client {
+    pub fn device_settings_client(&self) -> device_settings::Client {
         device_settings::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn hardware_component_groups(&self) -> hardware_component_groups::Client {
+    pub fn hardware_component_groups_client(&self) -> hardware_component_groups::Client {
         hardware_component_groups::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn managers(&self) -> managers::Client {
+    pub fn managers_client(&self) -> managers::Client {
         managers::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn storage_account_credentials(&self) -> storage_account_credentials::Client {
+    pub fn storage_account_credentials_client(&self) -> storage_account_credentials::Client {
         storage_account_credentials::Client(self.clone())
     }
-    pub fn volume_containers(&self) -> volume_containers::Client {
+    pub fn volume_containers_client(&self) -> volume_containers::Client {
         volume_containers::Client(self.clone())
     }
-    pub fn volumes(&self) -> volumes::Client {
+    pub fn volumes_client(&self) -> volumes::Client {
         volumes::Client(self.clone())
     }
 }

--- a/services/mgmt/streamanalytics/src/package_2021_10_preview/operations.rs
+++ b/services/mgmt/streamanalytics/src/package_2021_10_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn functions(&self) -> functions::Client {
+    pub fn functions_client(&self) -> functions::Client {
         functions::Client(self.clone())
     }
-    pub fn inputs(&self) -> inputs::Client {
+    pub fn inputs_client(&self) -> inputs::Client {
         inputs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn outputs(&self) -> outputs::Client {
+    pub fn outputs_client(&self) -> outputs::Client {
         outputs::Client(self.clone())
     }
-    pub fn private_endpoints(&self) -> private_endpoints::Client {
+    pub fn private_endpoints_client(&self) -> private_endpoints::Client {
         private_endpoints::Client(self.clone())
     }
-    pub fn streaming_jobs(&self) -> streaming_jobs::Client {
+    pub fn streaming_jobs_client(&self) -> streaming_jobs::Client {
         streaming_jobs::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn transformations(&self) -> transformations::Client {
+    pub fn transformations_client(&self) -> transformations::Client {
         transformations::Client(self.clone())
     }
 }

--- a/services/mgmt/streamanalytics/src/package_pure_2016_03/operations.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2016_03/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn functions(&self) -> functions::Client {
+    pub fn functions_client(&self) -> functions::Client {
         functions::Client(self.clone())
     }
-    pub fn inputs(&self) -> inputs::Client {
+    pub fn inputs_client(&self) -> inputs::Client {
         inputs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn outputs(&self) -> outputs::Client {
+    pub fn outputs_client(&self) -> outputs::Client {
         outputs::Client(self.clone())
     }
-    pub fn streaming_jobs(&self) -> streaming_jobs::Client {
+    pub fn streaming_jobs_client(&self) -> streaming_jobs::Client {
         streaming_jobs::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn transformations(&self) -> transformations::Client {
+    pub fn transformations_client(&self) -> transformations::Client {
         transformations::Client(self.clone())
     }
 }

--- a/services/mgmt/streamanalytics/src/package_pure_2017_04_preview/operations.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2017_04_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn functions(&self) -> functions::Client {
+    pub fn functions_client(&self) -> functions::Client {
         functions::Client(self.clone())
     }
-    pub fn inputs(&self) -> inputs::Client {
+    pub fn inputs_client(&self) -> inputs::Client {
         inputs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn outputs(&self) -> outputs::Client {
+    pub fn outputs_client(&self) -> outputs::Client {
         outputs::Client(self.clone())
     }
-    pub fn streaming_jobs(&self) -> streaming_jobs::Client {
+    pub fn streaming_jobs_client(&self) -> streaming_jobs::Client {
         streaming_jobs::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn transformations(&self) -> transformations::Client {
+    pub fn transformations_client(&self) -> transformations::Client {
         transformations::Client(self.clone())
     }
 }

--- a/services/mgmt/streamanalytics/src/package_pure_2020_03/operations.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2020_03/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn functions(&self) -> functions::Client {
+    pub fn functions_client(&self) -> functions::Client {
         functions::Client(self.clone())
     }
-    pub fn inputs(&self) -> inputs::Client {
+    pub fn inputs_client(&self) -> inputs::Client {
         inputs::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn outputs(&self) -> outputs::Client {
+    pub fn outputs_client(&self) -> outputs::Client {
         outputs::Client(self.clone())
     }
-    pub fn private_endpoints(&self) -> private_endpoints::Client {
+    pub fn private_endpoints_client(&self) -> private_endpoints::Client {
         private_endpoints::Client(self.clone())
     }
-    pub fn streaming_jobs(&self) -> streaming_jobs::Client {
+    pub fn streaming_jobs_client(&self) -> streaming_jobs::Client {
         streaming_jobs::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn transformations(&self) -> transformations::Client {
+    pub fn transformations_client(&self) -> transformations::Client {
         transformations::Client(self.clone())
     }
 }

--- a/services/mgmt/streamanalytics/src/package_pure_2020_03_preview/operations.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2020_03_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn private_endpoints(&self) -> private_endpoints::Client {
+    pub fn private_endpoints_client(&self) -> private_endpoints::Client {
         private_endpoints::Client(self.clone())
     }
 }

--- a/services/mgmt/subscription/src/package_2019_03_preview/operations.rs
+++ b/services/mgmt/subscription/src/package_2019_03_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn subscription_factory(&self) -> subscription_factory::Client {
+    pub fn subscription_factory_client(&self) -> subscription_factory::Client {
         subscription_factory::Client(self.clone())
     }
-    pub fn subscription_operation(&self) -> subscription_operation::Client {
+    pub fn subscription_operation_client(&self) -> subscription_operation::Client {
         subscription_operation::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn tenants(&self) -> tenants::Client {
+    pub fn tenants_client(&self) -> tenants::Client {
         tenants::Client(self.clone())
     }
 }

--- a/services/mgmt/subscription/src/package_2019_10_preview/operations.rs
+++ b/services/mgmt/subscription/src/package_2019_10_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn subscription_operation(&self) -> subscription_operation::Client {
+    pub fn subscription_operation_client(&self) -> subscription_operation::Client {
         subscription_operation::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn tenants(&self) -> tenants::Client {
+    pub fn tenants_client(&self) -> tenants::Client {
         tenants::Client(self.clone())
     }
 }

--- a/services/mgmt/subscription/src/package_2020_01/operations.rs
+++ b/services/mgmt/subscription/src/package_2020_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn subscription_operation(&self) -> subscription_operation::Client {
+    pub fn subscription_operation_client(&self) -> subscription_operation::Client {
         subscription_operation::Client(self.clone())
     }
 }

--- a/services/mgmt/subscription/src/package_2020_09/operations.rs
+++ b/services/mgmt/subscription/src/package_2020_09/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn alias(&self) -> alias::Client {
+    pub fn alias_client(&self) -> alias::Client {
         alias::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn tenants(&self) -> tenants::Client {
+    pub fn tenants_client(&self) -> tenants::Client {
         tenants::Client(self.clone())
     }
 }

--- a/services/mgmt/subscription/src/package_2021_10/operations.rs
+++ b/services/mgmt/subscription/src/package_2021_10/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn alias(&self) -> alias::Client {
+    pub fn alias_client(&self) -> alias::Client {
         alias::Client(self.clone())
     }
-    pub fn billing_account(&self) -> billing_account::Client {
+    pub fn billing_account_client(&self) -> billing_account::Client {
         billing_account::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn subscription(&self) -> subscription::Client {
+    pub fn subscription_client(&self) -> subscription::Client {
         subscription::Client(self.clone())
     }
-    pub fn subscription_policy(&self) -> subscription_policy::Client {
+    pub fn subscription_policy_client(&self) -> subscription_policy::Client {
         subscription_policy::Client(self.clone())
     }
-    pub fn subscriptions(&self) -> subscriptions::Client {
+    pub fn subscriptions_client(&self) -> subscriptions::Client {
         subscriptions::Client(self.clone())
     }
-    pub fn tenants(&self) -> tenants::Client {
+    pub fn tenants_client(&self) -> tenants::Client {
         tenants::Client(self.clone())
     }
 }

--- a/services/mgmt/support/src/package_2019_05_preview/operations.rs
+++ b/services/mgmt/support/src/package_2019_05_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn communications(&self) -> communications::Client {
+    pub fn communications_client(&self) -> communications::Client {
         communications::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn problem_classifications(&self) -> problem_classifications::Client {
+    pub fn problem_classifications_client(&self) -> problem_classifications::Client {
         problem_classifications::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn support_tickets(&self) -> support_tickets::Client {
+    pub fn support_tickets_client(&self) -> support_tickets::Client {
         support_tickets::Client(self.clone())
     }
 }

--- a/services/mgmt/support/src/package_2020_04/operations.rs
+++ b/services/mgmt/support/src/package_2020_04/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn communications(&self) -> communications::Client {
+    pub fn communications_client(&self) -> communications::Client {
         communications::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn problem_classifications(&self) -> problem_classifications::Client {
+    pub fn problem_classifications_client(&self) -> problem_classifications::Client {
         problem_classifications::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
-    pub fn support_tickets(&self) -> support_tickets::Client {
+    pub fn support_tickets_client(&self) -> support_tickets::Client {
         support_tickets::Client(self.clone())
     }
 }

--- a/services/mgmt/support/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/support/src/package_preview_2021_06/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn look_up_resource_id(&self) -> look_up_resource_id::Client {
+    pub fn look_up_resource_id_client(&self) -> look_up_resource_id::Client {
         look_up_resource_id::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/synapse/src/package_composite_v1/operations.rs
+++ b/services/mgmt/synapse/src/package_composite_v1/operations.rs
@@ -74,203 +74,207 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_ad_only_authentications(&self) -> azure_ad_only_authentications::Client {
+    pub fn azure_ad_only_authentications_client(&self) -> azure_ad_only_authentications::Client {
         azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn big_data_pools(&self) -> big_data_pools::Client {
+    pub fn big_data_pools_client(&self) -> big_data_pools::Client {
         big_data_pools::Client(self.clone())
     }
-    pub fn data_masking_policies(&self) -> data_masking_policies::Client {
+    pub fn data_masking_policies_client(&self) -> data_masking_policies::Client {
         data_masking_policies::Client(self.clone())
     }
-    pub fn data_masking_rules(&self) -> data_masking_rules::Client {
+    pub fn data_masking_rules_client(&self) -> data_masking_rules::Client {
         data_masking_rules::Client(self.clone())
     }
-    pub fn extended_sql_pool_blob_auditing_policies(&self) -> extended_sql_pool_blob_auditing_policies::Client {
+    pub fn extended_sql_pool_blob_auditing_policies_client(&self) -> extended_sql_pool_blob_auditing_policies::Client {
         extended_sql_pool_blob_auditing_policies::Client(self.clone())
     }
-    pub fn integration_runtime_auth_keys(&self) -> integration_runtime_auth_keys::Client {
+    pub fn integration_runtime_auth_keys_client(&self) -> integration_runtime_auth_keys::Client {
         integration_runtime_auth_keys::Client(self.clone())
     }
-    pub fn integration_runtime_connection_infos(&self) -> integration_runtime_connection_infos::Client {
+    pub fn integration_runtime_connection_infos_client(&self) -> integration_runtime_connection_infos::Client {
         integration_runtime_connection_infos::Client(self.clone())
     }
-    pub fn integration_runtime_credentials(&self) -> integration_runtime_credentials::Client {
+    pub fn integration_runtime_credentials_client(&self) -> integration_runtime_credentials::Client {
         integration_runtime_credentials::Client(self.clone())
     }
-    pub fn integration_runtime_monitoring_data(&self) -> integration_runtime_monitoring_data::Client {
+    pub fn integration_runtime_monitoring_data_client(&self) -> integration_runtime_monitoring_data::Client {
         integration_runtime_monitoring_data::Client(self.clone())
     }
-    pub fn integration_runtime_node_ip_address(&self) -> integration_runtime_node_ip_address::Client {
+    pub fn integration_runtime_node_ip_address_client(&self) -> integration_runtime_node_ip_address::Client {
         integration_runtime_node_ip_address::Client(self.clone())
     }
-    pub fn integration_runtime_nodes(&self) -> integration_runtime_nodes::Client {
+    pub fn integration_runtime_nodes_client(&self) -> integration_runtime_nodes::Client {
         integration_runtime_nodes::Client(self.clone())
     }
-    pub fn integration_runtime_object_metadata(&self) -> integration_runtime_object_metadata::Client {
+    pub fn integration_runtime_object_metadata_client(&self) -> integration_runtime_object_metadata::Client {
         integration_runtime_object_metadata::Client(self.clone())
     }
-    pub fn integration_runtime_status(&self) -> integration_runtime_status::Client {
+    pub fn integration_runtime_status_client(&self) -> integration_runtime_status::Client {
         integration_runtime_status::Client(self.clone())
     }
-    pub fn integration_runtimes(&self) -> integration_runtimes::Client {
+    pub fn integration_runtimes_client(&self) -> integration_runtimes::Client {
         integration_runtimes::Client(self.clone())
     }
-    pub fn ip_firewall_rules(&self) -> ip_firewall_rules::Client {
+    pub fn ip_firewall_rules_client(&self) -> ip_firewall_rules::Client {
         ip_firewall_rules::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn libraries(&self) -> libraries::Client {
+    pub fn libraries_client(&self) -> libraries::Client {
         libraries::Client(self.clone())
     }
-    pub fn library(&self) -> library::Client {
+    pub fn library_client(&self) -> library::Client {
         library::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_endpoint_connections_private_link_hub(&self) -> private_endpoint_connections_private_link_hub::Client {
+    pub fn private_endpoint_connections_private_link_hub_client(&self) -> private_endpoint_connections_private_link_hub::Client {
         private_endpoint_connections_private_link_hub::Client(self.clone())
     }
-    pub fn private_link_hub_private_link_resources(&self) -> private_link_hub_private_link_resources::Client {
+    pub fn private_link_hub_private_link_resources_client(&self) -> private_link_hub_private_link_resources::Client {
         private_link_hub_private_link_resources::Client(self.clone())
     }
-    pub fn private_link_hubs(&self) -> private_link_hubs::Client {
+    pub fn private_link_hubs_client(&self) -> private_link_hubs::Client {
         private_link_hubs::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_dropped_sql_pools(&self) -> restorable_dropped_sql_pools::Client {
+    pub fn restorable_dropped_sql_pools_client(&self) -> restorable_dropped_sql_pools::Client {
         restorable_dropped_sql_pools::Client(self.clone())
     }
-    pub fn spark_configuration(&self) -> spark_configuration::Client {
+    pub fn spark_configuration_client(&self) -> spark_configuration::Client {
         spark_configuration::Client(self.clone())
     }
-    pub fn spark_configurations(&self) -> spark_configurations::Client {
+    pub fn spark_configurations_client(&self) -> spark_configurations::Client {
         spark_configurations::Client(self.clone())
     }
-    pub fn sql_pool_blob_auditing_policies(&self) -> sql_pool_blob_auditing_policies::Client {
+    pub fn sql_pool_blob_auditing_policies_client(&self) -> sql_pool_blob_auditing_policies::Client {
         sql_pool_blob_auditing_policies::Client(self.clone())
     }
-    pub fn sql_pool_columns(&self) -> sql_pool_columns::Client {
+    pub fn sql_pool_columns_client(&self) -> sql_pool_columns::Client {
         sql_pool_columns::Client(self.clone())
     }
-    pub fn sql_pool_connection_policies(&self) -> sql_pool_connection_policies::Client {
+    pub fn sql_pool_connection_policies_client(&self) -> sql_pool_connection_policies::Client {
         sql_pool_connection_policies::Client(self.clone())
     }
-    pub fn sql_pool_data_warehouse_user_activities(&self) -> sql_pool_data_warehouse_user_activities::Client {
+    pub fn sql_pool_data_warehouse_user_activities_client(&self) -> sql_pool_data_warehouse_user_activities::Client {
         sql_pool_data_warehouse_user_activities::Client(self.clone())
     }
-    pub fn sql_pool_geo_backup_policies(&self) -> sql_pool_geo_backup_policies::Client {
+    pub fn sql_pool_geo_backup_policies_client(&self) -> sql_pool_geo_backup_policies::Client {
         sql_pool_geo_backup_policies::Client(self.clone())
     }
-    pub fn sql_pool_maintenance_window_options(&self) -> sql_pool_maintenance_window_options::Client {
+    pub fn sql_pool_maintenance_window_options_client(&self) -> sql_pool_maintenance_window_options::Client {
         sql_pool_maintenance_window_options::Client(self.clone())
     }
-    pub fn sql_pool_maintenance_windows(&self) -> sql_pool_maintenance_windows::Client {
+    pub fn sql_pool_maintenance_windows_client(&self) -> sql_pool_maintenance_windows::Client {
         sql_pool_maintenance_windows::Client(self.clone())
     }
-    pub fn sql_pool_metadata_sync_configs(&self) -> sql_pool_metadata_sync_configs::Client {
+    pub fn sql_pool_metadata_sync_configs_client(&self) -> sql_pool_metadata_sync_configs::Client {
         sql_pool_metadata_sync_configs::Client(self.clone())
     }
-    pub fn sql_pool_operation_results(&self) -> sql_pool_operation_results::Client {
+    pub fn sql_pool_operation_results_client(&self) -> sql_pool_operation_results::Client {
         sql_pool_operation_results::Client(self.clone())
     }
-    pub fn sql_pool_operations(&self) -> sql_pool_operations::Client {
+    pub fn sql_pool_operations_client(&self) -> sql_pool_operations::Client {
         sql_pool_operations::Client(self.clone())
     }
-    pub fn sql_pool_recommended_sensitivity_labels(&self) -> sql_pool_recommended_sensitivity_labels::Client {
+    pub fn sql_pool_recommended_sensitivity_labels_client(&self) -> sql_pool_recommended_sensitivity_labels::Client {
         sql_pool_recommended_sensitivity_labels::Client(self.clone())
     }
-    pub fn sql_pool_replication_links(&self) -> sql_pool_replication_links::Client {
+    pub fn sql_pool_replication_links_client(&self) -> sql_pool_replication_links::Client {
         sql_pool_replication_links::Client(self.clone())
     }
-    pub fn sql_pool_restore_points(&self) -> sql_pool_restore_points::Client {
+    pub fn sql_pool_restore_points_client(&self) -> sql_pool_restore_points::Client {
         sql_pool_restore_points::Client(self.clone())
     }
-    pub fn sql_pool_schemas(&self) -> sql_pool_schemas::Client {
+    pub fn sql_pool_schemas_client(&self) -> sql_pool_schemas::Client {
         sql_pool_schemas::Client(self.clone())
     }
-    pub fn sql_pool_security_alert_policies(&self) -> sql_pool_security_alert_policies::Client {
+    pub fn sql_pool_security_alert_policies_client(&self) -> sql_pool_security_alert_policies::Client {
         sql_pool_security_alert_policies::Client(self.clone())
     }
-    pub fn sql_pool_sensitivity_labels(&self) -> sql_pool_sensitivity_labels::Client {
+    pub fn sql_pool_sensitivity_labels_client(&self) -> sql_pool_sensitivity_labels::Client {
         sql_pool_sensitivity_labels::Client(self.clone())
     }
-    pub fn sql_pool_table_columns(&self) -> sql_pool_table_columns::Client {
+    pub fn sql_pool_table_columns_client(&self) -> sql_pool_table_columns::Client {
         sql_pool_table_columns::Client(self.clone())
     }
-    pub fn sql_pool_tables(&self) -> sql_pool_tables::Client {
+    pub fn sql_pool_tables_client(&self) -> sql_pool_tables::Client {
         sql_pool_tables::Client(self.clone())
     }
-    pub fn sql_pool_transparent_data_encryptions(&self) -> sql_pool_transparent_data_encryptions::Client {
+    pub fn sql_pool_transparent_data_encryptions_client(&self) -> sql_pool_transparent_data_encryptions::Client {
         sql_pool_transparent_data_encryptions::Client(self.clone())
     }
-    pub fn sql_pool_usages(&self) -> sql_pool_usages::Client {
+    pub fn sql_pool_usages_client(&self) -> sql_pool_usages::Client {
         sql_pool_usages::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessment_rule_baselines(&self) -> sql_pool_vulnerability_assessment_rule_baselines::Client {
+    pub fn sql_pool_vulnerability_assessment_rule_baselines_client(&self) -> sql_pool_vulnerability_assessment_rule_baselines::Client {
         sql_pool_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessment_scans(&self) -> sql_pool_vulnerability_assessment_scans::Client {
+    pub fn sql_pool_vulnerability_assessment_scans_client(&self) -> sql_pool_vulnerability_assessment_scans::Client {
         sql_pool_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessments(&self) -> sql_pool_vulnerability_assessments::Client {
+    pub fn sql_pool_vulnerability_assessments_client(&self) -> sql_pool_vulnerability_assessments::Client {
         sql_pool_vulnerability_assessments::Client(self.clone())
     }
-    pub fn sql_pool_workload_classifier(&self) -> sql_pool_workload_classifier::Client {
+    pub fn sql_pool_workload_classifier_client(&self) -> sql_pool_workload_classifier::Client {
         sql_pool_workload_classifier::Client(self.clone())
     }
-    pub fn sql_pool_workload_group(&self) -> sql_pool_workload_group::Client {
+    pub fn sql_pool_workload_group_client(&self) -> sql_pool_workload_group::Client {
         sql_pool_workload_group::Client(self.clone())
     }
-    pub fn sql_pools(&self) -> sql_pools::Client {
+    pub fn sql_pools_client(&self) -> sql_pools::Client {
         sql_pools::Client(self.clone())
     }
-    pub fn workspace_aad_admins(&self) -> workspace_aad_admins::Client {
+    pub fn workspace_aad_admins_client(&self) -> workspace_aad_admins::Client {
         workspace_aad_admins::Client(self.clone())
     }
-    pub fn workspace_managed_identity_sql_control_settings(&self) -> workspace_managed_identity_sql_control_settings::Client {
+    pub fn workspace_managed_identity_sql_control_settings_client(&self) -> workspace_managed_identity_sql_control_settings::Client {
         workspace_managed_identity_sql_control_settings::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_blob_auditing_policies(&self) -> workspace_managed_sql_server_blob_auditing_policies::Client {
+    pub fn workspace_managed_sql_server_blob_auditing_policies_client(
+        &self,
+    ) -> workspace_managed_sql_server_blob_auditing_policies::Client {
         workspace_managed_sql_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_dedicated_sql_minimal_tls_settings(
+    pub fn workspace_managed_sql_server_dedicated_sql_minimal_tls_settings_client(
         &self,
     ) -> workspace_managed_sql_server_dedicated_sql_minimal_tls_settings::Client {
         workspace_managed_sql_server_dedicated_sql_minimal_tls_settings::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_encryption_protector(&self) -> workspace_managed_sql_server_encryption_protector::Client {
+    pub fn workspace_managed_sql_server_encryption_protector_client(&self) -> workspace_managed_sql_server_encryption_protector::Client {
         workspace_managed_sql_server_encryption_protector::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_extended_blob_auditing_policies(
+    pub fn workspace_managed_sql_server_extended_blob_auditing_policies_client(
         &self,
     ) -> workspace_managed_sql_server_extended_blob_auditing_policies::Client {
         workspace_managed_sql_server_extended_blob_auditing_policies::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_recoverable_sql_pools(&self) -> workspace_managed_sql_server_recoverable_sql_pools::Client {
+    pub fn workspace_managed_sql_server_recoverable_sql_pools_client(&self) -> workspace_managed_sql_server_recoverable_sql_pools::Client {
         workspace_managed_sql_server_recoverable_sql_pools::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_security_alert_policy(&self) -> workspace_managed_sql_server_security_alert_policy::Client {
+    pub fn workspace_managed_sql_server_security_alert_policy_client(&self) -> workspace_managed_sql_server_security_alert_policy::Client {
         workspace_managed_sql_server_security_alert_policy::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_usages(&self) -> workspace_managed_sql_server_usages::Client {
+    pub fn workspace_managed_sql_server_usages_client(&self) -> workspace_managed_sql_server_usages::Client {
         workspace_managed_sql_server_usages::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_vulnerability_assessments(&self) -> workspace_managed_sql_server_vulnerability_assessments::Client {
+    pub fn workspace_managed_sql_server_vulnerability_assessments_client(
+        &self,
+    ) -> workspace_managed_sql_server_vulnerability_assessments::Client {
         workspace_managed_sql_server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn workspace_sql_aad_admins(&self) -> workspace_sql_aad_admins::Client {
+    pub fn workspace_sql_aad_admins_client(&self) -> workspace_sql_aad_admins::Client {
         workspace_sql_aad_admins::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/synapse/src/package_composite_v2/operations.rs
+++ b/services/mgmt/synapse/src/package_composite_v2/operations.rs
@@ -74,227 +74,231 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_ad_only_authentications(&self) -> azure_ad_only_authentications::Client {
+    pub fn azure_ad_only_authentications_client(&self) -> azure_ad_only_authentications::Client {
         azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn big_data_pools(&self) -> big_data_pools::Client {
+    pub fn big_data_pools_client(&self) -> big_data_pools::Client {
         big_data_pools::Client(self.clone())
     }
-    pub fn data_masking_policies(&self) -> data_masking_policies::Client {
+    pub fn data_masking_policies_client(&self) -> data_masking_policies::Client {
         data_masking_policies::Client(self.clone())
     }
-    pub fn data_masking_rules(&self) -> data_masking_rules::Client {
+    pub fn data_masking_rules_client(&self) -> data_masking_rules::Client {
         data_masking_rules::Client(self.clone())
     }
-    pub fn extended_sql_pool_blob_auditing_policies(&self) -> extended_sql_pool_blob_auditing_policies::Client {
+    pub fn extended_sql_pool_blob_auditing_policies_client(&self) -> extended_sql_pool_blob_auditing_policies::Client {
         extended_sql_pool_blob_auditing_policies::Client(self.clone())
     }
-    pub fn integration_runtime_auth_keys(&self) -> integration_runtime_auth_keys::Client {
+    pub fn integration_runtime_auth_keys_client(&self) -> integration_runtime_auth_keys::Client {
         integration_runtime_auth_keys::Client(self.clone())
     }
-    pub fn integration_runtime_connection_infos(&self) -> integration_runtime_connection_infos::Client {
+    pub fn integration_runtime_connection_infos_client(&self) -> integration_runtime_connection_infos::Client {
         integration_runtime_connection_infos::Client(self.clone())
     }
-    pub fn integration_runtime_credentials(&self) -> integration_runtime_credentials::Client {
+    pub fn integration_runtime_credentials_client(&self) -> integration_runtime_credentials::Client {
         integration_runtime_credentials::Client(self.clone())
     }
-    pub fn integration_runtime_monitoring_data(&self) -> integration_runtime_monitoring_data::Client {
+    pub fn integration_runtime_monitoring_data_client(&self) -> integration_runtime_monitoring_data::Client {
         integration_runtime_monitoring_data::Client(self.clone())
     }
-    pub fn integration_runtime_node_ip_address(&self) -> integration_runtime_node_ip_address::Client {
+    pub fn integration_runtime_node_ip_address_client(&self) -> integration_runtime_node_ip_address::Client {
         integration_runtime_node_ip_address::Client(self.clone())
     }
-    pub fn integration_runtime_nodes(&self) -> integration_runtime_nodes::Client {
+    pub fn integration_runtime_nodes_client(&self) -> integration_runtime_nodes::Client {
         integration_runtime_nodes::Client(self.clone())
     }
-    pub fn integration_runtime_object_metadata(&self) -> integration_runtime_object_metadata::Client {
+    pub fn integration_runtime_object_metadata_client(&self) -> integration_runtime_object_metadata::Client {
         integration_runtime_object_metadata::Client(self.clone())
     }
-    pub fn integration_runtime_status(&self) -> integration_runtime_status::Client {
+    pub fn integration_runtime_status_client(&self) -> integration_runtime_status::Client {
         integration_runtime_status::Client(self.clone())
     }
-    pub fn integration_runtimes(&self) -> integration_runtimes::Client {
+    pub fn integration_runtimes_client(&self) -> integration_runtimes::Client {
         integration_runtimes::Client(self.clone())
     }
-    pub fn ip_firewall_rules(&self) -> ip_firewall_rules::Client {
+    pub fn ip_firewall_rules_client(&self) -> ip_firewall_rules::Client {
         ip_firewall_rules::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn kusto_operations(&self) -> kusto_operations::Client {
+    pub fn kusto_operations_client(&self) -> kusto_operations::Client {
         kusto_operations::Client(self.clone())
     }
-    pub fn kusto_pool_attached_database_configurations(&self) -> kusto_pool_attached_database_configurations::Client {
+    pub fn kusto_pool_attached_database_configurations_client(&self) -> kusto_pool_attached_database_configurations::Client {
         kusto_pool_attached_database_configurations::Client(self.clone())
     }
-    pub fn kusto_pool_child_resource(&self) -> kusto_pool_child_resource::Client {
+    pub fn kusto_pool_child_resource_client(&self) -> kusto_pool_child_resource::Client {
         kusto_pool_child_resource::Client(self.clone())
     }
-    pub fn kusto_pool_data_connections(&self) -> kusto_pool_data_connections::Client {
+    pub fn kusto_pool_data_connections_client(&self) -> kusto_pool_data_connections::Client {
         kusto_pool_data_connections::Client(self.clone())
     }
-    pub fn kusto_pool_database_principal_assignments(&self) -> kusto_pool_database_principal_assignments::Client {
+    pub fn kusto_pool_database_principal_assignments_client(&self) -> kusto_pool_database_principal_assignments::Client {
         kusto_pool_database_principal_assignments::Client(self.clone())
     }
-    pub fn kusto_pool_databases(&self) -> kusto_pool_databases::Client {
+    pub fn kusto_pool_databases_client(&self) -> kusto_pool_databases::Client {
         kusto_pool_databases::Client(self.clone())
     }
-    pub fn kusto_pool_principal_assignments(&self) -> kusto_pool_principal_assignments::Client {
+    pub fn kusto_pool_principal_assignments_client(&self) -> kusto_pool_principal_assignments::Client {
         kusto_pool_principal_assignments::Client(self.clone())
     }
-    pub fn kusto_pools(&self) -> kusto_pools::Client {
+    pub fn kusto_pools_client(&self) -> kusto_pools::Client {
         kusto_pools::Client(self.clone())
     }
-    pub fn libraries(&self) -> libraries::Client {
+    pub fn libraries_client(&self) -> libraries::Client {
         libraries::Client(self.clone())
     }
-    pub fn library(&self) -> library::Client {
+    pub fn library_client(&self) -> library::Client {
         library::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_endpoint_connections_private_link_hub(&self) -> private_endpoint_connections_private_link_hub::Client {
+    pub fn private_endpoint_connections_private_link_hub_client(&self) -> private_endpoint_connections_private_link_hub::Client {
         private_endpoint_connections_private_link_hub::Client(self.clone())
     }
-    pub fn private_link_hub_private_link_resources(&self) -> private_link_hub_private_link_resources::Client {
+    pub fn private_link_hub_private_link_resources_client(&self) -> private_link_hub_private_link_resources::Client {
         private_link_hub_private_link_resources::Client(self.clone())
     }
-    pub fn private_link_hubs(&self) -> private_link_hubs::Client {
+    pub fn private_link_hubs_client(&self) -> private_link_hubs::Client {
         private_link_hubs::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_dropped_sql_pools(&self) -> restorable_dropped_sql_pools::Client {
+    pub fn restorable_dropped_sql_pools_client(&self) -> restorable_dropped_sql_pools::Client {
         restorable_dropped_sql_pools::Client(self.clone())
     }
-    pub fn spark_configuration(&self) -> spark_configuration::Client {
+    pub fn spark_configuration_client(&self) -> spark_configuration::Client {
         spark_configuration::Client(self.clone())
     }
-    pub fn spark_configurations(&self) -> spark_configurations::Client {
+    pub fn spark_configurations_client(&self) -> spark_configurations::Client {
         spark_configurations::Client(self.clone())
     }
-    pub fn sql_pool_blob_auditing_policies(&self) -> sql_pool_blob_auditing_policies::Client {
+    pub fn sql_pool_blob_auditing_policies_client(&self) -> sql_pool_blob_auditing_policies::Client {
         sql_pool_blob_auditing_policies::Client(self.clone())
     }
-    pub fn sql_pool_columns(&self) -> sql_pool_columns::Client {
+    pub fn sql_pool_columns_client(&self) -> sql_pool_columns::Client {
         sql_pool_columns::Client(self.clone())
     }
-    pub fn sql_pool_connection_policies(&self) -> sql_pool_connection_policies::Client {
+    pub fn sql_pool_connection_policies_client(&self) -> sql_pool_connection_policies::Client {
         sql_pool_connection_policies::Client(self.clone())
     }
-    pub fn sql_pool_data_warehouse_user_activities(&self) -> sql_pool_data_warehouse_user_activities::Client {
+    pub fn sql_pool_data_warehouse_user_activities_client(&self) -> sql_pool_data_warehouse_user_activities::Client {
         sql_pool_data_warehouse_user_activities::Client(self.clone())
     }
-    pub fn sql_pool_geo_backup_policies(&self) -> sql_pool_geo_backup_policies::Client {
+    pub fn sql_pool_geo_backup_policies_client(&self) -> sql_pool_geo_backup_policies::Client {
         sql_pool_geo_backup_policies::Client(self.clone())
     }
-    pub fn sql_pool_maintenance_window_options(&self) -> sql_pool_maintenance_window_options::Client {
+    pub fn sql_pool_maintenance_window_options_client(&self) -> sql_pool_maintenance_window_options::Client {
         sql_pool_maintenance_window_options::Client(self.clone())
     }
-    pub fn sql_pool_maintenance_windows(&self) -> sql_pool_maintenance_windows::Client {
+    pub fn sql_pool_maintenance_windows_client(&self) -> sql_pool_maintenance_windows::Client {
         sql_pool_maintenance_windows::Client(self.clone())
     }
-    pub fn sql_pool_metadata_sync_configs(&self) -> sql_pool_metadata_sync_configs::Client {
+    pub fn sql_pool_metadata_sync_configs_client(&self) -> sql_pool_metadata_sync_configs::Client {
         sql_pool_metadata_sync_configs::Client(self.clone())
     }
-    pub fn sql_pool_operation_results(&self) -> sql_pool_operation_results::Client {
+    pub fn sql_pool_operation_results_client(&self) -> sql_pool_operation_results::Client {
         sql_pool_operation_results::Client(self.clone())
     }
-    pub fn sql_pool_operations(&self) -> sql_pool_operations::Client {
+    pub fn sql_pool_operations_client(&self) -> sql_pool_operations::Client {
         sql_pool_operations::Client(self.clone())
     }
-    pub fn sql_pool_recommended_sensitivity_labels(&self) -> sql_pool_recommended_sensitivity_labels::Client {
+    pub fn sql_pool_recommended_sensitivity_labels_client(&self) -> sql_pool_recommended_sensitivity_labels::Client {
         sql_pool_recommended_sensitivity_labels::Client(self.clone())
     }
-    pub fn sql_pool_replication_links(&self) -> sql_pool_replication_links::Client {
+    pub fn sql_pool_replication_links_client(&self) -> sql_pool_replication_links::Client {
         sql_pool_replication_links::Client(self.clone())
     }
-    pub fn sql_pool_restore_points(&self) -> sql_pool_restore_points::Client {
+    pub fn sql_pool_restore_points_client(&self) -> sql_pool_restore_points::Client {
         sql_pool_restore_points::Client(self.clone())
     }
-    pub fn sql_pool_schemas(&self) -> sql_pool_schemas::Client {
+    pub fn sql_pool_schemas_client(&self) -> sql_pool_schemas::Client {
         sql_pool_schemas::Client(self.clone())
     }
-    pub fn sql_pool_security_alert_policies(&self) -> sql_pool_security_alert_policies::Client {
+    pub fn sql_pool_security_alert_policies_client(&self) -> sql_pool_security_alert_policies::Client {
         sql_pool_security_alert_policies::Client(self.clone())
     }
-    pub fn sql_pool_sensitivity_labels(&self) -> sql_pool_sensitivity_labels::Client {
+    pub fn sql_pool_sensitivity_labels_client(&self) -> sql_pool_sensitivity_labels::Client {
         sql_pool_sensitivity_labels::Client(self.clone())
     }
-    pub fn sql_pool_table_columns(&self) -> sql_pool_table_columns::Client {
+    pub fn sql_pool_table_columns_client(&self) -> sql_pool_table_columns::Client {
         sql_pool_table_columns::Client(self.clone())
     }
-    pub fn sql_pool_tables(&self) -> sql_pool_tables::Client {
+    pub fn sql_pool_tables_client(&self) -> sql_pool_tables::Client {
         sql_pool_tables::Client(self.clone())
     }
-    pub fn sql_pool_transparent_data_encryptions(&self) -> sql_pool_transparent_data_encryptions::Client {
+    pub fn sql_pool_transparent_data_encryptions_client(&self) -> sql_pool_transparent_data_encryptions::Client {
         sql_pool_transparent_data_encryptions::Client(self.clone())
     }
-    pub fn sql_pool_usages(&self) -> sql_pool_usages::Client {
+    pub fn sql_pool_usages_client(&self) -> sql_pool_usages::Client {
         sql_pool_usages::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessment_rule_baselines(&self) -> sql_pool_vulnerability_assessment_rule_baselines::Client {
+    pub fn sql_pool_vulnerability_assessment_rule_baselines_client(&self) -> sql_pool_vulnerability_assessment_rule_baselines::Client {
         sql_pool_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessment_scans(&self) -> sql_pool_vulnerability_assessment_scans::Client {
+    pub fn sql_pool_vulnerability_assessment_scans_client(&self) -> sql_pool_vulnerability_assessment_scans::Client {
         sql_pool_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessments(&self) -> sql_pool_vulnerability_assessments::Client {
+    pub fn sql_pool_vulnerability_assessments_client(&self) -> sql_pool_vulnerability_assessments::Client {
         sql_pool_vulnerability_assessments::Client(self.clone())
     }
-    pub fn sql_pool_workload_classifier(&self) -> sql_pool_workload_classifier::Client {
+    pub fn sql_pool_workload_classifier_client(&self) -> sql_pool_workload_classifier::Client {
         sql_pool_workload_classifier::Client(self.clone())
     }
-    pub fn sql_pool_workload_group(&self) -> sql_pool_workload_group::Client {
+    pub fn sql_pool_workload_group_client(&self) -> sql_pool_workload_group::Client {
         sql_pool_workload_group::Client(self.clone())
     }
-    pub fn sql_pools(&self) -> sql_pools::Client {
+    pub fn sql_pools_client(&self) -> sql_pools::Client {
         sql_pools::Client(self.clone())
     }
-    pub fn workspace_aad_admins(&self) -> workspace_aad_admins::Client {
+    pub fn workspace_aad_admins_client(&self) -> workspace_aad_admins::Client {
         workspace_aad_admins::Client(self.clone())
     }
-    pub fn workspace_managed_identity_sql_control_settings(&self) -> workspace_managed_identity_sql_control_settings::Client {
+    pub fn workspace_managed_identity_sql_control_settings_client(&self) -> workspace_managed_identity_sql_control_settings::Client {
         workspace_managed_identity_sql_control_settings::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_blob_auditing_policies(&self) -> workspace_managed_sql_server_blob_auditing_policies::Client {
+    pub fn workspace_managed_sql_server_blob_auditing_policies_client(
+        &self,
+    ) -> workspace_managed_sql_server_blob_auditing_policies::Client {
         workspace_managed_sql_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_dedicated_sql_minimal_tls_settings(
+    pub fn workspace_managed_sql_server_dedicated_sql_minimal_tls_settings_client(
         &self,
     ) -> workspace_managed_sql_server_dedicated_sql_minimal_tls_settings::Client {
         workspace_managed_sql_server_dedicated_sql_minimal_tls_settings::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_encryption_protector(&self) -> workspace_managed_sql_server_encryption_protector::Client {
+    pub fn workspace_managed_sql_server_encryption_protector_client(&self) -> workspace_managed_sql_server_encryption_protector::Client {
         workspace_managed_sql_server_encryption_protector::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_extended_blob_auditing_policies(
+    pub fn workspace_managed_sql_server_extended_blob_auditing_policies_client(
         &self,
     ) -> workspace_managed_sql_server_extended_blob_auditing_policies::Client {
         workspace_managed_sql_server_extended_blob_auditing_policies::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_recoverable_sql_pools(&self) -> workspace_managed_sql_server_recoverable_sql_pools::Client {
+    pub fn workspace_managed_sql_server_recoverable_sql_pools_client(&self) -> workspace_managed_sql_server_recoverable_sql_pools::Client {
         workspace_managed_sql_server_recoverable_sql_pools::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_security_alert_policy(&self) -> workspace_managed_sql_server_security_alert_policy::Client {
+    pub fn workspace_managed_sql_server_security_alert_policy_client(&self) -> workspace_managed_sql_server_security_alert_policy::Client {
         workspace_managed_sql_server_security_alert_policy::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_usages(&self) -> workspace_managed_sql_server_usages::Client {
+    pub fn workspace_managed_sql_server_usages_client(&self) -> workspace_managed_sql_server_usages::Client {
         workspace_managed_sql_server_usages::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_vulnerability_assessments(&self) -> workspace_managed_sql_server_vulnerability_assessments::Client {
+    pub fn workspace_managed_sql_server_vulnerability_assessments_client(
+        &self,
+    ) -> workspace_managed_sql_server_vulnerability_assessments::Client {
         workspace_managed_sql_server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn workspace_sql_aad_admins(&self) -> workspace_sql_aad_admins::Client {
+    pub fn workspace_sql_aad_admins_client(&self) -> workspace_sql_aad_admins::Client {
         workspace_sql_aad_admins::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/synapse/src/package_kusto_pool_2021_04_preview/operations.rs
+++ b/services/mgmt/synapse/src/package_kusto_pool_2021_04_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn data_connections(&self) -> data_connections::Client {
+    pub fn data_connections_client(&self) -> data_connections::Client {
         data_connections::Client(self.clone())
     }
-    pub fn database_principal_assignments(&self) -> database_principal_assignments::Client {
+    pub fn database_principal_assignments_client(&self) -> database_principal_assignments::Client {
         database_principal_assignments::Client(self.clone())
     }
-    pub fn databases(&self) -> databases::Client {
+    pub fn databases_client(&self) -> databases::Client {
         databases::Client(self.clone())
     }
-    pub fn kusto_operations(&self) -> kusto_operations::Client {
+    pub fn kusto_operations_client(&self) -> kusto_operations::Client {
         kusto_operations::Client(self.clone())
     }
-    pub fn kusto_pool_principal_assignments(&self) -> kusto_pool_principal_assignments::Client {
+    pub fn kusto_pool_principal_assignments_client(&self) -> kusto_pool_principal_assignments::Client {
         kusto_pool_principal_assignments::Client(self.clone())
     }
-    pub fn kusto_pools(&self) -> kusto_pools::Client {
+    pub fn kusto_pools_client(&self) -> kusto_pools::Client {
         kusto_pools::Client(self.clone())
     }
 }

--- a/services/mgmt/synapse/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/synapse/src/package_preview_2021_06/operations.rs
@@ -74,203 +74,207 @@ impl Client {
             pipeline,
         }
     }
-    pub fn azure_ad_only_authentications(&self) -> azure_ad_only_authentications::Client {
+    pub fn azure_ad_only_authentications_client(&self) -> azure_ad_only_authentications::Client {
         azure_ad_only_authentications::Client(self.clone())
     }
-    pub fn big_data_pools(&self) -> big_data_pools::Client {
+    pub fn big_data_pools_client(&self) -> big_data_pools::Client {
         big_data_pools::Client(self.clone())
     }
-    pub fn data_masking_policies(&self) -> data_masking_policies::Client {
+    pub fn data_masking_policies_client(&self) -> data_masking_policies::Client {
         data_masking_policies::Client(self.clone())
     }
-    pub fn data_masking_rules(&self) -> data_masking_rules::Client {
+    pub fn data_masking_rules_client(&self) -> data_masking_rules::Client {
         data_masking_rules::Client(self.clone())
     }
-    pub fn extended_sql_pool_blob_auditing_policies(&self) -> extended_sql_pool_blob_auditing_policies::Client {
+    pub fn extended_sql_pool_blob_auditing_policies_client(&self) -> extended_sql_pool_blob_auditing_policies::Client {
         extended_sql_pool_blob_auditing_policies::Client(self.clone())
     }
-    pub fn integration_runtime_auth_keys(&self) -> integration_runtime_auth_keys::Client {
+    pub fn integration_runtime_auth_keys_client(&self) -> integration_runtime_auth_keys::Client {
         integration_runtime_auth_keys::Client(self.clone())
     }
-    pub fn integration_runtime_connection_infos(&self) -> integration_runtime_connection_infos::Client {
+    pub fn integration_runtime_connection_infos_client(&self) -> integration_runtime_connection_infos::Client {
         integration_runtime_connection_infos::Client(self.clone())
     }
-    pub fn integration_runtime_credentials(&self) -> integration_runtime_credentials::Client {
+    pub fn integration_runtime_credentials_client(&self) -> integration_runtime_credentials::Client {
         integration_runtime_credentials::Client(self.clone())
     }
-    pub fn integration_runtime_monitoring_data(&self) -> integration_runtime_monitoring_data::Client {
+    pub fn integration_runtime_monitoring_data_client(&self) -> integration_runtime_monitoring_data::Client {
         integration_runtime_monitoring_data::Client(self.clone())
     }
-    pub fn integration_runtime_node_ip_address(&self) -> integration_runtime_node_ip_address::Client {
+    pub fn integration_runtime_node_ip_address_client(&self) -> integration_runtime_node_ip_address::Client {
         integration_runtime_node_ip_address::Client(self.clone())
     }
-    pub fn integration_runtime_nodes(&self) -> integration_runtime_nodes::Client {
+    pub fn integration_runtime_nodes_client(&self) -> integration_runtime_nodes::Client {
         integration_runtime_nodes::Client(self.clone())
     }
-    pub fn integration_runtime_object_metadata(&self) -> integration_runtime_object_metadata::Client {
+    pub fn integration_runtime_object_metadata_client(&self) -> integration_runtime_object_metadata::Client {
         integration_runtime_object_metadata::Client(self.clone())
     }
-    pub fn integration_runtime_status(&self) -> integration_runtime_status::Client {
+    pub fn integration_runtime_status_client(&self) -> integration_runtime_status::Client {
         integration_runtime_status::Client(self.clone())
     }
-    pub fn integration_runtimes(&self) -> integration_runtimes::Client {
+    pub fn integration_runtimes_client(&self) -> integration_runtimes::Client {
         integration_runtimes::Client(self.clone())
     }
-    pub fn ip_firewall_rules(&self) -> ip_firewall_rules::Client {
+    pub fn ip_firewall_rules_client(&self) -> ip_firewall_rules::Client {
         ip_firewall_rules::Client(self.clone())
     }
-    pub fn keys(&self) -> keys::Client {
+    pub fn keys_client(&self) -> keys::Client {
         keys::Client(self.clone())
     }
-    pub fn libraries(&self) -> libraries::Client {
+    pub fn libraries_client(&self) -> libraries::Client {
         libraries::Client(self.clone())
     }
-    pub fn library(&self) -> library::Client {
+    pub fn library_client(&self) -> library::Client {
         library::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_endpoint_connections_private_link_hub(&self) -> private_endpoint_connections_private_link_hub::Client {
+    pub fn private_endpoint_connections_private_link_hub_client(&self) -> private_endpoint_connections_private_link_hub::Client {
         private_endpoint_connections_private_link_hub::Client(self.clone())
     }
-    pub fn private_link_hub_private_link_resources(&self) -> private_link_hub_private_link_resources::Client {
+    pub fn private_link_hub_private_link_resources_client(&self) -> private_link_hub_private_link_resources::Client {
         private_link_hub_private_link_resources::Client(self.clone())
     }
-    pub fn private_link_hubs(&self) -> private_link_hubs::Client {
+    pub fn private_link_hubs_client(&self) -> private_link_hubs::Client {
         private_link_hubs::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn restorable_dropped_sql_pools(&self) -> restorable_dropped_sql_pools::Client {
+    pub fn restorable_dropped_sql_pools_client(&self) -> restorable_dropped_sql_pools::Client {
         restorable_dropped_sql_pools::Client(self.clone())
     }
-    pub fn spark_configuration(&self) -> spark_configuration::Client {
+    pub fn spark_configuration_client(&self) -> spark_configuration::Client {
         spark_configuration::Client(self.clone())
     }
-    pub fn spark_configurations(&self) -> spark_configurations::Client {
+    pub fn spark_configurations_client(&self) -> spark_configurations::Client {
         spark_configurations::Client(self.clone())
     }
-    pub fn sql_pool_blob_auditing_policies(&self) -> sql_pool_blob_auditing_policies::Client {
+    pub fn sql_pool_blob_auditing_policies_client(&self) -> sql_pool_blob_auditing_policies::Client {
         sql_pool_blob_auditing_policies::Client(self.clone())
     }
-    pub fn sql_pool_columns(&self) -> sql_pool_columns::Client {
+    pub fn sql_pool_columns_client(&self) -> sql_pool_columns::Client {
         sql_pool_columns::Client(self.clone())
     }
-    pub fn sql_pool_connection_policies(&self) -> sql_pool_connection_policies::Client {
+    pub fn sql_pool_connection_policies_client(&self) -> sql_pool_connection_policies::Client {
         sql_pool_connection_policies::Client(self.clone())
     }
-    pub fn sql_pool_data_warehouse_user_activities(&self) -> sql_pool_data_warehouse_user_activities::Client {
+    pub fn sql_pool_data_warehouse_user_activities_client(&self) -> sql_pool_data_warehouse_user_activities::Client {
         sql_pool_data_warehouse_user_activities::Client(self.clone())
     }
-    pub fn sql_pool_geo_backup_policies(&self) -> sql_pool_geo_backup_policies::Client {
+    pub fn sql_pool_geo_backup_policies_client(&self) -> sql_pool_geo_backup_policies::Client {
         sql_pool_geo_backup_policies::Client(self.clone())
     }
-    pub fn sql_pool_maintenance_window_options(&self) -> sql_pool_maintenance_window_options::Client {
+    pub fn sql_pool_maintenance_window_options_client(&self) -> sql_pool_maintenance_window_options::Client {
         sql_pool_maintenance_window_options::Client(self.clone())
     }
-    pub fn sql_pool_maintenance_windows(&self) -> sql_pool_maintenance_windows::Client {
+    pub fn sql_pool_maintenance_windows_client(&self) -> sql_pool_maintenance_windows::Client {
         sql_pool_maintenance_windows::Client(self.clone())
     }
-    pub fn sql_pool_metadata_sync_configs(&self) -> sql_pool_metadata_sync_configs::Client {
+    pub fn sql_pool_metadata_sync_configs_client(&self) -> sql_pool_metadata_sync_configs::Client {
         sql_pool_metadata_sync_configs::Client(self.clone())
     }
-    pub fn sql_pool_operation_results(&self) -> sql_pool_operation_results::Client {
+    pub fn sql_pool_operation_results_client(&self) -> sql_pool_operation_results::Client {
         sql_pool_operation_results::Client(self.clone())
     }
-    pub fn sql_pool_operations(&self) -> sql_pool_operations::Client {
+    pub fn sql_pool_operations_client(&self) -> sql_pool_operations::Client {
         sql_pool_operations::Client(self.clone())
     }
-    pub fn sql_pool_recommended_sensitivity_labels(&self) -> sql_pool_recommended_sensitivity_labels::Client {
+    pub fn sql_pool_recommended_sensitivity_labels_client(&self) -> sql_pool_recommended_sensitivity_labels::Client {
         sql_pool_recommended_sensitivity_labels::Client(self.clone())
     }
-    pub fn sql_pool_replication_links(&self) -> sql_pool_replication_links::Client {
+    pub fn sql_pool_replication_links_client(&self) -> sql_pool_replication_links::Client {
         sql_pool_replication_links::Client(self.clone())
     }
-    pub fn sql_pool_restore_points(&self) -> sql_pool_restore_points::Client {
+    pub fn sql_pool_restore_points_client(&self) -> sql_pool_restore_points::Client {
         sql_pool_restore_points::Client(self.clone())
     }
-    pub fn sql_pool_schemas(&self) -> sql_pool_schemas::Client {
+    pub fn sql_pool_schemas_client(&self) -> sql_pool_schemas::Client {
         sql_pool_schemas::Client(self.clone())
     }
-    pub fn sql_pool_security_alert_policies(&self) -> sql_pool_security_alert_policies::Client {
+    pub fn sql_pool_security_alert_policies_client(&self) -> sql_pool_security_alert_policies::Client {
         sql_pool_security_alert_policies::Client(self.clone())
     }
-    pub fn sql_pool_sensitivity_labels(&self) -> sql_pool_sensitivity_labels::Client {
+    pub fn sql_pool_sensitivity_labels_client(&self) -> sql_pool_sensitivity_labels::Client {
         sql_pool_sensitivity_labels::Client(self.clone())
     }
-    pub fn sql_pool_table_columns(&self) -> sql_pool_table_columns::Client {
+    pub fn sql_pool_table_columns_client(&self) -> sql_pool_table_columns::Client {
         sql_pool_table_columns::Client(self.clone())
     }
-    pub fn sql_pool_tables(&self) -> sql_pool_tables::Client {
+    pub fn sql_pool_tables_client(&self) -> sql_pool_tables::Client {
         sql_pool_tables::Client(self.clone())
     }
-    pub fn sql_pool_transparent_data_encryptions(&self) -> sql_pool_transparent_data_encryptions::Client {
+    pub fn sql_pool_transparent_data_encryptions_client(&self) -> sql_pool_transparent_data_encryptions::Client {
         sql_pool_transparent_data_encryptions::Client(self.clone())
     }
-    pub fn sql_pool_usages(&self) -> sql_pool_usages::Client {
+    pub fn sql_pool_usages_client(&self) -> sql_pool_usages::Client {
         sql_pool_usages::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessment_rule_baselines(&self) -> sql_pool_vulnerability_assessment_rule_baselines::Client {
+    pub fn sql_pool_vulnerability_assessment_rule_baselines_client(&self) -> sql_pool_vulnerability_assessment_rule_baselines::Client {
         sql_pool_vulnerability_assessment_rule_baselines::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessment_scans(&self) -> sql_pool_vulnerability_assessment_scans::Client {
+    pub fn sql_pool_vulnerability_assessment_scans_client(&self) -> sql_pool_vulnerability_assessment_scans::Client {
         sql_pool_vulnerability_assessment_scans::Client(self.clone())
     }
-    pub fn sql_pool_vulnerability_assessments(&self) -> sql_pool_vulnerability_assessments::Client {
+    pub fn sql_pool_vulnerability_assessments_client(&self) -> sql_pool_vulnerability_assessments::Client {
         sql_pool_vulnerability_assessments::Client(self.clone())
     }
-    pub fn sql_pool_workload_classifier(&self) -> sql_pool_workload_classifier::Client {
+    pub fn sql_pool_workload_classifier_client(&self) -> sql_pool_workload_classifier::Client {
         sql_pool_workload_classifier::Client(self.clone())
     }
-    pub fn sql_pool_workload_group(&self) -> sql_pool_workload_group::Client {
+    pub fn sql_pool_workload_group_client(&self) -> sql_pool_workload_group::Client {
         sql_pool_workload_group::Client(self.clone())
     }
-    pub fn sql_pools(&self) -> sql_pools::Client {
+    pub fn sql_pools_client(&self) -> sql_pools::Client {
         sql_pools::Client(self.clone())
     }
-    pub fn workspace_aad_admins(&self) -> workspace_aad_admins::Client {
+    pub fn workspace_aad_admins_client(&self) -> workspace_aad_admins::Client {
         workspace_aad_admins::Client(self.clone())
     }
-    pub fn workspace_managed_identity_sql_control_settings(&self) -> workspace_managed_identity_sql_control_settings::Client {
+    pub fn workspace_managed_identity_sql_control_settings_client(&self) -> workspace_managed_identity_sql_control_settings::Client {
         workspace_managed_identity_sql_control_settings::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_blob_auditing_policies(&self) -> workspace_managed_sql_server_blob_auditing_policies::Client {
+    pub fn workspace_managed_sql_server_blob_auditing_policies_client(
+        &self,
+    ) -> workspace_managed_sql_server_blob_auditing_policies::Client {
         workspace_managed_sql_server_blob_auditing_policies::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_dedicated_sql_minimal_tls_settings(
+    pub fn workspace_managed_sql_server_dedicated_sql_minimal_tls_settings_client(
         &self,
     ) -> workspace_managed_sql_server_dedicated_sql_minimal_tls_settings::Client {
         workspace_managed_sql_server_dedicated_sql_minimal_tls_settings::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_encryption_protector(&self) -> workspace_managed_sql_server_encryption_protector::Client {
+    pub fn workspace_managed_sql_server_encryption_protector_client(&self) -> workspace_managed_sql_server_encryption_protector::Client {
         workspace_managed_sql_server_encryption_protector::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_extended_blob_auditing_policies(
+    pub fn workspace_managed_sql_server_extended_blob_auditing_policies_client(
         &self,
     ) -> workspace_managed_sql_server_extended_blob_auditing_policies::Client {
         workspace_managed_sql_server_extended_blob_auditing_policies::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_recoverable_sql_pools(&self) -> workspace_managed_sql_server_recoverable_sql_pools::Client {
+    pub fn workspace_managed_sql_server_recoverable_sql_pools_client(&self) -> workspace_managed_sql_server_recoverable_sql_pools::Client {
         workspace_managed_sql_server_recoverable_sql_pools::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_security_alert_policy(&self) -> workspace_managed_sql_server_security_alert_policy::Client {
+    pub fn workspace_managed_sql_server_security_alert_policy_client(&self) -> workspace_managed_sql_server_security_alert_policy::Client {
         workspace_managed_sql_server_security_alert_policy::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_usages(&self) -> workspace_managed_sql_server_usages::Client {
+    pub fn workspace_managed_sql_server_usages_client(&self) -> workspace_managed_sql_server_usages::Client {
         workspace_managed_sql_server_usages::Client(self.clone())
     }
-    pub fn workspace_managed_sql_server_vulnerability_assessments(&self) -> workspace_managed_sql_server_vulnerability_assessments::Client {
+    pub fn workspace_managed_sql_server_vulnerability_assessments_client(
+        &self,
+    ) -> workspace_managed_sql_server_vulnerability_assessments::Client {
         workspace_managed_sql_server_vulnerability_assessments::Client(self.clone())
     }
-    pub fn workspace_sql_aad_admins(&self) -> workspace_sql_aad_admins::Client {
+    pub fn workspace_sql_aad_admins_client(&self) -> workspace_sql_aad_admins::Client {
         workspace_sql_aad_admins::Client(self.clone())
     }
-    pub fn workspaces(&self) -> workspaces::Client {
+    pub fn workspaces_client(&self) -> workspaces::Client {
         workspaces::Client(self.clone())
     }
 }

--- a/services/mgmt/synapse/src/package_sqlgen3_2020_04_01_preview/operations.rs
+++ b/services/mgmt/synapse/src/package_sqlgen3_2020_04_01_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn sql_databases(&self) -> sql_databases::Client {
+    pub fn sql_databases_client(&self) -> sql_databases::Client {
         sql_databases::Client(self.clone())
     }
-    pub fn sql_pools_v3(&self) -> sql_pools_v3::Client {
+    pub fn sql_pools_v3_client(&self) -> sql_pools_v3::Client {
         sql_pools_v3::Client(self.clone())
     }
-    pub fn sql_v3_operations(&self) -> sql_v3_operations::Client {
+    pub fn sql_v3_operations_client(&self) -> sql_v3_operations::Client {
         sql_v3_operations::Client(self.clone())
     }
 }

--- a/services/mgmt/testbase/src/package_2020_12_16_preview/operations.rs
+++ b/services/mgmt/testbase/src/package_2020_12_16_preview/operations.rs
@@ -74,49 +74,49 @@ impl Client {
             pipeline,
         }
     }
-    pub fn analysis_results(&self) -> analysis_results::Client {
+    pub fn analysis_results_client(&self) -> analysis_results::Client {
         analysis_results::Client(self.clone())
     }
-    pub fn available_os(&self) -> available_os::Client {
+    pub fn available_os_client(&self) -> available_os::Client {
         available_os::Client(self.clone())
     }
-    pub fn customer_events(&self) -> customer_events::Client {
+    pub fn customer_events_client(&self) -> customer_events::Client {
         customer_events::Client(self.clone())
     }
-    pub fn email_events(&self) -> email_events::Client {
+    pub fn email_events_client(&self) -> email_events::Client {
         email_events::Client(self.clone())
     }
-    pub fn favorite_processes(&self) -> favorite_processes::Client {
+    pub fn favorite_processes_client(&self) -> favorite_processes::Client {
         favorite_processes::Client(self.clone())
     }
-    pub fn flighting_rings(&self) -> flighting_rings::Client {
+    pub fn flighting_rings_client(&self) -> flighting_rings::Client {
         flighting_rings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn os_updates(&self) -> os_updates::Client {
+    pub fn os_updates_client(&self) -> os_updates::Client {
         os_updates::Client(self.clone())
     }
-    pub fn packages(&self) -> packages::Client {
+    pub fn packages_client(&self) -> packages::Client {
         packages::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn test_base_accounts(&self) -> test_base_accounts::Client {
+    pub fn test_base_accounts_client(&self) -> test_base_accounts::Client {
         test_base_accounts::Client(self.clone())
     }
-    pub fn test_results(&self) -> test_results::Client {
+    pub fn test_results_client(&self) -> test_results::Client {
         test_results::Client(self.clone())
     }
-    pub fn test_summaries(&self) -> test_summaries::Client {
+    pub fn test_summaries_client(&self) -> test_summaries::Client {
         test_summaries::Client(self.clone())
     }
-    pub fn test_types(&self) -> test_types::Client {
+    pub fn test_types_client(&self) -> test_types::Client {
         test_types::Client(self.clone())
     }
-    pub fn usage(&self) -> usage::Client {
+    pub fn usage_client(&self) -> usage::Client {
         usage::Client(self.clone())
     }
 }

--- a/services/mgmt/timeseriesinsights/src/package_2017_11_15/operations.rs
+++ b/services/mgmt/timeseriesinsights/src/package_2017_11_15/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_policies(&self) -> access_policies::Client {
+    pub fn access_policies_client(&self) -> access_policies::Client {
         access_policies::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn event_sources(&self) -> event_sources::Client {
+    pub fn event_sources_client(&self) -> event_sources::Client {
         event_sources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn reference_data_sets(&self) -> reference_data_sets::Client {
+    pub fn reference_data_sets_client(&self) -> reference_data_sets::Client {
         reference_data_sets::Client(self.clone())
     }
 }

--- a/services/mgmt/timeseriesinsights/src/package_2018_08_preview/operations.rs
+++ b/services/mgmt/timeseriesinsights/src/package_2018_08_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_policies(&self) -> access_policies::Client {
+    pub fn access_policies_client(&self) -> access_policies::Client {
         access_policies::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn event_sources(&self) -> event_sources::Client {
+    pub fn event_sources_client(&self) -> event_sources::Client {
         event_sources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn reference_data_sets(&self) -> reference_data_sets::Client {
+    pub fn reference_data_sets_client(&self) -> reference_data_sets::Client {
         reference_data_sets::Client(self.clone())
     }
 }

--- a/services/mgmt/timeseriesinsights/src/package_2020_05_15/operations.rs
+++ b/services/mgmt/timeseriesinsights/src/package_2020_05_15/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_policies(&self) -> access_policies::Client {
+    pub fn access_policies_client(&self) -> access_policies::Client {
         access_policies::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn event_sources(&self) -> event_sources::Client {
+    pub fn event_sources_client(&self) -> event_sources::Client {
         event_sources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn reference_data_sets(&self) -> reference_data_sets::Client {
+    pub fn reference_data_sets_client(&self) -> reference_data_sets::Client {
         reference_data_sets::Client(self.clone())
     }
 }

--- a/services/mgmt/timeseriesinsights/src/package_preview_2021_03/operations.rs
+++ b/services/mgmt/timeseriesinsights/src/package_preview_2021_03/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_policies(&self) -> access_policies::Client {
+    pub fn access_policies_client(&self) -> access_policies::Client {
         access_policies::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn event_sources(&self) -> event_sources::Client {
+    pub fn event_sources_client(&self) -> event_sources::Client {
         event_sources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn reference_data_sets(&self) -> reference_data_sets::Client {
+    pub fn reference_data_sets_client(&self) -> reference_data_sets::Client {
         reference_data_sets::Client(self.clone())
     }
 }

--- a/services/mgmt/timeseriesinsights/src/package_preview_2021_06/operations.rs
+++ b/services/mgmt/timeseriesinsights/src/package_preview_2021_06/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_policies(&self) -> access_policies::Client {
+    pub fn access_policies_client(&self) -> access_policies::Client {
         access_policies::Client(self.clone())
     }
-    pub fn environments(&self) -> environments::Client {
+    pub fn environments_client(&self) -> environments::Client {
         environments::Client(self.clone())
     }
-    pub fn event_sources(&self) -> event_sources::Client {
+    pub fn event_sources_client(&self) -> event_sources::Client {
         event_sources::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn reference_data_sets(&self) -> reference_data_sets::Client {
+    pub fn reference_data_sets_client(&self) -> reference_data_sets::Client {
         reference_data_sets::Client(self.clone())
     }
 }

--- a/services/mgmt/trafficmanager/src/package_2017_09_preview/operations.rs
+++ b/services/mgmt/trafficmanager/src/package_2017_09_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn geographic_hierarchies(&self) -> geographic_hierarchies::Client {
+    pub fn geographic_hierarchies_client(&self) -> geographic_hierarchies::Client {
         geographic_hierarchies::Client(self.clone())
     }
-    pub fn heat_map(&self) -> heat_map::Client {
+    pub fn heat_map_client(&self) -> heat_map::Client {
         heat_map::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn traffic_manager_user_metrics_keys(&self) -> traffic_manager_user_metrics_keys::Client {
+    pub fn traffic_manager_user_metrics_keys_client(&self) -> traffic_manager_user_metrics_keys::Client {
         traffic_manager_user_metrics_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/trafficmanager/src/package_2018_02/operations.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_02/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn geographic_hierarchies(&self) -> geographic_hierarchies::Client {
+    pub fn geographic_hierarchies_client(&self) -> geographic_hierarchies::Client {
         geographic_hierarchies::Client(self.clone())
     }
-    pub fn heat_map(&self) -> heat_map::Client {
+    pub fn heat_map_client(&self) -> heat_map::Client {
         heat_map::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn traffic_manager_user_metrics_keys(&self) -> traffic_manager_user_metrics_keys::Client {
+    pub fn traffic_manager_user_metrics_keys_client(&self) -> traffic_manager_user_metrics_keys::Client {
         traffic_manager_user_metrics_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/trafficmanager/src/package_2018_03/operations.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_03/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn geographic_hierarchies(&self) -> geographic_hierarchies::Client {
+    pub fn geographic_hierarchies_client(&self) -> geographic_hierarchies::Client {
         geographic_hierarchies::Client(self.clone())
     }
-    pub fn heat_map(&self) -> heat_map::Client {
+    pub fn heat_map_client(&self) -> heat_map::Client {
         heat_map::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
 }

--- a/services/mgmt/trafficmanager/src/package_2018_04/operations.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_04/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn geographic_hierarchies(&self) -> geographic_hierarchies::Client {
+    pub fn geographic_hierarchies_client(&self) -> geographic_hierarchies::Client {
         geographic_hierarchies::Client(self.clone())
     }
-    pub fn heat_map(&self) -> heat_map::Client {
+    pub fn heat_map_client(&self) -> heat_map::Client {
         heat_map::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn traffic_manager_user_metrics_keys(&self) -> traffic_manager_user_metrics_keys::Client {
+    pub fn traffic_manager_user_metrics_keys_client(&self) -> traffic_manager_user_metrics_keys::Client {
         traffic_manager_user_metrics_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/trafficmanager/src/package_2018_08/operations.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_08/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn endpoints(&self) -> endpoints::Client {
+    pub fn endpoints_client(&self) -> endpoints::Client {
         endpoints::Client(self.clone())
     }
-    pub fn geographic_hierarchies(&self) -> geographic_hierarchies::Client {
+    pub fn geographic_hierarchies_client(&self) -> geographic_hierarchies::Client {
         geographic_hierarchies::Client(self.clone())
     }
-    pub fn heat_map(&self) -> heat_map::Client {
+    pub fn heat_map_client(&self) -> heat_map::Client {
         heat_map::Client(self.clone())
     }
-    pub fn profiles(&self) -> profiles::Client {
+    pub fn profiles_client(&self) -> profiles::Client {
         profiles::Client(self.clone())
     }
-    pub fn traffic_manager_user_metrics_keys(&self) -> traffic_manager_user_metrics_keys::Client {
+    pub fn traffic_manager_user_metrics_keys_client(&self) -> traffic_manager_user_metrics_keys::Client {
         traffic_manager_user_metrics_keys::Client(self.clone())
     }
 }

--- a/services/mgmt/vi/src/package_2021_10_18_preview/operations.rs
+++ b/services/mgmt/vi/src/package_2021_10_18_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn generate(&self) -> generate::Client {
+    pub fn generate_client(&self) -> generate::Client {
         generate::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/vi/src/package_2021_10_27_preview/operations.rs
+++ b/services/mgmt/vi/src/package_2021_10_27_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn classic_accounts(&self) -> classic_accounts::Client {
+    pub fn classic_accounts_client(&self) -> classic_accounts::Client {
         classic_accounts::Client(self.clone())
     }
-    pub fn generate(&self) -> generate::Client {
+    pub fn generate_client(&self) -> generate::Client {
         generate::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn user_classic_accounts(&self) -> user_classic_accounts::Client {
+    pub fn user_classic_accounts_client(&self) -> user_classic_accounts::Client {
         user_classic_accounts::Client(self.clone())
     }
 }

--- a/services/mgmt/vi/src/package_2021_11_10_preview/operations.rs
+++ b/services/mgmt/vi/src/package_2021_11_10_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn classic_accounts(&self) -> classic_accounts::Client {
+    pub fn classic_accounts_client(&self) -> classic_accounts::Client {
         classic_accounts::Client(self.clone())
     }
-    pub fn generate(&self) -> generate::Client {
+    pub fn generate_client(&self) -> generate::Client {
         generate::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn user_classic_accounts(&self) -> user_classic_accounts::Client {
+    pub fn user_classic_accounts_client(&self) -> user_classic_accounts::Client {
         user_classic_accounts::Client(self.clone())
     }
 }

--- a/services/mgmt/vi/src/package_2022_04_13_preview/operations.rs
+++ b/services/mgmt/vi/src/package_2022_04_13_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn classic_accounts(&self) -> classic_accounts::Client {
+    pub fn classic_accounts_client(&self) -> classic_accounts::Client {
         classic_accounts::Client(self.clone())
     }
-    pub fn generate(&self) -> generate::Client {
+    pub fn generate_client(&self) -> generate::Client {
         generate::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn user_classic_accounts(&self) -> user_classic_accounts::Client {
+    pub fn user_classic_accounts_client(&self) -> user_classic_accounts::Client {
         user_classic_accounts::Client(self.clone())
     }
 }

--- a/services/mgmt/videoanalyzer/src/package_2021_05_01_preview/operations.rs
+++ b/services/mgmt/videoanalyzer/src/package_2021_05_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_policies(&self) -> access_policies::Client {
+    pub fn access_policies_client(&self) -> access_policies::Client {
         access_policies::Client(self.clone())
     }
-    pub fn edge_modules(&self) -> edge_modules::Client {
+    pub fn edge_modules_client(&self) -> edge_modules::Client {
         edge_modules::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn video_analyzers(&self) -> video_analyzers::Client {
+    pub fn video_analyzers_client(&self) -> video_analyzers::Client {
         video_analyzers::Client(self.clone())
     }
-    pub fn videos(&self) -> videos::Client {
+    pub fn videos_client(&self) -> videos::Client {
         videos::Client(self.clone())
     }
 }

--- a/services/mgmt/videoanalyzer/src/package_preview_2021_11/operations.rs
+++ b/services/mgmt/videoanalyzer/src/package_preview_2021_11/operations.rs
@@ -74,55 +74,55 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_policies(&self) -> access_policies::Client {
+    pub fn access_policies_client(&self) -> access_policies::Client {
         access_policies::Client(self.clone())
     }
-    pub fn edge_modules(&self) -> edge_modules::Client {
+    pub fn edge_modules_client(&self) -> edge_modules::Client {
         edge_modules::Client(self.clone())
     }
-    pub fn live_pipeline_operation_statuses(&self) -> live_pipeline_operation_statuses::Client {
+    pub fn live_pipeline_operation_statuses_client(&self) -> live_pipeline_operation_statuses::Client {
         live_pipeline_operation_statuses::Client(self.clone())
     }
-    pub fn live_pipelines(&self) -> live_pipelines::Client {
+    pub fn live_pipelines_client(&self) -> live_pipelines::Client {
         live_pipelines::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operation_results(&self) -> operation_results::Client {
+    pub fn operation_results_client(&self) -> operation_results::Client {
         operation_results::Client(self.clone())
     }
-    pub fn operation_statuses(&self) -> operation_statuses::Client {
+    pub fn operation_statuses_client(&self) -> operation_statuses::Client {
         operation_statuses::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn pipeline_job_operation_statuses(&self) -> pipeline_job_operation_statuses::Client {
+    pub fn pipeline_job_operation_statuses_client(&self) -> pipeline_job_operation_statuses::Client {
         pipeline_job_operation_statuses::Client(self.clone())
     }
-    pub fn pipeline_jobs(&self) -> pipeline_jobs::Client {
+    pub fn pipeline_jobs_client(&self) -> pipeline_jobs::Client {
         pipeline_jobs::Client(self.clone())
     }
-    pub fn pipeline_topologies(&self) -> pipeline_topologies::Client {
+    pub fn pipeline_topologies_client(&self) -> pipeline_topologies::Client {
         pipeline_topologies::Client(self.clone())
     }
-    pub fn private_endpoint_connections(&self) -> private_endpoint_connections::Client {
+    pub fn private_endpoint_connections_client(&self) -> private_endpoint_connections::Client {
         private_endpoint_connections::Client(self.clone())
     }
-    pub fn private_link_resources(&self) -> private_link_resources::Client {
+    pub fn private_link_resources_client(&self) -> private_link_resources::Client {
         private_link_resources::Client(self.clone())
     }
-    pub fn video_analyzer_operation_results(&self) -> video_analyzer_operation_results::Client {
+    pub fn video_analyzer_operation_results_client(&self) -> video_analyzer_operation_results::Client {
         video_analyzer_operation_results::Client(self.clone())
     }
-    pub fn video_analyzer_operation_statuses(&self) -> video_analyzer_operation_statuses::Client {
+    pub fn video_analyzer_operation_statuses_client(&self) -> video_analyzer_operation_statuses::Client {
         video_analyzer_operation_statuses::Client(self.clone())
     }
-    pub fn video_analyzers(&self) -> video_analyzers::Client {
+    pub fn video_analyzers_client(&self) -> video_analyzers::Client {
         video_analyzers::Client(self.clone())
     }
-    pub fn videos(&self) -> videos::Client {
+    pub fn videos_client(&self) -> videos::Client {
         videos::Client(self.clone())
     }
 }

--- a/services/mgmt/visualstudio/src/package_2014_04_preview/operations.rs
+++ b/services/mgmt/visualstudio/src/package_2014_04_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn accounts(&self) -> accounts::Client {
+    pub fn accounts_client(&self) -> accounts::Client {
         accounts::Client(self.clone())
     }
-    pub fn extensions(&self) -> extensions::Client {
+    pub fn extensions_client(&self) -> extensions::Client {
         extensions::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn projects(&self) -> projects::Client {
+    pub fn projects_client(&self) -> projects::Client {
         projects::Client(self.clone())
     }
 }

--- a/services/mgmt/vmware/examples/private_cloud_list.rs
+++ b/services/mgmt/vmware/examples/private_cloud_list.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = azure_mgmt_vmware::ClientBuilder::new(credential).build();
 
     let mut count = 0;
-    let mut clouds = client.private_clouds().list_in_subscription(subscription_id).into_stream();
+    let mut clouds = client.private_clouds_client().list_in_subscription(subscription_id).into_stream();
     while let Some(clouds) = clouds.next().await {
         let clouds = clouds?;
         count += clouds.value.len();

--- a/services/mgmt/vmware/src/package_2020_03_20/operations.rs
+++ b/services/mgmt/vmware/src/package_2020_03_20/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn authorizations(&self) -> authorizations::Client {
+    pub fn authorizations_client(&self) -> authorizations::Client {
         authorizations::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn hcx_enterprise_sites(&self) -> hcx_enterprise_sites::Client {
+    pub fn hcx_enterprise_sites_client(&self) -> hcx_enterprise_sites::Client {
         hcx_enterprise_sites::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_clouds(&self) -> private_clouds::Client {
+    pub fn private_clouds_client(&self) -> private_clouds::Client {
         private_clouds::Client(self.clone())
     }
 }

--- a/services/mgmt/vmware/src/package_2021_06_01/operations.rs
+++ b/services/mgmt/vmware/src/package_2021_06_01/operations.rs
@@ -74,46 +74,46 @@ impl Client {
             pipeline,
         }
     }
-    pub fn addons(&self) -> addons::Client {
+    pub fn addons_client(&self) -> addons::Client {
         addons::Client(self.clone())
     }
-    pub fn authorizations(&self) -> authorizations::Client {
+    pub fn authorizations_client(&self) -> authorizations::Client {
         authorizations::Client(self.clone())
     }
-    pub fn cloud_links(&self) -> cloud_links::Client {
+    pub fn cloud_links_client(&self) -> cloud_links::Client {
         cloud_links::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn datastores(&self) -> datastores::Client {
+    pub fn datastores_client(&self) -> datastores::Client {
         datastores::Client(self.clone())
     }
-    pub fn global_reach_connections(&self) -> global_reach_connections::Client {
+    pub fn global_reach_connections_client(&self) -> global_reach_connections::Client {
         global_reach_connections::Client(self.clone())
     }
-    pub fn hcx_enterprise_sites(&self) -> hcx_enterprise_sites::Client {
+    pub fn hcx_enterprise_sites_client(&self) -> hcx_enterprise_sites::Client {
         hcx_enterprise_sites::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_clouds(&self) -> private_clouds::Client {
+    pub fn private_clouds_client(&self) -> private_clouds::Client {
         private_clouds::Client(self.clone())
     }
-    pub fn script_cmdlets(&self) -> script_cmdlets::Client {
+    pub fn script_cmdlets_client(&self) -> script_cmdlets::Client {
         script_cmdlets::Client(self.clone())
     }
-    pub fn script_executions(&self) -> script_executions::Client {
+    pub fn script_executions_client(&self) -> script_executions::Client {
         script_executions::Client(self.clone())
     }
-    pub fn script_packages(&self) -> script_packages::Client {
+    pub fn script_packages_client(&self) -> script_packages::Client {
         script_packages::Client(self.clone())
     }
-    pub fn workload_networks(&self) -> workload_networks::Client {
+    pub fn workload_networks_client(&self) -> workload_networks::Client {
         workload_networks::Client(self.clone())
     }
 }

--- a/services/mgmt/vmware/src/package_2021_12_01/operations.rs
+++ b/services/mgmt/vmware/src/package_2021_12_01/operations.rs
@@ -74,52 +74,52 @@ impl Client {
             pipeline,
         }
     }
-    pub fn addons(&self) -> addons::Client {
+    pub fn addons_client(&self) -> addons::Client {
         addons::Client(self.clone())
     }
-    pub fn authorizations(&self) -> authorizations::Client {
+    pub fn authorizations_client(&self) -> authorizations::Client {
         authorizations::Client(self.clone())
     }
-    pub fn cloud_links(&self) -> cloud_links::Client {
+    pub fn cloud_links_client(&self) -> cloud_links::Client {
         cloud_links::Client(self.clone())
     }
-    pub fn clusters(&self) -> clusters::Client {
+    pub fn clusters_client(&self) -> clusters::Client {
         clusters::Client(self.clone())
     }
-    pub fn datastores(&self) -> datastores::Client {
+    pub fn datastores_client(&self) -> datastores::Client {
         datastores::Client(self.clone())
     }
-    pub fn global_reach_connections(&self) -> global_reach_connections::Client {
+    pub fn global_reach_connections_client(&self) -> global_reach_connections::Client {
         global_reach_connections::Client(self.clone())
     }
-    pub fn hcx_enterprise_sites(&self) -> hcx_enterprise_sites::Client {
+    pub fn hcx_enterprise_sites_client(&self) -> hcx_enterprise_sites::Client {
         hcx_enterprise_sites::Client(self.clone())
     }
-    pub fn locations(&self) -> locations::Client {
+    pub fn locations_client(&self) -> locations::Client {
         locations::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn placement_policies(&self) -> placement_policies::Client {
+    pub fn placement_policies_client(&self) -> placement_policies::Client {
         placement_policies::Client(self.clone())
     }
-    pub fn private_clouds(&self) -> private_clouds::Client {
+    pub fn private_clouds_client(&self) -> private_clouds::Client {
         private_clouds::Client(self.clone())
     }
-    pub fn script_cmdlets(&self) -> script_cmdlets::Client {
+    pub fn script_cmdlets_client(&self) -> script_cmdlets::Client {
         script_cmdlets::Client(self.clone())
     }
-    pub fn script_executions(&self) -> script_executions::Client {
+    pub fn script_executions_client(&self) -> script_executions::Client {
         script_executions::Client(self.clone())
     }
-    pub fn script_packages(&self) -> script_packages::Client {
+    pub fn script_packages_client(&self) -> script_packages::Client {
         script_packages::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
-    pub fn workload_networks(&self) -> workload_networks::Client {
+    pub fn workload_networks_client(&self) -> workload_networks::Client {
         workload_networks::Client(self.clone())
     }
 }

--- a/services/mgmt/vmwarecloudsimple/src/package_2019_04_01/operations.rs
+++ b/services/mgmt/vmwarecloudsimple/src/package_2019_04_01/operations.rs
@@ -74,37 +74,37 @@ impl Client {
             pipeline,
         }
     }
-    pub fn customization_policies(&self) -> customization_policies::Client {
+    pub fn customization_policies_client(&self) -> customization_policies::Client {
         customization_policies::Client(self.clone())
     }
-    pub fn dedicated_cloud_nodes(&self) -> dedicated_cloud_nodes::Client {
+    pub fn dedicated_cloud_nodes_client(&self) -> dedicated_cloud_nodes::Client {
         dedicated_cloud_nodes::Client(self.clone())
     }
-    pub fn dedicated_cloud_services(&self) -> dedicated_cloud_services::Client {
+    pub fn dedicated_cloud_services_client(&self) -> dedicated_cloud_services::Client {
         dedicated_cloud_services::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn private_clouds(&self) -> private_clouds::Client {
+    pub fn private_clouds_client(&self) -> private_clouds::Client {
         private_clouds::Client(self.clone())
     }
-    pub fn resource_pools(&self) -> resource_pools::Client {
+    pub fn resource_pools_client(&self) -> resource_pools::Client {
         resource_pools::Client(self.clone())
     }
-    pub fn skus_availability(&self) -> skus_availability::Client {
+    pub fn skus_availability_client(&self) -> skus_availability::Client {
         skus_availability::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn virtual_machine_templates(&self) -> virtual_machine_templates::Client {
+    pub fn virtual_machine_templates_client(&self) -> virtual_machine_templates::Client {
         virtual_machine_templates::Client(self.clone())
     }
-    pub fn virtual_machines(&self) -> virtual_machines::Client {
+    pub fn virtual_machines_client(&self) -> virtual_machines::Client {
         virtual_machines::Client(self.clone())
     }
-    pub fn virtual_networks(&self) -> virtual_networks::Client {
+    pub fn virtual_networks_client(&self) -> virtual_networks::Client {
         virtual_networks::Client(self.clone())
     }
 }

--- a/services/mgmt/web/src/package_2020_12/operations.rs
+++ b/services/mgmt/web/src/package_2020_12/operations.rs
@@ -74,55 +74,55 @@ impl Client {
             pipeline,
         }
     }
-    pub fn app_service_certificate_orders(&self) -> app_service_certificate_orders::Client {
+    pub fn app_service_certificate_orders_client(&self) -> app_service_certificate_orders::Client {
         app_service_certificate_orders::Client(self.clone())
     }
-    pub fn app_service_environments(&self) -> app_service_environments::Client {
+    pub fn app_service_environments_client(&self) -> app_service_environments::Client {
         app_service_environments::Client(self.clone())
     }
-    pub fn app_service_plans(&self) -> app_service_plans::Client {
+    pub fn app_service_plans_client(&self) -> app_service_plans::Client {
         app_service_plans::Client(self.clone())
     }
-    pub fn certificate_orders_diagnostics(&self) -> certificate_orders_diagnostics::Client {
+    pub fn certificate_orders_diagnostics_client(&self) -> certificate_orders_diagnostics::Client {
         certificate_orders_diagnostics::Client(self.clone())
     }
-    pub fn certificate_registration_provider(&self) -> certificate_registration_provider::Client {
+    pub fn certificate_registration_provider_client(&self) -> certificate_registration_provider::Client {
         certificate_registration_provider::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn deleted_web_apps(&self) -> deleted_web_apps::Client {
+    pub fn deleted_web_apps_client(&self) -> deleted_web_apps::Client {
         deleted_web_apps::Client(self.clone())
     }
-    pub fn diagnostics(&self) -> diagnostics::Client {
+    pub fn diagnostics_client(&self) -> diagnostics::Client {
         diagnostics::Client(self.clone())
     }
-    pub fn domain_registration_provider(&self) -> domain_registration_provider::Client {
+    pub fn domain_registration_provider_client(&self) -> domain_registration_provider::Client {
         domain_registration_provider::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn global(&self) -> global::Client {
+    pub fn global_client(&self) -> global::Client {
         global::Client(self.clone())
     }
-    pub fn provider(&self) -> provider::Client {
+    pub fn provider_client(&self) -> provider::Client {
         provider::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn resource_health_metadata(&self) -> resource_health_metadata::Client {
+    pub fn resource_health_metadata_client(&self) -> resource_health_metadata::Client {
         resource_health_metadata::Client(self.clone())
     }
-    pub fn static_sites(&self) -> static_sites::Client {
+    pub fn static_sites_client(&self) -> static_sites::Client {
         static_sites::Client(self.clone())
     }
-    pub fn top_level_domains(&self) -> top_level_domains::Client {
+    pub fn top_level_domains_client(&self) -> top_level_domains::Client {
         top_level_domains::Client(self.clone())
     }
-    pub fn web_apps(&self) -> web_apps::Client {
+    pub fn web_apps_client(&self) -> web_apps::Client {
         web_apps::Client(self.clone())
     }
 }

--- a/services/mgmt/web/src/package_2021_01/operations.rs
+++ b/services/mgmt/web/src/package_2021_01/operations.rs
@@ -74,58 +74,58 @@ impl Client {
             pipeline,
         }
     }
-    pub fn app_service_certificate_orders(&self) -> app_service_certificate_orders::Client {
+    pub fn app_service_certificate_orders_client(&self) -> app_service_certificate_orders::Client {
         app_service_certificate_orders::Client(self.clone())
     }
-    pub fn app_service_environments(&self) -> app_service_environments::Client {
+    pub fn app_service_environments_client(&self) -> app_service_environments::Client {
         app_service_environments::Client(self.clone())
     }
-    pub fn app_service_plans(&self) -> app_service_plans::Client {
+    pub fn app_service_plans_client(&self) -> app_service_plans::Client {
         app_service_plans::Client(self.clone())
     }
-    pub fn certificate_orders_diagnostics(&self) -> certificate_orders_diagnostics::Client {
+    pub fn certificate_orders_diagnostics_client(&self) -> certificate_orders_diagnostics::Client {
         certificate_orders_diagnostics::Client(self.clone())
     }
-    pub fn certificate_registration_provider(&self) -> certificate_registration_provider::Client {
+    pub fn certificate_registration_provider_client(&self) -> certificate_registration_provider::Client {
         certificate_registration_provider::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn deleted_web_apps(&self) -> deleted_web_apps::Client {
+    pub fn deleted_web_apps_client(&self) -> deleted_web_apps::Client {
         deleted_web_apps::Client(self.clone())
     }
-    pub fn diagnostics(&self) -> diagnostics::Client {
+    pub fn diagnostics_client(&self) -> diagnostics::Client {
         diagnostics::Client(self.clone())
     }
-    pub fn domain_registration_provider(&self) -> domain_registration_provider::Client {
+    pub fn domain_registration_provider_client(&self) -> domain_registration_provider::Client {
         domain_registration_provider::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn global(&self) -> global::Client {
+    pub fn global_client(&self) -> global::Client {
         global::Client(self.clone())
     }
-    pub fn kube_environments(&self) -> kube_environments::Client {
+    pub fn kube_environments_client(&self) -> kube_environments::Client {
         kube_environments::Client(self.clone())
     }
-    pub fn provider(&self) -> provider::Client {
+    pub fn provider_client(&self) -> provider::Client {
         provider::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn resource_health_metadata(&self) -> resource_health_metadata::Client {
+    pub fn resource_health_metadata_client(&self) -> resource_health_metadata::Client {
         resource_health_metadata::Client(self.clone())
     }
-    pub fn static_sites(&self) -> static_sites::Client {
+    pub fn static_sites_client(&self) -> static_sites::Client {
         static_sites::Client(self.clone())
     }
-    pub fn top_level_domains(&self) -> top_level_domains::Client {
+    pub fn top_level_domains_client(&self) -> top_level_domains::Client {
         top_level_domains::Client(self.clone())
     }
-    pub fn web_apps(&self) -> web_apps::Client {
+    pub fn web_apps_client(&self) -> web_apps::Client {
         web_apps::Client(self.clone())
     }
 }

--- a/services/mgmt/web/src/package_2021_01_15/operations.rs
+++ b/services/mgmt/web/src/package_2021_01_15/operations.rs
@@ -74,58 +74,58 @@ impl Client {
             pipeline,
         }
     }
-    pub fn app_service_certificate_orders(&self) -> app_service_certificate_orders::Client {
+    pub fn app_service_certificate_orders_client(&self) -> app_service_certificate_orders::Client {
         app_service_certificate_orders::Client(self.clone())
     }
-    pub fn app_service_environments(&self) -> app_service_environments::Client {
+    pub fn app_service_environments_client(&self) -> app_service_environments::Client {
         app_service_environments::Client(self.clone())
     }
-    pub fn app_service_plans(&self) -> app_service_plans::Client {
+    pub fn app_service_plans_client(&self) -> app_service_plans::Client {
         app_service_plans::Client(self.clone())
     }
-    pub fn certificate_orders_diagnostics(&self) -> certificate_orders_diagnostics::Client {
+    pub fn certificate_orders_diagnostics_client(&self) -> certificate_orders_diagnostics::Client {
         certificate_orders_diagnostics::Client(self.clone())
     }
-    pub fn certificate_registration_provider(&self) -> certificate_registration_provider::Client {
+    pub fn certificate_registration_provider_client(&self) -> certificate_registration_provider::Client {
         certificate_registration_provider::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn deleted_web_apps(&self) -> deleted_web_apps::Client {
+    pub fn deleted_web_apps_client(&self) -> deleted_web_apps::Client {
         deleted_web_apps::Client(self.clone())
     }
-    pub fn diagnostics(&self) -> diagnostics::Client {
+    pub fn diagnostics_client(&self) -> diagnostics::Client {
         diagnostics::Client(self.clone())
     }
-    pub fn domain_registration_provider(&self) -> domain_registration_provider::Client {
+    pub fn domain_registration_provider_client(&self) -> domain_registration_provider::Client {
         domain_registration_provider::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn global(&self) -> global::Client {
+    pub fn global_client(&self) -> global::Client {
         global::Client(self.clone())
     }
-    pub fn kube_environments(&self) -> kube_environments::Client {
+    pub fn kube_environments_client(&self) -> kube_environments::Client {
         kube_environments::Client(self.clone())
     }
-    pub fn provider(&self) -> provider::Client {
+    pub fn provider_client(&self) -> provider::Client {
         provider::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn resource_health_metadata(&self) -> resource_health_metadata::Client {
+    pub fn resource_health_metadata_client(&self) -> resource_health_metadata::Client {
         resource_health_metadata::Client(self.clone())
     }
-    pub fn static_sites(&self) -> static_sites::Client {
+    pub fn static_sites_client(&self) -> static_sites::Client {
         static_sites::Client(self.clone())
     }
-    pub fn top_level_domains(&self) -> top_level_domains::Client {
+    pub fn top_level_domains_client(&self) -> top_level_domains::Client {
         top_level_domains::Client(self.clone())
     }
-    pub fn web_apps(&self) -> web_apps::Client {
+    pub fn web_apps_client(&self) -> web_apps::Client {
         web_apps::Client(self.clone())
     }
 }

--- a/services/mgmt/web/src/package_2021_02/operations.rs
+++ b/services/mgmt/web/src/package_2021_02/operations.rs
@@ -74,58 +74,58 @@ impl Client {
             pipeline,
         }
     }
-    pub fn app_service_certificate_orders(&self) -> app_service_certificate_orders::Client {
+    pub fn app_service_certificate_orders_client(&self) -> app_service_certificate_orders::Client {
         app_service_certificate_orders::Client(self.clone())
     }
-    pub fn app_service_environments(&self) -> app_service_environments::Client {
+    pub fn app_service_environments_client(&self) -> app_service_environments::Client {
         app_service_environments::Client(self.clone())
     }
-    pub fn app_service_plans(&self) -> app_service_plans::Client {
+    pub fn app_service_plans_client(&self) -> app_service_plans::Client {
         app_service_plans::Client(self.clone())
     }
-    pub fn certificate_orders_diagnostics(&self) -> certificate_orders_diagnostics::Client {
+    pub fn certificate_orders_diagnostics_client(&self) -> certificate_orders_diagnostics::Client {
         certificate_orders_diagnostics::Client(self.clone())
     }
-    pub fn certificate_registration_provider(&self) -> certificate_registration_provider::Client {
+    pub fn certificate_registration_provider_client(&self) -> certificate_registration_provider::Client {
         certificate_registration_provider::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn deleted_web_apps(&self) -> deleted_web_apps::Client {
+    pub fn deleted_web_apps_client(&self) -> deleted_web_apps::Client {
         deleted_web_apps::Client(self.clone())
     }
-    pub fn diagnostics(&self) -> diagnostics::Client {
+    pub fn diagnostics_client(&self) -> diagnostics::Client {
         diagnostics::Client(self.clone())
     }
-    pub fn domain_registration_provider(&self) -> domain_registration_provider::Client {
+    pub fn domain_registration_provider_client(&self) -> domain_registration_provider::Client {
         domain_registration_provider::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn global(&self) -> global::Client {
+    pub fn global_client(&self) -> global::Client {
         global::Client(self.clone())
     }
-    pub fn kube_environments(&self) -> kube_environments::Client {
+    pub fn kube_environments_client(&self) -> kube_environments::Client {
         kube_environments::Client(self.clone())
     }
-    pub fn provider(&self) -> provider::Client {
+    pub fn provider_client(&self) -> provider::Client {
         provider::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn resource_health_metadata(&self) -> resource_health_metadata::Client {
+    pub fn resource_health_metadata_client(&self) -> resource_health_metadata::Client {
         resource_health_metadata::Client(self.clone())
     }
-    pub fn static_sites(&self) -> static_sites::Client {
+    pub fn static_sites_client(&self) -> static_sites::Client {
         static_sites::Client(self.clone())
     }
-    pub fn top_level_domains(&self) -> top_level_domains::Client {
+    pub fn top_level_domains_client(&self) -> top_level_domains::Client {
         top_level_domains::Client(self.clone())
     }
-    pub fn web_apps(&self) -> web_apps::Client {
+    pub fn web_apps_client(&self) -> web_apps::Client {
         web_apps::Client(self.clone())
     }
 }

--- a/services/mgmt/web/src/package_2021_03/operations.rs
+++ b/services/mgmt/web/src/package_2021_03/operations.rs
@@ -74,64 +74,64 @@ impl Client {
             pipeline,
         }
     }
-    pub fn app_service_certificate_orders(&self) -> app_service_certificate_orders::Client {
+    pub fn app_service_certificate_orders_client(&self) -> app_service_certificate_orders::Client {
         app_service_certificate_orders::Client(self.clone())
     }
-    pub fn app_service_environments(&self) -> app_service_environments::Client {
+    pub fn app_service_environments_client(&self) -> app_service_environments::Client {
         app_service_environments::Client(self.clone())
     }
-    pub fn app_service_plans(&self) -> app_service_plans::Client {
+    pub fn app_service_plans_client(&self) -> app_service_plans::Client {
         app_service_plans::Client(self.clone())
     }
-    pub fn certificate_orders_diagnostics(&self) -> certificate_orders_diagnostics::Client {
+    pub fn certificate_orders_diagnostics_client(&self) -> certificate_orders_diagnostics::Client {
         certificate_orders_diagnostics::Client(self.clone())
     }
-    pub fn certificate_registration_provider(&self) -> certificate_registration_provider::Client {
+    pub fn certificate_registration_provider_client(&self) -> certificate_registration_provider::Client {
         certificate_registration_provider::Client(self.clone())
     }
-    pub fn certificates(&self) -> certificates::Client {
+    pub fn certificates_client(&self) -> certificates::Client {
         certificates::Client(self.clone())
     }
-    pub fn container_apps(&self) -> container_apps::Client {
+    pub fn container_apps_client(&self) -> container_apps::Client {
         container_apps::Client(self.clone())
     }
-    pub fn container_apps_revisions(&self) -> container_apps_revisions::Client {
+    pub fn container_apps_revisions_client(&self) -> container_apps_revisions::Client {
         container_apps_revisions::Client(self.clone())
     }
-    pub fn deleted_web_apps(&self) -> deleted_web_apps::Client {
+    pub fn deleted_web_apps_client(&self) -> deleted_web_apps::Client {
         deleted_web_apps::Client(self.clone())
     }
-    pub fn diagnostics(&self) -> diagnostics::Client {
+    pub fn diagnostics_client(&self) -> diagnostics::Client {
         diagnostics::Client(self.clone())
     }
-    pub fn domain_registration_provider(&self) -> domain_registration_provider::Client {
+    pub fn domain_registration_provider_client(&self) -> domain_registration_provider::Client {
         domain_registration_provider::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn global(&self) -> global::Client {
+    pub fn global_client(&self) -> global::Client {
         global::Client(self.clone())
     }
-    pub fn kube_environments(&self) -> kube_environments::Client {
+    pub fn kube_environments_client(&self) -> kube_environments::Client {
         kube_environments::Client(self.clone())
     }
-    pub fn provider(&self) -> provider::Client {
+    pub fn provider_client(&self) -> provider::Client {
         provider::Client(self.clone())
     }
-    pub fn recommendations(&self) -> recommendations::Client {
+    pub fn recommendations_client(&self) -> recommendations::Client {
         recommendations::Client(self.clone())
     }
-    pub fn resource_health_metadata(&self) -> resource_health_metadata::Client {
+    pub fn resource_health_metadata_client(&self) -> resource_health_metadata::Client {
         resource_health_metadata::Client(self.clone())
     }
-    pub fn static_sites(&self) -> static_sites::Client {
+    pub fn static_sites_client(&self) -> static_sites::Client {
         static_sites::Client(self.clone())
     }
-    pub fn top_level_domains(&self) -> top_level_domains::Client {
+    pub fn top_level_domains_client(&self) -> top_level_domains::Client {
         top_level_domains::Client(self.clone())
     }
-    pub fn web_apps(&self) -> web_apps::Client {
+    pub fn web_apps_client(&self) -> web_apps::Client {
         web_apps::Client(self.clone())
     }
 }

--- a/services/mgmt/webpubsub/src/package_2021_04_01_preview/operations.rs
+++ b/services/mgmt/webpubsub/src/package_2021_04_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn web_pub_sub(&self) -> web_pub_sub::Client {
+    pub fn web_pub_sub_client(&self) -> web_pub_sub::Client {
         web_pub_sub::Client(self.clone())
     }
-    pub fn web_pub_sub_private_endpoint_connections(&self) -> web_pub_sub_private_endpoint_connections::Client {
+    pub fn web_pub_sub_private_endpoint_connections_client(&self) -> web_pub_sub_private_endpoint_connections::Client {
         web_pub_sub_private_endpoint_connections::Client(self.clone())
     }
-    pub fn web_pub_sub_private_link_resources(&self) -> web_pub_sub_private_link_resources::Client {
+    pub fn web_pub_sub_private_link_resources_client(&self) -> web_pub_sub_private_link_resources::Client {
         web_pub_sub_private_link_resources::Client(self.clone())
     }
-    pub fn web_pub_sub_shared_private_link_resources(&self) -> web_pub_sub_shared_private_link_resources::Client {
+    pub fn web_pub_sub_shared_private_link_resources_client(&self) -> web_pub_sub_shared_private_link_resources::Client {
         web_pub_sub_shared_private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/webpubsub/src/package_2021_06_01_preview/operations.rs
+++ b/services/mgmt/webpubsub/src/package_2021_06_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn web_pub_sub(&self) -> web_pub_sub::Client {
+    pub fn web_pub_sub_client(&self) -> web_pub_sub::Client {
         web_pub_sub::Client(self.clone())
     }
-    pub fn web_pub_sub_private_endpoint_connections(&self) -> web_pub_sub_private_endpoint_connections::Client {
+    pub fn web_pub_sub_private_endpoint_connections_client(&self) -> web_pub_sub_private_endpoint_connections::Client {
         web_pub_sub_private_endpoint_connections::Client(self.clone())
     }
-    pub fn web_pub_sub_private_link_resources(&self) -> web_pub_sub_private_link_resources::Client {
+    pub fn web_pub_sub_private_link_resources_client(&self) -> web_pub_sub_private_link_resources::Client {
         web_pub_sub_private_link_resources::Client(self.clone())
     }
-    pub fn web_pub_sub_shared_private_link_resources(&self) -> web_pub_sub_shared_private_link_resources::Client {
+    pub fn web_pub_sub_shared_private_link_resources_client(&self) -> web_pub_sub_shared_private_link_resources::Client {
         web_pub_sub_shared_private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/webpubsub/src/package_2021_09_01_preview/operations.rs
+++ b/services/mgmt/webpubsub/src/package_2021_09_01_preview/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn web_pub_sub(&self) -> web_pub_sub::Client {
+    pub fn web_pub_sub_client(&self) -> web_pub_sub::Client {
         web_pub_sub::Client(self.clone())
     }
-    pub fn web_pub_sub_private_endpoint_connections(&self) -> web_pub_sub_private_endpoint_connections::Client {
+    pub fn web_pub_sub_private_endpoint_connections_client(&self) -> web_pub_sub_private_endpoint_connections::Client {
         web_pub_sub_private_endpoint_connections::Client(self.clone())
     }
-    pub fn web_pub_sub_private_link_resources(&self) -> web_pub_sub_private_link_resources::Client {
+    pub fn web_pub_sub_private_link_resources_client(&self) -> web_pub_sub_private_link_resources::Client {
         web_pub_sub_private_link_resources::Client(self.clone())
     }
-    pub fn web_pub_sub_shared_private_link_resources(&self) -> web_pub_sub_shared_private_link_resources::Client {
+    pub fn web_pub_sub_shared_private_link_resources_client(&self) -> web_pub_sub_shared_private_link_resources::Client {
         web_pub_sub_shared_private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/webpubsub/src/package_2021_10_01/operations.rs
+++ b/services/mgmt/webpubsub/src/package_2021_10_01/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn usages(&self) -> usages::Client {
+    pub fn usages_client(&self) -> usages::Client {
         usages::Client(self.clone())
     }
-    pub fn web_pub_sub(&self) -> web_pub_sub::Client {
+    pub fn web_pub_sub_client(&self) -> web_pub_sub::Client {
         web_pub_sub::Client(self.clone())
     }
-    pub fn web_pub_sub_hubs(&self) -> web_pub_sub_hubs::Client {
+    pub fn web_pub_sub_hubs_client(&self) -> web_pub_sub_hubs::Client {
         web_pub_sub_hubs::Client(self.clone())
     }
-    pub fn web_pub_sub_private_endpoint_connections(&self) -> web_pub_sub_private_endpoint_connections::Client {
+    pub fn web_pub_sub_private_endpoint_connections_client(&self) -> web_pub_sub_private_endpoint_connections::Client {
         web_pub_sub_private_endpoint_connections::Client(self.clone())
     }
-    pub fn web_pub_sub_private_link_resources(&self) -> web_pub_sub_private_link_resources::Client {
+    pub fn web_pub_sub_private_link_resources_client(&self) -> web_pub_sub_private_link_resources::Client {
         web_pub_sub_private_link_resources::Client(self.clone())
     }
-    pub fn web_pub_sub_shared_private_link_resources(&self) -> web_pub_sub_shared_private_link_resources::Client {
+    pub fn web_pub_sub_shared_private_link_resources_client(&self) -> web_pub_sub_shared_private_link_resources::Client {
         web_pub_sub_shared_private_link_resources::Client(self.clone())
     }
 }

--- a/services/mgmt/windowsesu/src/package_2019_09_16_preview/operations.rs
+++ b/services/mgmt/windowsesu/src/package_2019_09_16_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn multiple_activation_keys(&self) -> multiple_activation_keys::Client {
+    pub fn multiple_activation_keys_client(&self) -> multiple_activation_keys::Client {
         multiple_activation_keys::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/windowsiot/src/package_2018_02_preview/operations.rs
+++ b/services/mgmt/windowsiot/src/package_2018_02_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/windowsiot/src/package_2019_06/operations.rs
+++ b/services/mgmt/windowsiot/src/package_2019_06/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn services(&self) -> services::Client {
+    pub fn services_client(&self) -> services::Client {
         services::Client(self.clone())
     }
 }

--- a/services/mgmt/workloadmonitor/src/package_2018_08_31_preview/operations.rs
+++ b/services/mgmt/workloadmonitor/src/package_2018_08_31_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn components(&self) -> components::Client {
+    pub fn components_client(&self) -> components::Client {
         components::Client(self.clone())
     }
-    pub fn components_summary(&self) -> components_summary::Client {
+    pub fn components_summary_client(&self) -> components_summary::Client {
         components_summary::Client(self.clone())
     }
-    pub fn monitor_instances(&self) -> monitor_instances::Client {
+    pub fn monitor_instances_client(&self) -> monitor_instances::Client {
         monitor_instances::Client(self.clone())
     }
-    pub fn monitor_instances_summary(&self) -> monitor_instances_summary::Client {
+    pub fn monitor_instances_summary_client(&self) -> monitor_instances_summary::Client {
         monitor_instances_summary::Client(self.clone())
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn notification_settings(&self) -> notification_settings::Client {
+    pub fn notification_settings_client(&self) -> notification_settings::Client {
         notification_settings::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/workloadmonitor/src/package_2020_01_13_preview/operations.rs
+++ b/services/mgmt/workloadmonitor/src/package_2020_01_13_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn health_monitors(&self) -> health_monitors::Client {
+    pub fn health_monitors_client(&self) -> health_monitors::Client {
         health_monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
 }

--- a/services/mgmt/workloads/src/package_2021_12_01_preview/operations.rs
+++ b/services/mgmt/workloads/src/package_2021_12_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn monitors(&self) -> monitors::Client {
+    pub fn monitors_client(&self) -> monitors::Client {
         monitors::Client(self.clone())
     }
-    pub fn operations(&self) -> operations::Client {
+    pub fn operations_client(&self) -> operations::Client {
         operations::Client(self.clone())
     }
-    pub fn php_workloads(&self) -> php_workloads::Client {
+    pub fn php_workloads_client(&self) -> php_workloads::Client {
         php_workloads::Client(self.clone())
     }
-    pub fn provider_instances(&self) -> provider_instances::Client {
+    pub fn provider_instances_client(&self) -> provider_instances::Client {
         provider_instances::Client(self.clone())
     }
-    pub fn sap_application_server_instances(&self) -> sap_application_server_instances::Client {
+    pub fn sap_application_server_instances_client(&self) -> sap_application_server_instances::Client {
         sap_application_server_instances::Client(self.clone())
     }
-    pub fn sap_central_instances(&self) -> sap_central_instances::Client {
+    pub fn sap_central_instances_client(&self) -> sap_central_instances::Client {
         sap_central_instances::Client(self.clone())
     }
-    pub fn sap_database_instances(&self) -> sap_database_instances::Client {
+    pub fn sap_database_instances_client(&self) -> sap_database_instances::Client {
         sap_database_instances::Client(self.clone())
     }
-    pub fn sap_virtual_instances(&self) -> sap_virtual_instances::Client {
+    pub fn sap_virtual_instances_client(&self) -> sap_virtual_instances::Client {
         sap_virtual_instances::Client(self.clone())
     }
-    pub fn skus(&self) -> skus::Client {
+    pub fn skus_client(&self) -> skus::Client {
         skus::Client(self.clone())
     }
-    pub fn wordpress_instances(&self) -> wordpress_instances::Client {
+    pub fn wordpress_instances_client(&self) -> wordpress_instances::Client {
         wordpress_instances::Client(self.clone())
     }
 }

--- a/services/svc/applicationinsights/examples/query.rs
+++ b/services/svc/applicationinsights/examples/query.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         applications: None,
     };
 
-    let response = client.query().execute(app_id, body).into_future().await?;
+    let response = client.query_client().execute(app_id, body).into_future().await?;
 
     let unnamed = "unnamed".to_string();
 

--- a/services/svc/applicationinsights/src/v1/operations.rs
+++ b/services/svc/applicationinsights/src/v1/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn events(&self) -> events::Client {
+    pub fn events_client(&self) -> events::Client {
         events::Client(self.clone())
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn metrics(&self) -> metrics::Client {
+    pub fn metrics_client(&self) -> metrics::Client {
         metrics::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
 }

--- a/services/svc/attestation/src/package_2018_09_01/operations.rs
+++ b/services/svc/attestation/src/package_2018_09_01/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn metadata_configuration(&self) -> metadata_configuration::Client {
+    pub fn metadata_configuration_client(&self) -> metadata_configuration::Client {
         metadata_configuration::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_certificates(&self) -> policy_certificates::Client {
+    pub fn policy_certificates_client(&self) -> policy_certificates::Client {
         policy_certificates::Client(self.clone())
     }
-    pub fn signing_certificates(&self) -> signing_certificates::Client {
+    pub fn signing_certificates_client(&self) -> signing_certificates::Client {
         signing_certificates::Client(self.clone())
     }
 }

--- a/services/svc/attestation/src/package_2020_10_01/operations.rs
+++ b/services/svc/attestation/src/package_2020_10_01/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attestation(&self) -> attestation::Client {
+    pub fn attestation_client(&self) -> attestation::Client {
         attestation::Client(self.clone())
     }
-    pub fn metadata_configuration(&self) -> metadata_configuration::Client {
+    pub fn metadata_configuration_client(&self) -> metadata_configuration::Client {
         metadata_configuration::Client(self.clone())
     }
-    pub fn policy(&self) -> policy::Client {
+    pub fn policy_client(&self) -> policy::Client {
         policy::Client(self.clone())
     }
-    pub fn policy_certificates(&self) -> policy_certificates::Client {
+    pub fn policy_certificates_client(&self) -> policy_certificates::Client {
         policy_certificates::Client(self.clone())
     }
-    pub fn signing_certificates(&self) -> signing_certificates::Client {
+    pub fn signing_certificates_client(&self) -> signing_certificates::Client {
         signing_certificates::Client(self.clone())
     }
 }

--- a/services/svc/batch/examples/create_task.rs
+++ b/services/svc/batch/examples/create_task.rs
@@ -31,12 +31,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("creating job");
     let job_params = JobAddParameter::new(job_id.clone(), pool_info);
-    client.job().add(job_params).into_future().await?;
+    client.job_client().add(job_params).into_future().await?;
 
     println!("creating task");
     let command_line = "echo hello there".to_string();
     let task = TaskAddParameter::new(task_id.to_string(), command_line);
-    client.task().add(job_id, task).into_future().await?;
+    client.task_client().add(job_id, task).into_future().await?;
 
     Ok(())
 }

--- a/services/svc/batch/examples/list_jobs.rs
+++ b/services/svc/batch/examples/list_jobs.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .scopes(scopes)
         .build();
 
-    let mut stream = client.job().list().into_stream();
+    let mut stream = client.job_client().list().into_stream();
     while let Some(jobs) = stream.next().await {
         let jobs = jobs?;
         for job in jobs.value {

--- a/services/svc/batch/examples/list_pools.rs
+++ b/services/svc/batch/examples/list_pools.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .scopes(scopes)
         .build();
 
-    let mut stream = client.pool().list().into_stream();
+    let mut stream = client.pool_client().list().into_stream();
     while let Some(pools) = stream.next().await {
         let pools = pools?;
         for pool in pools.value {

--- a/services/svc/batch/src/package_2019_08_10_0/operations.rs
+++ b/services/svc/batch/src/package_2019_08_10_0/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account(&self) -> account::Client {
+    pub fn account_client(&self) -> account::Client {
         account::Client(self.clone())
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn compute_node(&self) -> compute_node::Client {
+    pub fn compute_node_client(&self) -> compute_node::Client {
         compute_node::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn task(&self) -> task::Client {
+    pub fn task_client(&self) -> task::Client {
         task::Client(self.clone())
     }
 }

--- a/services/svc/batch/src/package_2020_03_11_0/operations.rs
+++ b/services/svc/batch/src/package_2020_03_11_0/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account(&self) -> account::Client {
+    pub fn account_client(&self) -> account::Client {
         account::Client(self.clone())
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn compute_node(&self) -> compute_node::Client {
+    pub fn compute_node_client(&self) -> compute_node::Client {
         compute_node::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn task(&self) -> task::Client {
+    pub fn task_client(&self) -> task::Client {
         task::Client(self.clone())
     }
 }

--- a/services/svc/batch/src/package_2020_09_12_0/operations.rs
+++ b/services/svc/batch/src/package_2020_09_12_0/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account(&self) -> account::Client {
+    pub fn account_client(&self) -> account::Client {
         account::Client(self.clone())
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn compute_node(&self) -> compute_node::Client {
+    pub fn compute_node_client(&self) -> compute_node::Client {
         compute_node::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn task(&self) -> task::Client {
+    pub fn task_client(&self) -> task::Client {
         task::Client(self.clone())
     }
 }

--- a/services/svc/batch/src/package_2021_06_14_0/operations.rs
+++ b/services/svc/batch/src/package_2021_06_14_0/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account(&self) -> account::Client {
+    pub fn account_client(&self) -> account::Client {
         account::Client(self.clone())
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn compute_node(&self) -> compute_node::Client {
+    pub fn compute_node_client(&self) -> compute_node::Client {
         compute_node::Client(self.clone())
     }
-    pub fn compute_node_extension(&self) -> compute_node_extension::Client {
+    pub fn compute_node_extension_client(&self) -> compute_node_extension::Client {
         compute_node_extension::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn task(&self) -> task::Client {
+    pub fn task_client(&self) -> task::Client {
         task::Client(self.clone())
     }
 }

--- a/services/svc/batch/src/package_2022_01_15_0/operations.rs
+++ b/services/svc/batch/src/package_2022_01_15_0/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn account(&self) -> account::Client {
+    pub fn account_client(&self) -> account::Client {
         account::Client(self.clone())
     }
-    pub fn application(&self) -> application::Client {
+    pub fn application_client(&self) -> application::Client {
         application::Client(self.clone())
     }
-    pub fn certificate(&self) -> certificate::Client {
+    pub fn certificate_client(&self) -> certificate::Client {
         certificate::Client(self.clone())
     }
-    pub fn compute_node(&self) -> compute_node::Client {
+    pub fn compute_node_client(&self) -> compute_node::Client {
         compute_node::Client(self.clone())
     }
-    pub fn compute_node_extension(&self) -> compute_node_extension::Client {
+    pub fn compute_node_extension_client(&self) -> compute_node_extension::Client {
         compute_node_extension::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn job_schedule(&self) -> job_schedule::Client {
+    pub fn job_schedule_client(&self) -> job_schedule::Client {
         job_schedule::Client(self.clone())
     }
-    pub fn pool(&self) -> pool::Client {
+    pub fn pool_client(&self) -> pool::Client {
         pool::Client(self.clone())
     }
-    pub fn task(&self) -> task::Client {
+    pub fn task_client(&self) -> task::Client {
         task::Client(self.clone())
     }
 }

--- a/services/svc/blobstorage/src/package_2020_10/operations.rs
+++ b/services/svc/blobstorage/src/package_2020_10/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn append_blob(&self) -> append_blob::Client {
+    pub fn append_blob_client(&self) -> append_blob::Client {
         append_blob::Client(self.clone())
     }
-    pub fn blob(&self) -> blob::Client {
+    pub fn blob_client(&self) -> blob::Client {
         blob::Client(self.clone())
     }
-    pub fn block_blob(&self) -> block_blob::Client {
+    pub fn block_blob_client(&self) -> block_blob::Client {
         block_blob::Client(self.clone())
     }
-    pub fn container(&self) -> container::Client {
+    pub fn container_client(&self) -> container::Client {
         container::Client(self.clone())
     }
-    pub fn page_blob(&self) -> page_blob::Client {
+    pub fn page_blob_client(&self) -> page_blob::Client {
         page_blob::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/blobstorage/src/package_2020_12/operations.rs
+++ b/services/svc/blobstorage/src/package_2020_12/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn append_blob(&self) -> append_blob::Client {
+    pub fn append_blob_client(&self) -> append_blob::Client {
         append_blob::Client(self.clone())
     }
-    pub fn blob(&self) -> blob::Client {
+    pub fn blob_client(&self) -> blob::Client {
         blob::Client(self.clone())
     }
-    pub fn block_blob(&self) -> block_blob::Client {
+    pub fn block_blob_client(&self) -> block_blob::Client {
         block_blob::Client(self.clone())
     }
-    pub fn container(&self) -> container::Client {
+    pub fn container_client(&self) -> container::Client {
         container::Client(self.clone())
     }
-    pub fn page_blob(&self) -> page_blob::Client {
+    pub fn page_blob_client(&self) -> page_blob::Client {
         page_blob::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/blobstorage/src/package_2021_02/operations.rs
+++ b/services/svc/blobstorage/src/package_2021_02/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn append_blob(&self) -> append_blob::Client {
+    pub fn append_blob_client(&self) -> append_blob::Client {
         append_blob::Client(self.clone())
     }
-    pub fn blob(&self) -> blob::Client {
+    pub fn blob_client(&self) -> blob::Client {
         blob::Client(self.clone())
     }
-    pub fn block_blob(&self) -> block_blob::Client {
+    pub fn block_blob_client(&self) -> block_blob::Client {
         block_blob::Client(self.clone())
     }
-    pub fn container(&self) -> container::Client {
+    pub fn container_client(&self) -> container::Client {
         container::Client(self.clone())
     }
-    pub fn page_blob(&self) -> page_blob::Client {
+    pub fn page_blob_client(&self) -> page_blob::Client {
         page_blob::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/blobstorage/src/package_2021_04/operations.rs
+++ b/services/svc/blobstorage/src/package_2021_04/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn append_blob(&self) -> append_blob::Client {
+    pub fn append_blob_client(&self) -> append_blob::Client {
         append_blob::Client(self.clone())
     }
-    pub fn blob(&self) -> blob::Client {
+    pub fn blob_client(&self) -> blob::Client {
         blob::Client(self.clone())
     }
-    pub fn block_blob(&self) -> block_blob::Client {
+    pub fn block_blob_client(&self) -> block_blob::Client {
         block_blob::Client(self.clone())
     }
-    pub fn container(&self) -> container::Client {
+    pub fn container_client(&self) -> container::Client {
         container::Client(self.clone())
     }
-    pub fn page_blob(&self) -> page_blob::Client {
+    pub fn page_blob_client(&self) -> page_blob::Client {
         page_blob::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/blobstorage/src/package_2021_08/operations.rs
+++ b/services/svc/blobstorage/src/package_2021_08/operations.rs
@@ -74,22 +74,22 @@ impl Client {
             pipeline,
         }
     }
-    pub fn append_blob(&self) -> append_blob::Client {
+    pub fn append_blob_client(&self) -> append_blob::Client {
         append_blob::Client(self.clone())
     }
-    pub fn blob(&self) -> blob::Client {
+    pub fn blob_client(&self) -> blob::Client {
         blob::Client(self.clone())
     }
-    pub fn block_blob(&self) -> block_blob::Client {
+    pub fn block_blob_client(&self) -> block_blob::Client {
         block_blob::Client(self.clone())
     }
-    pub fn container(&self) -> container::Client {
+    pub fn container_client(&self) -> container::Client {
         container::Client(self.clone())
     }
-    pub fn page_blob(&self) -> page_blob::Client {
+    pub fn page_blob_client(&self) -> page_blob::Client {
         page_blob::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/containerregistry/src/package_2019_08/operations.rs
+++ b/services/svc/containerregistry/src/package_2019_08/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn access_tokens(&self) -> access_tokens::Client {
+    pub fn access_tokens_client(&self) -> access_tokens::Client {
         access_tokens::Client(self.clone())
     }
-    pub fn blob(&self) -> blob::Client {
+    pub fn blob_client(&self) -> blob::Client {
         blob::Client(self.clone())
     }
-    pub fn manifests(&self) -> manifests::Client {
+    pub fn manifests_client(&self) -> manifests::Client {
         manifests::Client(self.clone())
     }
-    pub fn refresh_tokens(&self) -> refresh_tokens::Client {
+    pub fn refresh_tokens_client(&self) -> refresh_tokens::Client {
         refresh_tokens::Client(self.clone())
     }
-    pub fn repository(&self) -> repository::Client {
+    pub fn repository_client(&self) -> repository::Client {
         repository::Client(self.clone())
     }
-    pub fn tag(&self) -> tag::Client {
+    pub fn tag_client(&self) -> tag::Client {
         tag::Client(self.clone())
     }
-    pub fn v2_support(&self) -> v2_support::Client {
+    pub fn v2_support_client(&self) -> v2_support::Client {
         v2_support::Client(self.clone())
     }
 }

--- a/services/svc/cosmosdb/src/package_2019_02/operations.rs
+++ b/services/svc/cosmosdb/src/package_2019_02/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn table(&self) -> table::Client {
+    pub fn table_client(&self) -> table::Client {
         table::Client(self.clone())
     }
 }

--- a/services/svc/datalakeanalytics/src/package_catalog_2016_11/operations.rs
+++ b/services/svc/datalakeanalytics/src/package_catalog_2016_11/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn catalog(&self) -> catalog::Client {
+    pub fn catalog_client(&self) -> catalog::Client {
         catalog::Client(self.clone())
     }
 }

--- a/services/svc/datalakeanalytics/src/package_job_2015_11_preview/operations.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2015_11_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
 }

--- a/services/svc/datalakeanalytics/src/package_job_2016_03_preview/operations.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2016_03_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
 }

--- a/services/svc/datalakeanalytics/src/package_job_2016_11/operations.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2016_11/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn pipeline(&self) -> pipeline::Client {
+    pub fn pipeline_client(&self) -> pipeline::Client {
         pipeline::Client(self.clone())
     }
-    pub fn recurrence(&self) -> recurrence::Client {
+    pub fn recurrence_client(&self) -> recurrence::Client {
         recurrence::Client(self.clone())
     }
 }

--- a/services/svc/datalakeanalytics/src/package_job_2017_09_preview/operations.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2017_09_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn job(&self) -> job::Client {
+    pub fn job_client(&self) -> job::Client {
         job::Client(self.clone())
     }
-    pub fn pipeline(&self) -> pipeline::Client {
+    pub fn pipeline_client(&self) -> pipeline::Client {
         pipeline::Client(self.clone())
     }
-    pub fn recurrence(&self) -> recurrence::Client {
+    pub fn recurrence_client(&self) -> recurrence::Client {
         recurrence::Client(self.clone())
     }
 }

--- a/services/svc/deviceprovisioningservices/src/package_2021_10_01/operations.rs
+++ b/services/svc/deviceprovisioningservices/src/package_2021_10_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn device_registration_state(&self) -> device_registration_state::Client {
+    pub fn device_registration_state_client(&self) -> device_registration_state::Client {
         device_registration_state::Client(self.clone())
     }
-    pub fn enrollment_group(&self) -> enrollment_group::Client {
+    pub fn enrollment_group_client(&self) -> enrollment_group::Client {
         enrollment_group::Client(self.clone())
     }
-    pub fn individual_enrollment(&self) -> individual_enrollment::Client {
+    pub fn individual_enrollment_client(&self) -> individual_enrollment::Client {
         individual_enrollment::Client(self.clone())
     }
 }

--- a/services/svc/deviceupdate/src/package_2020_09_01/operations.rs
+++ b/services/svc/deviceupdate/src/package_2020_09_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn deployments(&self) -> deployments::Client {
+    pub fn deployments_client(&self) -> deployments::Client {
         deployments::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn updates(&self) -> updates::Client {
+    pub fn updates_client(&self) -> updates::Client {
         updates::Client(self.clone())
     }
 }

--- a/services/svc/deviceupdate/src/package_2021_06_01_preview/operations.rs
+++ b/services/svc/deviceupdate/src/package_2021_06_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn device_management(&self) -> device_management::Client {
+    pub fn device_management_client(&self) -> device_management::Client {
         device_management::Client(self.clone())
     }
-    pub fn device_update(&self) -> device_update::Client {
+    pub fn device_update_client(&self) -> device_update::Client {
         device_update::Client(self.clone())
     }
 }

--- a/services/svc/deviceupdate/src/package_2022_07_01_preview/operations.rs
+++ b/services/svc/deviceupdate/src/package_2022_07_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn device_management(&self) -> device_management::Client {
+    pub fn device_management_client(&self) -> device_management::Client {
         device_management::Client(self.clone())
     }
-    pub fn device_update(&self) -> device_update::Client {
+    pub fn device_update_client(&self) -> device_update::Client {
         device_update::Client(self.clone())
     }
 }

--- a/services/svc/digitaltwins/src/package_2020_05_31_preview/operations.rs
+++ b/services/svc/digitaltwins/src/package_2020_05_31_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twin_models(&self) -> digital_twin_models::Client {
+    pub fn digital_twin_models_client(&self) -> digital_twin_models::Client {
         digital_twin_models::Client(self.clone())
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn event_routes(&self) -> event_routes::Client {
+    pub fn event_routes_client(&self) -> event_routes::Client {
         event_routes::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
 }

--- a/services/svc/digitaltwins/src/package_2020_10_31/operations.rs
+++ b/services/svc/digitaltwins/src/package_2020_10_31/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twin_models(&self) -> digital_twin_models::Client {
+    pub fn digital_twin_models_client(&self) -> digital_twin_models::Client {
         digital_twin_models::Client(self.clone())
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn event_routes(&self) -> event_routes::Client {
+    pub fn event_routes_client(&self) -> event_routes::Client {
         event_routes::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
 }

--- a/services/svc/digitaltwins/src/package_2021_06_30_preview/operations.rs
+++ b/services/svc/digitaltwins/src/package_2021_06_30_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn digital_twin_models(&self) -> digital_twin_models::Client {
+    pub fn digital_twin_models_client(&self) -> digital_twin_models::Client {
         digital_twin_models::Client(self.clone())
     }
-    pub fn digital_twins(&self) -> digital_twins::Client {
+    pub fn digital_twins_client(&self) -> digital_twins::Client {
         digital_twins::Client(self.clone())
     }
-    pub fn event_routes(&self) -> event_routes::Client {
+    pub fn event_routes_client(&self) -> event_routes::Client {
         event_routes::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
 }

--- a/services/svc/filestorage/src/package_2020_10/operations.rs
+++ b/services/svc/filestorage/src/package_2020_10/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn directory(&self) -> directory::Client {
+    pub fn directory_client(&self) -> directory::Client {
         directory::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn share(&self) -> share::Client {
+    pub fn share_client(&self) -> share::Client {
         share::Client(self.clone())
     }
 }

--- a/services/svc/filestorage/src/package_2021_02/operations.rs
+++ b/services/svc/filestorage/src/package_2021_02/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn directory(&self) -> directory::Client {
+    pub fn directory_client(&self) -> directory::Client {
         directory::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn share(&self) -> share::Client {
+    pub fn share_client(&self) -> share::Client {
         share::Client(self.clone())
     }
 }

--- a/services/svc/filestorage/src/package_2021_04/operations.rs
+++ b/services/svc/filestorage/src/package_2021_04/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn directory(&self) -> directory::Client {
+    pub fn directory_client(&self) -> directory::Client {
         directory::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn share(&self) -> share::Client {
+    pub fn share_client(&self) -> share::Client {
         share::Client(self.clone())
     }
 }

--- a/services/svc/filestorage/src/package_2021_06/operations.rs
+++ b/services/svc/filestorage/src/package_2021_06/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn directory(&self) -> directory::Client {
+    pub fn directory_client(&self) -> directory::Client {
         directory::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
-    pub fn share(&self) -> share::Client {
+    pub fn share_client(&self) -> share::Client {
         share::Client(self.clone())
     }
 }

--- a/services/svc/graphrbac/src/v1_6/operations.rs
+++ b/services/svc/graphrbac/src/v1_6/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn applications(&self) -> applications::Client {
+    pub fn applications_client(&self) -> applications::Client {
         applications::Client(self.clone())
     }
-    pub fn deleted_applications(&self) -> deleted_applications::Client {
+    pub fn deleted_applications_client(&self) -> deleted_applications::Client {
         deleted_applications::Client(self.clone())
     }
-    pub fn domains(&self) -> domains::Client {
+    pub fn domains_client(&self) -> domains::Client {
         domains::Client(self.clone())
     }
-    pub fn groups(&self) -> groups::Client {
+    pub fn groups_client(&self) -> groups::Client {
         groups::Client(self.clone())
     }
-    pub fn o_auth2_permission_grant(&self) -> o_auth2_permission_grant::Client {
+    pub fn o_auth2_permission_grant_client(&self) -> o_auth2_permission_grant::Client {
         o_auth2_permission_grant::Client(self.clone())
     }
-    pub fn objects(&self) -> objects::Client {
+    pub fn objects_client(&self) -> objects::Client {
         objects::Client(self.clone())
     }
-    pub fn service_principals(&self) -> service_principals::Client {
+    pub fn service_principals_client(&self) -> service_principals::Client {
         service_principals::Client(self.clone())
     }
-    pub fn signed_in_user(&self) -> signed_in_user::Client {
+    pub fn signed_in_user_client(&self) -> signed_in_user::Client {
         signed_in_user::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/svc/imds/src/package_2021_01_01/operations.rs
+++ b/services/svc/imds/src/package_2021_01_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attested(&self) -> attested::Client {
+    pub fn attested_client(&self) -> attested::Client {
         attested::Client(self.clone())
     }
-    pub fn identity(&self) -> identity::Client {
+    pub fn identity_client(&self) -> identity::Client {
         identity::Client(self.clone())
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
 }

--- a/services/svc/imds/src/package_2021_02_01/operations.rs
+++ b/services/svc/imds/src/package_2021_02_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attested(&self) -> attested::Client {
+    pub fn attested_client(&self) -> attested::Client {
         attested::Client(self.clone())
     }
-    pub fn identity(&self) -> identity::Client {
+    pub fn identity_client(&self) -> identity::Client {
         identity::Client(self.clone())
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
 }

--- a/services/svc/imds/src/package_2021_03_01/operations.rs
+++ b/services/svc/imds/src/package_2021_03_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attested(&self) -> attested::Client {
+    pub fn attested_client(&self) -> attested::Client {
         attested::Client(self.clone())
     }
-    pub fn identity(&self) -> identity::Client {
+    pub fn identity_client(&self) -> identity::Client {
         identity::Client(self.clone())
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
 }

--- a/services/svc/imds/src/package_2021_05_01/operations.rs
+++ b/services/svc/imds/src/package_2021_05_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attested(&self) -> attested::Client {
+    pub fn attested_client(&self) -> attested::Client {
         attested::Client(self.clone())
     }
-    pub fn identity(&self) -> identity::Client {
+    pub fn identity_client(&self) -> identity::Client {
         identity::Client(self.clone())
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
 }

--- a/services/svc/imds/src/package_2021_10_01/operations.rs
+++ b/services/svc/imds/src/package_2021_10_01/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn attested(&self) -> attested::Client {
+    pub fn attested_client(&self) -> attested::Client {
         attested::Client(self.clone())
     }
-    pub fn identity(&self) -> identity::Client {
+    pub fn identity_client(&self) -> identity::Client {
         identity::Client(self.clone())
     }
-    pub fn instances(&self) -> instances::Client {
+    pub fn instances_client(&self) -> instances::Client {
         instances::Client(self.clone())
     }
 }

--- a/services/svc/iotcentral/src/package_1_0/operations.rs
+++ b/services/svc/iotcentral/src/package_1_0/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_tokens(&self) -> api_tokens::Client {
+    pub fn api_tokens_client(&self) -> api_tokens::Client {
         api_tokens::Client(self.clone())
     }
-    pub fn device_templates(&self) -> device_templates::Client {
+    pub fn device_templates_client(&self) -> device_templates::Client {
         device_templates::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/svc/iotcentral/src/package_1_1_preview/operations.rs
+++ b/services/svc/iotcentral/src/package_1_1_preview/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_tokens(&self) -> api_tokens::Client {
+    pub fn api_tokens_client(&self) -> api_tokens::Client {
         api_tokens::Client(self.clone())
     }
-    pub fn destinations(&self) -> destinations::Client {
+    pub fn destinations_client(&self) -> destinations::Client {
         destinations::Client(self.clone())
     }
-    pub fn device_groups(&self) -> device_groups::Client {
+    pub fn device_groups_client(&self) -> device_groups::Client {
         device_groups::Client(self.clone())
     }
-    pub fn device_templates(&self) -> device_templates::Client {
+    pub fn device_templates_client(&self) -> device_templates::Client {
         device_templates::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn exports(&self) -> exports::Client {
+    pub fn exports_client(&self) -> exports::Client {
         exports::Client(self.clone())
     }
-    pub fn file_uploads(&self) -> file_uploads::Client {
+    pub fn file_uploads_client(&self) -> file_uploads::Client {
         file_uploads::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn organizations(&self) -> organizations::Client {
+    pub fn organizations_client(&self) -> organizations::Client {
         organizations::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/svc/iotcentral/src/package_1_2_preview/operations.rs
+++ b/services/svc/iotcentral/src/package_1_2_preview/operations.rs
@@ -74,40 +74,40 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_tokens(&self) -> api_tokens::Client {
+    pub fn api_tokens_client(&self) -> api_tokens::Client {
         api_tokens::Client(self.clone())
     }
-    pub fn destinations(&self) -> destinations::Client {
+    pub fn destinations_client(&self) -> destinations::Client {
         destinations::Client(self.clone())
     }
-    pub fn device_groups(&self) -> device_groups::Client {
+    pub fn device_groups_client(&self) -> device_groups::Client {
         device_groups::Client(self.clone())
     }
-    pub fn device_templates(&self) -> device_templates::Client {
+    pub fn device_templates_client(&self) -> device_templates::Client {
         device_templates::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn exports(&self) -> exports::Client {
+    pub fn exports_client(&self) -> exports::Client {
         exports::Client(self.clone())
     }
-    pub fn file_uploads(&self) -> file_uploads::Client {
+    pub fn file_uploads_client(&self) -> file_uploads::Client {
         file_uploads::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn organizations(&self) -> organizations::Client {
+    pub fn organizations_client(&self) -> organizations::Client {
         organizations::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/svc/iotcentral/src/package_2021_04_30_preview/operations.rs
+++ b/services/svc/iotcentral/src/package_2021_04_30_preview/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_tokens(&self) -> api_tokens::Client {
+    pub fn api_tokens_client(&self) -> api_tokens::Client {
         api_tokens::Client(self.clone())
     }
-    pub fn continuous_data_exports(&self) -> continuous_data_exports::Client {
+    pub fn continuous_data_exports_client(&self) -> continuous_data_exports::Client {
         continuous_data_exports::Client(self.clone())
     }
-    pub fn device_groups(&self) -> device_groups::Client {
+    pub fn device_groups_client(&self) -> device_groups::Client {
         device_groups::Client(self.clone())
     }
-    pub fn device_templates(&self) -> device_templates::Client {
+    pub fn device_templates_client(&self) -> device_templates::Client {
         device_templates::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/svc/iotcentral/src/package_2022_05_31/operations.rs
+++ b/services/svc/iotcentral/src/package_2022_05_31/operations.rs
@@ -74,28 +74,28 @@ impl Client {
             pipeline,
         }
     }
-    pub fn api_tokens(&self) -> api_tokens::Client {
+    pub fn api_tokens_client(&self) -> api_tokens::Client {
         api_tokens::Client(self.clone())
     }
-    pub fn device_groups(&self) -> device_groups::Client {
+    pub fn device_groups_client(&self) -> device_groups::Client {
         device_groups::Client(self.clone())
     }
-    pub fn device_templates(&self) -> device_templates::Client {
+    pub fn device_templates_client(&self) -> device_templates::Client {
         device_templates::Client(self.clone())
     }
-    pub fn devices(&self) -> devices::Client {
+    pub fn devices_client(&self) -> devices::Client {
         devices::Client(self.clone())
     }
-    pub fn file_uploads(&self) -> file_uploads::Client {
+    pub fn file_uploads_client(&self) -> file_uploads::Client {
         file_uploads::Client(self.clone())
     }
-    pub fn organizations(&self) -> organizations::Client {
+    pub fn organizations_client(&self) -> organizations::Client {
         organizations::Client(self.clone())
     }
-    pub fn roles(&self) -> roles::Client {
+    pub fn roles_client(&self) -> roles::Client {
         roles::Client(self.clone())
     }
-    pub fn users(&self) -> users::Client {
+    pub fn users_client(&self) -> users::Client {
         users::Client(self.clone())
     }
 }

--- a/services/svc/keyvault/src/package_7_2/operations.rs
+++ b/services/svc/keyvault/src/package_7_2/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hsm_security_domain(&self) -> hsm_security_domain::Client {
+    pub fn hsm_security_domain_client(&self) -> hsm_security_domain::Client {
         hsm_security_domain::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
 }

--- a/services/svc/keyvault/src/package_7_2_preview/operations.rs
+++ b/services/svc/keyvault/src/package_7_2_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hsm_security_domain(&self) -> hsm_security_domain::Client {
+    pub fn hsm_security_domain_client(&self) -> hsm_security_domain::Client {
         hsm_security_domain::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
 }

--- a/services/svc/keyvault/src/package_7_3/operations.rs
+++ b/services/svc/keyvault/src/package_7_3/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hsm_security_domain(&self) -> hsm_security_domain::Client {
+    pub fn hsm_security_domain_client(&self) -> hsm_security_domain::Client {
         hsm_security_domain::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
 }

--- a/services/svc/keyvault/src/package_preview_7_3_preview/operations.rs
+++ b/services/svc/keyvault/src/package_preview_7_3_preview/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn hsm_security_domain(&self) -> hsm_security_domain::Client {
+    pub fn hsm_security_domain_client(&self) -> hsm_security_domain::Client {
         hsm_security_domain::Client(self.clone())
     }
-    pub fn role_assignments(&self) -> role_assignments::Client {
+    pub fn role_assignments_client(&self) -> role_assignments::Client {
         role_assignments::Client(self.clone())
     }
-    pub fn role_definitions(&self) -> role_definitions::Client {
+    pub fn role_definitions_client(&self) -> role_definitions::Client {
         role_definitions::Client(self.clone())
     }
 }

--- a/services/svc/loadtestservice/src/package_2021_07_01_preview/operations.rs
+++ b/services/svc/loadtestservice/src/package_2021_07_01_preview/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn app_component(&self) -> app_component::Client {
+    pub fn app_component_client(&self) -> app_component::Client {
         app_component::Client(self.clone())
     }
-    pub fn file(&self) -> file::Client {
+    pub fn file_client(&self) -> file::Client {
         file::Client(self.clone())
     }
-    pub fn server_metrics(&self) -> server_metrics::Client {
+    pub fn server_metrics_client(&self) -> server_metrics::Client {
         server_metrics::Client(self.clone())
     }
-    pub fn test(&self) -> test::Client {
+    pub fn test_client(&self) -> test::Client {
         test::Client(self.clone())
     }
-    pub fn test_run(&self) -> test_run::Client {
+    pub fn test_run_client(&self) -> test_run::Client {
         test_run::Client(self.clone())
     }
 }

--- a/services/svc/loadtestservice/src/package_2022_06_01_preview/operations.rs
+++ b/services/svc/loadtestservice/src/package_2022_06_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn app_component(&self) -> app_component::Client {
+    pub fn app_component_client(&self) -> app_component::Client {
         app_component::Client(self.clone())
     }
-    pub fn server_metrics(&self) -> server_metrics::Client {
+    pub fn server_metrics_client(&self) -> server_metrics::Client {
         server_metrics::Client(self.clone())
     }
-    pub fn test(&self) -> test::Client {
+    pub fn test_client(&self) -> test::Client {
         test::Client(self.clone())
     }
-    pub fn test_run(&self) -> test_run::Client {
+    pub fn test_run_client(&self) -> test_run::Client {
         test_run::Client(self.clone())
     }
 }

--- a/services/svc/marketplacecatalog/src/package_2021_10_01/operations.rs
+++ b/services/svc/marketplacecatalog/src/package_2021_10_01/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn public_offers(&self) -> public_offers::Client {
+    pub fn public_offers_client(&self) -> public_offers::Client {
         public_offers::Client(self.clone())
     }
 }

--- a/services/svc/mixedreality/src/package_2021_01_01/operations.rs
+++ b/services/svc/mixedreality/src/package_2021_01_01/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn remote_rendering(&self) -> remote_rendering::Client {
+    pub fn remote_rendering_client(&self) -> remote_rendering::Client {
         remote_rendering::Client(self.clone())
     }
 }

--- a/services/svc/monitor/src/package_2018_09_preview/operations.rs
+++ b/services/svc/monitor/src/package_2018_09_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn metrics(&self) -> metrics::Client {
+    pub fn metrics_client(&self) -> metrics::Client {
         metrics::Client(self.clone())
     }
 }

--- a/services/svc/operationalinsights/src/v1/operations.rs
+++ b/services/svc/operationalinsights/src/v1/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
 }

--- a/services/svc/operationalinsights/src/v20171001/operations.rs
+++ b/services/svc/operationalinsights/src/v20171001/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
 }

--- a/services/svc/operationalinsights/src/v20210519/operations.rs
+++ b/services/svc/operationalinsights/src/v20210519/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn metadata(&self) -> metadata::Client {
+    pub fn metadata_client(&self) -> metadata::Client {
         metadata::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
 }

--- a/services/svc/purview/src/package_2021_05_01_preview/operations.rs
+++ b/services/svc/purview/src/package_2021_05_01_preview/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn collection(&self) -> collection::Client {
+    pub fn collection_client(&self) -> collection::Client {
         collection::Client(self.clone())
     }
-    pub fn discovery(&self) -> discovery::Client {
+    pub fn discovery_client(&self) -> discovery::Client {
         discovery::Client(self.clone())
     }
-    pub fn entity(&self) -> entity::Client {
+    pub fn entity_client(&self) -> entity::Client {
         entity::Client(self.clone())
     }
-    pub fn glossary(&self) -> glossary::Client {
+    pub fn glossary_client(&self) -> glossary::Client {
         glossary::Client(self.clone())
     }
-    pub fn lineage(&self) -> lineage::Client {
+    pub fn lineage_client(&self) -> lineage::Client {
         lineage::Client(self.clone())
     }
-    pub fn relationship(&self) -> relationship::Client {
+    pub fn relationship_client(&self) -> relationship::Client {
         relationship::Client(self.clone())
     }
-    pub fn types(&self) -> types::Client {
+    pub fn types_client(&self) -> types::Client {
         types::Client(self.clone())
     }
 }

--- a/services/svc/purview/src/package_2021_07_01_preview/operations.rs
+++ b/services/svc/purview/src/package_2021_07_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn metadata_policy(&self) -> metadata_policy::Client {
+    pub fn metadata_policy_client(&self) -> metadata_policy::Client {
         metadata_policy::Client(self.clone())
     }
-    pub fn metadata_roles(&self) -> metadata_roles::Client {
+    pub fn metadata_roles_client(&self) -> metadata_roles::Client {
         metadata_roles::Client(self.clone())
     }
 }

--- a/services/svc/purview/src/package_2021_10_01_preview/operations.rs
+++ b/services/svc/purview/src/package_2021_10_01_preview/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn classification_rules(&self) -> classification_rules::Client {
+    pub fn classification_rules_client(&self) -> classification_rules::Client {
         classification_rules::Client(self.clone())
     }
-    pub fn data_sources(&self) -> data_sources::Client {
+    pub fn data_sources_client(&self) -> data_sources::Client {
         data_sources::Client(self.clone())
     }
-    pub fn filters(&self) -> filters::Client {
+    pub fn filters_client(&self) -> filters::Client {
         filters::Client(self.clone())
     }
-    pub fn key_vault_connections(&self) -> key_vault_connections::Client {
+    pub fn key_vault_connections_client(&self) -> key_vault_connections::Client {
         key_vault_connections::Client(self.clone())
     }
-    pub fn scan_result(&self) -> scan_result::Client {
+    pub fn scan_result_client(&self) -> scan_result::Client {
         scan_result::Client(self.clone())
     }
-    pub fn scan_rulesets(&self) -> scan_rulesets::Client {
+    pub fn scan_rulesets_client(&self) -> scan_rulesets::Client {
         scan_rulesets::Client(self.clone())
     }
-    pub fn scans(&self) -> scans::Client {
+    pub fn scans_client(&self) -> scans::Client {
         scans::Client(self.clone())
     }
-    pub fn system_scan_rulesets(&self) -> system_scan_rulesets::Client {
+    pub fn system_scan_rulesets_client(&self) -> system_scan_rulesets::Client {
         system_scan_rulesets::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/svc/purview/src/package_2022_02_01_preview/operations.rs
+++ b/services/svc/purview/src/package_2022_02_01_preview/operations.rs
@@ -74,34 +74,34 @@ impl Client {
             pipeline,
         }
     }
-    pub fn classification_rules(&self) -> classification_rules::Client {
+    pub fn classification_rules_client(&self) -> classification_rules::Client {
         classification_rules::Client(self.clone())
     }
-    pub fn credential(&self) -> credential::Client {
+    pub fn credential_client(&self) -> credential::Client {
         credential::Client(self.clone())
     }
-    pub fn data_sources(&self) -> data_sources::Client {
+    pub fn data_sources_client(&self) -> data_sources::Client {
         data_sources::Client(self.clone())
     }
-    pub fn filters(&self) -> filters::Client {
+    pub fn filters_client(&self) -> filters::Client {
         filters::Client(self.clone())
     }
-    pub fn key_vault_connections(&self) -> key_vault_connections::Client {
+    pub fn key_vault_connections_client(&self) -> key_vault_connections::Client {
         key_vault_connections::Client(self.clone())
     }
-    pub fn scan_result(&self) -> scan_result::Client {
+    pub fn scan_result_client(&self) -> scan_result::Client {
         scan_result::Client(self.clone())
     }
-    pub fn scan_rulesets(&self) -> scan_rulesets::Client {
+    pub fn scan_rulesets_client(&self) -> scan_rulesets::Client {
         scan_rulesets::Client(self.clone())
     }
-    pub fn scans(&self) -> scans::Client {
+    pub fn scans_client(&self) -> scans::Client {
         scans::Client(self.clone())
     }
-    pub fn system_scan_rulesets(&self) -> system_scan_rulesets::Client {
+    pub fn system_scan_rulesets_client(&self) -> system_scan_rulesets::Client {
         system_scan_rulesets::Client(self.clone())
     }
-    pub fn triggers(&self) -> triggers::Client {
+    pub fn triggers_client(&self) -> triggers::Client {
         triggers::Client(self.clone())
     }
 }

--- a/services/svc/purview/src/package_preview_2022_03/operations.rs
+++ b/services/svc/purview/src/package_preview_2022_03/operations.rs
@@ -74,25 +74,25 @@ impl Client {
             pipeline,
         }
     }
-    pub fn collection(&self) -> collection::Client {
+    pub fn collection_client(&self) -> collection::Client {
         collection::Client(self.clone())
     }
-    pub fn discovery(&self) -> discovery::Client {
+    pub fn discovery_client(&self) -> discovery::Client {
         discovery::Client(self.clone())
     }
-    pub fn entity(&self) -> entity::Client {
+    pub fn entity_client(&self) -> entity::Client {
         entity::Client(self.clone())
     }
-    pub fn glossary(&self) -> glossary::Client {
+    pub fn glossary_client(&self) -> glossary::Client {
         glossary::Client(self.clone())
     }
-    pub fn lineage(&self) -> lineage::Client {
+    pub fn lineage_client(&self) -> lineage::Client {
         lineage::Client(self.clone())
     }
-    pub fn relationship(&self) -> relationship::Client {
+    pub fn relationship_client(&self) -> relationship::Client {
         relationship::Client(self.clone())
     }
-    pub fn types(&self) -> types::Client {
+    pub fn types_client(&self) -> types::Client {
         types::Client(self.clone())
     }
 }

--- a/services/svc/quantum/src/package_2019_11_04_preview/operations.rs
+++ b/services/svc/quantum/src/package_2019_11_04_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn providers(&self) -> providers::Client {
+    pub fn providers_client(&self) -> providers::Client {
         providers::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn storage(&self) -> storage::Client {
+    pub fn storage_client(&self) -> storage::Client {
         storage::Client(self.clone())
     }
 }

--- a/services/svc/quantum/src/package_2021_05_06_preview/operations.rs
+++ b/services/svc/quantum/src/package_2021_05_06_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn providers(&self) -> providers::Client {
+    pub fn providers_client(&self) -> providers::Client {
         providers::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn storage(&self) -> storage::Client {
+    pub fn storage_client(&self) -> storage::Client {
         storage::Client(self.clone())
     }
 }

--- a/services/svc/quantum/src/package_2021_11_01_preview/operations.rs
+++ b/services/svc/quantum/src/package_2021_11_01_preview/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn jobs(&self) -> jobs::Client {
+    pub fn jobs_client(&self) -> jobs::Client {
         jobs::Client(self.clone())
     }
-    pub fn providers(&self) -> providers::Client {
+    pub fn providers_client(&self) -> providers::Client {
         providers::Client(self.clone())
     }
-    pub fn quotas(&self) -> quotas::Client {
+    pub fn quotas_client(&self) -> quotas::Client {
         quotas::Client(self.clone())
     }
-    pub fn storage(&self) -> storage::Client {
+    pub fn storage_client(&self) -> storage::Client {
         storage::Client(self.clone())
     }
 }

--- a/services/svc/queuestorage/src/package_2018_03/operations.rs
+++ b/services/svc/queuestorage/src/package_2018_03/operations.rs
@@ -74,16 +74,16 @@ impl Client {
             pipeline,
         }
     }
-    pub fn message_id(&self) -> message_id::Client {
+    pub fn message_id_client(&self) -> message_id::Client {
         message_id::Client(self.clone())
     }
-    pub fn messages(&self) -> messages::Client {
+    pub fn messages_client(&self) -> messages::Client {
         messages::Client(self.clone())
     }
-    pub fn queue(&self) -> queue::Client {
+    pub fn queue_client(&self) -> queue::Client {
         queue::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/schemaregistry/src/package_2021_10/operations.rs
+++ b/services/svc/schemaregistry/src/package_2021_10/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn schema(&self) -> schema::Client {
+    pub fn schema_client(&self) -> schema::Client {
         schema::Client(self.clone())
     }
-    pub fn schema_groups(&self) -> schema_groups::Client {
+    pub fn schema_groups_client(&self) -> schema_groups::Client {
         schema_groups::Client(self.clone())
     }
 }

--- a/services/svc/servicefabric/src/v7_1/operations.rs
+++ b/services/svc/servicefabric/src/v7_1/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn mesh_application(&self) -> mesh_application::Client {
+    pub fn mesh_application_client(&self) -> mesh_application::Client {
         mesh_application::Client(self.clone())
     }
-    pub fn mesh_code_package(&self) -> mesh_code_package::Client {
+    pub fn mesh_code_package_client(&self) -> mesh_code_package::Client {
         mesh_code_package::Client(self.clone())
     }
-    pub fn mesh_gateway(&self) -> mesh_gateway::Client {
+    pub fn mesh_gateway_client(&self) -> mesh_gateway::Client {
         mesh_gateway::Client(self.clone())
     }
-    pub fn mesh_network(&self) -> mesh_network::Client {
+    pub fn mesh_network_client(&self) -> mesh_network::Client {
         mesh_network::Client(self.clone())
     }
-    pub fn mesh_secret(&self) -> mesh_secret::Client {
+    pub fn mesh_secret_client(&self) -> mesh_secret::Client {
         mesh_secret::Client(self.clone())
     }
-    pub fn mesh_secret_value(&self) -> mesh_secret_value::Client {
+    pub fn mesh_secret_value_client(&self) -> mesh_secret_value::Client {
         mesh_secret_value::Client(self.clone())
     }
-    pub fn mesh_service(&self) -> mesh_service::Client {
+    pub fn mesh_service_client(&self) -> mesh_service::Client {
         mesh_service::Client(self.clone())
     }
-    pub fn mesh_service_replica(&self) -> mesh_service_replica::Client {
+    pub fn mesh_service_replica_client(&self) -> mesh_service_replica::Client {
         mesh_service_replica::Client(self.clone())
     }
-    pub fn mesh_volume(&self) -> mesh_volume::Client {
+    pub fn mesh_volume_client(&self) -> mesh_volume::Client {
         mesh_volume::Client(self.clone())
     }
 }

--- a/services/svc/servicefabric/src/v7_2/operations.rs
+++ b/services/svc/servicefabric/src/v7_2/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn mesh_application(&self) -> mesh_application::Client {
+    pub fn mesh_application_client(&self) -> mesh_application::Client {
         mesh_application::Client(self.clone())
     }
-    pub fn mesh_code_package(&self) -> mesh_code_package::Client {
+    pub fn mesh_code_package_client(&self) -> mesh_code_package::Client {
         mesh_code_package::Client(self.clone())
     }
-    pub fn mesh_gateway(&self) -> mesh_gateway::Client {
+    pub fn mesh_gateway_client(&self) -> mesh_gateway::Client {
         mesh_gateway::Client(self.clone())
     }
-    pub fn mesh_network(&self) -> mesh_network::Client {
+    pub fn mesh_network_client(&self) -> mesh_network::Client {
         mesh_network::Client(self.clone())
     }
-    pub fn mesh_secret(&self) -> mesh_secret::Client {
+    pub fn mesh_secret_client(&self) -> mesh_secret::Client {
         mesh_secret::Client(self.clone())
     }
-    pub fn mesh_secret_value(&self) -> mesh_secret_value::Client {
+    pub fn mesh_secret_value_client(&self) -> mesh_secret_value::Client {
         mesh_secret_value::Client(self.clone())
     }
-    pub fn mesh_service(&self) -> mesh_service::Client {
+    pub fn mesh_service_client(&self) -> mesh_service::Client {
         mesh_service::Client(self.clone())
     }
-    pub fn mesh_service_replica(&self) -> mesh_service_replica::Client {
+    pub fn mesh_service_replica_client(&self) -> mesh_service_replica::Client {
         mesh_service_replica::Client(self.clone())
     }
-    pub fn mesh_volume(&self) -> mesh_volume::Client {
+    pub fn mesh_volume_client(&self) -> mesh_volume::Client {
         mesh_volume::Client(self.clone())
     }
 }

--- a/services/svc/servicefabric/src/v8_0/operations.rs
+++ b/services/svc/servicefabric/src/v8_0/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn mesh_application(&self) -> mesh_application::Client {
+    pub fn mesh_application_client(&self) -> mesh_application::Client {
         mesh_application::Client(self.clone())
     }
-    pub fn mesh_code_package(&self) -> mesh_code_package::Client {
+    pub fn mesh_code_package_client(&self) -> mesh_code_package::Client {
         mesh_code_package::Client(self.clone())
     }
-    pub fn mesh_gateway(&self) -> mesh_gateway::Client {
+    pub fn mesh_gateway_client(&self) -> mesh_gateway::Client {
         mesh_gateway::Client(self.clone())
     }
-    pub fn mesh_network(&self) -> mesh_network::Client {
+    pub fn mesh_network_client(&self) -> mesh_network::Client {
         mesh_network::Client(self.clone())
     }
-    pub fn mesh_secret(&self) -> mesh_secret::Client {
+    pub fn mesh_secret_client(&self) -> mesh_secret::Client {
         mesh_secret::Client(self.clone())
     }
-    pub fn mesh_secret_value(&self) -> mesh_secret_value::Client {
+    pub fn mesh_secret_value_client(&self) -> mesh_secret_value::Client {
         mesh_secret_value::Client(self.clone())
     }
-    pub fn mesh_service(&self) -> mesh_service::Client {
+    pub fn mesh_service_client(&self) -> mesh_service::Client {
         mesh_service::Client(self.clone())
     }
-    pub fn mesh_service_replica(&self) -> mesh_service_replica::Client {
+    pub fn mesh_service_replica_client(&self) -> mesh_service_replica::Client {
         mesh_service_replica::Client(self.clone())
     }
-    pub fn mesh_volume(&self) -> mesh_volume::Client {
+    pub fn mesh_volume_client(&self) -> mesh_volume::Client {
         mesh_volume::Client(self.clone())
     }
 }

--- a/services/svc/servicefabric/src/v8_1/operations.rs
+++ b/services/svc/servicefabric/src/v8_1/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn mesh_application(&self) -> mesh_application::Client {
+    pub fn mesh_application_client(&self) -> mesh_application::Client {
         mesh_application::Client(self.clone())
     }
-    pub fn mesh_code_package(&self) -> mesh_code_package::Client {
+    pub fn mesh_code_package_client(&self) -> mesh_code_package::Client {
         mesh_code_package::Client(self.clone())
     }
-    pub fn mesh_gateway(&self) -> mesh_gateway::Client {
+    pub fn mesh_gateway_client(&self) -> mesh_gateway::Client {
         mesh_gateway::Client(self.clone())
     }
-    pub fn mesh_network(&self) -> mesh_network::Client {
+    pub fn mesh_network_client(&self) -> mesh_network::Client {
         mesh_network::Client(self.clone())
     }
-    pub fn mesh_secret(&self) -> mesh_secret::Client {
+    pub fn mesh_secret_client(&self) -> mesh_secret::Client {
         mesh_secret::Client(self.clone())
     }
-    pub fn mesh_secret_value(&self) -> mesh_secret_value::Client {
+    pub fn mesh_secret_value_client(&self) -> mesh_secret_value::Client {
         mesh_secret_value::Client(self.clone())
     }
-    pub fn mesh_service(&self) -> mesh_service::Client {
+    pub fn mesh_service_client(&self) -> mesh_service::Client {
         mesh_service::Client(self.clone())
     }
-    pub fn mesh_service_replica(&self) -> mesh_service_replica::Client {
+    pub fn mesh_service_replica_client(&self) -> mesh_service_replica::Client {
         mesh_service_replica::Client(self.clone())
     }
-    pub fn mesh_volume(&self) -> mesh_volume::Client {
+    pub fn mesh_volume_client(&self) -> mesh_volume::Client {
         mesh_volume::Client(self.clone())
     }
 }

--- a/services/svc/servicefabric/src/v8_2/operations.rs
+++ b/services/svc/servicefabric/src/v8_2/operations.rs
@@ -74,31 +74,31 @@ impl Client {
             pipeline,
         }
     }
-    pub fn mesh_application(&self) -> mesh_application::Client {
+    pub fn mesh_application_client(&self) -> mesh_application::Client {
         mesh_application::Client(self.clone())
     }
-    pub fn mesh_code_package(&self) -> mesh_code_package::Client {
+    pub fn mesh_code_package_client(&self) -> mesh_code_package::Client {
         mesh_code_package::Client(self.clone())
     }
-    pub fn mesh_gateway(&self) -> mesh_gateway::Client {
+    pub fn mesh_gateway_client(&self) -> mesh_gateway::Client {
         mesh_gateway::Client(self.clone())
     }
-    pub fn mesh_network(&self) -> mesh_network::Client {
+    pub fn mesh_network_client(&self) -> mesh_network::Client {
         mesh_network::Client(self.clone())
     }
-    pub fn mesh_secret(&self) -> mesh_secret::Client {
+    pub fn mesh_secret_client(&self) -> mesh_secret::Client {
         mesh_secret::Client(self.clone())
     }
-    pub fn mesh_secret_value(&self) -> mesh_secret_value::Client {
+    pub fn mesh_secret_value_client(&self) -> mesh_secret_value::Client {
         mesh_secret_value::Client(self.clone())
     }
-    pub fn mesh_service(&self) -> mesh_service::Client {
+    pub fn mesh_service_client(&self) -> mesh_service::Client {
         mesh_service::Client(self.clone())
     }
-    pub fn mesh_service_replica(&self) -> mesh_service_replica::Client {
+    pub fn mesh_service_replica_client(&self) -> mesh_service_replica::Client {
         mesh_service_replica::Client(self.clone())
     }
-    pub fn mesh_volume(&self) -> mesh_volume::Client {
+    pub fn mesh_volume_client(&self) -> mesh_volume::Client {
         mesh_volume::Client(self.clone())
     }
 }

--- a/services/svc/storagedatalake/src/package_2020_06/operations.rs
+++ b/services/svc/storagedatalake/src/package_2020_06/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn file_system(&self) -> file_system::Client {
+    pub fn file_system_client(&self) -> file_system::Client {
         file_system::Client(self.clone())
     }
-    pub fn path(&self) -> path::Client {
+    pub fn path_client(&self) -> path::Client {
         path::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/storagedatalake/src/package_2020_10/operations.rs
+++ b/services/svc/storagedatalake/src/package_2020_10/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn file_system(&self) -> file_system::Client {
+    pub fn file_system_client(&self) -> file_system::Client {
         file_system::Client(self.clone())
     }
-    pub fn path(&self) -> path::Client {
+    pub fn path_client(&self) -> path::Client {
         path::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/storagedatalake/src/package_2021_04/operations.rs
+++ b/services/svc/storagedatalake/src/package_2021_04/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn file_system(&self) -> file_system::Client {
+    pub fn file_system_client(&self) -> file_system::Client {
         file_system::Client(self.clone())
     }
-    pub fn path(&self) -> path::Client {
+    pub fn path_client(&self) -> path::Client {
         path::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/storagedatalake/src/package_2021_06/operations.rs
+++ b/services/svc/storagedatalake/src/package_2021_06/operations.rs
@@ -74,13 +74,13 @@ impl Client {
             pipeline,
         }
     }
-    pub fn file_system(&self) -> file_system::Client {
+    pub fn file_system_client(&self) -> file_system::Client {
         file_system::Client(self.clone())
     }
-    pub fn path(&self) -> path::Client {
+    pub fn path_client(&self) -> path::Client {
         path::Client(self.clone())
     }
-    pub fn service(&self) -> service::Client {
+    pub fn service_client(&self) -> service::Client {
         service::Client(self.clone())
     }
 }

--- a/services/svc/synapse/src/package_spark_2019_11_01_preview/operations.rs
+++ b/services/svc/synapse/src/package_spark_2019_11_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn spark_batch(&self) -> spark_batch::Client {
+    pub fn spark_batch_client(&self) -> spark_batch::Client {
         spark_batch::Client(self.clone())
     }
-    pub fn spark_session(&self) -> spark_session::Client {
+    pub fn spark_session_client(&self) -> spark_session::Client {
         spark_session::Client(self.clone())
     }
 }

--- a/services/svc/synapse/src/package_spark_2020_12_01/operations.rs
+++ b/services/svc/synapse/src/package_spark_2020_12_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn spark_batch(&self) -> spark_batch::Client {
+    pub fn spark_batch_client(&self) -> spark_batch::Client {
         spark_batch::Client(self.clone())
     }
-    pub fn spark_session(&self) -> spark_session::Client {
+    pub fn spark_session_client(&self) -> spark_session::Client {
         spark_session::Client(self.clone())
     }
 }

--- a/services/svc/synapse/src/package_vnet_2019_06_01_preview/operations.rs
+++ b/services/svc/synapse/src/package_vnet_2019_06_01_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn managed_private_endpoints(&self) -> managed_private_endpoints::Client {
+    pub fn managed_private_endpoints_client(&self) -> managed_private_endpoints::Client {
         managed_private_endpoints::Client(self.clone())
     }
 }

--- a/services/svc/synapse/src/package_vnet_2020_12_01/operations.rs
+++ b/services/svc/synapse/src/package_vnet_2020_12_01/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn managed_private_endpoints(&self) -> managed_private_endpoints::Client {
+    pub fn managed_private_endpoints_client(&self) -> managed_private_endpoints::Client {
         managed_private_endpoints::Client(self.clone())
     }
 }

--- a/services/svc/synapse/src/package_vnet_2021_06_01_preview/operations.rs
+++ b/services/svc/synapse/src/package_vnet_2021_06_01_preview/operations.rs
@@ -74,7 +74,7 @@ impl Client {
             pipeline,
         }
     }
-    pub fn managed_private_endpoints(&self) -> managed_private_endpoints::Client {
+    pub fn managed_private_endpoints_client(&self) -> managed_private_endpoints::Client {
         managed_private_endpoints::Client(self.clone())
     }
 }

--- a/services/svc/timeseriesinsights/src/package_2020_07_31/operations.rs
+++ b/services/svc/timeseriesinsights/src/package_2020_07_31/operations.rs
@@ -74,19 +74,19 @@ impl Client {
             pipeline,
         }
     }
-    pub fn model_settings(&self) -> model_settings::Client {
+    pub fn model_settings_client(&self) -> model_settings::Client {
         model_settings::Client(self.clone())
     }
-    pub fn query(&self) -> query::Client {
+    pub fn query_client(&self) -> query::Client {
         query::Client(self.clone())
     }
-    pub fn time_series_hierarchies(&self) -> time_series_hierarchies::Client {
+    pub fn time_series_hierarchies_client(&self) -> time_series_hierarchies::Client {
         time_series_hierarchies::Client(self.clone())
     }
-    pub fn time_series_instances(&self) -> time_series_instances::Client {
+    pub fn time_series_instances_client(&self) -> time_series_instances::Client {
         time_series_instances::Client(self.clone())
     }
-    pub fn time_series_types(&self) -> time_series_types::Client {
+    pub fn time_series_types_client(&self) -> time_series_types::Client {
         time_series_types::Client(self.clone())
     }
 }

--- a/services/svc/webpubsub/src/package_2021_05_01_preview/operations.rs
+++ b/services/svc/webpubsub/src/package_2021_05_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn health_api(&self) -> health_api::Client {
+    pub fn health_api_client(&self) -> health_api::Client {
         health_api::Client(self.clone())
     }
-    pub fn web_pub_sub(&self) -> web_pub_sub::Client {
+    pub fn web_pub_sub_client(&self) -> web_pub_sub::Client {
         web_pub_sub::Client(self.clone())
     }
 }

--- a/services/svc/webpubsub/src/package_2021_08_01_preview/operations.rs
+++ b/services/svc/webpubsub/src/package_2021_08_01_preview/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn health_api(&self) -> health_api::Client {
+    pub fn health_api_client(&self) -> health_api::Client {
         health_api::Client(self.clone())
     }
-    pub fn web_pub_sub(&self) -> web_pub_sub::Client {
+    pub fn web_pub_sub_client(&self) -> web_pub_sub::Client {
         web_pub_sub::Client(self.clone())
     }
 }

--- a/services/svc/webpubsub/src/package_2021_10_01/operations.rs
+++ b/services/svc/webpubsub/src/package_2021_10_01/operations.rs
@@ -74,10 +74,10 @@ impl Client {
             pipeline,
         }
     }
-    pub fn health_api(&self) -> health_api::Client {
+    pub fn health_api_client(&self) -> health_api::Client {
         health_api::Client(self.clone())
     }
-    pub fn web_pub_sub(&self) -> web_pub_sub::Client {
+    pub fn web_pub_sub_client(&self) -> web_pub_sub::Client {
         web_pub_sub::Client(self.clone())
     }
 }


### PR DESCRIPTION
This adds a `_client` suffix to the function to retrieve the sub clients. The SDKs made the switch already. 
https://github.com/Azure/azure-sdk-for-rust/pull/676#issuecomment-1062406878