### PR TITLE
Option macro improvements

### DIFF
--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -305,36 +305,12 @@ macro_rules! request_header {
         $crate::request_header!($name, $header,);
     };
     ($(#[$outer:meta])* $name:ident, $header:ident, $(($variant:ident, $value:expr)), *) => {
-        #[derive(Debug, Clone)]
-        $(#[$outer])*
-        pub struct $name(std::borrow::Cow<'static, str>);
-
+        $crate::request_option!($(#[$outer])* $name);
         impl $name {
             $(
                 pub const $variant: $name = $name::from_static($value);
             )*
-
-            pub fn new<S>(s: S) -> Self
-            where
-                S: Into<std::borrow::Cow<'static, str>>,
-            {
-                Self(s.into())
-            }
-
-            pub const fn from_static(s: &'static str) -> Self {
-                Self(std::borrow::Cow::Borrowed(s))
-            }
         }
-
-        impl<S> From<S> for $name
-        where
-            S: Into<std::borrow::Cow<'static, str>>,
-        {
-            fn from(s: S) -> Self {
-                Self::new(s)
-            }
-        }
-
         impl $crate::headers::Header for $name {
             fn name(&self) -> $crate::headers::HeaderName {
                 $crate::headers::$header
@@ -356,6 +332,24 @@ macro_rules! request_header {
 #[macro_export]
 macro_rules! request_query {
     ($(#[$outer:meta])* $name:ident, $option:expr) => {
+        $crate::request_option!($(#[$outer])* $name);
+        impl $crate::AppendToUrlQuery for $name {
+            fn append_to_url_query(&self, url: &mut url::Url) {
+                url.query_pairs_mut().append_pair($option, &self.0);
+            }
+        }
+    };
+}
+
+/// The following macro invocation:
+/// ```
+/// # #[macro_use] extern crate azure_core;
+/// request_option!(Prefix);
+/// ```
+/// Turns into a request option useable either as a header or as a query string.
+#[macro_export]
+macro_rules! request_option {
+    ($(#[$outer:meta])* $name:ident) => {
         #[derive(Debug, Clone)]
         $(#[$outer])*
         pub struct $name(std::borrow::Cow<'static, str>);
@@ -379,12 +373,6 @@ macro_rules! request_query {
         {
             fn from(s: S) -> Self {
                 Self::new(s)
-            }
-        }
-
-        impl $crate::AppendToUrlQuery for $name {
-            fn append_to_url_query(&self, url: &mut url::Url) {
-                url.query_pairs_mut().append_pair($option, &self.0);
             }
         }
     };

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -294,7 +294,7 @@ macro_rules! future {
 /// ```
 /// # #[macro_use] extern crate azure_core;
 /// request_header!(
-///     #[doc="builds a client request id header"]
+///     /// Builds a client request id header
 ///     ClientRequestId, CLIENT_REQUEST_ID,
 /// );
 /// ```
@@ -347,11 +347,11 @@ macro_rules! request_header {
 /// The following macro invocation:
 /// ```
 /// # #[macro_use] extern crate azure_core;
-/// request_query_option!(Prefix, "prefix");
+/// request_query!(Prefix, "prefix");
 /// ```
 /// Turns into a request query option used to construct requests
 #[macro_export]
-macro_rules! request_query_option {
+macro_rules! request_query {
     ($(#[$outer:meta])* $name:ident, $option:expr) => {
         #[derive(Debug, Clone)]
         $(#[$outer])*

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -301,6 +301,9 @@ macro_rules! future {
 /// Turns into a Header value used to construct requests.
 #[macro_export]
 macro_rules! request_header {
+    ($(#[$outer:meta])* $name:ident, $header:ident) => {
+        $crate::request_header!($name, $header,);
+    };
     ($(#[$outer:meta])* $name:ident, $header:ident, $(($variant:ident, $value:expr)), *) => {
         #[derive(Debug, Clone)]
         $(#[$outer])*

--- a/sdk/core/src/request_options/mod.rs
+++ b/sdk/core/src/request_options/mod.rs
@@ -41,44 +41,43 @@ pub use source_lease_id::SourceLeaseId;
 pub use timeout::Timeout;
 
 request_header!(
-    #[doc = "Advertises which content encoding the client is able to understand.
-
-The Accept-Encoding request HTTP header advertises which content
-encoding, usually a compression algorithm, the client is able to
-understand. Using content negotiation, the server selects one of the
-proposals, uses it and informs the client of its choice with the
-Content-Encoding response header.
-
-Even if both the client and the server supports the same compression
-algorithms, the server may choose not to compress the body of a
-response, if the identity value is also acceptable.
-"]
+    /// Advertises which content encoding the client is able to understand.
+    ///
+    /// The Accept-Encoding request HTTP header advertises which content
+    /// encoding, usually a compression algorithm, the client is able to
+    /// understand. Using content negotiation, the server selects one of the
+    /// proposals, uses it and informs the client of its choice with the
+    /// Content-Encoding response header.
+    ///
+    /// Even if both the client and the server supports the same compression
+    /// algorithms, the server may choose not to compress the body of a
+    /// response, if the identity value is also acceptable.
     AcceptEncoding,
     ACCEPT_ENCODING,
 );
+
 request_header!(
-    #[doc = "The (friendly) version identifier for the client making the request"]
+    /// The (friendly) version identifier for the client making the request
     ClientVersion,
     CLIENT_VERSION,
 );
 request_header!(
-    #[doc = "The Content Type indicates the media type of the request body"]
+    /// The Content Type indicates the media type of the request body
     ContentType,
     CONTENT_TYPE,
     (APPLICATION_JSON, "application/json")
 );
 request_header!(
-    #[doc = "Advertises which content types the client is able to understand.
-
-The Accept request HTTP header advertises which content types, expressed
-as MIME types, the client is able to understand. Using content
-negotiation, the server then selects one of the proposals, uses it and
-informs the client of its choice with the Content-Type response header.
-Browsers set adequate values for this header depending of the context
-where the request is done: when fetching a CSS stylesheet a different
-value is set for the request than when fetching an image, video or a
-script.
-"]
+    /// Advertises which content types the client is able to understand.
+    ///
+    /// The Accept request HTTP header advertises which content types, expressed
+    /// as MIME types, the client is able to understand. Using content
+    /// negotiation, the server then selects one of the proposals, uses it and
+    /// informs the client of its choice with the Content-Type response header.
+    /// Browsers set adequate values for this header depending of the context
+    /// where the request is done: when fetching a CSS stylesheet a different
+    /// value is set for the request than when fetching an image, video or a
+    /// script.
     Accept,
     ACCEPT,
 );
@@ -92,7 +91,7 @@ request_header!(Continuation, CONTINUATION,);
 request_header!(IfTags, IF_TAGS,);
 request_header!(UserAgent, USER_AGENT,);
 request_header!(
-    #[doc = "The (friendly) name of the user making the request"]
+    /// The (friendly) name of the user making the request
     User,
     USER,
 );
@@ -100,7 +99,7 @@ request_header!(Version, VERSION,);
 
 request_query_option!(Prefix, "prefix");
 request_query_option!(
-    #[doc = "Set delimiter for the request"]
+    /// Set delimiter for the request
     Delimiter,
     "delimiter"
 );

--- a/sdk/core/src/request_options/mod.rs
+++ b/sdk/core/src/request_options/mod.rs
@@ -59,7 +59,7 @@ request_header!(
 request_header!(
     /// The (friendly) version identifier for the client making the request
     ClientVersion,
-    CLIENT_VERSION,
+    CLIENT_VERSION
 );
 request_header!(
     /// The Content Type indicates the media type of the request body
@@ -79,23 +79,23 @@ request_header!(
     /// value is set for the request than when fetching an image, video or a
     /// script.
     Accept,
-    ACCEPT,
+    ACCEPT
 );
-request_header!(ActivityId, ACTIVITY_ID,);
+request_header!(ActivityId, ACTIVITY_ID);
 request_header!(App, APP,);
-request_header!(ClientRequestId, CLIENT_REQUEST_ID,);
-request_header!(ContentDisposition, CONTENT_DISPOSITION,);
-request_header!(ContentEncoding, CONTENT_ENCODING,);
-request_header!(ContentLanguage, CONTENT_LANGUAGE,);
-request_header!(Continuation, CONTINUATION,);
-request_header!(IfTags, IF_TAGS,);
-request_header!(UserAgent, USER_AGENT,);
+request_header!(ClientRequestId, CLIENT_REQUEST_ID);
+request_header!(ContentDisposition, CONTENT_DISPOSITION);
+request_header!(ContentEncoding, CONTENT_ENCODING);
+request_header!(ContentLanguage, CONTENT_LANGUAGE);
+request_header!(Continuation, CONTINUATION);
+request_header!(IfTags, IF_TAGS);
+request_header!(UserAgent, USER_AGENT);
 request_header!(
     /// The (friendly) name of the user making the request
     User,
     USER,
 );
-request_header!(Version, VERSION,);
+request_header!(Version, VERSION);
 
 request_query!(Prefix, "prefix");
 request_query!(

--- a/sdk/core/src/request_options/mod.rs
+++ b/sdk/core/src/request_options/mod.rs
@@ -61,12 +61,14 @@ request_header!(
     ClientVersion,
     CLIENT_VERSION
 );
+
 request_header!(
     /// The Content Type indicates the media type of the request body
     ContentType,
     CONTENT_TYPE,
     (APPLICATION_JSON, "application/json")
 );
+
 request_header!(
     /// Advertises which content types the client is able to understand.
     ///
@@ -81,6 +83,13 @@ request_header!(
     Accept,
     ACCEPT
 );
+
+request_header!(
+    /// The (friendly) name of the user making the request
+    User,
+    USER,
+);
+
 request_header!(ActivityId, ACTIVITY_ID);
 request_header!(App, APP,);
 request_header!(ClientRequestId, CLIENT_REQUEST_ID);
@@ -90,16 +99,11 @@ request_header!(ContentLanguage, CONTENT_LANGUAGE);
 request_header!(Continuation, CONTINUATION);
 request_header!(IfTags, IF_TAGS);
 request_header!(UserAgent, USER_AGENT);
-request_header!(
-    /// The (friendly) name of the user making the request
-    User,
-    USER,
-);
 request_header!(Version, VERSION);
 
-request_query!(Prefix, "prefix");
 request_query!(
     /// Set delimiter for the request
     Delimiter,
     "delimiter"
 );
+request_query!(Prefix, "prefix");

--- a/sdk/core/src/request_options/mod.rs
+++ b/sdk/core/src/request_options/mod.rs
@@ -97,8 +97,8 @@ request_header!(
 );
 request_header!(Version, VERSION,);
 
-request_query_option!(Prefix, "prefix");
-request_query_option!(
+request_query!(Prefix, "prefix");
+request_query!(
     /// Set delimiter for the request
     Delimiter,
     "delimiter"

--- a/sdk/storage_blobs/src/options/mod.rs
+++ b/sdk/storage_blobs/src/options/mod.rs
@@ -36,7 +36,7 @@ pub use hash::Hash;
 pub use rehydrate_policy::RehydratePriority;
 pub use tags::Tags;
 
-request_query_option!(
+request_query!(
     /// This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
     ///
     ///See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]
@@ -44,7 +44,7 @@ request_query_option!(
     "version_id"
 );
 
-request_query_option!(
+request_query!(
     /// This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
     ///
     /// See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]

--- a/sdk/storage_blobs/src/options/mod.rs
+++ b/sdk/storage_blobs/src/options/mod.rs
@@ -37,17 +37,17 @@ pub use rehydrate_policy::RehydratePriority;
 pub use tags::Tags;
 
 request_query_option!(
-    #[doc = "This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
-
-See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]
+    /// This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
+    ///
+    ///See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]
     VersionId,
     "version_id"
 );
 
 request_query_option!(
-    #[doc = "This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
-
-See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]
+    /// This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
+    ///
+    /// See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]
     Snapshot,
     "snapshot"
 );

--- a/sdk/storage_datalake/src/request_options.rs
+++ b/sdk/storage_datalake/src/request_options.rs
@@ -201,4 +201,4 @@ impl Header for RenameSource {
 }
 
 request_query!(Directory, "directory");
-request_header!(AccessControlList, ACL,);
+request_header!(AccessControlList, ACL);

--- a/sdk/storage_datalake/src/request_options.rs
+++ b/sdk/storage_datalake/src/request_options.rs
@@ -200,5 +200,5 @@ impl Header for RenameSource {
     }
 }
 
-request_query_option!(Directory, "directory");
+request_query!(Directory, "directory");
 request_header!(AccessControlList, ACL,);


### PR DESCRIPTION
Building off of #953:

* Use `///` annotation instead of `#[doc]`
* Rename `request_query_option` to `request_query` to mirror `request_header`
* Allow there to be no trailing commas in `request_header`
* Share the internals of the macro so that they only need to be changed once
* Do some small house keeping