### PR TITLE
remove last timer builders from data_tables

### DIFF
--- a/sdk/data_tables/src/operations/insert_or_replace_or_merge_entity.rs
+++ b/sdk/data_tables/src/operations/insert_or_replace_or_merge_entity.rs
@@ -1,5 +1,5 @@
 use crate::{operations::*, prelude::*};
-use azure_core::{headers::*, prelude::*, CollectedResponse, Method};
+use azure_core::{headers::*, CollectedResponse, Method};
 use bytes::Bytes;
 use std::convert::TryInto;
 
@@ -8,15 +8,12 @@ operation! {
     client: EntityClient,
     body: Bytes,
     operation: InsertOperation,
-    ?timeout: Timeout
 }
 
 impl InsertOrReplaceOrMergeEntityBuilder {
     pub fn into_future(mut self) -> InsertOrReplaceOrMergeEntity {
         Box::pin(async move {
-            let mut url = self.client.url().clone();
-
-            self.timeout.append_to_url_query(&mut url);
+            let url = self.client.url().clone();
 
             let mut headers = Headers::new();
             headers.insert(CONTENT_TYPE, "application/json");

--- a/sdk/data_tables/src/operations/update_or_merge_entity.rs
+++ b/sdk/data_tables/src/operations/update_or_merge_entity.rs
@@ -1,5 +1,5 @@
 use crate::{operations::*, prelude::*, IfMatchCondition};
-use azure_core::{headers::*, prelude::*, CollectedResponse, Method};
+use azure_core::{headers::*, CollectedResponse, Method};
 use bytes::Bytes;
 use std::convert::TryInto;
 
@@ -9,7 +9,6 @@ operation! {
     body: Bytes,
     if_match_condition: IfMatchCondition,
     operation: UpdateOperation,
-    ?timeout: Timeout
 }
 
 impl UpdateOrMergeEntityBuilder {


### PR DESCRIPTION
Removes the final `timeout` builder parameters that were not included in #919.