### PR TITLE
add `--package` to `azure-autorust`

### DIFF
--- a/services/autorust/azure-autorust/src/main.rs
+++ b/services/autorust/azure-autorust/src/main.rs
@@ -15,13 +15,13 @@ struct Args {
     #[clap(long)]
     publish: bool,
 
-    /// Specify specific package to generate
+    /// Specify specific package to generate. Multiple accepted.
     #[clap(long = "package", short = 'p')]
-    packages: Vec<String>,
+    package: Vec<String>,
 }
 impl Args {
     pub fn packages(&self) -> Vec<&str> {
-        self.packages.iter().map(String::as_str).collect()
+        self.package.iter().map(String::as_str).collect()
     }
 }
 

--- a/services/autorust/azure-autorust/src/main.rs
+++ b/services/autorust/azure-autorust/src/main.rs
@@ -1,9 +1,9 @@
 // cargo run --release -p azure-autorust
+// cargo run --release -p azure-autorust -- -p azure_svc_blobstorage
 
 use autorust_codegen::{
     crates::{list_crate_names, list_dirs},
-    gen::gen_crate,
-    get_mgmt_readmes, get_svc_readmes,
+    gen, get_mgmt_readmes, get_svc_readmes,
     jinja::{CargoToml, CheckAllServicesYml, PublishSdksYml, PublishServicesYml},
     Result, RunConfig,
 };
