### PR TITLE
storage: Add support for setting StorageClient options to something other than the default.

### DIFF
--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -336,6 +336,11 @@ impl StorageClient {
         }
     }
 
+    pub fn with_options(mut self, options: StorageOptions) -> Self {
+        self.pipeline = new_pipeline_from_options(options, self.storage_credentials.clone());
+        self
+    }
+
     pub fn blob_storage_url(&self) -> &Url {
         &self.blob_storage_url
     }
@@ -543,6 +548,11 @@ pub struct StorageOptions {
 impl StorageOptions {
     fn new() -> StorageOptions {
         Self::default()
+    }
+
+    setters! {
+        options: ClientOptions => options,
+        timeout_policy: TimeoutPolicy => timeout_policy,
     }
 
     pub fn set_timeout(&mut self, default_timeout: Timeout) {


### PR DESCRIPTION
As far as I could tell there was no way to change the `ClientOptions`,
retries, etc from the default values. All of the existing public
constructors just call `StorageOptions::new()`.

I chose to just add a builder type method, but I am open to other
implementations. The important thing is to provide the ability to change
these values.