### PR TITLE
Migrate iothub to pipelines

### DIFF
--- a/sdk/core/src/policies/mod.rs
+++ b/sdk/core/src/policies/mod.rs
@@ -1,11 +1,13 @@
 mod custom_headers_policy;
 mod retry_policies;
 mod telemetry_policy;
+mod timeout_policy;
 mod transport;
 
 pub use custom_headers_policy::{CustomHeaders, CustomHeadersPolicy};
 pub use retry_policies::*;
 pub use telemetry_policy::*;
+pub use timeout_policy::*;
 pub use transport::*;
 
 use crate::{Context, Request, Response};

--- a/sdk/core/src/policies/timeout_policy.rs
+++ b/sdk/core/src/policies/timeout_policy.rs
@@ -1,6 +1,6 @@
+use crate::request_options::Timeout;
+use crate::{AppendToUrlQuery, Context, Policy, PolicyResult, Request};
 use std::sync::Arc;
-
-use azure_core::{prelude::*, Context, Policy, PolicyResult, Request};
 
 #[derive(Debug, Clone, Default)]
 pub struct TimeoutPolicy {

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -7,6 +7,7 @@ description = "Azure IoT Hub"
 license = "MIT"
 
 [dependencies]
+async-trait = "0.1"
 azure_core = { path = "../core", version = "0.3", default_features = false }
 base64 = "0.13"
 bytes = "1.0"

--- a/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
+++ b/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         }
     });
 
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
     service_client
         .apply_on_edge_device(device_id)
         .modules_content(modules_content)

--- a/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
+++ b/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
@@ -56,9 +56,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         }
     });
 
-    let http_client = azure_core::new_http_client();
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
     service_client
         .apply_on_edge_device(device_id)
         .modules_content(modules_content)

--- a/sdk/iot_hub/examples/configuration.rs
+++ b/sdk/iot_hub/examples/configuration.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(1)
         .expect("Please pass the configuration id as the first parameter");
 
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
 
     println!("Creating a new configuration with id: {}", configuration_id);
 

--- a/sdk/iot_hub/examples/configuration.rs
+++ b/sdk/iot_hub/examples/configuration.rs
@@ -1,4 +1,4 @@
-use azure_iot_hub::service::{resources::Configuration, ServiceClient};
+use azure_iot_hub::service::ServiceClient;
 use std::error::Error;
 
 #[tokio::main]
@@ -10,9 +10,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(1)
         .expect("Please pass the configuration id as the first parameter");
 
-    let http_client = azure_core::new_http_client();
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
 
     println!("Creating a new configuration with id: {}", configuration_id);
 
@@ -42,7 +40,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .get_configuration(configuration_id)
         .into_future()
         .await?;
