### PR TITLE
Builderify cosmos client construction

### DIFF
--- a/docs/mock_transport.md
+++ b/docs/mock_transport.md
@@ -6,7 +6,7 @@
 
 If you want to write a test case or an example that supports the mock testing framework you must create a client with a transaction name that matches a collection of transactions found in the "tests/transactions" directory at the root of the SDK workspace.
 
-For instance in `cosmos` you can use the `CosmosClient::new_with_transaction` function.
+For instance in `cosmos` you can use the `CosmosClient::with_mock` function.
 
 ```rust
 let account = "MyCosmosAccountName";

--- a/sdk/data_cosmos/examples/user_permission_token.rs
+++ b/sdk/data_cosmos/examples/user_permission_token.rs
@@ -76,8 +76,7 @@ async fn main() -> azure_core::Result<()> {
         "Replacing authorization_token with {:?}.",
         new_authorization_token
     );
-    let mut client = client.clone();
-    client.auth_token(new_authorization_token);
+    let client = client.clone().auth_token(new_authorization_token);
 
     // let's list the documents with the new auth token
     let list_documents_response = client
@@ -145,7 +144,7 @@ async fn main() -> azure_core::Result<()> {
         "Replacing authorization_token with {:?}.",
         new_authorization_token
     );
-    client.auth_token(new_authorization_token);
+    let client = client.auth_token(new_authorization_token);
 
     // now we have an "All" authorization_token
     // so the create_document should succeed!

--- a/sdk/data_cosmos/tests/permission_token_usage.rs
+++ b/sdk/data_cosmos/tests/permission_token_usage.rs
@@ -28,7 +28,7 @@ async fn permission_token_usage() {
     const USER_NAME: &str = "someone@cool.net";
     const PERMISSION: &str = "sdktest";
 
-    let mut client = setup::initialize().unwrap();
+    let client = setup::initialize().unwrap();
 
     // create a temp database
     let _create_database_response = client
@@ -75,7 +75,7 @@ async fn permission_token_usage() {
         .permission
         .permission_token
         .into();
-    client.auth_token(new_authorization_token);
+    let client = client.auth_token(new_authorization_token);
     let new_database = client.database_client(DATABASE_NAME);
 
     // let's list the collection content.
@@ -121,7 +121,7 @@ async fn permission_token_usage() {
         .permission
         .permission_token
         .into();
-    client.auth_token(new_authorization_token);
+    let client = client.auth_token(new_authorization_token);
     let new_database = client.database_client(DATABASE_NAME);
     let new_collection = new_database.collection_client(COLLECTION_NAME);
 

--- a/sdk/data_cosmos/tests/setup.rs
+++ b/sdk/data_cosmos/tests/setup.rs
@@ -33,7 +33,7 @@ pub fn initialize(transaction_name: impl Into<String>) -> azure_core::Result<Cos
     .flatten()
     .unwrap_or_else(|| AuthorizationToken::new_resource(String::new()));
 
-    Ok(CosmosClient::new_with_transaction(
+    Ok(CosmosClient::with_mock(
         account_name,
         authorization_token,
         transaction_name,


### PR DESCRIPTION
_worked on together with @rylev_

This is the first follow-up to https://github.com/Azure/azure-sdk-for-rust/pull/886, changing all existing constructor methods to match a builder-style pattern. We've reduced the number of `CosmosClient` constructors, which should trim things down a little.

In follow-up PRs we want to:
- see if we can move `CloudLocation` to `azure-core`
- see if we can add a general-purpose mechanism to switch the transport layer
    - which in turn would allow us to remove `CosmosClient::with_mock` in favor of passing your own transport layer.
- add builder methods to `CosmosClient` to modify the pipeline

This serves as a step in getting there. Thanks!