### PR TITLE
Define an options-based constructor for the Cosmos SDK

### DIFF
--- a/sdk/data_cosmos/examples/client_builder.rs
+++ b/sdk/data_cosmos/examples/client_builder.rs
@@ -1,0 +1,32 @@
+use azure_core::{RetryOptions, TransportOptions};
+use clap::Parser;
+
+use azure_data_cosmos::prelude::*;
+
+#[derive(Debug, Parser)]
+struct Args {
+    /// Cosmos primary key name
+    #[clap(env = "COSMOS_PRIMARY_KEY")]
+    primary_key: String,
+    /// The cosmos account your're using
+    #[clap(env = "COSMOS_ACCOUNT")]
+    account: String,
+    /// The name of the database
+    database_name: String,
+}
+
+#[tokio::main]
+async fn main() -> azure_core::Result<()> {
+    let args = Args::parse();
+    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+
+    let _database = CosmosClient::builder(args.account, authorization_token)
+        .retry(RetryOptions::default())
+        .transport(TransportOptions::default())
+        .build()
+        .database_client(args.database_name);
+
+    // ... the database client is now ready to be used!
+
+    Ok(())
+}

--- a/sdk/data_cosmos/examples/client_builder.rs
+++ b/sdk/data_cosmos/examples/client_builder.rs
@@ -1,6 +1,7 @@
 use azure_core::{RetryOptions, TransportOptions};
 use clap::Parser;
 
+use azure_data_cosmos::clients::CosmosClientOptions;
 use azure_data_cosmos::prelude::*;
 
 #[derive(Debug, Parser)]
@@ -20,11 +21,11 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
     let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
 
-    let _database = CosmosClient::builder(args.account, authorization_token)
+    let options = CosmosClientOptions::new(args.account, authorization_token)
         .retry(RetryOptions::default())
-        .transport(TransportOptions::default())
-        .build()
-        .database_client(args.database_name);
+        .transport(TransportOptions::default());
+
+    let _database = CosmosClient::with_options(options).database_client(args.database_name);
 
     // ... the database client is now ready to be used!
 

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -53,13 +53,6 @@ impl CosmosClientBuilder {
         self
     }
 
-    /// Enable the mocking framework.
-    #[cfg(feature = "mock_transport_framework")]
-    pub fn mock(self, enable: bool) -> Self {
-        self.mock = enable;
-        self
-    }
-
     /// Set the retry options.
     pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
         self.options = self.options.retry(retry);
