### PR TITLE
Add better retry policy defaults

### DIFF
--- a/sdk/core/src/options.rs
+++ b/sdk/core/src/options.rs
@@ -112,7 +112,7 @@ pub struct RetryOptions {
 
     /// The maximum number of retry attempts before giving up.
     ///
-    /// The default is 10.
+    /// The default is 8.
     pub max_retries: u32,
 
     /// The maximum permissible elapsed time since starting to retry.
@@ -133,6 +133,7 @@ impl RetryOptions {
         delay: Duration => delay,
         max_retries: u32 => max_retries,
         max_elapsed: Duration => max_elapsed,
+        max_delay: Duration => max_delay,
     }
 }
 
@@ -141,7 +142,7 @@ impl Default for RetryOptions {
         RetryOptions {
             mode: RetryMode::default(),
             delay: Duration::from_millis(200),
-            max_retries: 10,
+            max_retries: 8,
             max_elapsed: Duration::from_secs(60),
             max_delay: Duration::from_secs(30),
         }
@@ -150,13 +151,12 @@ impl Default for RetryOptions {
 
 impl RetryOptions {
     pub(crate) fn to_policy(&self) -> Arc<dyn Policy> {
-        let max_delay = self.max_delay.min(Duration::from_secs(1));
         match self.mode {
             RetryMode::Exponential => Arc::new(ExponentialRetryPolicy::new(
                 self.delay,
                 self.max_retries,
                 self.max_elapsed,
-                max_delay,
+                self.max_delay,
             )),
             RetryMode::Fixed => Arc::new(FixedRetryPolicy::new(
                 self.delay,

--- a/sdk/core/src/policies/retry_policies/fixed_retry.rs
+++ b/sdk/core/src/policies/retry_policies/fixed_retry.rs
@@ -16,7 +16,7 @@ pub struct FixedRetryPolicy {
 impl FixedRetryPolicy {
     pub(crate) fn new(delay: Duration, max_retries: u32, max_elapsed: Duration) -> Self {
         Self {
-            delay,
+            delay: delay.max(Duration::from_millis(10)),
             max_retries,
             max_elapsed,
         }

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -2,9 +2,11 @@ use crate::error::{Error, ErrorKind, HttpError};
 use crate::policies::{Policy, PolicyResult, Request};
 use crate::sleep::sleep;
 use crate::{Context, StatusCode};
+
+use time::OffsetDateTime;
+
 use std::sync::Arc;
 use std::time::Duration;
-use time::OffsetDateTime;
 
 /// A retry policy.
 ///
@@ -15,7 +17,7 @@ pub trait RetryPolicy {
     /// Determine if no more retries should be performed.
     ///
     /// Must return true if no more retries should be attempted.
-    fn is_expired(&self, first_retry_time: &mut Option<OffsetDateTime>, retry_count: u32) -> bool;
+    fn is_expired(&self, duration_since_start: Duration, retry_count: u32) -> bool;
     /// Determine how long before the next retry should be attempted.
     fn sleep_duration(&self, retry_count: u32) -> Duration;
 }
@@ -44,11 +46,14 @@ where
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult {
-        let mut first_retry_time = None;
         let mut retry_count = 0;
+        let mut start = None;
 
         loop {
-            let error = match next[0].send(ctx, request, &next[1..]).await {
+            let result = next[0].send(ctx, request, &next[1..]).await;
+            // only start keeping track of time after the first request is made
+            let start = start.get_or_insert_with(OffsetDateTime::now_utc);
+            let error = match result {
                 Ok(response) if response.status().is_success() => {
                     log::trace!(
                         "Successful response. Request={:?} response={:?}",
@@ -94,7 +99,10 @@ where
                 }
             };
 
-            if self.is_expired(&mut first_retry_time, retry_count) {
+            let time_since_start = (OffsetDateTime::now_utc() - *start)
+                .try_into()
+                .unwrap_or_default();
+            if self.is_expired(time_since_start, retry_count) {
                 return Err(error);
             }
             retry_count += 1;


### PR DESCRIPTION
After talking with @gorzell about retry policies I decided to take a look at improving the defaults. 

This moves to having the default be an exponential back off starting at 200ms and increasing quadratically every retry until hitting a ceiling of 30seconds. 

This seems like a better default than only retrying 3 times though it will not work for everyone including for @gorzell. 