### PR TITLE
Fix downloading single range from large blob 

### DIFF
--- a/sdk/storage_blobs/examples/blob_range.rs
+++ b/sdk/storage_blobs/examples/blob_range.rs
@@ -64,6 +64,15 @@ async fn main() -> azure_core::Result<()> {
         assert_eq!(chunk1.data[i], 72);
     }
 
+    // Download a single range stream.
+    let mut single_chunk = vec![];
+    let mut stream = blob_client.get().range(1024u64..1536).into_stream();
+    while let Some(result) = stream.next().await {
+        single_chunk.extend(result?.data);
+    }
+    assert_eq!(single_chunk.len(), 512);
+    assert!(single_chunk.iter().all(|x| *x == 72));
+
     // this time, only download them in chunks of 10 bytes
     let mut chunk2 = vec![];
 

--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -141,7 +141,9 @@ fn remaining_range(
     let requested_range = base_range.unwrap_or_else(|| Range::new(0, content_range.total_length()));
 
     // if the response said the end of the blob was downloaded, we're done
-    if content_range.end() >= requested_range.end {
+    // Note, we add + 1, as we don't need to re-fetch the last
+    // byte of the previous request.
+    if content_range.end() + 1 >= requested_range.end {
         return None;
     }
 
@@ -202,6 +204,13 @@ mod tests {
 
         let result = remaining_range(3, None, Some(ContentRange::new(0, 10, 20)));
         assert_eq!(result, Some(Range::new(11, 14)));
+
+        let result = remaining_range(
+            20,
+            Some(Range::new(5, 15)),
+            Some(ContentRange::new(5, 14, 20)),
+        );
+        assert_eq!(result, None);
 
         Ok(())
     }


### PR DESCRIPTION
Avoid sending subsequent request when downloading single range from a large blob.
Closes [this issue](https://github.com/Azure/azure-sdk-for-rust/issues/930)