### PR TITLE
Improve logging and error capabilities

### DIFF
--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -86,8 +86,8 @@ struct ErrorDetails {
 impl ErrorDetails {
     fn new(headers: &HashMap<String, String>, body: &[u8]) -> Self {
         let mut code = get_error_code_from_header(headers);
-        code = code.or_else(|| get_error_code_from_body(&body));
-        let message = get_error_message_from_body(&body);
+        code = code.or_else(|| get_error_code_from_body(body));
+        let message = get_error_message_from_body(body);
         Self { code, message }
     }
 }

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -386,7 +386,7 @@ mod tests {
         // Generate the display and error chain
         let mut error: &dyn std::error::Error = &error;
         let display = format!("{}", error);
-        let mut errors = vec![display.clone()];
+        let mut errors = vec![];
         while let Some(cause) = error.source() {
             errors.push(format!("{}", cause));
             error = cause;
@@ -410,7 +410,7 @@ mod tests {
             .unwrap()
             .downcast_ref::<std::io::Error>()
             .unwrap();
-        assert_eq!(format!("{}", downcasted), "third error");
+        assert_eq!(format!("{}", downcasted), "second error");
     }
 
     #[test]

--- a/sdk/core/src/http_client/reqwest.rs
+++ b/sdk/core/src/http_client/reqwest.rs
@@ -15,7 +15,8 @@ pub fn new_reqwest_client() -> std::sync::Arc<dyn HttpClient> {
 impl HttpClient for ::reqwest::Client {
     async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response> {
         let url = request.url().clone();
-        let mut req = self.request(try_from_method(request.method())?, url);
+        let method = request.method();
+        let mut req = self.request(try_from_method(method)?, url.clone());
         for (name, value) in request.headers().iter() {
             req = req.header(name.as_str(), value.as_str());
         }
@@ -31,6 +32,7 @@ impl HttpClient for ::reqwest::Client {
         }
         .context(ErrorKind::Other, "failed to build `reqwest` request")?;
 
+        log::info!("making {method} request to {url}");
         let rsp = self
             .execute(reqwest_request)
             .await

--- a/sdk/core/src/http_client/reqwest.rs
+++ b/sdk/core/src/http_client/reqwest.rs
@@ -32,7 +32,7 @@ impl HttpClient for ::reqwest::Client {
         }
         .context(ErrorKind::Other, "failed to build `reqwest` request")?;
 
-        log::info!("making {method} request to {url}");
+        log::debug!("performing request {method} '{url}' with `reqwest`");
         let rsp = self
             .execute(reqwest_request)
             .await

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -68,7 +68,7 @@ where
                             http_error.error_code().map(std::borrow::ToOwned::to_owned),
                         ),
                         http_error,
-                        "server returned error status which will not be retried",
+                        format!("server returned error status which will not be retried: {status}"),
                     );
 
                     if !RETRY_STATUSES.contains(&status) {

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -27,6 +27,7 @@ impl Policy for TransportPolicy {
         // there must be no more policies
         assert_eq!(0, next.len());
 
+        log::debug!("the following request will be passed to the transport policy: {request:#?}");
         let response = { self.transport_options.http_client.execute_request(request) };
 
         response.await


### PR DESCRIPTION
While investigating #946, I found a few things that improved my debugging experience:
* `info` logging the method and URL when a request is actually made
* `debug` logging the *full* request before it gets passed to the transport layer
* providing the ability to quickly turn an `Error` into an `HttpError` 
* improving the formatting of the `HttpError` `Display` trait
* including the "message" in the `HttpError` 
* when a request is not being retried because of its status code, provide the status code in the error