### PR TITLE
lower case metadata header to pass assertion

### DIFF
--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -114,7 +114,7 @@ impl TokenCredential for ImdsManagedIdentityCredential {
 
         let mut req = Request::new(url, Method::Get);
 
-        req.insert_header("Metadata", "true");
+        req.insert_header("metadata", "true");
 
         let msi_secret = std::env::var(MSI_SECRET_ENV_KEY);
         if let Ok(val) = msi_secret {


### PR DESCRIPTION
See #894
I didn't see that one header wasn't part of the AutoRust code.