### PR TITLE
no default features for http-types

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "1.0"
 chrono = "0.4"
 dyn-clone = "1.0"
 futures = "0.3"
-http-types = "2.12"
+http-types = { version = "2.12", default-features = false }
 log = "0.4"
 rand = "0.8"
 reqwest = { version = "0.11", features = [


### PR DESCRIPTION
`cargo audit` reported vulnerabilities in the cookie feature that we are not using.
https://github.com/http-rs/http-types/issues/505