@@ -84,6 +77,14 @@ impl CosmosClient {
     /// Create a new `CosmosClient` which connects to the account's instance in the public Azure cloud.
     pub fn new(account: impl Into<String>, auth_token: AuthorizationToken) -> Self {
         CosmosClientBuilder::new(account, auth_token).build()
+    }
+
+    /// Create a new `CosmosClientBuilder`.
+    pub fn builder(
+        account: impl Into<String>,
+        auth_token: AuthorizationToken,
+    ) -> CosmosClientBuilder {
+        CosmosClientBuilder::new(account, auth_token)
     }
 
     /// Set the auth token used

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -16,12 +16,12 @@ pub const EMULATOR_ACCOUNT_KEY: &str =
 
 /// A builder for the cosmos client.
 #[derive(Debug, Clone)]
-pub struct CosmosClientBuilder {
+pub struct CosmosClientOptions {
     cloud_location: CloudLocation,
     options: ClientOptions,
 }
 
-impl CosmosClientBuilder {
+impl CosmosClientOptions {
     /// Create a new instance of `CosmosClientBuilder`.
     pub fn new(account: impl Into<String>, auth_token: AuthorizationToken) -> Self {
         Self::with_location(CloudLocation::Public {
@@ -35,15 +35,6 @@ impl CosmosClientBuilder {
         Self {
             options: ClientOptions::default(),
             cloud_location,
-        }
-    }
-
-    /// Convert the builder into a `CosmosClient` instance.
-    pub fn build(self) -> CosmosClient {
-        let auth_token = self.cloud_location.auth_token();
-        CosmosClient {
-            pipeline: new_pipeline_from_options(self.options, auth_token),
-            cloud_location: self.cloud_location,
         }
     }
 
@@ -76,15 +67,16 @@ pub struct CosmosClient {
 impl CosmosClient {
     /// Create a new `CosmosClient` which connects to the account's instance in the public Azure cloud.
     pub fn new(account: impl Into<String>, auth_token: AuthorizationToken) -> Self {
-        CosmosClientBuilder::new(account, auth_token).build()
+        Self::with_options(CosmosClientOptions::new(account, auth_token))
     }
 
     /// Create a new `CosmosClientBuilder`.
-    pub fn builder(
-        account: impl Into<String>,
-        auth_token: AuthorizationToken,
-    ) -> CosmosClientBuilder {
-        CosmosClientBuilder::new(account, auth_token)
+    pub fn with_options(options: CosmosClientOptions) -> Self {
+        let auth_token = options.cloud_location.auth_token();
+        CosmosClient {
+            pipeline: new_pipeline_from_options(options.options, auth_token),
+            cloud_location: options.cloud_location,
+        }
     }
 
     /// Set the auth token used

--- a/sdk/data_cosmos/src/clients/mod.rs
+++ b/sdk/data_cosmos/src/clients/mod.rs
@@ -34,7 +34,7 @@ mod user_defined_function;
 
 pub use attachment::AttachmentClient;
 pub use collection::CollectionClient;
-pub use cosmos::CosmosClient;
+pub use cosmos::{CosmosClient, CosmosClientBuilder};
 pub use database::DatabaseClient;
 pub use document::DocumentClient;
 pub use permission::PermissionClient;

--- a/sdk/data_cosmos/src/clients/mod.rs
+++ b/sdk/data_cosmos/src/clients/mod.rs
@@ -34,7 +34,7 @@ mod user_defined_function;
 
 pub use attachment::AttachmentClient;
 pub use collection::CollectionClient;
-pub use cosmos::{CosmosClient, CosmosClientBuilder};
+pub use cosmos::{CosmosClient, CosmosClientOptions};
 pub use database::DatabaseClient;
 pub use document::DocumentClient;
 pub use permission::PermissionClient;


### PR DESCRIPTION
This is an alternative to https://github.com/Azure/azure-sdk-for-rust/pull/964, following the feedback provided in https://github.com/Azure/azure-sdk-for-rust/pull/964#pullrequestreview-1057377295 filed as a draft to use as a comparison for design discussion. Thanks!

## Discussion

Similar to #964 this attempts to keep a fluent builder-style API for options construction. I attempted to implement `Deref/DerefMut` for the `ClientOptions`, but that's incompatible with a builder-style API - the `deref` call will never be able to return the cosmos builder. We could rewrite this using a getter/setter-based approach instead, but that would be a separate PR (which I'm happy to file a separate draft for if people want to see it).

We also cannot directly pass the `azure_core::ClientOptions` to the Cosmos SDK since the cosmos SDK requires custom extensions. We could, of course, create layered options constructors - but I strongly suspect that will not help progress our goal of creating an ergonomic end-user experience.

The other decision I made is to keep the declaration of the `account` and `auth_token` tied to `CloudLocation`. This means that the client constructor is `CosmosClient::with_options(options)` instead of `CosmosClient::with_options(account, auth_token, options)`. We could change this, but the current design correctly surfaces that not all `CloudLocation` variants require an account name + auth token - which removes the need to just make up values to satisfy the interface.

In terms of implementation this appears to be roughly the same amount of code as https://github.com/Azure/azure-sdk-for-rust/pull/964. Which I think means, modulo any further changes, the decision for which API we prefer will mostly come down to which API we like best.