### PR TITLE
Add `CosmosClientBuilder` to the Cosmos SDK

### DIFF
--- a/sdk/data_cosmos/examples/client_builder.rs
+++ b/sdk/data_cosmos/examples/client_builder.rs
@@ -1,0 +1,32 @@
+use azure_core::{RetryOptions, TransportOptions};
+use clap::Parser;
+
+use azure_data_cosmos::prelude::*;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+}
+
+#[tokio::main]
+async fn main() -> azure_core::Result<()> {
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+
+    let _database = CosmosClient::builder(args.account, authorization_token)
+        .retry(RetryOptions::default())
+        .transport(TransportOptions::default())
+        .build()
+        .database_client(args.database_name);
+
+    // ... the database client is now ready to be used!
+
+    Ok(())
+}

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -23,6 +23,7 @@ pub struct CosmosClientBuilder {
 
 impl CosmosClientBuilder {
     /// Create a new instance of `CosmosClientBuilder`.
+    #[must_use]
     pub fn new(account: impl Into<String>, auth_token: AuthorizationToken) -> Self {
         Self::with_location(CloudLocation::Public {
             account: account.into(),
@@ -31,6 +32,7 @@ impl CosmosClientBuilder {
     }
 
     /// Create a new instance of `CosmosClientBuilder` with a cloud location.
+    #[must_use]
     pub fn with_location(cloud_location: CloudLocation) -> Self {
         Self {
             options: ClientOptions::default(),
@@ -39,6 +41,7 @@ impl CosmosClientBuilder {
     }
 
     /// Convert the builder into a `CosmosClient` instance.
+    #[must_use]
     pub fn build(self) -> CosmosClient {
         let auth_token = self.cloud_location.auth_token();
         CosmosClient {
@@ -48,25 +51,21 @@ impl CosmosClientBuilder {
     }
 
     /// Set the cloud location.
+    #[must_use]
     pub fn cloud_location(mut self, cloud_location: CloudLocation) -> Self {
         self.cloud_location = cloud_location;
         self
     }
 
-    /// Enable the mocking framework.
-    #[cfg(feature = "mock_transport_framework")]
-    pub fn mock(self, enable: bool) -> Self {
-        self.mock = enable;
-        self
-    }
-
     /// Set the retry options.
+    #[must_use]
     pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
         self.options = self.options.retry(retry);
         self
     }
 
     /// Set the transport options.
+    #[must_use]
     pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
         self.options = self.options.transport(transport);
         self
@@ -82,11 +81,22 @@ pub struct CosmosClient {
 
 impl CosmosClient {
     /// Create a new `CosmosClient` which connects to the account's instance in the public Azure cloud.
+    #[must_use]
     pub fn new(account: impl Into<String>, auth_token: AuthorizationToken) -> Self {
         CosmosClientBuilder::new(account, auth_token).build()
     }
 
+    /// Create a new `CosmosClientBuilder`.
+    #[must_use]
+    pub fn builder(
+        account: impl Into<String>,
+        auth_token: AuthorizationToken,
+    ) -> CosmosClientBuilder {
+        CosmosClientBuilder::new(account, auth_token)
+    }
+
     /// Set the auth token used
+    #[must_use]
     pub fn auth_token(mut self, auth_token: AuthorizationToken) -> Self {
         // we replace the AuthorizationPolicy. This is
         // the last-1 policy by construction.

--- a/sdk/data_cosmos/src/clients/mod.rs
+++ b/sdk/data_cosmos/src/clients/mod.rs
@@ -34,7 +34,7 @@ mod user_defined_function;
 
 pub use attachment::AttachmentClient;
 pub use collection::CollectionClient;
-pub use cosmos::CosmosClient;
+pub use cosmos::{CosmosClient, CosmosClientBuilder};
 pub use database::DatabaseClient;
 pub use document::DocumentClient;
 pub use permission::PermissionClient;


### PR DESCRIPTION
This patch adds a `ClientBuilder` to cosmos, which allows changing the settings on the client prior to construction.

## Examples

```rust
use azure_core::{RetryOptions, TransportOptions};
use azure_data_cosmos::CosmosClient;

let _database = CosmosClient::builder(args.account, authorization_token)
    .retry(RetryOptions::default())
    .transport(TransportOptions::default())
    .build()
    .database_client(args.database_name);
```

## Design

This replaces the `with_` methods on `CosmosClient` and moves them to `CosmosClientBuilder`. Using the builder various things can be configured on the client, such as the transport and retry policy. We've chosen to go with a separate builder type instead of adding the methods on the main client, because once constructed the pipeline inside the client needs to be `Arc`'ed - and we didn't want to require it to require an additional `RwLock` to function.

This patch intentionally has decided to go with adding methods to set specific groups of options. We could've taken this further by allowing each setting of each option to directly be set on the client. But because we have many different SDKs, the set of options may expand over time, and we will want to support reuse of options between SDKs, this should work as a reasonable middle-ground.

## Future Directions

This PR doesn't yet touch the options themselves, which currently support three different styles:

- `Default::default`
- struct literal instantiation (which means adding new fields to the struct is semver-incompatible)
- setters/getters

We almost certainly will want to convert the options to be in a builder style as well, but that's intentionally left for a follow-up patch. The intent for this PR was to setup just enough of an API surface that the other SDKs can follow the design without needing to do much more breakage in the future.

The other bit that this PR doesn't yet address is setting custom policies in the pipeline. The most important item to address was providing a way to disable the built-in retry middleware, which is now possible by passing the `retry` setting on the builder.

---

I hope this all makes sense; keen to hear what folks think!