### PR TITLE
Simplify the construction of URLs in blob sdk

### DIFF
--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -457,7 +457,10 @@ impl StorageClient {
         FindBlobsByTagsBuilder::new(self.clone(), expression)
     }
 
-    fn url_with_segments<'a, I>(mut url: url::Url, new_segments: I) -> azure_core::Result<url::Url>
+    pub fn url_with_segments<'a, I>(
+        mut url: url::Url,
+        new_segments: I,
+    ) -> azure_core::Result<url::Url>
     where
         I: IntoIterator<Item = &'a str>,
     {

--- a/sdk/storage_blobs/src/blob/operations/acquire_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/acquire_lease.rs
@@ -13,7 +13,7 @@ operation! {
 impl AcquireLeaseBuilder {
     pub fn into_future(mut self) -> AcquireLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "lease");
 

--- a/sdk/storage_blobs/src/blob/operations/append_block.rs
+++ b/sdk/storage_blobs/src/blob/operations/append_block.rs
@@ -14,7 +14,7 @@ operation! {
 impl AppendBlockBuilder {
     pub fn into_future(mut self) -> AppendBlock {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "appendblock");
 

--- a/sdk/storage_blobs/src/blob/operations/break_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/break_lease.rs
@@ -12,7 +12,7 @@ operation! {
 impl BreakLeaseBuilder {
     pub fn into_future(mut self) -> BreakLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "lease");
 

--- a/sdk/storage_blobs/src/blob/operations/change_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/change_lease.rs
@@ -11,7 +11,7 @@ operation! {
 impl ChangeLeaseBuilder {
     pub fn into_future(mut self) -> ChangeLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "lease");
 

--- a/sdk/storage_blobs/src/blob/operations/clear_page.rs
+++ b/sdk/storage_blobs/src/blob/operations/clear_page.rs
@@ -19,7 +19,7 @@ operation! {
 impl ClearPageBuilder {
     pub fn into_future(mut self) -> ClearPage {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "page");
 

--- a/sdk/storage_blobs/src/blob/operations/copy_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob.rs
@@ -27,7 +27,7 @@ operation! {
 impl CopyBlobBuilder {
     pub fn into_future(mut self) -> CopyBlob {
         Box::pin(async move {
-            let url = self.client.url_with_segments(None)?;
+            let url = self.client.url()?;
 
             let mut headers = Headers::new();
             headers.insert(COPY_SOURCE, self.source_url.as_str().to_owned());

--- a/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
@@ -29,7 +29,7 @@ operation! {
 impl CopyBlobFromUrlBuilder {
     pub fn into_future(mut self) -> CopyBlobFromUrl {
         Box::pin(async move {
-            let url = self.client.url_with_segments(None)?;
+            let url = self.client.url()?;
 
             let mut headers = Headers::new();
             headers.insert(COPY_SOURCE, self.source_url.to_string());

--- a/sdk/storage_blobs/src/blob/operations/delete_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob.rs
@@ -12,7 +12,7 @@ operation! {
 impl DeleteBlobBuilder {
     pub fn into_future(mut self) -> DeleteBlob {
         Box::pin(async move {
-            let url = self.client.url_with_segments(None)?;
+            let url = self.client.url()?;
 
             let mut headers = Headers::new();
             headers.add(self.lease_id);

--- a/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
@@ -12,7 +12,7 @@ operation! {
 impl DeleteBlobSnapshotBuilder {
     pub fn into_future(mut self) -> DeleteBlobSnapshot {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             (&self.snapshot).append_to_url_query(&mut url);
             let permanent = self.permanent.unwrap_or(false);

--- a/sdk/storage_blobs/src/blob/operations/delete_blob_version.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_version.rs
@@ -12,7 +12,7 @@ operation! {
 impl DeleteBlobVersionBuilder {
     pub fn into_future(mut self) -> DeleteBlobVersion {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             self.version_id.append_to_url_query(&mut url);
             if self.permanent.unwrap_or_default() {

--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -24,7 +24,7 @@ impl GetBlobBuilder {
             let this = self.clone();
             let mut ctx = self.context.clone();
             async move {
-                let mut url = this.client.url_with_segments(None)?;
+                let mut url = this.client.url()?;
 
                 let range = match continuation {
                     Some(range) => range,

--- a/sdk/storage_blobs/src/blob/operations/get_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_block_list.rs
@@ -17,7 +17,7 @@ operation! {
 impl GetBlockListBuilder {
     pub fn into_future(mut self) -> GetBlockList {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "blocklist");
             self.blob_versioning.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/operations/get_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_metadata.rs
@@ -13,7 +13,7 @@ operation! {
 impl GetMetadataBuilder {
     pub fn into_future(mut self) -> GetMetadata {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "metadata");
             self.blob_versioning.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
@@ -13,7 +13,7 @@ operation! {
 impl GetPageRangesBuilder {
     pub fn into_future(mut self) -> GetPageRanges {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "pagelist");
             self.blob_versioning.append_to_url_query(&mut url);

--- a/sdk/storage_blobs/src/blob/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_properties.rs
@@ -12,7 +12,7 @@ operation! {
 impl GetPropertiesBuilder {
     pub fn into_future(mut self) -> GetProperties {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             self.blob_versioning.append_to_url_query(&mut url);
 

--- a/sdk/storage_blobs/src/blob/operations/get_tags.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_tags.rs
@@ -13,7 +13,7 @@ operation! {
 impl GetTagsBuilder {
     pub fn into_future(mut self) -> GetTags {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "tags");
 

--- a/sdk/storage_blobs/src/blob/operations/put_append_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_append_blob.rs
@@ -17,7 +17,7 @@ operation! {
 impl PutAppendBlobBuilder {
     pub fn into_future(mut self) -> PutAppendBlob {
         Box::pin(async move {
-            let url = self.client.url_with_segments(None)?;
+            let url = self.client.url()?;
 
             let mut headers = Headers::new();
             headers.insert(BLOB_TYPE, "AppendBlob");

--- a/sdk/storage_blobs/src/blob/operations/put_block.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block.rs
@@ -15,7 +15,7 @@ operation! {
 impl PutBlockBuilder {
     pub fn into_future(mut self) -> PutBlock {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             self.block_id.append_to_url_query(&mut url);
             url.query_pairs_mut().append_pair("comp", "block");

--- a/sdk/storage_blobs/src/blob/operations/put_block_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_blob.rs
@@ -21,7 +21,7 @@ operation! {
 impl PutBlockBlobBuilder {
     pub fn into_future(mut self) -> PutBlockBlob {
         Box::pin(async move {
-            let url = self.client.url_with_segments(None)?;
+            let url = self.client.url()?;
 
             let mut headers = Headers::new();
             headers.insert(BLOB_TYPE, "BlockBlob");

--- a/sdk/storage_blobs/src/blob/operations/put_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_list.rs
@@ -22,7 +22,7 @@ operation! {
 impl PutBlockListBuilder {
     pub fn into_future(mut self) -> PutBlockList {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "blocklist");
 

--- a/sdk/storage_blobs/src/blob/operations/put_page.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_page.rs
@@ -18,7 +18,7 @@ operation! {
 impl PutPageBuilder {
     pub fn into_future(mut self) -> PutPage {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "page");
 

--- a/sdk/storage_blobs/src/blob/operations/put_page_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_page_blob.rs
@@ -21,7 +21,7 @@ operation! {
 impl PutPageBlobBuilder {
     pub fn into_future(mut self) -> PutPageBlob {
         Box::pin(async move {
-            let url = self.client.url_with_segments(None)?;
+            let url = self.client.url()?;
 
             let mut headers = Headers::new();
             headers.insert(BLOB_TYPE, "PageBlob");

--- a/sdk/storage_blobs/src/blob/operations/release_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/release_lease.rs
@@ -10,7 +10,7 @@ operation! {
 impl ReleaseLeaseBuilder {
     pub fn into_future(mut self) -> ReleaseLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "lease");
 

--- a/sdk/storage_blobs/src/blob/operations/renew_lease.rs
+++ b/sdk/storage_blobs/src/blob/operations/renew_lease.rs
@@ -10,7 +10,7 @@ operation! {
 impl RenewLeaseBuilder {
     pub fn into_future(mut self) -> RenewLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "lease");
 

--- a/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
@@ -13,7 +13,7 @@ operation! {
 impl SetBlobTierBuilder {
     pub fn into_future(mut self) -> SetBlobTier {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
             url.query_pairs_mut().append_pair("comp", "tier");
             self.blob_versioning.append_to_url_query(&mut url);
 

--- a/sdk/storage_blobs/src/blob/operations/set_expiry.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_expiry.rs
@@ -12,7 +12,7 @@ operation! {
 impl SetBlobExpiryBuilder {
     pub fn into_future(mut self) -> SetBlobExpiry {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
             url.query_pairs_mut().append_pair("comp", "expiry");
 
             let mut headers = self.blob_expiry.to_headers();

--- a/sdk/storage_blobs/src/blob/operations/set_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_metadata.rs
@@ -13,7 +13,7 @@ operation! {
 impl SetMetadataBuilder {
     pub fn into_future(mut self) -> SetMetadata {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "metadata");
 

--- a/sdk/storage_blobs/src/blob/operations/set_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_properties.rs
@@ -48,7 +48,7 @@ impl SetPropertiesBuilder {
 
     pub fn into_future(mut self) -> SetProperties {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "properties");
 

--- a/sdk/storage_blobs/src/blob/operations/set_tags.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_tags.rs
@@ -17,7 +17,7 @@ operation! {
 impl SetTagsBuilder {
     pub fn into_future(mut self) -> SetTags {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("comp", "tags");
 

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -268,10 +268,7 @@ impl BlobClient {
     }
 
     pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
-        StorageClient::url_with_segments(
-            self.container_client.url()?,
-            self.blob_name.split('/').into_iter(),
-        )
+        StorageClient::url_with_segments(self.container_client.url()?, self.blob_name.split('/'))
     }
 
     pub(crate) fn finalize_request(

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -232,7 +232,7 @@ impl BlobClient {
     where
         T: SasToken,
     {
-        let mut url = self.url_with_segments(None)?;
+        let mut url = self.url()?;
         url.set_query(Some(&signature.token()));
         Ok(url)
     }
@@ -267,13 +267,11 @@ impl BlobClient {
         &self.container_client
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
-    where
-        I: IntoIterator<Item = &'a str>,
-    {
-        let blob_name_with_segments = self.blob_name.split('/').into_iter().chain(segments);
-        self.container_client
-            .url_with_segments(blob_name_with_segments)
+    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+        StorageClient::url_with_segments(
+            self.container_client.url()?,
+            self.blob_name.split('/').into_iter(),
+        )
     }
 
     pub(crate) fn finalize_request(

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -44,11 +44,8 @@ impl BlobLeaseClient {
         &self.blob_client
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
-    where
-        I: IntoIterator<Item = &'a str>,
-    {
-        self.blob_client.url_with_segments(segments)
+    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+        self.blob_client.url()
     }
 
     pub(crate) fn finalize_request(

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -47,11 +47,8 @@ impl ContainerLeaseClient {
         &self.container_client
     }
 
-    pub(crate) fn url_with_segments<'a, I>(&'a self, segments: I) -> azure_core::Result<url::Url>
-    where
-        I: IntoIterator<Item = &'a str>,
-    {
-        self.container_client.url_with_segments(segments)
+    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+        self.container_client.url()
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/container/operations/acquire_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/acquire_lease.rs
@@ -14,7 +14,7 @@ operation! {
 impl AcquireLeaseBuilder {
     pub fn into_future(mut self) -> AcquireLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
             url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/container/operations/break_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/break_lease.rs
@@ -13,7 +13,7 @@ operation! {
 impl BreakLeaseBuilder {
     pub fn into_future(mut self) -> BreakLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
             url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/container/operations/create.rs
+++ b/sdk/storage_blobs/src/container/operations/create.rs
@@ -12,7 +12,7 @@ operation! {
 impl CreateBuilder {
     pub fn into_future(mut self) -> Create {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
 

--- a/sdk/storage_blobs/src/container/operations/delete.rs
+++ b/sdk/storage_blobs/src/container/operations/delete.rs
@@ -10,7 +10,7 @@ operation! {
 impl DeleteBuilder {
     pub fn into_future(mut self) -> Delete {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
 

--- a/sdk/storage_blobs/src/container/operations/get_acl.rs
+++ b/sdk/storage_blobs/src/container/operations/get_acl.rs
@@ -21,7 +21,7 @@ operation! {
 impl GetACLBuilder {
     pub fn into_future(mut self) -> GetACL {
         Box::pin(async move {
-            let url = self.client.url_with_segments(None)?;
+            let url = self.client.url()?;
 
             let mut headers = Headers::new();
             headers.add(self.lease_id);

--- a/sdk/storage_blobs/src/container/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/container/operations/get_properties.rs
@@ -18,7 +18,7 @@ operation! {
 impl GetPropertiesBuilder {
     pub fn into_future(mut self) -> GetProperties {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
 

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -32,7 +32,7 @@ impl ListBlobsBuilder {
             let this = self.clone();
             let mut ctx = self.context.clone();
             async move {
-                let mut url = this.client.url_with_segments(None)?;
+                let mut url = this.client.url()?;
 
                 url.query_pairs_mut().append_pair("restype", "container");
                 url.query_pairs_mut().append_pair("comp", "list");

--- a/sdk/storage_blobs/src/container/operations/release_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/release_lease.rs
@@ -11,7 +11,7 @@ operation! {
 impl ReleaseLeaseBuilder {
     pub fn into_future(mut self) -> ReleaseLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
             url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/container/operations/renew_lease.rs
+++ b/sdk/storage_blobs/src/container/operations/renew_lease.rs
@@ -12,7 +12,7 @@ operation! {
 impl RenewLeaseBuilder {
     pub fn into_future(mut self) -> RenewLease {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
             url.query_pairs_mut().append_pair("comp", "lease");

--- a/sdk/storage_blobs/src/container/operations/set_acl.rs
+++ b/sdk/storage_blobs/src/container/operations/set_acl.rs
@@ -13,7 +13,7 @@ operation! {
 impl SetACLBuilder {
     pub fn into_future(mut self) -> SetACL {
         Box::pin(async move {
-            let mut url = self.client.url_with_segments(None)?;
+            let mut url = self.client.url()?;
 
             url.query_pairs_mut().append_pair("restype", "container");
             url.query_pairs_mut().append_pair("comp", "acl");


### PR DESCRIPTION
Being able to extend the url with additional "segments" is almost never used so let's not complicate every call site. 