### PR TITLE
Allow wasm to compile

### DIFF
--- a/sdk/core/src/auth.rs
+++ b/sdk/core/src/auth.rs
@@ -33,7 +33,8 @@ impl TokenResponse {
 }
 
 /// Represents a credential capable of providing an OAuth token.
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait TokenCredential: Send + Sync {
     /// Gets a `TokenResponse` for the specified resource
     async fn get_token(&self, resource: &str) -> crate::Result<TokenResponse>;

--- a/sdk/core/src/bytes_stream.rs
+++ b/sdk/core/src/bytes_stream.rs
@@ -56,7 +56,8 @@ impl Stream for BytesStream {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl SeekableStream for BytesStream {
     async fn reset(&mut self) -> crate::Result<()> {
         self.bytes_read = 0;

--- a/sdk/core/src/http_client/mod.rs
+++ b/sdk/core/src/http_client/mod.rs
@@ -8,7 +8,7 @@ mod reqwest;
     target_arch = "wasm32",
     any(feature = "enable_reqwest", feature = "enable_reqwest_rustls")
 ))]
-compile_error!("The `enable_request` and `enable_reqwest_rustls` features are not allowed for `wasm32` targets`");
+compile_error!("The `enable_request` and `enable_reqwest_rustls` features are not allowed for `wasm32` targets");
 
 #[cfg(all(
     not(target_arch = "wasm32"),

--- a/sdk/core/src/http_client/noop.rs
+++ b/sdk/core/src/http_client/noop.rs
@@ -1,0 +1,19 @@
+use async_trait::async_trait;
+
+#[derive(Debug)]
+pub struct NoopClient;
+
+// TODO(rylev): we probably don't want to limit this to wasm32
+// as there will be wasm environments with threads.
+// This should instead be a feature flag
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl crate::HttpClient for NoopClient {
+    async fn execute_request(&self, _request: &crate::Request) -> crate::Result<crate::Response> {
+        panic!(
+            "A request was called on the default http client `NoopClient`.\
+	This client does nothing but panic by default. Make sure to enable an http\
+	 client that can actually perform requests. **TODO**: link to instructions on how to do this "
+        );
+    }
+}

--- a/sdk/core/src/http_client/noop.rs
+++ b/sdk/core/src/http_client/noop.rs
@@ -9,11 +9,12 @@ pub struct NoopClient;
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl crate::HttpClient for NoopClient {
-    async fn execute_request(&self, _request: &crate::Request) -> crate::Result<crate::Response> {
+    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response> {
         panic!(
             "A request was called on the default http client `NoopClient`.\
-	This client does nothing but panic by default. Make sure to enable an http\
-	 client that can actually perform requests. **TODO**: link to instructions on how to do this "
+	This client does nothing but panic. Make sure to enable an http\
+	 client that can actually perform requests. You can do this by ensuring that the `reqwest` feature is enabled.\n\
+     Request:\n{request:?}"
         );
     }
 }

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -45,7 +45,7 @@ pub use error::Result;
 pub use headers::Header;
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 #[cfg(not(target_arch = "wasm32"))]
-pub use http_client::new_http_client;
+pub use http_client::new_reqwest_client;
 pub use http_client::{to_json, HttpClient};
 pub use models::*;
 pub use options::*;

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -191,6 +191,11 @@ macro_rules! operation {
         }
         azure_core::__private::paste! {
         /// The future returned by calling `into_future` on the builder.
+        /// For wasm, we don't require that the future is `Send`
+        #[cfg(target_arch = "wasm32")]
+        pub type $name =
+            std::pin::Pin<std::boxed::Box<dyn std::future::Future<Output = azure_core::Result<[<$name Response>]>> + 'static>>;
+        #[cfg(not(target_arch = "wasm32"))]
         pub type $name =
             futures::future::BoxFuture<'static, azure_core::Result<[<$name Response>]>>;
         #[cfg(feature = "into_future")]

--- a/sdk/core/src/mock/player_policy.rs
+++ b/sdk/core/src/mock/player_policy.rs
@@ -18,7 +18,8 @@ impl MockTransportPlayerPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for MockTransportPlayerPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/mock/recorder_policy.rs
+++ b/sdk/core/src/mock/recorder_policy.rs
@@ -22,7 +22,8 @@ impl MockTransportRecorderPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for MockTransportRecorderPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/pageable.rs
+++ b/sdk/core/src/pageable.rs
@@ -20,18 +20,16 @@ macro_rules! r#try {
 #[pin_project]
 pub struct Pageable<T, E> {
     #[pin]
-    stream: std::pin::Pin<Box<dyn Stream<Item = Result<T, E>> + Send>>,
+    stream: std::pin::Pin<Box<dyn Stream<Item = Result<T, E>>>>,
 }
 
 impl<T, E> Pageable<T, E>
 where
-    T: Continuable + Send + Sync,
+    T: Continuable,
 {
-    pub fn new<F>(
-        make_request: impl Fn(Option<T::Continuation>) -> F + Clone + 'static + Send,
-    ) -> Self
+    pub fn new<F>(make_request: impl Fn(Option<T::Continuation>) -> F + Clone + 'static) -> Self
     where
-        F: std::future::Future<Output = Result<T, E>> + Send + 'static,
+        F: std::future::Future<Output = Result<T, E>> + 'static,
     {
         let stream = unfold(State::Init, move |state: State<T::Continuation>| {
             let make_request = make_request.clone();
@@ -83,7 +81,7 @@ impl<T, O> std::fmt::Debug for Pageable<T, O> {
 
 /// A type that can yield an optional continuation token
 pub trait Continuable {
-    type Continuation: Send + 'static;
+    type Continuation: 'static;
     fn continuation(&self) -> Option<Self::Continuation>;
 }
 

--- a/sdk/core/src/pipeline.rs
+++ b/sdk/core/src/pipeline.rs
@@ -1,4 +1,3 @@
-#[cfg(not(target_arch = "wasm32"))]
 use crate::policies::TransportPolicy;
 use crate::policies::{CustomHeadersPolicy, Policy, TelemetryPolicy};
 use crate::{ClientOptions, Context, Request, Response};
@@ -71,18 +70,14 @@ impl Pipeline {
         pipeline.extend_from_slice(&per_retry_policies);
         pipeline.extend_from_slice(&options.per_retry_policies);
 
-        // TODO: Add transport policy for WASM once https://github.com/Azure/azure-sdk-for-rust/issues/293 is resolved.
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            #[allow(unused_mut)]
-            let mut policy: Arc<dyn Policy> =
-                Arc::new(TransportPolicy::new(options.transport.clone()));
+        #[allow(unused_mut)]
+        let mut policy: Arc<dyn Policy> =
+            Arc::new(TransportPolicy::new(options.transport.clone()));
 
-            #[cfg(feature = "mock_transport_framework")]
-            crate::mock::set_mock_transport_policy(&mut policy, options.transport);
+        #[cfg(feature = "mock_transport_framework")]
+        crate::mock::set_mock_transport_policy(&mut policy, options.transport);
 
-            pipeline.push(policy);
-        }
+        pipeline.push(policy);
 
         Self { pipeline }
     }

--- a/sdk/core/src/policies/custom_headers_policy.rs
+++ b/sdk/core/src/policies/custom_headers_policy.rs
@@ -15,7 +15,8 @@ impl From<Headers> for CustomHeaders {
 #[derive(Clone, Debug, Default)]
 pub struct CustomHeadersPolicy {}
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for CustomHeadersPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/policies/mod.rs
+++ b/sdk/core/src/policies/mod.rs
@@ -3,12 +3,14 @@ mod retry_policies;
 mod telemetry_policy;
 mod transport;
 
-use crate::{Context, Request, Response};
 pub use custom_headers_policy::{CustomHeaders, CustomHeadersPolicy};
 pub use retry_policies::*;
-use std::sync::Arc;
 pub use telemetry_policy::*;
 pub use transport::*;
+
+use crate::{Context, Request, Response};
+use async_trait::async_trait;
+use std::sync::Arc;
 
 /// A specialized `Result` type for policies.
 pub type PolicyResult = crate::error::Result<Response>;
@@ -21,7 +23,8 @@ pub type PolicyResult = crate::error::Result<Response>;
 /// The only runtime enforced check is that the last policy must be a Transport policy. It's up to
 /// the implementer to call the following policy.
 /// The `C` generic represents the *contents* of the AuthorizationPolicy specific of this pipeline.
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait Policy: Send + Sync + std::fmt::Debug {
     async fn send(
         &self,

--- a/sdk/core/src/policies/retry_policies/no_retry.rs
+++ b/sdk/core/src/policies/retry_policies/no_retry.rs
@@ -10,7 +10,8 @@ pub struct NoRetryPolicy {
     _priv: std::marker::PhantomData<u32>,
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for NoRetryPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -32,7 +32,8 @@ const RETRY_STATUSES: &[StatusCode] = &[
     StatusCode::GatewayTimeout,
 ];
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<T> Policy for T
 where
     T: RetryPolicy + std::fmt::Debug + Send + Sync,

--- a/sdk/core/src/policies/telemetry_policy.rs
+++ b/sdk/core/src/policies/telemetry_policy.rs
@@ -56,7 +56,8 @@ impl<'a> TelemetryPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for TelemetryPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -1,27 +1,22 @@
-#[cfg(not(target_arch = "wasm32"))]
 use crate::policies::{Policy, PolicyResult};
-#[allow(unused_imports)]
 use crate::TransportOptions;
-#[allow(unused_imports)]
-use crate::{Context, HttpClient, Request, Response};
-#[cfg(not(target_arch = "wasm32"))]
+use crate::{Context, Request};
+use async_trait::async_trait;
 use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub struct TransportPolicy {
-    #[allow(unused)]
     pub(crate) transport_options: TransportOptions,
 }
 
 impl TransportPolicy {
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(transport_options: TransportOptions) -> Self {
         Self { transport_options }
     }
 }
 
-#[async_trait::async_trait]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl Policy for TransportPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/seekable_stream.rs
+++ b/sdk/core/src/seekable_stream.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use bytes::Bytes;
 use futures::io::AsyncRead;
 use futures::stream::Stream;
@@ -6,7 +5,8 @@ use futures::task::Poll;
 
 /// Enable a type implementing `AsyncRead` to be consumed as if it were
 /// a `Stream` of `Bytes`.
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait SeekableStream:
     AsyncRead + Unpin + std::fmt::Debug + Send + Sync + dyn_clone::DynClone
 {

--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.3" }
+azure_core = { path = "../core", version = "0.3", default-features = false }
 base64 = "0.13"
 chrono = "0.4"
 futures = "0.3"
@@ -30,7 +30,6 @@ bytes = "1.0"
 hmac = "0.12"
 sha2 = "0.10"
 
-
 [dev-dependencies]
 env_logger = "0.9"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
@@ -41,6 +40,7 @@ stop-token = { version = "0.7.0", features = ["tokio"] }
 clap = { version = "3.2.7", features = ["derive", "env"] }
 
 [features]
+default = ["azure_core/enable_reqwest"]
 test_e2e = []
 mock_transport_framework = [ "azure_core/mock_transport_framework"]
 into_future = []

--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -39,7 +39,8 @@ impl AuthorizationPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for AuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["api-bindings"]
 edition = "2021"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.3", default-features=false}
-azure_storage = { path = "../storage", version = "0.4", default-features=false, features=["account"]}
+azure_core = { path = "../core", version = "0.3", default-features = false}
+azure_storage = { path = "../storage", version = "0.4", default-features = false }
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"

--- a/sdk/device_update/Cargo.toml
+++ b/sdk/device_update/Cargo.toml
@@ -14,14 +14,14 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13"
-reqwest = { version = "0.11", features = ["json"], default_features=false }
+reqwest = { version = "0.11", features = ["json"], default_features = false }
 chrono = { version = "0.4", features = ["serde"] }
 const_format = "0.2"
 serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-azure_core = { path = "../core", version = "0.3" }
+azure_core = { path = "../core", version = "0.3", default_features = false }
 log = "0.4"
 azure_identity = { path = "../identity" }
 
@@ -33,5 +33,5 @@ async-trait = "0.1"
 
 [features]
 default = ["enable_reqwest"]
-enable_reqwest = ["reqwest/default-tls"]
+enable_reqwest = ["azure_core/enable_reqwest"]
 enable_reqwest_rustls = ["reqwest/rustls-tls"]

--- a/sdk/device_update/src/lib.rs
+++ b/sdk/device_update/src/lib.rs
@@ -23,7 +23,8 @@ mod tests {
 
     pub(crate) struct MockCredential;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     impl TokenCredential for MockCredential {
         async fn get_token(
             &self,

--- a/sdk/identity/examples/client_credentials_flow.rs
+++ b/sdk/identity/examples/client_credentials_flow.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let subscription_id =
         env::var("SUBSCRIPTION_ID").expect("Missing SUBSCRIPTION_ID environment variable.");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     // This will give you the final token to use in authorization.
     let token = client_credentials_flow::perform(
         http_client.clone(),

--- a/sdk/identity/examples/client_credentials_flow_blob.rs
+++ b/sdk/identity/examples/client_credentials_flow_blob.rs
@@ -20,7 +20,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .nth(2)
         .expect("please specify the container name as second command line parameter");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
 
     let token = client_credentials_flow::perform(
         http_client.clone(),

--- a/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
+++ b/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
@@ -33,7 +33,8 @@ impl AutoRefreshingTokenCredential {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for AutoRefreshingTokenCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         if let Some(Ok(token)) = self.current_token.read().await.as_ref() {

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -101,7 +101,8 @@ impl AzureCliCredential {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for AzureCliCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let tr = Self::get_access_token(Some(resource))?;

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -139,7 +139,8 @@ fn get_encoded_cert(cert: &X509) -> Result<String, ClientCertificateCredentialEr
     ))
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for ClientCertificateCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let options = self.options();

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -91,7 +91,8 @@ impl ClientSecretCredential {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for ClientSecretCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let options = self.options();

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -77,7 +77,8 @@ pub enum DefaultAzureCredentialEnum {
     AzureCli(AzureCliCredential),
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for DefaultAzureCredentialEnum {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         match self {
@@ -137,7 +138,8 @@ impl Default for DefaultAzureCredential {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for DefaultAzureCredential {
     /// Try to fetch a token using each of the credential sources until one succeeds
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -34,7 +34,8 @@ impl EnvironmentCredential {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for EnvironmentCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let tenant_id =

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -33,7 +33,7 @@ pub struct ImdsManagedIdentityCredential {
 impl Default for ImdsManagedIdentityCredential {
     /// Creates an instance of the `TransportOptions` using the default `HttpClient`.
     fn default() -> Self {
-        Self::new(azure_core::new_http_client())
+        Self::new(azure_core::new_reqwest_client())
     }
 }
 
@@ -88,7 +88,8 @@ impl ImdsManagedIdentityCredential {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for ImdsManagedIdentityCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let msi_endpoint = std::env::var(MSI_ENDPOINT_ENV_KEY)

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -7,7 +7,7 @@ description = "Azure IoT Hub"
 license = "MIT"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.3" }
+azure_core = { path = "../core", version = "0.3", default_features = false }
 base64 = "0.13"
 bytes = "1.0"
 chrono = "0.4"
@@ -25,3 +25,6 @@ hyper = "0.14"
 hyper-rustls = "0.23"
 reqwest = "0.11.0"
 tokio = { version = "1.0", features = ["macros"] }
+
+[features]
+default = ["azure_core/default"]

--- a/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
+++ b/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         }
     });
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
     service_client

--- a/sdk/iot_hub/examples/configuration.rs
+++ b/sdk/iot_hub/examples/configuration.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(1)
         .expect("Please pass the configuration id as the first parameter");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
 

--- a/sdk/iot_hub/examples/device_identity.rs
+++ b/sdk/iot_hub/examples/device_identity.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .expect("Please pass the device id as the first parameter");
 
     println!("Getting device twin for device '{}'", device_id);
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
     let device = service_client

--- a/sdk/iot_hub/examples/directmethod.rs
+++ b/sdk/iot_hub/examples/directmethod.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(4)
         .expect("Please pass the payload as the fourth parameter");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
     println!(

--- a/sdk/iot_hub/examples/gettwin.rs
+++ b/sdk/iot_hub/examples/gettwin.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("Getting device twin for device: {}", device_id);
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
     let twin = service_client.get_device_twin(device_id).await?;

--- a/sdk/iot_hub/examples/module_identity.rs
+++ b/sdk/iot_hub/examples/module_identity.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(2)
         .expect("Please pass the module id as the second parameter");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
     let module = service_client

--- a/sdk/iot_hub/examples/query_iothub.rs
+++ b/sdk/iot_hub/examples/query_iothub.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let query = "SELECT * FROM devices";
     println!("Invoking query '{}' on the IoT Hub", query);
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
 

--- a/sdk/iot_hub/examples/updatetwin.rs
+++ b/sdk/iot_hub/examples/updatetwin.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .expect("Please pass the payload as the second parameter");
 
     println!("Updating device twin for device: {}", device_id);
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
 
     let service_client =
         ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -821,7 +821,7 @@ mod tests {
     fn from_connectionstring_success() -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
 
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
         let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
         let _ = ServiceClient::from_connection_string(http_client, connection_string, 3600)?;
         Ok(())
@@ -832,7 +832,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
 
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
         let connection_string = "HostName==cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
         let _ = ServiceClient::from_connection_string(http_client.clone(), connection_string, 3600)
             .is_err();
@@ -847,7 +847,7 @@ mod tests {
     fn from_connectionstring_should_fail_on_empty_connection_string(
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
 
         let _ = ServiceClient::from_connection_string(http_client, "", 3600).is_err();
         Ok(())
@@ -857,7 +857,7 @@ mod tests {
     fn from_connectionstring_should_fail_on_incomplete_connection_string(
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
 
         let _ = ServiceClient::from_connection_string(http_client, "HostName=cool-iot-hub.azure-devices.net;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==", 3600).is_err();
         Ok(())
@@ -866,7 +866,7 @@ mod tests {
     #[test]
     fn update_module_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
 
         let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
         let service_client =
@@ -883,7 +883,7 @@ mod tests {
     #[test]
     fn replace_module_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
 
         let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
         let service_client =
@@ -900,7 +900,7 @@ mod tests {
     #[test]
     fn update_device_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
 
         let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
         let service_client =
@@ -917,7 +917,7 @@ mod tests {
     #[test]
     fn replace_device_twin_should_create_builder() -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
 
         let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
         let service_client =

--- a/sdk/iot_hub/src/service/requests/invoke_method_builder.rs
+++ b/sdk/iot_hub/src/service/requests/invoke_method_builder.rs
@@ -112,7 +112,7 @@ mod tests {
     fn directmethod_new_should_succeed() {
         use crate::service::InvokeMethodBuilder;
 
-        let http_client = azure_core::new_http_client();
+        let http_client = azure_core::new_reqwest_client();
         let service: ServiceClient = ServiceClient::from_sas_token(http_client, "test", "test");
         let direct_method = InvokeMethodBuilder::new(
             &service,

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2021"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.3" }
+azure_core = { path = "../core", version = "0.3", default_features = false }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -22,3 +22,6 @@ url = "2.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full"] }
+
+[features]
+default = ["azure_core/default"]

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 edition = "2021"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.3" }
+azure_core = { path = "../core", version = "0.3", default_features = false }
 base64 = "0.13"
 chrono = "0.4"
 log = "0.4"
@@ -31,4 +31,5 @@ tokio = { version = "1.0", features = ["macros"] }
 env_logger = "0.9"
 
 [features]
+default = ["azure_core/default"]
 test_e2e = []

--- a/sdk/messaging_servicebus/examples/service_bus00.rs
+++ b/sdk/messaging_servicebus/examples/service_bus00.rs
@@ -14,7 +14,7 @@ async fn main() {
     let policy_key =
         std::env::var("AZURE_POLICY_KEY").expect("Please set AZURE_POLICY_KEY env variable first!");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
 
     let client = Client::new(
         http_client,

--- a/sdk/messaging_servicebus/tests/service_bus.rs
+++ b/sdk/messaging_servicebus/tests/service_bus.rs
@@ -95,7 +95,7 @@ fn create_client() -> azure_core::Result<Client> {
     let policy_key =
         std::env::var("AZURE_POLICY_KEY").expect("Please set AZURE_POLICY_KEY env variable first!");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
 
     Ok(Client::new(
         http_client,

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-azure_core = { path = "../core", version = "0.3" }
+azure_core = { path = "../core", version = "0.3", default_features = false }
 
 [dev-dependencies]
 oauth2 = "4.0.0"
@@ -29,3 +29,6 @@ azure_identity = { path = "../identity" }
 mockito = "0.31"
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["full"] }
+
+[features]
+default = ["azure_core/default"]

--- a/sdk/security_keyvault/src/lib.rs
+++ b/sdk/security_keyvault/src/lib.rs
@@ -36,7 +36,8 @@ mod tests {
 
     pub(crate) struct MockCredential;
 
-    #[async_trait::async_trait]
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
     impl TokenCredential for MockCredential {
         async fn get_token(
             &self,

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.3", default-features=false }
+azure_core = { path = "../core", version = "0.3", default-features = false }
 base64 = "0.13"
 chrono = "0.4"
 futures = "0.3"
@@ -34,7 +34,6 @@ sha2 = "0.10"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros"] }
 env_logger = "0.9"
-azure_identity = { path = "../identity" }
 reqwest = "0.11"
 
 [features]

--- a/sdk/storage/examples/account00.rs
+++ b/sdk/storage/examples/account00.rs
@@ -2,6 +2,7 @@ use azure_storage::core::prelude::*;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
+    env_logger::init();
     // First we retrieve the account name and access key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage/src/account/operations/get_account_information.rs
+++ b/sdk/storage/src/account/operations/get_account_information.rs
@@ -1,3 +1,4 @@
+use crate::clients::ServiceType;
 use crate::core::prelude::*;
 use azure_core::headers::{
     account_kind_from_headers, date_from_headers, request_id_from_headers, sku_name_from_headers,
@@ -22,8 +23,7 @@ impl GetAccountInformationBuilder {
 
             let response = self
                 .client
-                .pipeline()
-                .send(&mut self.context, &mut request)
+                .send(&mut self.context, &mut request, ServiceType::Blob)
                 .await?;
 
             GetAccountInformationResponse::try_from(response.headers())

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -3,7 +3,7 @@ use crate::shared_access_signature::account_sas::{
     AccountSasPermissions, AccountSasResource, AccountSasResourceType, AccountSharedAccessSignature,
 };
 use crate::ConnectionString;
-use crate::{operations::*, TimeoutPolicy};
+use crate::TimeoutPolicy;
 use azure_core::prelude::Timeout;
 use azure_core::Method;
 use azure_core::{
@@ -398,10 +398,6 @@ impl StorageClient {
         Ok(request)
     }
 
-    pub(crate) fn pipeline(&self) -> &Pipeline {
-        &self.pipeline
-    }
-
     pub async fn send(
         &self,
         context: &mut Context,
@@ -414,6 +410,7 @@ impl StorageClient {
     }
 
     /// Prepares' an `azure_core::Request`.
+    #[cfg(feature = "account")]
     pub(crate) fn blob_storage_request(
         &self,
         http_method: azure_core::Method,
@@ -455,12 +452,16 @@ impl StorageClient {
     }
 
     #[cfg(feature = "account")]
-    pub fn get_account_information(&self) -> GetAccountInformationBuilder {
-        GetAccountInformationBuilder::new(self.clone())
+    pub fn get_account_information(&self) -> crate::operations::GetAccountInformationBuilder {
+        crate::operations::GetAccountInformationBuilder::new(self.clone())
     }
 
-    pub fn find_blobs_by_tags(&self, expression: String) -> FindBlobsByTagsBuilder {
-        FindBlobsByTagsBuilder::new(self.clone(), expression)
+    #[cfg(feature = "account")]
+    pub fn find_blobs_by_tags(
+        &self,
+        expression: String,
+    ) -> crate::operations::FindBlobsByTagsBuilder {
+        crate::operations::FindBlobsByTagsBuilder::new(self.clone(), expression)
     }
 
     fn url_with_segments<'a, I>(mut url: url::Url, new_segments: I) -> azure_core::Result<url::Url>

--- a/sdk/storage/src/core/timeout_policy.rs
+++ b/sdk/storage/src/core/timeout_policy.rs
@@ -13,7 +13,8 @@ impl TimeoutPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for TimeoutPolicy {
     async fn send(
         &self,

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -14,9 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.3", default-features = false }
-azure_storage = { path = "../storage", version = "0.4", default-features = false, features = [
-  "account",
-] }
+azure_storage = { path = "../storage", version = "0.4", default-features = false }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -15,7 +15,7 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify the storage account name as first command line parameter");
 
-    let http_client = azure_core::new_http_client();
+    let http_client = azure_core::new_reqwest_client();
 
     // the process requires two steps. The first is to ask for
     // the code to show to the user. This is done with the following

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.3" }
-azure_storage = { path = "../storage", version = "0.4" }
+azure_core = { path = "../core", version = "0.3", default-features = false }
+azure_storage = { path = "../storage", version = "0.4", default_features = false }
 base64 = "0.13"
 bytes = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/sdk/storage_datalake/src/authorization_policies/bearer_token.rs
+++ b/sdk/storage_datalake/src/authorization_policies/bearer_token.rs
@@ -16,7 +16,8 @@ impl BearerTokenAuthorizationPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for BearerTokenAuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/storage_datalake/src/authorization_policies/shared_key.rs
+++ b/sdk/storage_datalake/src/authorization_policies/shared_key.rs
@@ -15,7 +15,8 @@ impl SharedKeyAuthorizationPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for SharedKeyAuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/storage_datalake/src/authorization_policies/token_credential.rs
+++ b/sdk/storage_datalake/src/authorization_policies/token_credential.rs
@@ -32,7 +32,8 @@ impl TokenCredentialAuthorizationPolicy {
     }
 }
 
-#[async_trait::async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl Policy for TokenCredentialAuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.3", default-features=false }
-azure_storage = { path = "../storage", version = "0.4", default-features=false, features=["account"] }
+azure_storage = { path = "../storage", version = "0.4", default-features=false }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 log = "0.4"


### PR DESCRIPTION
This cleans up our wasm support a bit and paves the way for actual wasm support to be added in the near future.

## User experience 

Users can now compiler for `wasm32` targets as long as the `reqwest` features are not turned on (since reqwest does not have wasm support). 

If the user compiles for `wasm32` targets with the `reqwest` features enabled (as they are by default), they see the following error.

```
$ cargo c --target=wasm32-unknown-unknown -p azure_data_cosmos 

Checking azure_core v0.3.0 (/home/rylevick/code/azure-sdk/azure-sdk-for-rust/sdk/core)
error: The `enable_request` and `enable_reqwest_rustls` features are not allowed for `wasm32` targets`
  --> sdk/core/src/http_client/mod.rs:11:1
   |
11 | compile_error!("The `enable_request` and `enable_reqwest_rustls` features are not allowed for `wasm32` targets");
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `azure_core` due to previous error
```

## The noop client

We currently don't support any way for users to make requests when compiling for the `wasm32` target. In the future, we will provide an easy way for users to supply there own transport policies. Users who compile for wasm in the browser, can provide a transport policy that uses the browser APIs, while users compiling for wasi, can use a transport policy that uses wasi based APIs.

Since there is (IMO) no obvious default, we have a `NoopClient` that simply panics and prints out the outgoing request. Most users who will be using the `reqwest` feature, will never run into this.

## Some challenges

This solution isn't 100% elegant, but is IMO an improvement over the status quo. There are some downsides though:
* We do enforce `Send` futures for wasm targets. This causes us to have to propogate this out since by default `BoxFuture` and the `Future`s created by the `async_trait` macro are all constrained to be `Send`. So, we still have a lot of `cfg` markers for wasm, but there in much more predictable places and we don't have to add a bunch of `allow(unused)` directives everywhere.
* 