### PR TITLE
Fix `IntoFuture` bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,9 @@ jobs:
       - name: sdk tests
         run: cargo test --all --features mock_transport_framework
 
+      - name: check `into_future` feature
+        run: cargo check --all --features into_future
+
       - name: update readme of sdks
         run: |
           cargo install cargo-readme
@@ -78,6 +81,19 @@ jobs:
           if git status sdk | grep -q *.md; then
             echo "Run ./eng/scripts/cargo_readme.sh to update readmes" && exit 1
           fi
+
+  nightly:
+    name: Test Nightly
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - name: check `into_future` feature
+        run: cargo check --all --features into_future
 
   test-services:
     name: Services Tests

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -124,7 +124,7 @@ macro_rules! operation {
     // Construct the builder.
     (@builder
         // The name of the operation and any generic params along with their constraints
-        $name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)* ),*>,
+        $name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)* ),* $(+ $lt:lifetime)?>,
         // The client
         client: $client:ty,
         // The required fields that will be used in the constructor
@@ -170,7 +170,7 @@ macro_rules! operation {
         }
     };
     // Construct a builder and the `Future` related code
-    ($name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)* ),*>,
+    ($name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)* ),* $(+ $lt:lifetime)?>,
         client: $client:ty,
         @required
         $($required:ident: $rtype:ty,)*
@@ -180,7 +180,7 @@ macro_rules! operation {
         $($nosetter:ident: $nstype:ty),*
         ) => {
         $crate::operation! {
-            @builder $name<$($generic: $first_constraint $(+ $constraint)*),*>,
+            @builder $name<$($generic: $first_constraint $(+ $constraint)*),* $(+ $lt)*>,
             client: $client,
             @required
             $($required: $rtype,)*
@@ -192,7 +192,7 @@ macro_rules! operation {
         $crate::future!($name);
         azure_core::__private::paste! {
         #[cfg(feature = "into_future")]
-        impl std::future::IntoFuture for [<$name Builder>] {
+        impl <$($generic: $first_constraint $(+ $constraint)*)* $(+ $lt)*> std::future::IntoFuture for [<$name Builder>]<$($generic),*> {
             type IntoFuture = $name;
             type Output = <$name as std::future::Future>::Output;
             fn into_future(self) -> Self::IntoFuture {
@@ -251,13 +251,13 @@ macro_rules! operation {
             }
     };
     // `operation! { CreateDocument<D: Serialize>, client: UserClient, ?consistency_level: ConsistencyLevel, ??other_field: bool }`
-    ($name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)*),*>,
+    ($name:ident<$($generic:ident: $first_constraint:ident $(+ $constraint:ident)*),* $(+ $lt:lifetime)?>,
         client: $client:ty,
         $($required:ident: $rtype:ty,)*
         $(?$optional:ident: $otype:ty,)*
         $(#[skip] $nosetter:ident: $nstype:ty),*) => {
             $crate::operation!{
-                $name<$($generic: $first_constraint $(+ $constraint)*),*>,
+                $name<$($generic: $first_constraint $(+ $constraint)*),* $(+ $lt)*>,
                 client: $client,
                 @required
                 $($required: $rtype,)*

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -12,7 +12,7 @@ use std::convert::TryFrom;
 use azure_core::{collect_pinned_stream, Response as HttpResponse};
 
 operation! {
-    CreateDocument<D: Serialize + CosmosEntity + Send>,
+    CreateDocument<D: Serialize + CosmosEntity + Send + 'static>,
     client: CollectionClient,
     document: D,
     ?is_upsert: bool,

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 operation! {
-    ReplaceDocument<D: Serialize + Send>,
+    ReplaceDocument<D: Serialize + Send + 'static>,
     client: DocumentClient,
     document: D,
     ?indexing_directive: IndexingDirective,


### PR DESCRIPTION
The use of `into_future` broke, and we didn't notice. This fixes the issue, and adds `into_future` testing to CI. Once `IntoFuture` lands on stable, this can be removed. 