-    let configuration: Configuration = configuration.try_into()?;
 
     println!(
         "Successfully retrieved the new configuration '{:?}'",

--- a/sdk/iot_hub/examples/device_identity.rs
+++ b/sdk/iot_hub/examples/device_identity.rs
@@ -13,9 +13,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .expect("Please pass the device id as the first parameter");
 
     println!("Getting device twin for device '{}'", device_id);
-    let http_client = azure_core::new_http_client();
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
     let device = service_client
         .create_device_identity(
             &device_id,
@@ -27,6 +25,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         )
         .into_future()
         .await?;
+    let device: DeviceIdentityResponse = device.try_into()?;
 
     println!("Successfully created a new device '{}'", device.device_id);
 

--- a/sdk/iot_hub/examples/device_identity.rs
+++ b/sdk/iot_hub/examples/device_identity.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .expect("Please pass the device id as the first parameter");
 
     println!("Getting device twin for device '{}'", device_id);
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
     let device = service_client
         .create_device_identity(
             &device_id,

--- a/sdk/iot_hub/examples/directmethod.rs
+++ b/sdk/iot_hub/examples/directmethod.rs
@@ -23,9 +23,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(4)
         .expect("Please pass the payload as the fourth parameter");
 
-    let http_client = azure_core::new_http_client();
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
     println!(
         "Sending direct method {} to {}:{} on: {}",
         method_name, device_id, module_id, service_client.iot_hub_name

--- a/sdk/iot_hub/examples/directmethod.rs
+++ b/sdk/iot_hub/examples/directmethod.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(4)
         .expect("Please pass the payload as the fourth parameter");
 
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
     println!(
         "Sending direct method {} to {}:{} on: {}",
         method_name, device_id, module_id, service_client.iot_hub_name

--- a/sdk/iot_hub/examples/gettwin.rs
+++ b/sdk/iot_hub/examples/gettwin.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("Getting device twin for device: {}", device_id);
 
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
     let twin = service_client
         .get_device_twin(device_id)
         .into_future()

--- a/sdk/iot_hub/examples/gettwin.rs
+++ b/sdk/iot_hub/examples/gettwin.rs
@@ -12,9 +12,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("Getting device twin for device: {}", device_id);
 
-    let http_client = azure_core::new_http_client();
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
     let twin = service_client
         .get_device_twin(device_id)
         .into_future()

--- a/sdk/iot_hub/examples/module_identity.rs
+++ b/sdk/iot_hub/examples/module_identity.rs
@@ -16,9 +16,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(2)
         .expect("Please pass the module id as the second parameter");
 
-    let http_client = azure_core::new_http_client();
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
     let module = service_client
         .create_module_identity(
             &device_id,

--- a/sdk/iot_hub/examples/module_identity.rs
+++ b/sdk/iot_hub/examples/module_identity.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .nth(2)
         .expect("Please pass the module id as the second parameter");
 
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
     let module = service_client
         .create_module_identity(
             &device_id,

--- a/sdk/iot_hub/examples/query_iothub.rs
+++ b/sdk/iot_hub/examples/query_iothub.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let query = "SELECT * FROM devices";
     println!("Invoking query '{}' on the IoT Hub", query);
 
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
 
     let response = service_client
         .query(query)

--- a/sdk/iot_hub/examples/query_iothub.rs
+++ b/sdk/iot_hub/examples/query_iothub.rs
@@ -11,9 +11,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let query = "SELECT * FROM devices";
     println!("Invoking query '{}' on the IoT Hub", query);
 
-    let http_client = azure_core::new_http_client();
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
 
     let response = service_client
         .query(query)

--- a/sdk/iot_hub/examples/updatetwin.rs
+++ b/sdk/iot_hub/examples/updatetwin.rs
@@ -16,10 +16,8 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .expect("Please pass the payload as the second parameter");
 
     println!("Updating device twin for device: {}", device_id);
-    let http_client = azure_core::new_http_client();
 
-    let service_client =
-        ServiceClient::from_connection_string(http_client, iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
     let updated_twin = service_client
         .update_device_twin(device_id)
         .desired_properties(serde_json::from_str(&payload)?)

--- a/sdk/iot_hub/examples/updatetwin.rs
+++ b/sdk/iot_hub/examples/updatetwin.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     println!("Updating device twin for device: {}", device_id);
 
-    let service_client = ServiceClient::from_connection_string(iot_hub_connection_string, 3600)?;
+    let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
     let updated_twin = service_client
         .update_device_twin(device_id)
         .desired_properties(serde_json::from_str(&payload)?)

--- a/sdk/iot_hub/src/authorization_policy.rs
+++ b/sdk/iot_hub/src/authorization_policy.rs
@@ -1,0 +1,60 @@
+use crate::service::IoTHubCredentials;
+use azure_core::error::{ErrorKind, ResultExt};
+use azure_core::{
+    headers::{self, *},
+    Context, Policy, PolicyResult, Request,
+};
+use std::sync::Arc;
+
+const IOTHUB_TOKEN_SCOPE: &str = "https://iothubs.azure.net";
+
+#[derive(Debug, Clone)]
+pub struct AuthorizationPolicy {
+    credentials: IoTHubCredentials,
+}
+
+impl AuthorizationPolicy {
+    pub(crate) fn new(credentials: IoTHubCredentials) -> Self {
+        Self { credentials }
+    }
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl Policy for AuthorizationPolicy {
+    async fn send(
+        &self,
+        ctx: &Context,
+        request: &mut Request,
+        next: &[Arc<dyn Policy>],
+    ) -> PolicyResult {
+        assert!(
+            !next.is_empty(),
+            "Authorization policies cannot be the last policy of a pipeline"
+        );
+        let request = match &self.credentials {
+            IoTHubCredentials::SASToken(sas_token) => {
+                request.insert_header(headers::AUTHORIZATION, sas_token);
+                request
+            }
+            IoTHubCredentials::BearerToken(token) => {
+                request.insert_header(AUTHORIZATION, format!("Bearer {}", token));
+                request
+            }
+            IoTHubCredentials::TokenCredential(token_credential) => {
+                let bearer_token = token_credential
+                    .get_token(IOTHUB_TOKEN_SCOPE)
+                    .await
+                    .context(ErrorKind::Credential, "failed to get bearer token")?;
+
+                request.insert_header(
+                    AUTHORIZATION,
+                    format!("Bearer {}", bearer_token.token.secret()),
+                );
+                request
+            }
+        };
+
+        next[0].send(ctx, request, &next[1..]).await
+    }
+}

--- a/sdk/iot_hub/src/lib.rs
+++ b/sdk/iot_hub/src/lib.rs
@@ -2,5 +2,6 @@
 #![deny(missing_docs)]
 //! The IoT Hub crate contains a client that can be used to manage the IoT Hub.
 
+mod authorization_policy;
 /// The service module contains the IoT Hub Service Client that can be used to manage the IoT Hub.
 pub mod service;

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -47,10 +47,6 @@ pub enum IoTHubCredentials {
 impl std::fmt::Debug for IoTHubCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            // IoTHubCredentials::Key(_, _) => f
-            //     .debug_struct("IoTHubCredentials")
-            //     .field("credential", &"Key")
-            //     .finish(),
             IoTHubCredentials::SASToken(_) => f
                 .debug_struct("IoTHubCredentials")
                 .field("credential", &"SASToken")

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -1,6 +1,10 @@
+use crate::authorization_policy::AuthorizationPolicy;
 use azure_core::error::{Error, ErrorKind, ResultExt};
 use azure_core::request_options::ContentType;
-use azure_core::{headers, CollectedResponse, HttpClient, Method, Request, Url};
+use azure_core::{
+    auth::TokenCredential, prelude::Timeout, ClientOptions, CollectedResponse, Context, Method,
+    Pipeline, Request, Response, TimeoutPolicy, Url,
+};
 use base64::{decode, encode_config};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
@@ -29,6 +33,40 @@ use self::resources::{AuthenticationMechanism, Status};
 /// The API version to use for any requests
 pub const API_VERSION: &str = "2020-05-31-preview";
 
+/// Credential for authorizing requests against IoT Hub
+#[derive(Clone)]
+pub enum IoTHubCredentials {
+    /// Authorize via SAS token
+    SASToken(String),
+    /// Authorize via BearerToken token
+    BearerToken(String),
+    /// Authorize using a TokenCredential
+    TokenCredential(Arc<dyn TokenCredential>),
+}
+
+impl std::fmt::Debug for IoTHubCredentials {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            // IoTHubCredentials::Key(_, _) => f
+            //     .debug_struct("IoTHubCredentials")
+            //     .field("credential", &"Key")
+            //     .finish(),
+            IoTHubCredentials::SASToken(_) => f
+                .debug_struct("IoTHubCredentials")
+                .field("credential", &"SASToken")
+                .finish(),
+            IoTHubCredentials::BearerToken(_) => f
+                .debug_struct("IoTHubCredentials")
+                .field("credential", &"BearerToken")
+                .finish(),
+            IoTHubCredentials::TokenCredential(_) => f
+                .debug_struct("IoTHubCredentials")
+                .field("credential", &"TokenCredential")
+                .finish(),
+        }
+    }
+}
+
 /// The ServiceClient is the main entry point for communicating with the IoT Hub.
 ///
 /// There are several ways to construct the IoTHub Service object. Either by:
@@ -38,11 +76,9 @@ pub const API_VERSION: &str = "2020-05-31-preview";
 /// use to communicate with the IoT Hub.
 #[derive(Clone, Debug)]
 pub struct ServiceClient {
-    http_client: Arc<dyn HttpClient>,
     /// The name of the IoT Hub.
     pub iot_hub_name: String,
-    /// The SAS token that is used for authentication.
-    pub(crate) sas_token: String,
+    pipeline: Pipeline,
 }
 
 impl ServiceClient {
@@ -51,28 +87,25 @@ impl ServiceClient {
     /// # Example
     /// ```
     /// use std::sync::Arc;
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// let http_client = azure_core::new_http_client();
     /// let iot_hub_name = "cool-iot-hub";
     /// let sas_token = "<a generated sas token>";
     ///
-    /// let iot_hub = ServiceClient::from_sas_token(http_client, iot_hub_name, sas_token);
+    /// let iot_hub = ServiceClient::from_sas_token(iot_hub_name, sas_token);
     /// ```
-    pub fn from_sas_token<S, T>(
-        http_client: Arc<dyn HttpClient>,
-        iot_hub_name: S,
-        sas_token: T,
-    ) -> Self
+    pub fn from_sas_token<S, T>(iot_hub_name: S, sas_token: T) -> Self
     where
         S: Into<String>,
         T: Into<String>,
     {
+        let pipeline = new_pipeline_from_options(
+            ServiceOptions::default(),
+            IoTHubCredentials::SASToken(sas_token.into()),
+        );
         Self {
-            http_client,
             iot_hub_name: iot_hub_name.into(),
-            sas_token: sas_token.into(),
+            pipeline,
         }
     }
 
@@ -119,20 +152,16 @@ impl ServiceClient {
     /// The private key should preferably be of a user / group that has the rights to make service requests.
     /// ```
     /// use std::sync::Arc;
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
-    ///
-    /// let http_client = azure_core::new_http_client();
     ///
     /// let iot_hub_name = "iot-hub";
     /// let key_name = "iot_hubowner";
     /// let private_key = "YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     ///
-    /// let result = ServiceClient::from_private_key(http_client, iot_hub_name, key_name, private_key, 3600);
+    /// let result = ServiceClient::from_private_key(iot_hub_name, key_name, private_key, 3600);
     /// assert!(result.is_ok());
     /// ```
     pub fn from_private_key<S, T, U>(
-        http_client: Arc<dyn HttpClient>,
         iot_hub_name: S,
         key_name: T,
         private_key: U,
@@ -152,10 +181,14 @@ impl ServiceClient {
             expires_in_seconds,
         )?;
 
+        let pipeline = new_pipeline_from_options(
+            ServiceOptions::default(),
+            IoTHubCredentials::SASToken(sas_token),
+        );
+
         Ok(Self {
-            http_client,
             iot_hub_name: iot_hub_name_str,
-            sas_token,
+            pipeline,
         })
     }
 
@@ -164,17 +197,14 @@ impl ServiceClient {
     /// The connection string should preferably be from a user / group that has the rights to make service requests.
     /// ```
     /// use std::sync::Arc;
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// let http_client = azure_core::new_http_client();
     /// let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     ///
-    /// let result = ServiceClient::from_connection_string(http_client, connection_string, 3600);
+    /// let result = ServiceClient::from_connection_string(connection_string, 3600);
     /// assert!(result.is_ok());
     /// ```
     pub fn from_connection_string<S>(
-        http_client: Arc<dyn HttpClient>,
         connection_string: S,
         expires_in_seconds: u64,
     ) -> azure_core::Result<Self>
@@ -241,22 +271,24 @@ impl ServiceClient {
             Self::generate_sas_token(iot_hub_name, key_name, primary_key, expires_in_seconds)
                 .context(ErrorKind::Other, "generate SAS token error")?;
 
+        let pipeline = new_pipeline_from_options(
+            ServiceOptions::default(),
+            IoTHubCredentials::SASToken(sas_token),
+        );
+
         Ok(Self {
-            http_client,
             iot_hub_name: iot_hub_name.to_string(),
-            sas_token,
+            pipeline,
         })
     }
 
     /// Create a new device method
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the service client!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the service client!");
     /// let device_method = iot_hub.create_device_method("some-device", "hello-world", serde_json::json!({}));
     /// ```
     pub fn create_device_method<S, T>(
@@ -275,12 +307,10 @@ impl ServiceClient {
     /// Create a new module method
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device_method = iot_hub.create_module_method("some-device", "some-module", "hello-world", serde_json::json!({}));
     /// ```
     pub fn create_module_method<S, T, U>(
@@ -302,12 +332,10 @@ impl ServiceClient {
     /// Get the module twin of a given device and module
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.get_module_twin("some-device", "some-module");
     /// ```
     pub fn get_module_twin<S, T>(&self, device_id: S, module_id: T) -> GetTwinBuilder
@@ -321,12 +349,10 @@ impl ServiceClient {
     /// Get the device twin of a given device
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.get_device_twin("some-device");
     /// ```
     pub fn get_device_twin<S>(&self, device_id: S) -> GetTwinBuilder
@@ -339,12 +365,10 @@ impl ServiceClient {
     /// Update the module twin of a given device or module
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.update_module_twin("some-device", "some-module")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
@@ -362,12 +386,10 @@ impl ServiceClient {
     /// Replace the module twin of a given device and module
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.replace_module_twin("some-device", "some-module")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
@@ -389,12 +411,10 @@ impl ServiceClient {
     /// Update the device twin of a given device
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.update_device_twin("some-device")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
@@ -410,12 +430,10 @@ impl ServiceClient {
     /// Replace the device twin of a given device
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.replace_device_twin("some-device")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
@@ -431,12 +449,10 @@ impl ServiceClient {
     /// Get the identity of a given device
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.get_device_identity("some-device");
     /// ```
     pub fn get_device_identity<S>(&self, device_id: S) -> GetIdentityBuilder
@@ -449,13 +465,11 @@ impl ServiceClient {
     /// Create a new device identity
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.create_device_identity("some-existing-device", Status::Enabled, AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key"))
     ///     .into_future();
     /// ```
@@ -481,13 +495,11 @@ impl ServiceClient {
     /// Update an existing device identity
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.update_device_identity("some-existing-device", Status::Enabled, AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key"), "etag-of-device-to-update");
     /// ```
     pub fn update_device_identity<S1, S2>(
@@ -517,12 +529,10 @@ impl ServiceClient {
     /// an unconditional delete will be performed.
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.delete_device_identity("some-device-id", "some-etag");
     /// ```
     pub fn delete_device_identity<S, T>(&self, device_id: S, if_match: T) -> DeleteIdentityBuilder
@@ -536,12 +546,10 @@ impl ServiceClient {
     /// Get the identity of a given module
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.get_module_identity("some-device", "some-module");
     /// ```
     pub fn get_module_identity<S, T>(&self, device_id: S, module_id: T) -> GetIdentityBuilder
@@ -555,13 +563,11 @@ impl ServiceClient {
     /// Create a new module identity
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.create_module_identity("some-existing-device", "some-existing-module", "IoTEdge", AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key")).into_future();
     /// ```
     pub fn create_module_identity<S1, S2, S3>(
@@ -590,13 +596,11 @@ impl ServiceClient {
     /// Update an existing module identity
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.update_module_identity("some-existing-device", "some-existing-module", "IoTEdge", AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key"), "etag-of-device-to-update");
     /// ```
     pub fn update_module_identity<S1, S2, S3, S4>(
@@ -630,12 +634,10 @@ impl ServiceClient {
     /// an unconditional delete will be performed.
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.delete_module_identity("some-device-id", "some-module-id", "some-etag");
     /// ```
     pub fn delete_module_identity<S, T, U>(
@@ -660,12 +662,10 @@ impl ServiceClient {
     /// Invoke a query
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let query_builder = iot_hub.query("$SOME_QUERY");
     /// ```
     pub fn query<Q>(&self, query: Q) -> QueryBuilder
@@ -678,12 +678,10 @@ impl ServiceClient {
     /// Apply configuration on an Edge device
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let edge_configuration_builder = iot_hub.apply_on_edge_device("some-device");
     /// ```
     pub fn apply_on_edge_device<S>(&self, device_id: S) -> ApplyOnEdgeDeviceBuilder
@@ -696,12 +694,10 @@ impl ServiceClient {
     /// Get a configuration
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.get_configuration("some-configuration");
     /// ```
     pub fn get_configuration<S>(&self, configuration_id: S) -> GetConfigurationBuilder
@@ -714,12 +710,10 @@ impl ServiceClient {
     /// Get all configurations
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.get_configurations();
     /// ```
     pub fn get_configurations(&self) -> GetConfigurationBuilder {
@@ -729,13 +723,11 @@ impl ServiceClient {
     /// Create a new configuration.
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let configuration = iot_hub.create_configuration("some-configuration-id", 10, "tags.environment='test'")
     ///     .into_future();
     /// ```
@@ -761,13 +753,11 @@ impl ServiceClient {
     /// Update a configuration.
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     /// use azure_iot_hub::service::resources::{Status, AuthenticationMechanism};
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let configuration = iot_hub.update_configuration("some-configuration-id", 10, "tags.environment='test'", "some-etag-value")
     ///     .into_future();
     /// ```
@@ -798,12 +788,10 @@ impl ServiceClient {
     /// an unconditional delete will be performed.
     ///
     /// ```
-    /// use azure_core::HttpClient;
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// # let http_client = azure_core::new_http_client();
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.delete_configuration("some-configuration-id", "some-etag");
     /// ```
     pub fn delete_configuration<S, T>(
@@ -825,14 +813,52 @@ impl ServiceClient {
         method: Method,
     ) -> azure_core::Result<Request> {
         let mut request = Request::new(Url::parse(uri)?, method);
-        request.insert_header(headers::AUTHORIZATION, &self.sas_token);
         request.insert_headers(&ContentType::APPLICATION_JSON);
         Ok(request)
     }
 
-    /// Get the HttpClient of the IoTHub service
-    pub(crate) fn http_client(&self) -> &dyn HttpClient {
-        self.http_client.as_ref()
+    /// send the request via the request pipeline
+    pub async fn send(
+        &self,
+        context: &mut Context,
+        request: &mut Request,
+    ) -> azure_core::Result<Response> {
+        self.pipeline.send(context, request).await
+    }
+}
+
+/// Create a Pipeline from ServiceOptions
+fn new_pipeline_from_options(options: ServiceOptions, credentials: IoTHubCredentials) -> Pipeline {
+    let auth_policy: Arc<dyn azure_core::Policy> = Arc::new(AuthorizationPolicy::new(credentials));
+
+    // The `AuthorizationPolicy` must be the **last** retry policy.
+    // Policies can change the url and/or the headers, and the `AuthorizationPolicy`
+    // must be able to inspect them or the resulting token will be invalid.
+    let per_retry_policies = vec![
+        Arc::new(options.timeout_policy) as Arc<dyn azure_core::Policy>,
+        auth_policy,
+    ];
+
+    Pipeline::new(
+        option_env!("CARGO_PKG_NAME"),
+        option_env!("CARGO_PKG_VERSION"),
+        options.options,
+        Vec::new(),
+        per_retry_policies,
+    )
+}
+
+/// Options to cufigure the ServiceClient
+#[derive(Debug, Clone, Default)]
+pub struct ServiceOptions {
+    options: ClientOptions,
+    timeout_policy: TimeoutPolicy,
+}
+
+impl ServiceOptions {
+    /// set timeout duration for requests
+    pub fn set_timeout(&mut self, default_timeout: Timeout) {
+        self.timeout_policy = TimeoutPolicy::new(Some(default_timeout))
     }
 }
 
@@ -843,9 +869,8 @@ mod tests {
     fn from_connectionstring_success() -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
 
-        let http_client = azure_core::new_http_client();
         let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-        let _ = ServiceClient::from_connection_string(http_client, connection_string, 3600)?;
+        let _ = ServiceClient::from_connection_string(connection_string, 3600)?;
         Ok(())
     }
 
@@ -854,14 +879,11 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
 
-        let http_client = azure_core::new_http_client();
         let connection_string = "HostName==cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-        let _ = ServiceClient::from_connection_string(http_client.clone(), connection_string, 3600)
-            .is_err();
+        let _ = ServiceClient::from_connection_string(connection_string, 3600).is_err();
 
         let connection_string = "HostName=cool-iot-hub.azure-;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-        let _ =
-            ServiceClient::from_connection_string(http_client, connection_string, 3600).is_err();
+        let _ = ServiceClient::from_connection_string(connection_string, 3600).is_err();
         Ok(())
     }
 
@@ -869,9 +891,8 @@ mod tests {
     fn from_connectionstring_should_fail_on_empty_connection_string(
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
 
-        let _ = ServiceClient::from_connection_string(http_client, "", 3600).is_err();
+        let _ = ServiceClient::from_connection_string("", 3600).is_err();
         Ok(())
     }
 
@@ -879,9 +900,7 @@ mod tests {
     fn from_connectionstring_should_fail_on_incomplete_connection_string(
     ) -> Result<(), Box<dyn std::error::Error>> {
         use crate::service::ServiceClient;
-        let http_client = azure_core::new_http_client();
-
-        let _ = ServiceClient::from_connection_string(http_client, "HostName=cool-iot-hub.azure-devices.net;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==", 3600).is_err();
+        let _ = ServiceClient::from_connection_string( "HostName=cool-iot-hub.azure-devices.net;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==", 3600).is_err();
         Ok(())
     }
 }

--- a/sdk/iot_hub/src/service/operations/apply_on_edge_device.rs
+++ b/sdk/iot_hub/src/service/operations/apply_on_edge_device.rs
@@ -15,7 +15,7 @@ operation! {
 
 impl ApplyOnEdgeDeviceBuilder {
     /// Performs the apply on edge device request
-    pub fn into_future(self) -> ApplyOnEdgeDevice {
+    pub fn into_future(mut self) -> ApplyOnEdgeDevice {
         Box::pin(async move {
             let uri = format!(
                 "https://{}.azure-devices.net/devices/{}/applyConfigurationContent?api-version={}",
@@ -32,10 +32,8 @@ impl ApplyOnEdgeDeviceBuilder {
             let body = azure_core::to_json(&body)?;
             request.set_body(body);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await?;
+            self.client.send(&mut self.context, &mut request).await?;
+
             Ok(())
         })
     }

--- a/sdk/iot_hub/src/service/operations/create_or_update_configuration.rs
+++ b/sdk/iot_hub/src/service/operations/create_or_update_configuration.rs
@@ -2,7 +2,6 @@ use azure_core::headers;
 use azure_core::Method;
 use serde::Serialize;
 use std::collections::HashMap;
-use std::convert::TryInto;
 
 use crate::service::resources::{ConfigurationContent, ConfigurationMetrics};
 use crate::service::responses::ConfigurationResponse;
@@ -70,7 +69,7 @@ impl CreateOrUpdateConfigurationBuilder {
     }
 
     /// Performs the create or update request on the device identity
-    pub fn into_future(self) -> CreateOrUpdateConfiguration {
+    pub fn into_future(mut self) -> CreateOrUpdateConfiguration {
         Box::pin(async move {
             let uri = format!(
                 "https://{}.azure-devices.net/configurations/{}?api-version={}",
@@ -102,11 +101,9 @@ impl CreateOrUpdateConfigurationBuilder {
             let body = azure_core::to_json(&body)?;
             request.set_body(body);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await?
-                .try_into()
+            let response = self.client.send(&mut self.context, &mut request).await?;
+
+            CreateOrUpdateConfigurationResponse::try_from(response).await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/create_or_update_device_identity.rs
+++ b/sdk/iot_hub/src/service/operations/create_or_update_device_identity.rs
@@ -2,7 +2,7 @@ use crate::service::resources::{
     identity::DesiredCapability, identity::IdentityOperation, AuthenticationMechanism,
     DeviceCapabilities, Status,
 };
-use crate::service::responses::DeviceIdentityResponse;
+use crate::service::responses::CreateOrUpdateDeviceIdentityResponse;
 use crate::service::{ServiceClient, API_VERSION};
 use azure_core::error::{Error, ErrorKind};
 use azure_core::headers;
@@ -70,16 +70,6 @@ impl CreateOrUpdateDeviceIdentityBuilder {
 
             CreateOrUpdateDeviceIdentityResponse::try_from(response).await
         })
-    }
-}
-
-pub type CreateOrUpdateDeviceIdentityResponse = DeviceIdentityResponse;
-
-impl CreateOrUpdateDeviceIdentityResponse {
-    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
-        let collected = azure_core::CollectedResponse::from_response(response).await?;
-        let body = collected.body();
-        Ok(serde_json::from_slice(body)?)
     }
 }
 

--- a/sdk/iot_hub/src/service/operations/create_or_update_module_identity.rs
+++ b/sdk/iot_hub/src/service/operations/create_or_update_module_identity.rs
@@ -5,7 +5,6 @@ use azure_core::error::{Error, ErrorKind};
 use azure_core::headers;
 use azure_core::Method;
 use serde::Serialize;
-use std::convert::TryInto;
 
 azure_core::operation! {
     /// The CreateOrUpdateModuleIdentityBuilder is used to construct a new module identity
@@ -22,7 +21,7 @@ azure_core::operation! {
 
 impl CreateOrUpdateModuleIdentityBuilder {
     /// Performs the create or update request on the device identity
-    pub fn into_future(self) -> CreateOrUpdateModuleIdentity {
+    pub fn into_future(mut self) -> CreateOrUpdateModuleIdentity {
         Box::pin(async move {
             let uri = format!(
                 "https://{}.azure-devices.net/devices/{}/modules/{}?api-version={}",
@@ -51,16 +50,22 @@ impl CreateOrUpdateModuleIdentityBuilder {
             let body = azure_core::to_json(&body)?;
             request.set_body(body);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await?
-                .try_into()
+            let response = self.client.send(&mut self.context, &mut request).await?;
+
+            CreateOrUpdateModuleIdentityResponse::try_from(response).await
         })
     }
 }
 
 pub type CreateOrUpdateModuleIdentityResponse = ModuleIdentityResponse;
+
+impl CreateOrUpdateModuleIdentityResponse {
+    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
+        let collected = azure_core::CollectedResponse::from_response(response).await?;
+        let body = collected.body();
+        Ok(serde_json::from_slice(body)?)
+    }
+}
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/iot_hub/src/service/operations/create_or_update_module_identity.rs
+++ b/sdk/iot_hub/src/service/operations/create_or_update_module_identity.rs
@@ -1,5 +1,5 @@
 use crate::service::resources::{identity::IdentityOperation, AuthenticationMechanism};
-use crate::service::responses::ModuleIdentityResponse;
+use crate::service::responses::CreateOrUpdateModuleIdentityResponse;
 use crate::service::{ServiceClient, API_VERSION};
 use azure_core::error::{Error, ErrorKind};
 use azure_core::headers;
@@ -54,16 +54,6 @@ impl CreateOrUpdateModuleIdentityBuilder {
 
             CreateOrUpdateModuleIdentityResponse::try_from(response).await
         })
-    }
-}
-
-pub type CreateOrUpdateModuleIdentityResponse = ModuleIdentityResponse;
-
-impl CreateOrUpdateModuleIdentityResponse {
-    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
-        let collected = azure_core::CollectedResponse::from_response(response).await?;
-        let body = collected.body();
-        Ok(serde_json::from_slice(body)?)
     }
 }
 

--- a/sdk/iot_hub/src/service/operations/delete_configuration.rs
+++ b/sdk/iot_hub/src/service/operations/delete_configuration.rs
@@ -13,7 +13,7 @@ azure_core::operation! {
 
 impl DeleteConfigurationBuilder {
     /// Execute the request to delete the configuration.
-    pub fn into_future(self) -> DeleteConfiguration {
+    pub fn into_future(mut self) -> DeleteConfiguration {
         Box::pin(async move {
             let uri = format!(
                 "https://{}.azure-devices.net/configurations/{}?api-version={}",
@@ -25,10 +25,8 @@ impl DeleteConfigurationBuilder {
 
             request.set_body(azure_core::EMPTY_BODY);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await?;
+            self.client.send(&mut self.context, &mut request).await?;
+
             Ok(())
         })
     }

--- a/sdk/iot_hub/src/service/operations/delete_identity.rs
+++ b/sdk/iot_hub/src/service/operations/delete_identity.rs
@@ -13,7 +13,7 @@ azure_core::operation! {
 
 impl DeleteIdentityBuilder {
     /// Execute the request to delete the module or device identity.
-    pub fn into_future(self) -> DeleteIdentity {
+    pub fn into_future(mut self) -> DeleteIdentity {
         Box::pin(async move {
             let uri = match &self.module_id {
                 Some(module_id) => format!(
@@ -31,10 +31,7 @@ impl DeleteIdentityBuilder {
 
             request.set_body(azure_core::EMPTY_BODY);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await?;
+            self.client.send(&mut self.context, &mut request).await?;
             Ok(())
         })
     }

--- a/sdk/iot_hub/src/service/operations/get_configuration.rs
+++ b/sdk/iot_hub/src/service/operations/get_configuration.rs
@@ -1,3 +1,4 @@
+use crate::service::responses::ConfigurationResponse;
 use crate::service::{ServiceClient, API_VERSION};
 use azure_core::Method;
 
@@ -11,7 +12,7 @@ azure_core::operation! {
 
 impl GetConfigurationBuilder {
     /// Execute the request to get the configuration of a given identifier.
-    pub fn into_future(self) -> GetConfiguration {
+    pub fn into_future(mut self) -> GetConfiguration {
         Box::pin(async move {
             let uri = match self.configuration_id {
                 Some(val) => format!(
@@ -27,12 +28,11 @@ impl GetConfigurationBuilder {
             let mut request = self.client.finalize_request(&uri, Method::Get)?;
             request.set_body(azure_core::EMPTY_BODY);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await
+            let response = self.client.send(&mut self.context, &mut request).await?;
+
+            GetConfigurationResponse::try_from(response).await
         })
     }
 }
 
-pub type GetConfigurationResponse = crate::service::CollectedResponse;
+pub type GetConfigurationResponse = ConfigurationResponse;

--- a/sdk/iot_hub/src/service/operations/get_identity.rs
+++ b/sdk/iot_hub/src/service/operations/get_identity.rs
@@ -1,4 +1,4 @@
-use crate::service::{ServiceClient, API_VERSION};
+use crate::service::{CollectedResponse, ServiceClient, API_VERSION};
 use azure_core::Method;
 
 azure_core::operation! {
@@ -11,7 +11,7 @@ azure_core::operation! {
 
 impl GetIdentityBuilder {
     /// Execute the request to get the identity of a device or module.
-    pub fn into_future(self) -> GetIdentity {
+    pub fn into_future(mut self) -> GetIdentity {
         Box::pin(async move {
             let uri = match self.module_id {
                 Some(module_id) => format!(
@@ -27,12 +27,11 @@ impl GetIdentityBuilder {
             let mut request = self.client.finalize_request(&uri, Method::Get)?;
             request.set_body(azure_core::EMPTY_BODY);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await
+            let response = self.client.send(&mut self.context, &mut request).await?;
+
+            GetIdentityResponse::from_response(response).await
         })
     }
 }
 
-pub type GetIdentityResponse = crate::service::CollectedResponse;
+pub type GetIdentityResponse = CollectedResponse;

--- a/sdk/iot_hub/src/service/operations/get_twin.rs
+++ b/sdk/iot_hub/src/service/operations/get_twin.rs
@@ -11,7 +11,7 @@ azure_core::operation! {
 
 impl GetTwinBuilder {
     /// Execute the request to get the twin of a module or device.
-    pub fn into_future(self) -> GetTwin {
+    pub fn into_future(mut self) -> GetTwin {
         Box::pin(async move {
             let uri = match self.module_id {
                 Some(val) => format!(
@@ -27,10 +27,9 @@ impl GetTwinBuilder {
             let mut request = self.client.finalize_request(&uri, Method::Get)?;
             request.set_body(azure_core::EMPTY_BODY);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await
+            let response = self.client.send(&mut self.context, &mut request).await?;
+
+            GetTwinResponse::from_response(response).await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/invoke_method.rs
+++ b/sdk/iot_hub/src/service/operations/invoke_method.rs
@@ -2,7 +2,6 @@ use crate::service::responses::InvokeMethodResponse;
 use crate::service::{ServiceClient, API_VERSION};
 use azure_core::Method;
 use serde::Serialize;
-use std::convert::TryInto;
 
 azure_core::operation! {
     /// The InvokeMethodBuilder is used for constructing the request to
@@ -19,7 +18,7 @@ azure_core::operation! {
 
 impl InvokeMethodBuilder {
     /// Turn the builder into a `Future`
-    pub fn into_future(self) -> InvokeMethod {
+    pub fn into_future(mut self) -> InvokeMethod {
         Box::pin(async move {
             let uri = match &self.module_id {
                 Some(module_id_value) => format!(
@@ -44,11 +43,9 @@ impl InvokeMethodBuilder {
 
             request.set_body(body);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await?
-                .try_into()
+            let response = self.client.send(&mut self.context, &mut request).await?;
+
+            InvokeMethodResponse::try_from(response).await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
+++ b/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
@@ -28,9 +28,8 @@ impl UpdateOrReplaceTwinBuilder {
     /// ```
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     /// use azure_iot_hub::service::ServiceClient;
-    /// # let http_client = azure_core::new_http_client();
     ///
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.update_device_twin("some-device")
     ///                  .tag("TagName", "TagValue")
     ///                  .tag("AnotherTag", "WithAnotherValue")
@@ -51,14 +50,13 @@ impl UpdateOrReplaceTwinBuilder {
     /// use azure_iot_hub::service::ServiceClient;
     ///
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// # let http_client = azure_core::new_http_client();
-    /// let iot_hub = ServiceClient::from_connection_string(http_client, connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.update_device_twin("some-device")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
     ///              .into_future();
     /// ```
-    pub fn into_future(self) -> UpdateOrReplaceTwin {
+    pub fn into_future(mut self) -> UpdateOrReplaceTwin {
         Box::pin(async move {
             let body = DesiredTwinBody {
                 tags: self.desired_tags.unwrap_or_default(),
@@ -86,10 +84,9 @@ impl UpdateOrReplaceTwinBuilder {
 
             request.set_body(body);
 
-            self.client
-                .http_client()
-                .execute_request_check_status(&request)
-                .await
+            let response = self.client.send(&mut self.context, &mut request).await?;
+
+            UpdateOrReplaceTwinResponse::from_response(response).await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
+++ b/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
@@ -29,7 +29,7 @@ impl UpdateOrReplaceTwinBuilder {
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     /// use azure_iot_hub::service::ServiceClient;
     ///
-    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::new_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.update_device_twin("some-device")
     ///                  .tag("TagName", "TagValue")
     ///                  .tag("AnotherTag", "WithAnotherValue")
@@ -50,7 +50,7 @@ impl UpdateOrReplaceTwinBuilder {
     /// use azure_iot_hub::service::ServiceClient;
     ///
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
-    /// let iot_hub = ServiceClient::from_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
+    /// let iot_hub = ServiceClient::new_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let twin = iot_hub.update_device_twin("some-device")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))

--- a/sdk/iot_hub/src/service/responses/configuration_response.rs
+++ b/sdk/iot_hub/src/service/responses/configuration_response.rs
@@ -1,5 +1,5 @@
 use crate::service::resources::Configuration;
-use azure_core::error::Error;
+use azure_core::{error::Error, CollectedResponse};
 use serde::{Deserialize, Serialize};
 
 /// The configuration response
@@ -9,15 +9,11 @@ pub type ConfigurationResponse = Configuration;
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct MultipleConfigurationResponse(Vec<ConfigurationResponse>);
 
-impl std::convert::TryFrom<crate::service::CollectedResponse> for ConfigurationResponse {
-    type Error = Error;
-
-    fn try_from(response: crate::service::CollectedResponse) -> azure_core::Result<Self> {
-        let body = response.body();
-
-        let configuration_response: ConfigurationResponse = serde_json::from_slice(body)?;
-
-        Ok(configuration_response)
+impl ConfigurationResponse {
+    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
+        let collected = CollectedResponse::from_response(response).await?;
+        let body = collected.body();
+        Ok(serde_json::from_slice(body)?)
     }
 }
 

--- a/sdk/iot_hub/src/service/responses/device_identity_response.rs
+++ b/sdk/iot_hub/src/service/responses/device_identity_response.rs
@@ -48,3 +48,14 @@ impl std::convert::TryFrom<crate::service::CollectedResponse> for DeviceIdentity
         Ok(device_identity_response)
     }
 }
+
+/// Response of CreateOrUpdateDeviceIdentity
+pub type CreateOrUpdateDeviceIdentityResponse = DeviceIdentityResponse;
+
+impl CreateOrUpdateDeviceIdentityResponse {
+    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
+        let collected = azure_core::CollectedResponse::from_response(response).await?;
+        let body = collected.body();
+        Ok(serde_json::from_slice(body)?)
+    }
+}

--- a/sdk/iot_hub/src/service/responses/invoke_method_response.rs
+++ b/sdk/iot_hub/src/service/responses/invoke_method_response.rs
@@ -1,4 +1,3 @@
-use azure_core::error::Error;
 use serde::Deserialize;
 
 /// The DirectMethodResponse struct contains the response
@@ -11,14 +10,10 @@ pub struct InvokeMethodResponse {
     pub payload: Option<serde_json::Value>,
 }
 
-impl std::convert::TryFrom<crate::service::CollectedResponse> for InvokeMethodResponse {
-    type Error = Error;
-
-    fn try_from(response: crate::service::CollectedResponse) -> azure_core::Result<Self> {
-        let body = response.body();
-
-        let invoke_method_response: InvokeMethodResponse = serde_json::from_slice(body)?;
-
-        Ok(invoke_method_response)
+impl InvokeMethodResponse {
+    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
+        let collected = azure_core::CollectedResponse::from_response(response).await?;
+        let body = collected.body();
+        Ok(serde_json::from_slice(body)?)
     }
 }

--- a/sdk/iot_hub/src/service/responses/mod.rs
+++ b/sdk/iot_hub/src/service/responses/mod.rs
@@ -7,9 +7,9 @@ mod module_twin_response;
 mod query_response;
 
 pub use configuration_response::{ConfigurationResponse, MultipleConfigurationResponse};
-pub use device_identity_response::DeviceIdentityResponse;
+pub use device_identity_response::{CreateOrUpdateDeviceIdentityResponse, DeviceIdentityResponse};
 pub use device_twin_response::DeviceTwinResponse;
 pub use invoke_method_response::InvokeMethodResponse;
-pub use module_identity_response::ModuleIdentityResponse;
+pub use module_identity_response::{CreateOrUpdateModuleIdentityResponse, ModuleIdentityResponse};
 pub use module_twin_response::ModuleTwinResponse;
 pub use query_response::QueryResponse;

--- a/sdk/iot_hub/src/service/responses/module_identity_response.rs
+++ b/sdk/iot_hub/src/service/responses/module_identity_response.rs
@@ -40,3 +40,14 @@ impl std::convert::TryFrom<crate::service::CollectedResponse> for ModuleIdentity
         Ok(module_identity_response)
     }
 }
+
+/// Response for CreateOrUpdateModuleIdentity
+pub type CreateOrUpdateModuleIdentityResponse = ModuleIdentityResponse;
+
+impl CreateOrUpdateModuleIdentityResponse {
+    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
+        let collected = azure_core::CollectedResponse::from_response(response).await?;
+        let body = collected.body();
+        Ok(serde_json::from_slice(body)?)
+    }
+}

--- a/sdk/storage/src/core/clients/storage_client.rs
+++ b/sdk/storage/src/core/clients/storage_client.rs
@@ -4,14 +4,13 @@ use crate::shared_access_signature::account_sas::{
     AccountSasPermissions, AccountSasResource, AccountSasResourceType, AccountSharedAccessSignature,
 };
 use crate::ConnectionString;
-use crate::TimeoutPolicy;
 use azure_core::date;
 use azure_core::{
     auth::TokenCredential,
     error::{Error, ErrorKind, ResultExt},
     headers::*,
     prelude::Timeout,
-    Body, ClientOptions, Context, Method, Pipeline, Request, Response,
+    Body, ClientOptions, Context, Method, Pipeline, Request, Response, TimeoutPolicy,
 };
 use std::sync::Arc;
 use time::OffsetDateTime;
@@ -514,7 +513,7 @@ fn get_endpoint_uri(
     })
 }
 
-/// Create a Pipeline from CosmosOptions
+/// Create a Pipeline from StorageOptions
 fn new_pipeline_from_options(options: StorageOptions, credentials: StorageCredentials) -> Pipeline {
     let auth_policy: Arc<dyn azure_core::Policy> = Arc::new(AuthorizationPolicy::new(credentials));
 

--- a/sdk/storage/src/core/mod.rs
+++ b/sdk/storage/src/core/mod.rs
@@ -7,7 +7,6 @@ pub mod hmac;
 mod macros;
 pub mod prelude;
 pub mod shared_access_signature;
-mod timeout_policy;
 
 pub use self::connection_string::{ConnectionString, EndpointProtocol};
 pub use self::connection_string_builder::ConnectionStringBuilder;
@@ -19,7 +18,6 @@ pub mod storage_shared_key_credential;
 mod stored_access_policy;
 pub use azure_core::error::{Error, ErrorKind, ResultExt};
 pub mod xml;
-pub use timeout_policy::TimeoutPolicy;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IPRange {


### PR DESCRIPTION
part of #802

Migrating the iothub sdk to pipelines architecture.

I tried to retain the API surface. There are some methods that return generic `CollectedResponse` and implement the `TryInto` for a specific return type. In these cases I implemented the "async try_from" that is generally used on the type alias, as to not have conflicts / ambiguities. An example being `get_identity` used for module and device identity methods.

I also added an authorization policy along with the option to use identities for authorization. I never really worked with iothub, but looking at the docs it seems that is a valid auth method. Currently there is no way to specify client options, albeit them being used for constructing the pipeline. This was deliberate, as I understand a new builder pattern for the clients is being worked on and there were no options before as well.

Lastly I reused the timeout policy from storage and moved it to core. 

@rylev @ctaggart 