@@ -14,52 +14,63 @@ struct Args {
     /// Generate the publish GitHub workflows
     #[clap(long)]
     publish: bool,
+
+    /// Specify specific package to generate
+    #[clap(long = "package", short = 'p')]
+    packages: Vec<String>,
+}
+impl Args {
+    pub fn packages(&self) -> Vec<&str> {
+        self.packages.iter().map(String::as_str).collect()
+    }
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    gen_mgmt()?;
-    gen_svc()?;
-    gen_services_workspace()?;
-    gen_workflow_check_all_services()?;
-    if args.publish {
-        gen_workflow_publish_sdks()?;
-        gen_workflow_publish_services()?;
-    }
-    Ok(())
-}
-
-fn gen_mgmt() -> Result<()> {
-    const OUTPUT_FOLDER: &str = "../mgmt";
-    const ONLY_SERVICES: &[&str] = &[];
-    let run_config = &mut RunConfig::new("azure_mgmt_");
-    for (i, spec) in get_mgmt_readmes()?.iter().enumerate() {
-        if !ONLY_SERVICES.is_empty() {
-            if ONLY_SERVICES.contains(&spec.spec()) {
-                println!("{} {}", i + 1, spec.spec());
-                gen_crate(spec, run_config, OUTPUT_FOLDER)?;
-            }
-        } else {
-            println!("{} {}", i + 1, spec.spec());
-            gen_crate(spec, run_config, OUTPUT_FOLDER)?;
+    gen_mgmt(&args.packages())?;
+    gen_svc(&args.packages())?;
+    if args.packages().is_empty() {
+        gen_services_workspace()?;
+        gen_workflow_check_all_services()?;
+        if args.publish {
+            gen_workflow_publish_sdks()?;
+            gen_workflow_publish_services()?;
         }
     }
     Ok(())
 }
 
-fn gen_svc() -> Result<()> {
-    const OUTPUT_FOLDER: &str = "../svc";
-    const ONLY_SERVICES: &[&str] = &[];
-    let run_config = &mut RunConfig::new("azure_svc_");
-    for (i, spec) in get_svc_readmes()?.iter().enumerate() {
-        if !ONLY_SERVICES.is_empty() {
-            if ONLY_SERVICES.contains(&spec.spec()) {
+fn gen_mgmt(only_packages: &Vec<&str>) -> Result<()> {
+    const OUTPUT_FOLDER: &str = "../mgmt";
+    let run_config = &mut RunConfig::new("azure_mgmt_");
+    for (i, spec) in get_mgmt_readmes()?.iter().enumerate() {
+        if !only_packages.is_empty() {
+            let package_name = gen::package_name(spec, run_config);
+            if only_packages.contains(&package_name.as_str()) {
                 println!("{} {}", i + 1, spec.spec());
-                gen_crate(spec, run_config, OUTPUT_FOLDER)?;
+                gen::gen_crate(spec, run_config, OUTPUT_FOLDER)?;
             }
         } else {
             println!("{} {}", i + 1, spec.spec());
-            gen_crate(spec, run_config, OUTPUT_FOLDER)?;
+            gen::gen_crate(spec, run_config, OUTPUT_FOLDER)?;
+        }
+    }
+    Ok(())
+}
+
+fn gen_svc(only_packages: &Vec<&str>) -> Result<()> {
+    const OUTPUT_FOLDER: &str = "../svc";
+    let run_config = &mut RunConfig::new("azure_svc_");
+    for (i, spec) in get_svc_readmes()?.iter().enumerate() {
+        if !only_packages.is_empty() {
+            let package_name = gen::package_name(spec, run_config);
+            if only_packages.contains(&package_name.as_str()) {
+                println!("{} {}", i + 1, spec.spec());
+                gen::gen_crate(spec, run_config, OUTPUT_FOLDER)?;
+            }
+        } else {
+            println!("{} {}", i + 1, spec.spec());
+            gen::gen_crate(spec, run_config, OUTPUT_FOLDER)?;
         }
     }
     Ok(())

--- a/services/autorust/azure-autorust/src/main.rs
+++ b/services/autorust/azure-autorust/src/main.rs
@@ -19,6 +19,7 @@ struct Args {
     #[clap(long = "package", short = 'p')]
     package: Vec<String>,
 }
+
 impl Args {
     pub fn packages(&self) -> Vec<&str> {
         self.package.iter().map(String::as_str).collect()

--- a/services/autorust/codegen/src/cargo_toml.rs
+++ b/services/autorust/codegen/src/cargo_toml.rs
@@ -6,7 +6,7 @@ use std::{
     io::{prelude::*, LineWriter},
 };
 
-pub fn create(crate_name: &str, tags: &[&Tag], default_tag: &Tag, path: &Utf8Path) -> Result<()> {
+pub fn create(package_name: &str, tags: &[&Tag], default_tag: &Tag, path: &Utf8Path) -> Result<()> {
     let file = File::create(path)?;
     let mut file = LineWriter::new(file);
     let default_feature = default_tag.rust_feature_name();
@@ -54,7 +54,7 @@ enable_reqwest = ["azure_core/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
 no-default-tag = []
 "#,
-            crate_name, crate_name, default_feature
+            package_name, package_name, default_feature
         )
         .as_bytes(),
     )?;

--- a/services/autorust/codegen/src/gen.rs
+++ b/services/autorust/codegen/src/gen.rs
@@ -5,10 +5,16 @@ use crate::{
 };
 use std::{collections::HashMap, fs};
 
+/// Get the package name, such as "azure_svc_blobstorage".
+/// It is a concatenation of the prefix such as "azure_svc" & the service name such as "blobstorage".
+pub fn package_name(spec: &SpecReadme, run_config: &RunConfig) -> String {
+    format!("{}{}", &run_config.crate_name_prefix, &spec.service_name())
+}
+
 pub fn gen_crate(spec: &SpecReadme, run_config: &RunConfig, output_folder: &str) -> Result<()> {
     let spec_config = spec.config()?;
     let service_name = &spec.service_name();
-    let crate_name = &format!("{}{}", &run_config.crate_name_prefix, service_name);
+    let package_name = &package_name(spec, run_config);
     let output_folder = &io::join(output_folder, service_name)?;
     let mut package_config = autorust_toml::read(&io::join(&output_folder, "autorust.toml")?)?;
     if package_config.tags.sort.is_none() {
@@ -65,10 +71,10 @@ pub fn gen_crate(spec: &SpecReadme, run_config: &RunConfig, output_folder: &str)
         spec_config.tag()
     };
     let default_tag = cargo_toml::get_default_tag(tags, default_tag_name);
-    cargo_toml::create(crate_name, tags, default_tag, &io::join(output_folder, "Cargo.toml")?)?;
+    cargo_toml::create(package_name, tags, default_tag, &io::join(output_folder, "Cargo.toml")?)?;
     lib_rs::create(tags, &io::join(src_folder, "lib.rs")?, false)?;
     let readme = ReadmeMd {
-        crate_name,
+        package_name,
         readme_url: readme_md::url(spec.readme().as_str()),
         tags,
         default_tag,

--- a/services/autorust/codegen/src/readme_md.rs
+++ b/services/autorust/codegen/src/readme_md.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 #[derive(Template)]
 #[template(path = "readme.md.jinja")]
 pub struct ReadmeMd<'a> {
-    pub crate_name: &'a str,
+    pub package_name: &'a str,
     pub readme_url: String,
     pub tags: &'a Vec<&'a Tag>,
     pub default_tag: &'a Tag,

--- a/services/autorust/codegen/templates/readme.md.jinja
+++ b/services/autorust/codegen/templates/readme.md.jinja
@@ -1,4 +1,4 @@
-# {{ crate_name }} crate
+# {{ package_name }} crate
 
 This is a generated [Azure SDK for Rust](https://github.com/Azure/azure-sdk-for-rust) crate from the Azure REST API specifications listed in:
 


### PR DESCRIPTION
This allows the packages to generate to be limited. This is useful for development. Previously, `ONLY_SERVICES` was being hardcoded.