### PR TITLE
add retry and transport options for services

### DIFF
--- a/services/autorust/codegen/src/codegen_operations.rs
+++ b/services/autorust/codegen/src/codegen_operations.rs
@@ -83,33 +83,56 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
             credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
             endpoint: Option<String>,
             scopes: Option<Vec<String>>,
+            options: azure_core::ClientOptions,
         }
 
         #default_endpoint_code
 
         impl ClientBuilder {
+            #[doc = "Create a new instance of `ClientBuilder`."]
+            #[must_use]
             pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
                 Self {
                     credential,
                     endpoint: None,
                     scopes: None,
+                    options: azure_core::ClientOptions::default(),
                 }
             }
 
+            #[doc = "Set the endpoint."]
+            #[must_use]
             pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
                 self.endpoint = Some(endpoint.into());
                 self
             }
-
+            #[doc = "Set the scopes."]
+            #[must_use]
             pub fn scopes(mut self, scopes: &[&str]) -> Self {
                 self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
                 self
             }
 
+            #[doc = "Set the retry options."]
+            #[must_use]
+            pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+                self.options = self.options.retry(retry);
+                self
+            }
+
+            #[doc = "Set the transport options."]
+            #[must_use]
+            pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+                self.options = self.options.transport(transport);
+                self
+            }
+
+            #[doc = "Convert the builder into a `Client` instance."]
+            #[must_use]
             pub fn build(self) -> Client {
                 let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
                 let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-                Client::new(endpoint, self.credential, scopes)
+                Client::new(endpoint, self.credential, scopes, self.options)
             }
         }
 
@@ -127,12 +150,21 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
                 let mut context = azure_core::Context::default();
                 self.pipeline.send(&mut context, request).await
             }
-            pub fn new(endpoint: impl Into<String>, credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>, scopes: Vec<String>) -> Self {
+
+            #[doc = "Create a new `ClientBuilder`."]
+            #[must_use]
+            pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+                ClientBuilder::new(credential)
+            }
+
+            #[doc = "Create a new `Client`."]
+            #[must_use]
+            pub fn new(endpoint: impl Into<String>, credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>, scopes: Vec<String>, options: azure_core::ClientOptions) -> Self {
                 let endpoint = endpoint.into();
                 let pipeline = azure_core::Pipeline::new(
                     option_env!("CARGO_PKG_NAME"),
                     option_env!("CARGO_PKG_VERSION"),
-                    azure_core::ClientOptions::default(),
+                    options,
                     Vec::new(),
                     Vec::new(),
                 );

--- a/services/autorust/codegen/src/codegen_operations.rs
+++ b/services/autorust/codegen/src/codegen_operations.rs
@@ -106,6 +106,7 @@ pub fn create_client(modules: &[String], endpoint: Option<&str>) -> Result<Token
                 self.endpoint = Some(endpoint.into());
                 self
             }
+
             #[doc = "Set the scopes."]
             #[must_use]
             pub fn scopes(mut self, scopes: &[&str]) -> Self {

--- a/services/mgmt/activedirectory/src/package_2017_04_01/mod.rs
+++ b/services/mgmt/activedirectory/src/package_2017_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/activedirectory/src/package_2020_03/mod.rs
+++ b/services/mgmt/activedirectory/src/package_2020_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/activedirectory/src/package_preview_2017_04/mod.rs
+++ b/services/mgmt/activedirectory/src/package_preview_2017_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/activedirectory/src/package_preview_2020_03/mod.rs
+++ b/services/mgmt/activedirectory/src/package_preview_2020_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/activedirectory/src/package_preview_2020_07/mod.rs
+++ b/services/mgmt/activedirectory/src/package_preview_2020_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/addons/src/package_2017_05/mod.rs
+++ b/services/mgmt/addons/src/package_2017_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/addons/src/package_2018_03/mod.rs
+++ b/services/mgmt/addons/src/package_2018_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/adhybridhealthservice/src/package_2014_01/mod.rs
+++ b/services/mgmt/adhybridhealthservice/src/package_2014_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/adp/src/package_2020_07_01_preview/mod.rs
+++ b/services/mgmt/adp/src/package_2020_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/adp/src/package_2021_02_01_preview/mod.rs
+++ b/services/mgmt/adp/src/package_2021_02_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/adp/src/package_2021_11_01_preview/mod.rs
+++ b/services/mgmt/adp/src/package_2021_11_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/advisor/src/package_2017_03/mod.rs
+++ b/services/mgmt/advisor/src/package_2017_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/advisor/src/package_2017_04/mod.rs
+++ b/services/mgmt/advisor/src/package_2017_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/advisor/src/package_2020_01/mod.rs
+++ b/services/mgmt/advisor/src/package_2020_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/advisor/src/package_2020_07_preview/mod.rs
+++ b/services/mgmt/advisor/src/package_2020_07_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/advisor/src/package_2022_02_preview/mod.rs
+++ b/services/mgmt/advisor/src/package_2022_02_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/agrifood/src/package_2020_05_12_preview/mod.rs
+++ b/services/mgmt/agrifood/src/package_2020_05_12_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/alertsmanagement/src/package_2019_06_preview/mod.rs
+++ b/services/mgmt/alertsmanagement/src/package_2019_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/alertsmanagement/src/package_2021_08/mod.rs
+++ b/services/mgmt/alertsmanagement/src/package_2021_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/alertsmanagement/src/package_preview_2019_05/mod.rs
+++ b/services/mgmt/alertsmanagement/src/package_preview_2019_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/alertsmanagement/src/package_preview_2021_01/mod.rs
+++ b/services/mgmt/alertsmanagement/src/package_preview_2021_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/alertsmanagement/src/package_preview_2021_08/mod.rs
+++ b/services/mgmt/alertsmanagement/src/package_preview_2021_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/analysisservices/src/package_2016_05/mod.rs
+++ b/services/mgmt/analysisservices/src/package_2016_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/analysisservices/src/package_2017_07/mod.rs
+++ b/services/mgmt/analysisservices/src/package_2017_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/analysisservices/src/package_2017_08_beta/mod.rs
+++ b/services/mgmt/analysisservices/src/package_2017_08_beta/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/apimanagement/src/package_preview_2019_12/mod.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2019_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/apimanagement/src/package_preview_2020_06/mod.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2020_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/apimanagement/src/package_preview_2021_01/mod.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2021_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/apimanagement/src/package_preview_2021_04/mod.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/apimanagement/src/package_preview_2021_12/mod.rs
+++ b/services/mgmt/apimanagement/src/package_preview_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/app/src/package_2022_01_01_preview/mod.rs
+++ b/services/mgmt/app/src/package_2022_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/app/src/package_2022_03/mod.rs
+++ b/services/mgmt/app/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appconfiguration/src/package_2020_07_01_preview/mod.rs
+++ b/services/mgmt/appconfiguration/src/package_2020_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appconfiguration/src/package_2021_03_01_preview/mod.rs
+++ b/services/mgmt/appconfiguration/src/package_2021_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appconfiguration/src/package_2021_10_01_preview/mod.rs
+++ b/services/mgmt/appconfiguration/src/package_2021_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appconfiguration/src/package_2022_03_01_preview/mod.rs
+++ b/services/mgmt/appconfiguration/src/package_2022_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appconfiguration/src/package_2022_05_01/mod.rs
+++ b/services/mgmt/appconfiguration/src/package_2022_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/applicationinsights/src/package_2022_01_11/mod.rs
+++ b/services/mgmt/applicationinsights/src/package_2022_01_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/applicationinsights/src/package_2022_02_01/mod.rs
+++ b/services/mgmt/applicationinsights/src/package_2022_02_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/applicationinsights/src/package_2022_04_01/mod.rs
+++ b/services/mgmt/applicationinsights/src/package_2022_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/applicationinsights/src/package_2022_06_15/mod.rs
+++ b/services/mgmt/applicationinsights/src/package_2022_06_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/applicationinsights/src/package_preview_2020_02/mod.rs
+++ b/services/mgmt/applicationinsights/src/package_preview_2020_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appplatform/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/appplatform/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appplatform/src/package_preview_2021_09/mod.rs
+++ b/services/mgmt/appplatform/src/package_preview_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appplatform/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/appplatform/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appplatform/src/package_preview_2022_03/mod.rs
+++ b/services/mgmt/appplatform/src/package_preview_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/appplatform/src/package_preview_2022_05/mod.rs
+++ b/services/mgmt/appplatform/src/package_preview_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/arcdata/src/package_2021_08_01/mod.rs
+++ b/services/mgmt/arcdata/src/package_2021_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/arcdata/src/package_2021_11_01/mod.rs
+++ b/services/mgmt/arcdata/src/package_2021_11_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/arcdata/src/package_preview_2021_06_01/mod.rs
+++ b/services/mgmt/arcdata/src/package_preview_2021_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/arcdata/src/package_preview_2021_07_01/mod.rs
+++ b/services/mgmt/arcdata/src/package_preview_2021_07_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/arcdata/src/package_preview_2022_03/mod.rs
+++ b/services/mgmt/arcdata/src/package_preview_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/attestation/src/package_2018_09_01/mod.rs
+++ b/services/mgmt/attestation/src/package_2018_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/attestation/src/package_2020_10_01/mod.rs
+++ b/services/mgmt/attestation/src/package_2020_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/attestation/src/package_2021_06_01/mod.rs
+++ b/services/mgmt/attestation/src/package_2021_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/authorization/src/package_2020_04_01_preview/mod.rs
+++ b/services/mgmt/authorization/src/package_2020_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/authorization/src/package_2020_08_01_preview/mod.rs
+++ b/services/mgmt/authorization/src/package_2020_08_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/authorization/src/package_2020_10_01_preview/mod.rs
+++ b/services/mgmt/authorization/src/package_2020_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/authorization/src/package_2022_04_01/mod.rs
+++ b/services/mgmt/authorization/src/package_2022_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/authorization/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/authorization/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automanage/src/package_2020_06_30_preview/mod.rs
+++ b/services/mgmt/automanage/src/package_2020_06_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automanage/src/package_2021_04_30_preview/mod.rs
+++ b/services/mgmt/automanage/src/package_2021_04_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automanage/src/package_2022_05/mod.rs
+++ b/services/mgmt/automanage/src/package_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automation/src/package_2019_06/mod.rs
+++ b/services/mgmt/automation/src/package_2019_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automation/src/package_2020_01_13_preview/mod.rs
+++ b/services/mgmt/automation/src/package_2020_01_13_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automation/src/package_2021_06_22/mod.rs
+++ b/services/mgmt/automation/src/package_2021_06_22/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automation/src/package_2022_01_31/mod.rs
+++ b/services/mgmt/automation/src/package_2022_01_31/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/automation/src/package_2022_02_22/mod.rs
+++ b/services/mgmt/automation/src/package_2022_02_22/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/baremetalinfrastructure/src/package_2020_08_06_preview/mod.rs
+++ b/services/mgmt/baremetalinfrastructure/src/package_2020_08_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/baremetalinfrastructure/src/package_2021_08_09/mod.rs
+++ b/services/mgmt/baremetalinfrastructure/src/package_2021_08_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/batch/examples/list_accounts.rs
+++ b/services/mgmt/batch/examples/list_accounts.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let credential = Arc::new(AzureCliCredential {});
     let subscription_id = AzureCliCredential::get_subscription()?;
-    let client = azure_mgmt_batch::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_batch::Client::builder(credential).build();
 
     let mut accounts = client.batch_account_client().list(subscription_id).into_stream();
     while let Some(accounts) = accounts.next().await {

--- a/services/mgmt/batch/examples/list_pools.rs
+++ b/services/mgmt/batch/examples/list_pools.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let credential = Arc::new(AzureCliCredential {});
     let subscription_id = AzureCliCredential::get_subscription()?;
-    let client = azure_mgmt_batch::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_batch::Client::builder(credential).build();
 
     let mut pools = client
         .pool_client()

--- a/services/mgmt/batch/src/package_2020_09/mod.rs
+++ b/services/mgmt/batch/src/package_2020_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/batch/src/package_2021_01/mod.rs
+++ b/services/mgmt/batch/src/package_2021_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/batch/src/package_2021_06/mod.rs
+++ b/services/mgmt/batch/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/batch/src/package_2022_01/mod.rs
+++ b/services/mgmt/batch/src/package_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/batch/src/package_2022_06/mod.rs
+++ b/services/mgmt/batch/src/package_2022_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/billing/src/package_2019_10_preview/mod.rs
+++ b/services/mgmt/billing/src/package_2019_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/billing/src/package_2020_05/mod.rs
+++ b/services/mgmt/billing/src/package_2020_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/billing/src/package_2020_09_preview/mod.rs
+++ b/services/mgmt/billing/src/package_2020_09_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/billing/src/package_2020_11_preview/mod.rs
+++ b/services/mgmt/billing/src/package_2020_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/billing/src/package_2021_10/mod.rs
+++ b/services/mgmt/billing/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/blockchain/src/package_2018_06_01_preview/mod.rs
+++ b/services/mgmt/blockchain/src/package_2018_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/blueprint/src/package_2017_11_preview/mod.rs
+++ b/services/mgmt/blueprint/src/package_2017_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/blueprint/src/package_2018_11_preview/mod.rs
+++ b/services/mgmt/blueprint/src/package_2018_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/botservice/src/package_2017_12_01/mod.rs
+++ b/services/mgmt/botservice/src/package_2017_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/botservice/src/package_2018_07_12/mod.rs
+++ b/services/mgmt/botservice/src/package_2018_07_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/botservice/src/package_2020_06_02/mod.rs
+++ b/services/mgmt/botservice/src/package_2020_06_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/botservice/src/package_2021_03_01/mod.rs
+++ b/services/mgmt/botservice/src/package_2021_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/botservice/src/package_preview_2021_05/mod.rs
+++ b/services/mgmt/botservice/src/package_preview_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cdn/src/package_2019_06_preview/mod.rs
+++ b/services/mgmt/cdn/src/package_2019_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cdn/src/package_2019_12/mod.rs
+++ b/services/mgmt/cdn/src/package_2019_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cdn/src/package_2020_04/mod.rs
+++ b/services/mgmt/cdn/src/package_2020_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cdn/src/package_2020_09/mod.rs
+++ b/services/mgmt/cdn/src/package_2020_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cdn/src/package_2021_06/mod.rs
+++ b/services/mgmt/cdn/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/changeanalysis/src/package_2020_04_01_preview/mod.rs
+++ b/services/mgmt/changeanalysis/src/package_2020_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/changeanalysis/src/package_2021_04_01/mod.rs
+++ b/services/mgmt/changeanalysis/src/package_2021_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/changeanalysis/src/package_2021_04_01_preview/mod.rs
+++ b/services/mgmt/changeanalysis/src/package_2021_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/chaos/src/package_2021_09_15_preview/mod.rs
+++ b/services/mgmt/chaos/src/package_2021_09_15_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/chaos/src/package_2022_07_01_preview/mod.rs
+++ b/services/mgmt/chaos/src/package_2022_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cloudshell/src/package_2018_10_01/mod.rs
+++ b/services/mgmt/cloudshell/src/package_2018_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cognitiveservices/src/package_2016_02_preview/mod.rs
+++ b/services/mgmt/cognitiveservices/src/package_2016_02_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cognitiveservices/src/package_2017_04/mod.rs
+++ b/services/mgmt/cognitiveservices/src/package_2017_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cognitiveservices/src/package_2021_04/mod.rs
+++ b/services/mgmt/cognitiveservices/src/package_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cognitiveservices/src/package_2021_10/mod.rs
+++ b/services/mgmt/cognitiveservices/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cognitiveservices/src/package_2022_03/mod.rs
+++ b/services/mgmt/cognitiveservices/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/commerce/src/package_2015_06_preview/mod.rs
+++ b/services/mgmt/commerce/src/package_2015_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/commerce/src/profile_hybrid_2020_09_01/mod.rs
+++ b/services/mgmt/commerce/src/profile_hybrid_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/communication/src/package_2020_08_20/mod.rs
+++ b/services/mgmt/communication/src/package_2020_08_20/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/communication/src/package_2020_08_20_preview/mod.rs
+++ b/services/mgmt/communication/src/package_2020_08_20_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/communication/src/package_2021_10_01_preview/mod.rs
+++ b/services/mgmt/communication/src/package_2021_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/communication/src/package_preview_2022_07/mod.rs
+++ b/services/mgmt/communication/src/package_preview_2022_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/compute/examples/list_free_linux_images.rs
+++ b/services/mgmt/compute/examples/list_free_linux_images.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let credential = Arc::new(AzureCliCredential {});
     let subscription_id = AzureCliCredential::get_subscription()?;
-    let client = azure_mgmt_compute::ClientBuilder::new(credential)
+    let client = azure_mgmt_compute::Client::builder(credential)
         .build()
         .virtual_machine_images_client();
 

--- a/services/mgmt/compute/examples/vm_list.rs
+++ b/services/mgmt/compute/examples/vm_list.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let credential = Arc::new(AzureCliCredential {});
     let subscription_id = AzureCliCredential::get_subscription()?;
-    let client = azure_mgmt_compute::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_compute::Client::builder(credential).build();
 
     let mut count = 0;
     let mut vms = client.virtual_machines_client().list_all(subscription_id).into_stream();

--- a/services/mgmt/compute/src/package_2021_12_01/mod.rs
+++ b/services/mgmt/compute/src/package_2021_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/compute/src/package_2022_01_03/mod.rs
+++ b/services/mgmt/compute/src/package_2022_01_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/compute/src/package_2022_03_01/mod.rs
+++ b/services/mgmt/compute/src/package_2022_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/compute/src/package_2022_03_02/mod.rs
+++ b/services/mgmt/compute/src/package_2022_03_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/compute/src/package_2022_04_04/mod.rs
+++ b/services/mgmt/compute/src/package_2022_04_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confidentialledger/src/package_2020_12_01_preview/mod.rs
+++ b/services/mgmt/confidentialledger/src/package_2020_12_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confidentialledger/src/package_2021_05_13_preview/mod.rs
+++ b/services/mgmt/confidentialledger/src/package_2021_05_13_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confidentialledger/src/package_2022_05_13/mod.rs
+++ b/services/mgmt/confidentialledger/src/package_2022_05_13/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confluent/src/package_2020_03_01/mod.rs
+++ b/services/mgmt/confluent/src/package_2020_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confluent/src/package_2020_03_01_preview/mod.rs
+++ b/services/mgmt/confluent/src/package_2020_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confluent/src/package_2021_03_01_preview/mod.rs
+++ b/services/mgmt/confluent/src/package_2021_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confluent/src/package_2021_12_01/mod.rs
+++ b/services/mgmt/confluent/src/package_2021_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/confluent/src/package_preview_2021_09/mod.rs
+++ b/services/mgmt/confluent/src/package_preview_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/connectedvmware/src/package_2020_10_01_preview/mod.rs
+++ b/services/mgmt/connectedvmware/src/package_2020_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/connectedvmware/src/package_2022_01_10_preview/mod.rs
+++ b/services/mgmt/connectedvmware/src/package_2022_01_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/consumption/src/package_2019_10/mod.rs
+++ b/services/mgmt/consumption/src/package_2019_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/consumption/src/package_2021_10/mod.rs
+++ b/services/mgmt/consumption/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/consumption/src/package_preview_2018_11/mod.rs
+++ b/services/mgmt/consumption/src/package_preview_2018_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/consumption/src/package_preview_2019_04/mod.rs
+++ b/services/mgmt/consumption/src/package_preview_2019_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/consumption/src/package_preview_2019_05/mod.rs
+++ b/services/mgmt/consumption/src/package_preview_2019_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerinstance/src/package_2020_11/mod.rs
+++ b/services/mgmt/containerinstance/src/package_2020_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerinstance/src/package_2021_03/mod.rs
+++ b/services/mgmt/containerinstance/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerinstance/src/package_2021_07/mod.rs
+++ b/services/mgmt/containerinstance/src/package_2021_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerinstance/src/package_2021_09/mod.rs
+++ b/services/mgmt/containerinstance/src/package_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerinstance/src/package_2021_10/mod.rs
+++ b/services/mgmt/containerinstance/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerregistry/src/package_2021_06_preview/mod.rs
+++ b/services/mgmt/containerregistry/src/package_2021_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerregistry/src/package_2021_08_preview/mod.rs
+++ b/services/mgmt/containerregistry/src/package_2021_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerregistry/src/package_2021_09/mod.rs
+++ b/services/mgmt/containerregistry/src/package_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerregistry/src/package_2021_12_preview/mod.rs
+++ b/services/mgmt/containerregistry/src/package_2021_12_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerregistry/src/package_2022_02_preview/mod.rs
+++ b/services/mgmt/containerregistry/src/package_2022_02_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerservice/src/package_preview_2022_02/mod.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerservice/src/package_preview_2022_03/mod.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerservice/src/package_preview_2022_04/mod.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerservice/src/package_preview_2022_05/mod.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/containerservice/src/package_preview_2022_06/mod.rs
+++ b/services/mgmt/containerservice/src/package_preview_2022_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cosmosdb/src/package_preview_2021_04/mod.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cosmosdb/src/package_preview_2021_10/mod.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cosmosdb/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cosmosdb/src/package_preview_2022_02/mod.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cosmosdb/src/package_preview_2022_05/mod.rs
+++ b/services/mgmt/cosmosdb/src/package_preview_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/costmanagement/src/package_preview_2020_03/mod.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2020_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/costmanagement/src/package_preview_2020_12/mod.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2020_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/costmanagement/src/package_preview_2022_02/mod.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/costmanagement/src/package_preview_2022_04/mod.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/costmanagement/src/package_preview_2022_06/mod.rs
+++ b/services/mgmt/costmanagement/src/package_preview_2022_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cpim/src/package_2019_01_01_preview/mod.rs
+++ b/services/mgmt/cpim/src/package_2019_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cpim/src/package_2020_05_01_preview/mod.rs
+++ b/services/mgmt/cpim/src/package_2020_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/cpim/src/package_2021_04_01/mod.rs
+++ b/services/mgmt/cpim/src/package_2021_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/customerinsights/src/package_2017_01/mod.rs
+++ b/services/mgmt/customerinsights/src/package_2017_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/customerinsights/src/package_2017_04/mod.rs
+++ b/services/mgmt/customerinsights/src/package_2017_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/customerlockbox/src/package_2018_02_28_preview/mod.rs
+++ b/services/mgmt/customerlockbox/src/package_2018_02_28_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/customproviders/src/package_2018_09_01_preview/mod.rs
+++ b/services/mgmt/customproviders/src/package_2018_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dashboard/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/dashboard/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dashboard/src/package_2022_05_01_preview/mod.rs
+++ b/services/mgmt/dashboard/src/package_2022_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dashboard/src/package_2022_08_01/mod.rs
+++ b/services/mgmt/dashboard/src/package_2022_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/data/src/package_2017_03_01_preview/mod.rs
+++ b/services/mgmt/data/src/package_2017_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/data/src/package_preview_2019_07/mod.rs
+++ b/services/mgmt/data/src/package_preview_2019_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databox/src/package_2021_03/mod.rs
+++ b/services/mgmt/databox/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databox/src/package_2021_05/mod.rs
+++ b/services/mgmt/databox/src/package_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databox/src/package_2021_08_preview/mod.rs
+++ b/services/mgmt/databox/src/package_2021_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databox/src/package_2021_12/mod.rs
+++ b/services/mgmt/databox/src/package_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databox/src/package_2022_02/mod.rs
+++ b/services/mgmt/databox/src/package_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databoxedge/src/package_2020_12_01/mod.rs
+++ b/services/mgmt/databoxedge/src/package_2020_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databoxedge/src/package_2021_02_01/mod.rs
+++ b/services/mgmt/databoxedge/src/package_2021_02_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databoxedge/src/package_2021_02_01_preview/mod.rs
+++ b/services/mgmt/databoxedge/src/package_2021_02_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databoxedge/src/package_2021_06_01/mod.rs
+++ b/services/mgmt/databoxedge/src/package_2021_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databoxedge/src/package_2021_06_01_preview/mod.rs
+++ b/services/mgmt/databoxedge/src/package_2021_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databricks/src/package_2018_04_01/mod.rs
+++ b/services/mgmt/databricks/src/package_2018_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/databricks/src/package_2022_04_01_preview/mod.rs
+++ b/services/mgmt/databricks/src/package_2022_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datacatalog/src/package_2016_03_30/mod.rs
+++ b/services/mgmt/datacatalog/src/package_2016_03_30/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datadog/src/package_2020_02_preview/mod.rs
+++ b/services/mgmt/datadog/src/package_2020_02_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datadog/src/package_2021_03/mod.rs
+++ b/services/mgmt/datadog/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datafactory/src/package_2017_09_preview/mod.rs
+++ b/services/mgmt/datafactory/src/package_2017_09_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datafactory/src/package_2018_06/mod.rs
+++ b/services/mgmt/datafactory/src/package_2018_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datalakeanalytics/src/package_2015_10_preview/mod.rs
+++ b/services/mgmt/datalakeanalytics/src/package_2015_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datalakeanalytics/src/package_2016_11/mod.rs
+++ b/services/mgmt/datalakeanalytics/src/package_2016_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datalakeanalytics/src/package_preview_2019_11/mod.rs
+++ b/services/mgmt/datalakeanalytics/src/package_preview_2019_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datalakestore/src/package_2015_10_preview/mod.rs
+++ b/services/mgmt/datalakestore/src/package_2015_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datalakestore/src/package_2016_11/mod.rs
+++ b/services/mgmt/datalakestore/src/package_2016_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datamigration/src/package_2018_04_19/mod.rs
+++ b/services/mgmt/datamigration/src/package_2018_04_19/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datamigration/src/package_2021_06/mod.rs
+++ b/services/mgmt/datamigration/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datamigration/src/package_preview_2021_10/mod.rs
+++ b/services/mgmt/datamigration/src/package_preview_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datamigration/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/datamigration/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datamigration/src/package_preview_2022_03/mod.rs
+++ b/services/mgmt/datamigration/src/package_preview_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dataprotection/src/package_2021_07/mod.rs
+++ b/services/mgmt/dataprotection/src/package_2021_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dataprotection/src/package_2022_01/mod.rs
+++ b/services/mgmt/dataprotection/src/package_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dataprotection/src/package_2022_03/mod.rs
+++ b/services/mgmt/dataprotection/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dataprotection/src/package_2022_04/mod.rs
+++ b/services/mgmt/dataprotection/src/package_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dataprotection/src/package_2022_05/mod.rs
+++ b/services/mgmt/dataprotection/src/package_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datashare/src/package_2018_11_01_preview/mod.rs
+++ b/services/mgmt/datashare/src/package_2018_11_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datashare/src/package_2019_11_01/mod.rs
+++ b/services/mgmt/datashare/src/package_2019_11_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datashare/src/package_2020_09_01/mod.rs
+++ b/services/mgmt/datashare/src/package_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datashare/src/package_2020_10_01_preview/mod.rs
+++ b/services/mgmt/datashare/src/package_2020_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/datashare/src/package_2021_08_01/mod.rs
+++ b/services/mgmt/datashare/src/package_2021_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/deploymentmanager/src/package_2019_11_01_preview/mod.rs
+++ b/services/mgmt/deploymentmanager/src/package_2019_11_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/desktopvirtualization/src/package_2021_04_01_preview/mod.rs
+++ b/services/mgmt/desktopvirtualization/src/package_2021_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/desktopvirtualization/src/package_2021_07/mod.rs
+++ b/services/mgmt/desktopvirtualization/src/package_2021_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/desktopvirtualization/src/package_preview_2021_09/mod.rs
+++ b/services/mgmt/desktopvirtualization/src/package_preview_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/desktopvirtualization/src/package_preview_2022_02/mod.rs
+++ b/services/mgmt/desktopvirtualization/src/package_preview_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/desktopvirtualization/src/package_preview_2022_04/mod.rs
+++ b/services/mgmt/desktopvirtualization/src/package_preview_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/devcenter/src/package_2022_08_01_preview/mod.rs
+++ b/services/mgmt/devcenter/src/package_2022_08_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/developerhub/src/package_preview_2022_04/mod.rs
+++ b/services/mgmt/developerhub/src/package_preview_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/deviceupdate/src/package_2020_03_01_preview/mod.rs
+++ b/services/mgmt/deviceupdate/src/package_2020_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/deviceupdate/src/package_2022_04_01_preview/mod.rs
+++ b/services/mgmt/deviceupdate/src/package_2022_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/deviceupdate/src/package_2022_10_01/mod.rs
+++ b/services/mgmt/deviceupdate/src/package_2022_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/devops/src/package_2019_07_01_preview/mod.rs
+++ b/services/mgmt/devops/src/package_2019_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/devops/src/package_2020_07_13_preview/mod.rs
+++ b/services/mgmt/devops/src/package_2020_07_13_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/devspaces/src/package_2019_04_01/mod.rs
+++ b/services/mgmt/devspaces/src/package_2019_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/devtestlabs/src/package_2015_05_preview/mod.rs
+++ b/services/mgmt/devtestlabs/src/package_2015_05_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/devtestlabs/src/package_2016_05/mod.rs
+++ b/services/mgmt/devtestlabs/src/package_2016_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/devtestlabs/src/package_2018_09/mod.rs
+++ b/services/mgmt/devtestlabs/src/package_2018_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dfp/src/package_2021_02_01_preview/mod.rs
+++ b/services/mgmt/dfp/src/package_2021_02_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/digitaltwins/src/package_2020_03_01_preview/mod.rs
+++ b/services/mgmt/digitaltwins/src/package_2020_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/digitaltwins/src/package_2020_10/mod.rs
+++ b/services/mgmt/digitaltwins/src/package_2020_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/digitaltwins/src/package_2020_12/mod.rs
+++ b/services/mgmt/digitaltwins/src/package_2020_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/digitaltwins/src/package_2021_06_30_preview/mod.rs
+++ b/services/mgmt/digitaltwins/src/package_2021_06_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/digitaltwins/src/package_2022_05/mod.rs
+++ b/services/mgmt/digitaltwins/src/package_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dnc/src/package_2020_08_08_preview/mod.rs
+++ b/services/mgmt/dnc/src/package_2020_08_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dnc/src/package_2021_03_15/mod.rs
+++ b/services/mgmt/dnc/src/package_2021_03_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dns/src/package_2017_09/mod.rs
+++ b/services/mgmt/dns/src/package_2017_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dns/src/package_2017_10/mod.rs
+++ b/services/mgmt/dns/src/package_2017_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dns/src/package_2018_03_preview/mod.rs
+++ b/services/mgmt/dns/src/package_2018_03_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dns/src/package_2018_05/mod.rs
+++ b/services/mgmt/dns/src/package_2018_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dns/src/profile_hybrid_2020_09_01/mod.rs
+++ b/services/mgmt/dns/src/profile_hybrid_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dnsresolver/src/package_2020_04_preview/mod.rs
+++ b/services/mgmt/dnsresolver/src/package_2020_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dnsresolver/src/package_2022_07/mod.rs
+++ b/services/mgmt/dnsresolver/src/package_2022_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/domainservices/src/package_2017_01/mod.rs
+++ b/services/mgmt/domainservices/src/package_2017_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/domainservices/src/package_2017_06/mod.rs
+++ b/services/mgmt/domainservices/src/package_2017_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/domainservices/src/package_2020_01/mod.rs
+++ b/services/mgmt/domainservices/src/package_2020_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/domainservices/src/package_2021_03/mod.rs
+++ b/services/mgmt/domainservices/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/domainservices/src/package_2021_05/mod.rs
+++ b/services/mgmt/domainservices/src/package_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dynatrace/src/package_2021_09_01/mod.rs
+++ b/services/mgmt/dynatrace/src/package_2021_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/dynatrace/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/dynatrace/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/edgeorder/src/package_2020_12_preview/mod.rs
+++ b/services/mgmt/edgeorder/src/package_2020_12_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/edgeorder/src/package_2021_12/mod.rs
+++ b/services/mgmt/edgeorder/src/package_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/edgeorderpartner/src/package_2020_12_preview/mod.rs
+++ b/services/mgmt/edgeorderpartner/src/package_2020_12_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/education/src/package_2021_12_01_preview/mod.rs
+++ b/services/mgmt/education/src/package_2021_12_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/elastic/src/package_2020_07_01/mod.rs
+++ b/services/mgmt/elastic/src/package_2020_07_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/elastic/src/package_2020_07_01_preview/mod.rs
+++ b/services/mgmt/elastic/src/package_2020_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/elastic/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/elastic/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/elastic/src/package_2021_10_01_preview/mod.rs
+++ b/services/mgmt/elastic/src/package_2021_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/elasticsan/src/package_2021_11_20_preview/mod.rs
+++ b/services/mgmt/elasticsan/src/package_2021_11_20_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/engagementfabric/src/package_2018_09_preview/mod.rs
+++ b/services/mgmt/engagementfabric/src/package_2018_09_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/enterpriseknowledgegraph/src/package_2018_12_03/mod.rs
+++ b/services/mgmt/enterpriseknowledgegraph/src/package_2018_12_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventgrid/src/package_2021_10_preview/mod.rs
+++ b/services/mgmt/eventgrid/src/package_2021_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventgrid/src/package_2021_12/mod.rs
+++ b/services/mgmt/eventgrid/src/package_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventgrid/src/package_2022_06/mod.rs
+++ b/services/mgmt/eventgrid/src/package_2022_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventhub/src/package_2021_01_preview/mod.rs
+++ b/services/mgmt/eventhub/src/package_2021_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventhub/src/package_2021_06_preview/mod.rs
+++ b/services/mgmt/eventhub/src/package_2021_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventhub/src/package_2021_11/mod.rs
+++ b/services/mgmt/eventhub/src/package_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventhub/src/package_2022_01_preview/mod.rs
+++ b/services/mgmt/eventhub/src/package_2022_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/eventhub/src/profile_hybrid_2020_09_01/mod.rs
+++ b/services/mgmt/eventhub/src/profile_hybrid_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/extendedlocation/src/package_2021_03_15_preview/mod.rs
+++ b/services/mgmt/extendedlocation/src/package_2021_03_15_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/extendedlocation/src/package_2021_08_15/mod.rs
+++ b/services/mgmt/extendedlocation/src/package_2021_08_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/extendedlocation/src/package_2021_08_31_preview/mod.rs
+++ b/services/mgmt/extendedlocation/src/package_2021_08_31_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/fluidrelay/src/package_2022_02_15/mod.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_02_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/fluidrelay/src/package_2022_04_21/mod.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_04_21/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/fluidrelay/src/package_2022_05_11/mod.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_05_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/fluidrelay/src/package_2022_05_26/mod.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_05_26/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/fluidrelay/src/package_2022_06_01/mod.rs
+++ b/services/mgmt/fluidrelay/src/package_2022_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/frontdoor/src/package_2020_04/mod.rs
+++ b/services/mgmt/frontdoor/src/package_2020_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/frontdoor/src/package_2020_05/mod.rs
+++ b/services/mgmt/frontdoor/src/package_2020_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/frontdoor/src/package_2020_11/mod.rs
+++ b/services/mgmt/frontdoor/src/package_2020_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/frontdoor/src/package_2021_06/mod.rs
+++ b/services/mgmt/frontdoor/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/frontdoor/src/package_2022_05/mod.rs
+++ b/services/mgmt/frontdoor/src/package_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/guestconfiguration/src/package_2018_06_30_preview/mod.rs
+++ b/services/mgmt/guestconfiguration/src/package_2018_06_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/guestconfiguration/src/package_2018_11_20/mod.rs
+++ b/services/mgmt/guestconfiguration/src/package_2018_11_20/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/guestconfiguration/src/package_2020_06_25/mod.rs
+++ b/services/mgmt/guestconfiguration/src/package_2020_06_25/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/guestconfiguration/src/package_2021_01_25/mod.rs
+++ b/services/mgmt/guestconfiguration/src/package_2021_01_25/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/guestconfiguration/src/package_2022_01_25/mod.rs
+++ b/services/mgmt/guestconfiguration/src/package_2022_01_25/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hanaon/src/package_2017_11/mod.rs
+++ b/services/mgmt/hanaon/src/package_2017_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hanaon/src/package_2020_02_07_preview/mod.rs
+++ b/services/mgmt/hanaon/src/package_2020_02_07_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hardwaresecuritymodules/src/package_2018_10/mod.rs
+++ b/services/mgmt/hardwaresecuritymodules/src/package_2018_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hardwaresecuritymodules/src/package_2021_11/mod.rs
+++ b/services/mgmt/hardwaresecuritymodules/src/package_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hdinsight/src/package_2015_03_preview/mod.rs
+++ b/services/mgmt/hdinsight/src/package_2015_03_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hdinsight/src/package_2018_06_preview/mod.rs
+++ b/services/mgmt/hdinsight/src/package_2018_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hdinsight/src/package_2021_06/mod.rs
+++ b/services/mgmt/hdinsight/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthbot/src/package_2020_10_20_preview/mod.rs
+++ b/services/mgmt/healthbot/src/package_2020_10_20_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthbot/src/package_2020_12_08/mod.rs
+++ b/services/mgmt/healthbot/src/package_2020_12_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthbot/src/package_2020_12_08_preview/mod.rs
+++ b/services/mgmt/healthbot/src/package_2020_12_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthbot/src/package_2021_06_10/mod.rs
+++ b/services/mgmt/healthbot/src/package_2021_06_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthbot/src/package_2021_08_24/mod.rs
+++ b/services/mgmt/healthbot/src/package_2021_08_24/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthcareapis/src/package_2021_11/mod.rs
+++ b/services/mgmt/healthcareapis/src/package_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthcareapis/src/package_2022_05/mod.rs
+++ b/services/mgmt/healthcareapis/src/package_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthcareapis/src/package_2022_06/mod.rs
+++ b/services/mgmt/healthcareapis/src/package_2022_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthcareapis/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/healthcareapis/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/healthcareapis/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/healthcareapis/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridcompute/src/package_preview_2021_04/mod.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridcompute/src/package_preview_2021_05/mod.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridcompute/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridcompute/src/package_preview_2021_12/mod.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridcompute/src/package_preview_2022_05/mod.rs
+++ b/services/mgmt/hybridcompute/src/package_preview_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridconnectivity/src/package_2021_10_06_preview/mod.rs
+++ b/services/mgmt/hybridconnectivity/src/package_2021_10_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridconnectivity/src/package_2022_05_01_preview/mod.rs
+++ b/services/mgmt/hybridconnectivity/src/package_2022_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybriddatamanager/src/package_2016_06/mod.rs
+++ b/services/mgmt/hybriddatamanager/src/package_2016_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybriddatamanager/src/package_2019_06/mod.rs
+++ b/services/mgmt/hybriddatamanager/src/package_2019_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridkubernetes/src/package_2020_01_01_preview/mod.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2020_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridkubernetes/src/package_2021_03_01/mod.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2021_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridkubernetes/src/package_2021_04_01_preview/mod.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2021_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridkubernetes/src/package_2021_10_01/mod.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridkubernetes/src/package_2022_05_01_preview/mod.rs
+++ b/services/mgmt/hybridkubernetes/src/package_2022_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridnetwork/src/package_2020_01_01_preview/mod.rs
+++ b/services/mgmt/hybridnetwork/src/package_2020_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridnetwork/src/package_2021_05_01/mod.rs
+++ b/services/mgmt/hybridnetwork/src/package_2021_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/hybridnetwork/src/package_2022_01_01_preview/mod.rs
+++ b/services/mgmt/hybridnetwork/src/package_2022_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/imagebuilder/src/package_2019_02/mod.rs
+++ b/services/mgmt/imagebuilder/src/package_2019_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/imagebuilder/src/package_2020_02/mod.rs
+++ b/services/mgmt/imagebuilder/src/package_2020_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/imagebuilder/src/package_2021_10/mod.rs
+++ b/services/mgmt/imagebuilder/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/imagebuilder/src/package_2022_02/mod.rs
+++ b/services/mgmt/imagebuilder/src/package_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/imagebuilder/src/package_preview_2019_05/mod.rs
+++ b/services/mgmt/imagebuilder/src/package_preview_2019_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/intune/src/package_2015_01_preview/mod.rs
+++ b/services/mgmt/intune/src/package_2015_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/intune/src/package_2015_01_privatepreview/mod.rs
+++ b/services/mgmt/intune/src/package_2015_01_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iotcentral/src/package_2018_09_01/mod.rs
+++ b/services/mgmt/iotcentral/src/package_2018_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iotcentral/src/package_2021_06/mod.rs
+++ b/services/mgmt/iotcentral/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iotcentral/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/iotcentral/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iothub/src/package_preview_2020_07/mod.rs
+++ b/services/mgmt/iothub/src/package_preview_2020_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iothub/src/package_preview_2020_08_31/mod.rs
+++ b/services/mgmt/iothub/src/package_preview_2020_08_31/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iothub/src/package_preview_2021_02/mod.rs
+++ b/services/mgmt/iothub/src/package_preview_2021_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iothub/src/package_preview_2021_03/mod.rs
+++ b/services/mgmt/iothub/src/package_preview_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iothub/src/package_preview_2021_07_02/mod.rs
+++ b/services/mgmt/iothub/src/package_preview_2021_07_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/iotspaces/src/package_2017_10_preview/mod.rs
+++ b/services/mgmt/iotspaces/src/package_2017_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/keyvault/src/package_preview_2021_04/mod.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/keyvault/src/package_preview_2021_04_full/mod.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_04_full/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/keyvault/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/keyvault/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/keyvault/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/keyvault/src/profile_hybrid_2020_09_01/mod.rs
+++ b/services/mgmt/keyvault/src/profile_hybrid_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kubernetesconfiguration/src/package_2022_07/mod.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_2022_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01_15/mod.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2022_01_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kubernetesconfiguration/src/package_preview_2022_04/mod.rs
+++ b/services/mgmt/kubernetesconfiguration/src/package_preview_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kusto/src/schema_2017_09_07_privatepreview/mod.rs
+++ b/services/mgmt/kusto/src/schema_2017_09_07_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kusto/src/schema_2018_09_07_preview/mod.rs
+++ b/services/mgmt/kusto/src/schema_2018_09_07_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kusto/src/schema_2019_01_21/mod.rs
+++ b/services/mgmt/kusto/src/schema_2019_01_21/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kusto/src/schema_2019_05_15/mod.rs
+++ b/services/mgmt/kusto/src/schema_2019_05_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/kusto/src/schema_2019_09_07/mod.rs
+++ b/services/mgmt/kusto/src/schema_2019_09_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/labservices/src/package_2018_10/mod.rs
+++ b/services/mgmt/labservices/src/package_2018_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/labservices/src/package_preview_2021_10/mod.rs
+++ b/services/mgmt/labservices/src/package_preview_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/labservices/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/labservices/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/loadtestservice/src/package_2021_12_01_preview/mod.rs
+++ b/services/mgmt/loadtestservice/src/package_2021_12_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/loadtestservice/src/package_2022_04_15_preview/mod.rs
+++ b/services/mgmt/loadtestservice/src/package_2022_04_15_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/logic/src/package_2018_07_preview/mod.rs
+++ b/services/mgmt/logic/src/package_2018_07_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/logic/src/package_2019_05/mod.rs
+++ b/services/mgmt/logic/src/package_2019_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/logz/src/package_2020_10_01/mod.rs
+++ b/services/mgmt/logz/src/package_2020_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/logz/src/package_2020_10_01_preview/mod.rs
+++ b/services/mgmt/logz/src/package_2020_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/logz/src/package_2022_01_01_preview/mod.rs
+++ b/services/mgmt/logz/src/package_2022_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/m365securityandcompliance/src/package_2021_03_25_preview/mod.rs
+++ b/services/mgmt/m365securityandcompliance/src/package_2021_03_25_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearning/src/package_commitmentplans_2016_05_preview/mod.rs
+++ b/services/mgmt/machinelearning/src/package_commitmentplans_2016_05_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearning/src/package_webservices_2016_05_preview/mod.rs
+++ b/services/mgmt/machinelearning/src/package_webservices_2016_05_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearning/src/package_webservices_2017_01/mod.rs
+++ b/services/mgmt/machinelearning/src/package_webservices_2017_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearning/src/package_workspaces_2016_04/mod.rs
+++ b/services/mgmt/machinelearning/src/package_workspaces_2016_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearning/src/package_workspaces_2019_10/mod.rs
+++ b/services/mgmt/machinelearning/src/package_workspaces_2019_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningcompute/src/package_2017_06_preview/mod.rs
+++ b/services/mgmt/machinelearningcompute/src/package_2017_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningcompute/src/package_2017_08_preview/mod.rs
+++ b/services/mgmt/machinelearningcompute/src/package_2017_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningexperimentation/src/package_2017_05_preview/mod.rs
+++ b/services/mgmt/machinelearningexperimentation/src/package_2017_05_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningservices/src/package_2021_07_01/mod.rs
+++ b/services/mgmt/machinelearningservices/src/package_2021_07_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningservices/src/package_2022_01_01_preview/mod.rs
+++ b/services/mgmt/machinelearningservices/src/package_2022_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningservices/src/package_2022_02_01_preview/mod.rs
+++ b/services/mgmt/machinelearningservices/src/package_2022_02_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningservices/src/package_2022_05_01/mod.rs
+++ b/services/mgmt/machinelearningservices/src/package_2022_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/machinelearningservices/src/package_preview_2020_05/mod.rs
+++ b/services/mgmt/machinelearningservices/src/package_preview_2020_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maintenance/src/package_2021_05/mod.rs
+++ b/services/mgmt/maintenance/src/package_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maintenance/src/package_preview_2020_07/mod.rs
+++ b/services/mgmt/maintenance/src/package_preview_2020_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maintenance/src/package_preview_2021_04/mod.rs
+++ b/services/mgmt/maintenance/src/package_preview_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maintenance/src/package_preview_2021_09/mod.rs
+++ b/services/mgmt/maintenance/src/package_preview_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maintenance/src/package_preview_2022_07/mod.rs
+++ b/services/mgmt/maintenance/src/package_preview_2022_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managednetwork/src/package_2019_06_01_preview/mod.rs
+++ b/services/mgmt/managednetwork/src/package_2019_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managedservices/src/package_2019_04_preview/mod.rs
+++ b/services/mgmt/managedservices/src/package_2019_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managedservices/src/package_2019_06/mod.rs
+++ b/services/mgmt/managedservices/src/package_2019_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managedservices/src/package_2019_09/mod.rs
+++ b/services/mgmt/managedservices/src/package_2019_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managedservices/src/package_2020_02_preview/mod.rs
+++ b/services/mgmt/managedservices/src/package_2020_02_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managedservices/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/managedservices/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managementgroups/src/package_2019_11/mod.rs
+++ b/services/mgmt/managementgroups/src/package_2019_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managementgroups/src/package_2020_02/mod.rs
+++ b/services/mgmt/managementgroups/src/package_2020_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managementgroups/src/package_2020_05/mod.rs
+++ b/services/mgmt/managementgroups/src/package_2020_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managementgroups/src/package_2020_10/mod.rs
+++ b/services/mgmt/managementgroups/src/package_2020_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managementgroups/src/package_2021_04/mod.rs
+++ b/services/mgmt/managementgroups/src/package_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/managementpartner/src/package_2018_02/mod.rs
+++ b/services/mgmt/managementpartner/src/package_2018_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maps/src/package_2018_05/mod.rs
+++ b/services/mgmt/maps/src/package_2018_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maps/src/package_2021_02/mod.rs
+++ b/services/mgmt/maps/src/package_2021_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maps/src/package_preview_2020_02/mod.rs
+++ b/services/mgmt/maps/src/package_preview_2020_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maps/src/package_preview_2021_07/mod.rs
+++ b/services/mgmt/maps/src/package_preview_2021_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/maps/src/package_preview_2021_12/mod.rs
+++ b/services/mgmt/maps/src/package_preview_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mariadb/src/package_2018_06_01/mod.rs
+++ b/services/mgmt/mariadb/src/package_2018_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mariadb/src/package_2018_06_01_preview/mod.rs
+++ b/services/mgmt/mariadb/src/package_2018_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mariadb/src/package_2018_06_01_privatepreview/mod.rs
+++ b/services/mgmt/mariadb/src/package_2018_06_01_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mariadb/src/package_2020_01_01/mod.rs
+++ b/services/mgmt/mariadb/src/package_2020_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mariadb/src/package_2020_01_01_privatepreview/mod.rs
+++ b/services/mgmt/mariadb/src/package_2020_01_01_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplace/src/package_2021_06_01/mod.rs
+++ b/services/mgmt/marketplace/src/package_2021_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplace/src/package_2021_12/mod.rs
+++ b/services/mgmt/marketplace/src/package_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplace/src/package_2022_03/mod.rs
+++ b/services/mgmt/marketplace/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplacecatalog/src/package_2022_02_02/mod.rs
+++ b/services/mgmt/marketplacecatalog/src/package_2022_02_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplacenotifications/src/package_2021_03_03/mod.rs
+++ b/services/mgmt/marketplacenotifications/src/package_2021_03_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplacenotifications/src/package_composite_v1/mod.rs
+++ b/services/mgmt/marketplacenotifications/src/package_composite_v1/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplaceordering/src/package_2015_06_01/mod.rs
+++ b/services/mgmt/marketplaceordering/src/package_2015_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/marketplaceordering/src/package_2021_01_01/mod.rs
+++ b/services/mgmt/marketplaceordering/src/package_2021_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mediaservices/src/package_2020_05/mod.rs
+++ b/services/mgmt/mediaservices/src/package_2020_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mediaservices/src/package_2021_05/mod.rs
+++ b/services/mgmt/mediaservices/src/package_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mediaservices/src/package_2021_06/mod.rs
+++ b/services/mgmt/mediaservices/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mediaservices/src/package_2021_11/mod.rs
+++ b/services/mgmt/mediaservices/src/package_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mediaservices/src/package_account_2021_11/mod.rs
+++ b/services/mgmt/mediaservices/src/package_account_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/migrate/src/package_2018_02/mod.rs
+++ b/services/mgmt/migrate/src/package_2018_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/migrate/src/package_2019_10/mod.rs
+++ b/services/mgmt/migrate/src/package_2019_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/migrate/src/package_2020_01/mod.rs
+++ b/services/mgmt/migrate/src/package_2020_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/migrate/src/package_2020_05/mod.rs
+++ b/services/mgmt/migrate/src/package_2020_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/migrate/src/package_2020_07/mod.rs
+++ b/services/mgmt/migrate/src/package_2020_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/migrateprojects/src/package_2018_09/mod.rs
+++ b/services/mgmt/migrateprojects/src/package_2018_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mobilenetwork/src/package_2022_01_01_preview/mod.rs
+++ b/services/mgmt/mobilenetwork/src/package_2022_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mobilenetwork/src/package_2022_03_01_preview/mod.rs
+++ b/services/mgmt/mobilenetwork/src/package_2022_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mobilenetwork/src/package_2022_04_01_preview/mod.rs
+++ b/services/mgmt/mobilenetwork/src/package_2022_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/monitor/src/package_2019_11/mod.rs
+++ b/services/mgmt/monitor/src/package_2019_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/monitor/src/package_2020_03/mod.rs
+++ b/services/mgmt/monitor/src/package_2020_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/monitor/src/package_2021_04/mod.rs
+++ b/services/mgmt/monitor/src/package_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/msi/src/package_2015_08_31_preview/mod.rs
+++ b/services/mgmt/msi/src/package_2015_08_31_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/msi/src/package_2018_11_30/mod.rs
+++ b/services/mgmt/msi/src/package_2018_11_30/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/msi/src/package_preview_2021_09_30/mod.rs
+++ b/services/mgmt/msi/src/package_preview_2021_09_30/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/msi/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/msi/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mysql/src/package_2020_07_01_preview/mod.rs
+++ b/services/mgmt/mysql/src/package_2020_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mysql/src/package_2020_07_01_privatepreview/mod.rs
+++ b/services/mgmt/mysql/src/package_2020_07_01_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mysql/src/package_flexibleserver_2021_05_01/mod.rs
+++ b/services/mgmt/mysql/src/package_flexibleserver_2021_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mysql/src/package_flexibleserver_2021_05_01_preview/mod.rs
+++ b/services/mgmt/mysql/src/package_flexibleserver_2021_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/mysql/src/package_flexibleserver_2021_12_01_preview/mod.rs
+++ b/services/mgmt/mysql/src/package_flexibleserver_2021_12_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/netapp/src/package_netapp_2021_06_01/mod.rs
+++ b/services/mgmt/netapp/src/package_netapp_2021_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/netapp/src/package_netapp_2021_08_01/mod.rs
+++ b/services/mgmt/netapp/src/package_netapp_2021_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/netapp/src/package_netapp_2021_10_01/mod.rs
+++ b/services/mgmt/netapp/src/package_netapp_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/netapp/src/package_netapp_2022_01_01/mod.rs
+++ b/services/mgmt/netapp/src/package_netapp_2022_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/netapp/src/package_netapp_2022_03_01/mod.rs
+++ b/services/mgmt/netapp/src/package_netapp_2022_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/network/examples/list_azure_service_addresses.rs
+++ b/services/mgmt/network/examples/list_azure_service_addresses.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let location = std::env::args().nth(1).expect("please specify region");
     let credential = Arc::new(AzureCliCredential {});
     let subscription_id = AzureCliCredential::get_subscription()?;
-    let client = azure_mgmt_network::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_network::Client::builder(credential).build();
 
     let response = client.service_tags_client().list(location, subscription_id).into_future().await?;
     for entry in response.values {

--- a/services/mgmt/network/src/package_2021_05/mod.rs
+++ b/services/mgmt/network/src/package_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/network/src/package_2021_08/mod.rs
+++ b/services/mgmt/network/src/package_2021_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/networkfunction/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/networkfunction/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/networkfunction/src/package_2022_05_01/mod.rs
+++ b/services/mgmt/networkfunction/src/package_2022_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/networkfunction/src/package_2022_08_01/mod.rs
+++ b/services/mgmt/networkfunction/src/package_2022_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/nginx/src/package_2021_05_01_preview/mod.rs
+++ b/services/mgmt/nginx/src/package_2021_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/notificationhubs/src/package_2014_09/mod.rs
+++ b/services/mgmt/notificationhubs/src/package_2014_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/notificationhubs/src/package_2016_03/mod.rs
+++ b/services/mgmt/notificationhubs/src/package_2016_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/notificationhubs/src/package_2017_04/mod.rs
+++ b/services/mgmt/notificationhubs/src/package_2017_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/oep/src/package_2021_06_01_preview/mod.rs
+++ b/services/mgmt/oep/src/package_2021_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/oep/src/package_2022_04_04_preview/mod.rs
+++ b/services/mgmt/oep/src/package_2022_04_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/operationalinsights/src/package_2020_03_preview/mod.rs
+++ b/services/mgmt/operationalinsights/src/package_2020_03_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/operationalinsights/src/package_2020_08/mod.rs
+++ b/services/mgmt/operationalinsights/src/package_2020_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/operationalinsights/src/package_2020_10/mod.rs
+++ b/services/mgmt/operationalinsights/src/package_2020_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/operationalinsights/src/package_2021_06/mod.rs
+++ b/services/mgmt/operationalinsights/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/operationalinsights/src/package_2021_12_01_preview/mod.rs
+++ b/services/mgmt/operationalinsights/src/package_2021_12_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/operationsmanagement/src/package_2015_11_preview/mod.rs
+++ b/services/mgmt/operationsmanagement/src/package_2015_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/orbital/src/package_2021_04_04_preview/mod.rs
+++ b/services/mgmt/orbital/src/package_2021_04_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/orbital/src/package_2022_03_01/mod.rs
+++ b/services/mgmt/orbital/src/package_2022_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/peering/src/package_2020_04_01/mod.rs
+++ b/services/mgmt/peering/src/package_2020_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/peering/src/package_2020_10_01/mod.rs
+++ b/services/mgmt/peering/src/package_2020_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/peering/src/package_2021_01_01/mod.rs
+++ b/services/mgmt/peering/src/package_2021_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/peering/src/package_2021_06_01/mod.rs
+++ b/services/mgmt/peering/src/package_2021_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/peering/src/package_2022_01_01/mod.rs
+++ b/services/mgmt/peering/src/package_2022_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/policyinsights/src/package_2020_07/mod.rs
+++ b/services/mgmt/policyinsights/src/package_2020_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/policyinsights/src/package_2020_07_preview/mod.rs
+++ b/services/mgmt/policyinsights/src/package_2020_07_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/policyinsights/src/package_2021_01/mod.rs
+++ b/services/mgmt/policyinsights/src/package_2021_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/policyinsights/src/package_2021_10/mod.rs
+++ b/services/mgmt/policyinsights/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/policyinsights/src/package_2022_03/mod.rs
+++ b/services/mgmt/policyinsights/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/portal/src/package_2015_08_01_preview/mod.rs
+++ b/services/mgmt/portal/src/package_2015_08_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/portal/src/package_2018_10_01_preview/mod.rs
+++ b/services/mgmt/portal/src/package_2018_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/portal/src/package_2019_01_01_preview/mod.rs
+++ b/services/mgmt/portal/src/package_2019_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/portal/src/package_2020_09_01_preview/mod.rs
+++ b/services/mgmt/portal/src/package_2020_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/postgresql/src/package_2021_06_15_privatepreview/mod.rs
+++ b/services/mgmt/postgresql/src/package_2021_06_15_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/postgresql/src/package_flexibleserver_2021_06/mod.rs
+++ b/services/mgmt/postgresql/src/package_flexibleserver_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/postgresql/src/package_flexibleserver_2021_06_preview/mod.rs
+++ b/services/mgmt/postgresql/src/package_flexibleserver_2021_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/postgresql/src/package_flexibleserver_2022_01_preview/mod.rs
+++ b/services/mgmt/postgresql/src/package_flexibleserver_2022_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/postgresql/src/package_flexibleserver_2022_03_privatepreview/mod.rs
+++ b/services/mgmt/postgresql/src/package_flexibleserver_2022_03_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/postgresqlhsc/src/package_2020_10_05_privatepreview/mod.rs
+++ b/services/mgmt/postgresqlhsc/src/package_2020_10_05_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/powerbidedicated/src/package_2017_10_01/mod.rs
+++ b/services/mgmt/powerbidedicated/src/package_2017_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/powerbidedicated/src/package_2021_01_01/mod.rs
+++ b/services/mgmt/powerbidedicated/src/package_2021_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/powerbiembedded/src/package_2016_01/mod.rs
+++ b/services/mgmt/powerbiembedded/src/package_2016_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/powerbiprivatelinks/src/package_2020_06_01/mod.rs
+++ b/services/mgmt/powerbiprivatelinks/src/package_2020_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/powerplatform/src/package_2020_10_30_preview/mod.rs
+++ b/services/mgmt/powerplatform/src/package_2020_10_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/privatedns/src/package_2018_09/mod.rs
+++ b/services/mgmt/privatedns/src/package_2018_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/privatedns/src/package_2020_01/mod.rs
+++ b/services/mgmt/privatedns/src/package_2020_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/privatedns/src/package_2020_06/mod.rs
+++ b/services/mgmt/privatedns/src/package_2020_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/providerhub/src/package_2020_11_20/mod.rs
+++ b/services/mgmt/providerhub/src/package_2020_11_20/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/providerhub/src/package_2021_05_01_preview/mod.rs
+++ b/services/mgmt/providerhub/src/package_2021_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/providerhub/src/package_2021_06_01_preview/mod.rs
+++ b/services/mgmt/providerhub/src/package_2021_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/providerhub/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/providerhub/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/purview/src/package_2020_12_01_preview/mod.rs
+++ b/services/mgmt/purview/src/package_2020_12_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/purview/src/package_2021_07_01/mod.rs
+++ b/services/mgmt/purview/src/package_2021_07_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/quantum/src/package_2019_11_04_preview/mod.rs
+++ b/services/mgmt/quantum/src/package_2019_11_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/quantum/src/package_2022_01_10_preview/mod.rs
+++ b/services/mgmt/quantum/src/package_2022_01_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/quota/src/package_2021_03_15/mod.rs
+++ b/services/mgmt/quota/src/package_2021_03_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/quota/src/package_2021_03_15_preview/mod.rs
+++ b/services/mgmt/quota/src/package_2021_03_15_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recommendationsservice/src/package_2022_02_01/mod.rs
+++ b/services/mgmt/recommendationsservice/src/package_2022_02_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservices/src/package_2022_02/mod.rs
+++ b/services/mgmt/recoveryservices/src/package_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservices/src/package_2022_03/mod.rs
+++ b/services/mgmt/recoveryservices/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservices/src/package_2022_04/mod.rs
+++ b/services/mgmt/recoveryservices/src/package_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservices/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/recoveryservices/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservices/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/recoveryservices/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicesbackup/src/package_2022_02/mod.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicesbackup/src/package_2022_03/mod.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicesbackup/src/package_2022_06_01_preview/mod.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_2022_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2018_12_20/mod.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2018_12_20/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2021_11_15/mod.rs
+++ b/services/mgmt/recoveryservicesbackup/src/package_passivestamp_2021_11_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2021_11/mod.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2021_12/mod.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2022_01/mod.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2022_02/mod.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/recoveryservicessiterecovery/src/package_2022_03/mod.rs
+++ b/services/mgmt/recoveryservicessiterecovery/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redhatopenshift/src/package_2020_04_30/mod.rs
+++ b/services/mgmt/redhatopenshift/src/package_2020_04_30/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redhatopenshift/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/redhatopenshift/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redhatopenshift/src/package_2022_04_01/mod.rs
+++ b/services/mgmt/redhatopenshift/src/package_2022_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redis/src/package_2018_03/mod.rs
+++ b/services/mgmt/redis/src/package_2018_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redis/src/package_2019_07_preview/mod.rs
+++ b/services/mgmt/redis/src/package_2019_07_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redis/src/package_2020_06/mod.rs
+++ b/services/mgmt/redis/src/package_2020_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redis/src/package_2020_12/mod.rs
+++ b/services/mgmt/redis/src/package_2020_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redis/src/package_2021_06/mod.rs
+++ b/services/mgmt/redis/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redisenterprise/src/package_2020_10_01_preview/mod.rs
+++ b/services/mgmt/redisenterprise/src/package_2020_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redisenterprise/src/package_2021_03/mod.rs
+++ b/services/mgmt/redisenterprise/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redisenterprise/src/package_2021_08/mod.rs
+++ b/services/mgmt/redisenterprise/src/package_2021_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redisenterprise/src/package_2022_01/mod.rs
+++ b/services/mgmt/redisenterprise/src/package_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/redisenterprise/src/package_preview_2021_02/mod.rs
+++ b/services/mgmt/redisenterprise/src/package_preview_2021_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/relay/src/package_2016_07/mod.rs
+++ b/services/mgmt/relay/src/package_2016_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/relay/src/package_2017_04/mod.rs
+++ b/services/mgmt/relay/src/package_2017_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/relay/src/package_2018_01_preview/mod.rs
+++ b/services/mgmt/relay/src/package_2018_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/relay/src/package_2021_11_01/mod.rs
+++ b/services/mgmt/relay/src/package_2021_11_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/reservations/src/package_2020_11_preview/mod.rs
+++ b/services/mgmt/reservations/src/package_2020_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/reservations/src/package_2021_07_01/mod.rs
+++ b/services/mgmt/reservations/src/package_2021_07_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/reservations/src/package_2022_03/mod.rs
+++ b/services/mgmt/reservations/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/reservations/src/package_preview_2019_04/mod.rs
+++ b/services/mgmt/reservations/src/package_preview_2019_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/reservations/src/package_preview_2019_07_19/mod.rs
+++ b/services/mgmt/reservations/src/package_preview_2019_07_19/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourceconnector/src/package_2021_10_31_preview/mod.rs
+++ b/services/mgmt/resourceconnector/src/package_2021_10_31_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourceconnector/src/package_2022_04_15_preview/mod.rs
+++ b/services/mgmt/resourceconnector/src/package_2022_04_15_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcegraph/src/package_2021_03/mod.rs
+++ b/services/mgmt/resourcegraph/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcegraph/src/package_preview_2020_04/mod.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2020_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcegraph/src/package_preview_2020_09/mod.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2020_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcegraph/src/package_preview_2021_03/mod.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcegraph/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/resourcegraph/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcehealth/src/package_2017_07/mod.rs
+++ b/services/mgmt/resourcehealth/src/package_2017_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcehealth/src/package_2018_07_01/mod.rs
+++ b/services/mgmt/resourcehealth/src/package_2018_07_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcehealth/src/package_2018_08_preview/mod.rs
+++ b/services/mgmt/resourcehealth/src/package_2018_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcehealth/src/package_2020_05_01/mod.rs
+++ b/services/mgmt/resourcehealth/src/package_2020_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcehealth/src/package_2020_05_01_preview/mod.rs
+++ b/services/mgmt/resourcehealth/src/package_2020_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcemover/src/package_2019_10_01_preview/mod.rs
+++ b/services/mgmt/resourcemover/src/package_2019_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcemover/src/package_2021_01_01/mod.rs
+++ b/services/mgmt/resourcemover/src/package_2021_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resourcemover/src/package_2021_08_01/mod.rs
+++ b/services/mgmt/resourcemover/src/package_2021_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resources/examples/group_create.rs
+++ b/services/mgmt/resources/examples/group_create.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subscription_id = &AzureCliCredential::get_subscription()?;
     let resource_group_name = &env::var("RESOURCE_GROUP_NAME").map_err(|_| "RESOURCE_GROUP_NAME required")?;
     let resource_group_location = env::var("RESOURCE_GROUP_LOCATION").map_err(|_| "RESOURCE_GROUP_LOCATION required")?;
-    let client = azure_mgmt_resources::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_resources::Client::builder(credential).build();
 
     let group = ResourceGroup {
         id: None,

--- a/services/mgmt/resources/src/package_features_2021_07/mod.rs
+++ b/services/mgmt/resources/src/package_features_2021_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resources/src/package_locks_2020_05/mod.rs
+++ b/services/mgmt/resources/src/package_locks_2020_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resources/src/package_policy_2021_06/mod.rs
+++ b/services/mgmt/resources/src/package_policy_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resources/src/package_resources_2021_04/mod.rs
+++ b/services/mgmt/resources/src/package_resources_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/resources/src/package_subscriptions_2021_01/mod.rs
+++ b/services/mgmt/resources/src/package_subscriptions_2021_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/saas/src/package_2018_03_01_beta/mod.rs
+++ b/services/mgmt/saas/src/package_2018_03_01_beta/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/scheduler/src/package_2014_08_preview/mod.rs
+++ b/services/mgmt/scheduler/src/package_2014_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/scheduler/src/package_2016_01/mod.rs
+++ b/services/mgmt/scheduler/src/package_2016_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/scheduler/src/package_2016_03/mod.rs
+++ b/services/mgmt/scheduler/src/package_2016_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/scvmm/src/package_2020_06_05_preview/mod.rs
+++ b/services/mgmt/scvmm/src/package_2020_06_05_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/search/src/package_2019_10_preview/mod.rs
+++ b/services/mgmt/search/src/package_2019_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/search/src/package_2020_03/mod.rs
+++ b/services/mgmt/search/src/package_2020_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/search/src/package_2020_08/mod.rs
+++ b/services/mgmt/search/src/package_2020_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/search/src/package_2020_08_preview/mod.rs
+++ b/services/mgmt/search/src/package_2020_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/search/src/package_2021_04_preview/mod.rs
+++ b/services/mgmt/search/src/package_2021_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/security/src/package_preview_2021_10/mod.rs
+++ b/services/mgmt/security/src/package_preview_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/security/src/package_preview_2021_12/mod.rs
+++ b/services/mgmt/security/src/package_preview_2021_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/security/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/security/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/security/src/package_preview_2022_05/mod.rs
+++ b/services/mgmt/security/src/package_preview_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/security/src/package_preview_2022_07/mod.rs
+++ b/services/mgmt/security/src/package_preview_2022_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/securityandcompliance/src/package_2021_01_11/mod.rs
+++ b/services/mgmt/securityandcompliance/src/package_2021_01_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/securityandcompliance/src/package_2021_03_08/mod.rs
+++ b/services/mgmt/securityandcompliance/src/package_2021_03_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/securityinsights/src/package_preview_2022_01/mod.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/securityinsights/src/package_preview_2022_04/mod.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/securityinsights/src/package_preview_2022_05/mod.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/securityinsights/src/package_preview_2022_06/mod.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/securityinsights/src/package_preview_2022_07/mod.rs
+++ b/services/mgmt/securityinsights/src/package_preview_2022_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/serialconsole/src/package_2018_05/mod.rs
+++ b/services/mgmt/serialconsole/src/package_2018_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicebus/src/package_2018_01_preview/mod.rs
+++ b/services/mgmt/servicebus/src/package_2018_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicebus/src/package_2021_01_preview/mod.rs
+++ b/services/mgmt/servicebus/src/package_2021_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicebus/src/package_2021_06_preview/mod.rs
+++ b/services/mgmt/servicebus/src/package_2021_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicebus/src/package_2021_11/mod.rs
+++ b/services/mgmt/servicebus/src/package_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicebus/src/package_2022_01_preview/mod.rs
+++ b/services/mgmt/servicebus/src/package_2022_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2021_09_privatepreview/mod.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2021_09_privatepreview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2021_11_preview/mod.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2021_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2022_01/mod.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2022_02_preview/mod.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2022_02_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicefabricmanagedclusters/src/package_2022_06_preview/mod.rs
+++ b/services/mgmt/servicefabricmanagedclusters/src/package_2022_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicefabricmesh/src/package_2018_07_01_preview/mod.rs
+++ b/services/mgmt/servicefabricmesh/src/package_2018_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicefabricmesh/src/package_2018_09_01_preview/mod.rs
+++ b/services/mgmt/servicefabricmesh/src/package_2018_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicelinker/src/package_2021_11_01_preview/mod.rs
+++ b/services/mgmt/servicelinker/src/package_2021_11_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicelinker/src/package_2022_01_01_preview/mod.rs
+++ b/services/mgmt/servicelinker/src/package_2022_01_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicelinker/src/package_2022_05_01/mod.rs
+++ b/services/mgmt/servicelinker/src/package_2022_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/servicemap/src/package_2015_11_preview/mod.rs
+++ b/services/mgmt/servicemap/src/package_2015_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/signalr/src/package_2021_04_01_preview/mod.rs
+++ b/services/mgmt/signalr/src/package_2021_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/signalr/src/package_2021_06_01_preview/mod.rs
+++ b/services/mgmt/signalr/src/package_2021_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/signalr/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/signalr/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/signalr/src/package_2021_10_01/mod.rs
+++ b/services/mgmt/signalr/src/package_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/signalr/src/package_2022_02_01/mod.rs
+++ b/services/mgmt/signalr/src/package_2022_02_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/softwareplan/src/package_2019_06_01_preview/mod.rs
+++ b/services/mgmt/softwareplan/src/package_2019_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/softwareplan/src/package_2019_12_01/mod.rs
+++ b/services/mgmt/softwareplan/src/package_2019_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/solutions/src/package_managedapplications_2018_09/mod.rs
+++ b/services/mgmt/solutions/src/package_managedapplications_2018_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/solutions/src/package_managedapplications_2019_07/mod.rs
+++ b/services/mgmt/solutions/src/package_managedapplications_2019_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/solutions/src/package_managedapplications_2020_08/mod.rs
+++ b/services/mgmt/solutions/src/package_managedapplications_2020_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/solutions/src/package_managedapplications_2021_02/mod.rs
+++ b/services/mgmt/solutions/src/package_managedapplications_2021_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/solutions/src/package_managedapplications_2021_07/mod.rs
+++ b/services/mgmt/solutions/src/package_managedapplications_2021_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sql/src/package_composite_v2/mod.rs
+++ b/services/mgmt/sql/src/package_composite_v2/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sql/src/package_composite_v3/mod.rs
+++ b/services/mgmt/sql/src/package_composite_v3/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sql/src/package_composite_v4/mod.rs
+++ b/services/mgmt/sql/src/package_composite_v4/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sql/src/package_composite_v5/mod.rs
+++ b/services/mgmt/sql/src/package_composite_v5/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sql/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/sql/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sqlvirtualmachine/src/package_2017_03_01_preview/mod.rs
+++ b/services/mgmt/sqlvirtualmachine/src/package_2017_03_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sqlvirtualmachine/src/package_2022_02/mod.rs
+++ b/services/mgmt/sqlvirtualmachine/src/package_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sqlvirtualmachine/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/sqlvirtualmachine/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/sqlvirtualmachine/src/package_preview_2022_02/mod.rs
+++ b/services/mgmt/sqlvirtualmachine/src/package_preview_2022_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/stack/src/package_2016_01/mod.rs
+++ b/services/mgmt/stack/src/package_2016_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/stack/src/package_2017_06_01/mod.rs
+++ b/services/mgmt/stack/src/package_2017_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/stack/src/package_2022_06/mod.rs
+++ b/services/mgmt/stack/src/package_2022_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/stack/src/package_preview_2020_06/mod.rs
+++ b/services/mgmt/stack/src/package_preview_2020_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storage/examples/storage_account_list.rs
+++ b/services/mgmt/storage/examples/storage_account_list.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let credential = Arc::new(AzureCliCredential {});
     let subscription_id = AzureCliCredential::get_subscription()?;
-    let client = azure_mgmt_storage::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_storage::Client::builder(credential).build();
 
     let mut count = 0;
     let mut stream = client.storage_accounts_client().list(subscription_id).into_stream();

--- a/services/mgmt/storage/examples/storage_containers_list.rs
+++ b/services/mgmt/storage/examples/storage_containers_list.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let credential = Arc::new(AzureCliCredential {});
     let subscription_id = AzureCliCredential::get_subscription()?;
-    let client = azure_mgmt_storage::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_storage::Client::builder(credential).build();
 
     let group = std::env::args().nth(1).expect("please specify resource group");
     let account = std::env::args().nth(2).expect("please specify account");

--- a/services/mgmt/storage/src/package_2021_04/mod.rs
+++ b/services/mgmt/storage/src/package_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storage/src/package_2021_06/mod.rs
+++ b/services/mgmt/storage/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storage/src/package_2021_08/mod.rs
+++ b/services/mgmt/storage/src/package_2021_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storage/src/package_2021_09/mod.rs
+++ b/services/mgmt/storage/src/package_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storage/src/profile_hybrid_2020_09_01/mod.rs
+++ b/services/mgmt/storage/src/profile_hybrid_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagecache/src/package_2021_03/mod.rs
+++ b/services/mgmt/storagecache/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagecache/src/package_2021_05/mod.rs
+++ b/services/mgmt/storagecache/src/package_2021_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagecache/src/package_2021_09/mod.rs
+++ b/services/mgmt/storagecache/src/package_2021_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagecache/src/package_2022_01/mod.rs
+++ b/services/mgmt/storagecache/src/package_2022_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagecache/src/package_2022_05/mod.rs
+++ b/services/mgmt/storagecache/src/package_2022_05/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storageimportexport/src/package_2016_11/mod.rs
+++ b/services/mgmt/storageimportexport/src/package_2016_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storageimportexport/src/package_2020_08/mod.rs
+++ b/services/mgmt/storageimportexport/src/package_2020_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storageimportexport/src/package_preview_2021_01/mod.rs
+++ b/services/mgmt/storageimportexport/src/package_preview_2021_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagemover/src/package_2022_07_01_preview/mod.rs
+++ b/services/mgmt/storagemover/src/package_2022_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagepool/src/package_2020_03_15_preview/mod.rs
+++ b/services/mgmt/storagepool/src/package_2020_03_15_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagepool/src/package_2021_04_01_preview/mod.rs
+++ b/services/mgmt/storagepool/src/package_2021_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagepool/src/package_2021_08_01/mod.rs
+++ b/services/mgmt/storagepool/src/package_2021_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagesync/src/package_2019_03_01/mod.rs
+++ b/services/mgmt/storagesync/src/package_2019_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagesync/src/package_2019_06_01/mod.rs
+++ b/services/mgmt/storagesync/src/package_2019_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagesync/src/package_2019_10_01/mod.rs
+++ b/services/mgmt/storagesync/src/package_2019_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagesync/src/package_2020_03_01/mod.rs
+++ b/services/mgmt/storagesync/src/package_2020_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storagesync/src/package_2020_09_01/mod.rs
+++ b/services/mgmt/storagesync/src/package_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storsimple1200series/src/package_2016_10/mod.rs
+++ b/services/mgmt/storsimple1200series/src/package_2016_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/storsimple8000series/src/package_2017_06/mod.rs
+++ b/services/mgmt/storsimple8000series/src/package_2017_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/streamanalytics/src/package_2021_10_preview/mod.rs
+++ b/services/mgmt/streamanalytics/src/package_2021_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/streamanalytics/src/package_pure_2016_03/mod.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2016_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/streamanalytics/src/package_pure_2017_04_preview/mod.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2017_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/streamanalytics/src/package_pure_2020_03/mod.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2020_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/streamanalytics/src/package_pure_2020_03_preview/mod.rs
+++ b/services/mgmt/streamanalytics/src/package_pure_2020_03_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/subscription/src/package_2019_03_preview/mod.rs
+++ b/services/mgmt/subscription/src/package_2019_03_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/subscription/src/package_2019_10_preview/mod.rs
+++ b/services/mgmt/subscription/src/package_2019_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/subscription/src/package_2020_01/mod.rs
+++ b/services/mgmt/subscription/src/package_2020_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/subscription/src/package_2020_09/mod.rs
+++ b/services/mgmt/subscription/src/package_2020_09/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/subscription/src/package_2021_10/mod.rs
+++ b/services/mgmt/subscription/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/support/src/package_2019_05_preview/mod.rs
+++ b/services/mgmt/support/src/package_2019_05_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/support/src/package_2020_04/mod.rs
+++ b/services/mgmt/support/src/package_2020_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/support/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/support/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/synapse/src/package_composite_v1/mod.rs
+++ b/services/mgmt/synapse/src/package_composite_v1/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/synapse/src/package_composite_v2/mod.rs
+++ b/services/mgmt/synapse/src/package_composite_v2/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/synapse/src/package_kusto_pool_2021_04_preview/mod.rs
+++ b/services/mgmt/synapse/src/package_kusto_pool_2021_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/synapse/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/synapse/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/synapse/src/package_sqlgen3_2020_04_01_preview/mod.rs
+++ b/services/mgmt/synapse/src/package_sqlgen3_2020_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/testbase/src/package_2020_12_16_preview/mod.rs
+++ b/services/mgmt/testbase/src/package_2020_12_16_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/testbase/src/package_2022_04_01_preview/mod.rs
+++ b/services/mgmt/testbase/src/package_2022_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/timeseriesinsights/src/package_2017_11_15/mod.rs
+++ b/services/mgmt/timeseriesinsights/src/package_2017_11_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/timeseriesinsights/src/package_2018_08_preview/mod.rs
+++ b/services/mgmt/timeseriesinsights/src/package_2018_08_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/timeseriesinsights/src/package_2020_05_15/mod.rs
+++ b/services/mgmt/timeseriesinsights/src/package_2020_05_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/timeseriesinsights/src/package_preview_2021_03/mod.rs
+++ b/services/mgmt/timeseriesinsights/src/package_preview_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/timeseriesinsights/src/package_preview_2021_06/mod.rs
+++ b/services/mgmt/timeseriesinsights/src/package_preview_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/trafficmanager/src/package_2017_09_preview/mod.rs
+++ b/services/mgmt/trafficmanager/src/package_2017_09_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/trafficmanager/src/package_2018_02/mod.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/trafficmanager/src/package_2018_03/mod.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/trafficmanager/src/package_2018_04/mod.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/trafficmanager/src/package_2018_08/mod.rs
+++ b/services/mgmt/trafficmanager/src/package_2018_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vi/src/package_2021_10_18_preview/mod.rs
+++ b/services/mgmt/vi/src/package_2021_10_18_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vi/src/package_2021_10_27_preview/mod.rs
+++ b/services/mgmt/vi/src/package_2021_10_27_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vi/src/package_2021_11_10_preview/mod.rs
+++ b/services/mgmt/vi/src/package_2021_11_10_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vi/src/package_2022_04_13_preview/mod.rs
+++ b/services/mgmt/vi/src/package_2022_04_13_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vi/src/package_2022_08_01/mod.rs
+++ b/services/mgmt/vi/src/package_2022_08_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/videoanalyzer/src/package_2021_05_01_preview/mod.rs
+++ b/services/mgmt/videoanalyzer/src/package_2021_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/videoanalyzer/src/package_preview_2021_11/mod.rs
+++ b/services/mgmt/videoanalyzer/src/package_preview_2021_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/visualstudio/src/package_2014_04_preview/mod.rs
+++ b/services/mgmt/visualstudio/src/package_2014_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vmware/examples/private_cloud_list.rs
+++ b/services/mgmt/vmware/examples/private_cloud_list.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subscription_id = AzureCliCredential::get_subscription()?;
     let credential = Arc::new(AzureCliCredential {});
-    let client = azure_mgmt_vmware::ClientBuilder::new(credential).build();
+    let client = azure_mgmt_vmware::Client::builder(credential).build();
 
     let mut count = 0;
     let mut clouds = client.private_clouds_client().list_in_subscription(subscription_id).into_stream();

--- a/services/mgmt/vmware/src/package_2020_03_20/mod.rs
+++ b/services/mgmt/vmware/src/package_2020_03_20/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vmware/src/package_2021_06_01/mod.rs
+++ b/services/mgmt/vmware/src/package_2021_06_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vmware/src/package_2021_12_01/mod.rs
+++ b/services/mgmt/vmware/src/package_2021_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/vmwarecloudsimple/src/package_2019_04_01/mod.rs
+++ b/services/mgmt/vmwarecloudsimple/src/package_2019_04_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/web/src/package_2021_01/mod.rs
+++ b/services/mgmt/web/src/package_2021_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/web/src/package_2021_01_15/mod.rs
+++ b/services/mgmt/web/src/package_2021_01_15/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/web/src/package_2021_02/mod.rs
+++ b/services/mgmt/web/src/package_2021_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/web/src/package_2021_03/mod.rs
+++ b/services/mgmt/web/src/package_2021_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/web/src/package_2022_03/mod.rs
+++ b/services/mgmt/web/src/package_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/webpubsub/src/package_2021_04_01_preview/mod.rs
+++ b/services/mgmt/webpubsub/src/package_2021_04_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/webpubsub/src/package_2021_06_01_preview/mod.rs
+++ b/services/mgmt/webpubsub/src/package_2021_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/webpubsub/src/package_2021_09_01_preview/mod.rs
+++ b/services/mgmt/webpubsub/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/webpubsub/src/package_2021_10_01/mod.rs
+++ b/services/mgmt/webpubsub/src/package_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/windowsesu/src/package_2019_09_16_preview/mod.rs
+++ b/services/mgmt/windowsesu/src/package_2019_09_16_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/windowsiot/src/package_2018_02_preview/mod.rs
+++ b/services/mgmt/windowsiot/src/package_2018_02_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/windowsiot/src/package_2019_06/mod.rs
+++ b/services/mgmt/windowsiot/src/package_2019_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/workloadmonitor/src/package_2018_08_31_preview/mod.rs
+++ b/services/mgmt/workloadmonitor/src/package_2018_08_31_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/workloadmonitor/src/package_2020_01_13_preview/mod.rs
+++ b/services/mgmt/workloadmonitor/src/package_2020_01_13_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/mgmt/workloads/src/package_2021_12_01_preview/mod.rs
+++ b/services/mgmt/workloads/src/package_2021_12_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/appconfiguration/src/package_2019_07/mod.rs
+++ b/services/svc/appconfiguration/src/package_2019_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/applicationinsights/examples/query.rs
+++ b/services/svc/applicationinsights/examples/query.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let endpoint = format!("{}/v1", ENDPOINT);
     let credential = Arc::new(AzureCliCredential {});
-    let client = azure_svc_applicationinsights::ClientBuilder::new(credential)
+    let client = azure_svc_applicationinsights::Client::builder(credential)
         .endpoint(endpoint)
         .build();
 

--- a/services/svc/applicationinsights/src/v1/mod.rs
+++ b/services/svc/applicationinsights/src/v1/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://api.applicationinsights.io/v1";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/attestation/src/package_2018_09_01/mod.rs
+++ b/services/svc/attestation/src/package_2018_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/attestation/src/package_2020_10_01/mod.rs
+++ b/services/svc/attestation/src/package_2020_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/batch/examples/create_task.rs
+++ b/services/svc/batch/examples/create_task.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let endpoint = format!("https://{}.{}.batch.azure.com", account_name, region);
     let scopes = &["https://batch.core.windows.net/"];
     let credential = Arc::new(AzureCliCredential {});
-    let client = azure_svc_batch::ClientBuilder::new(credential)
+    let client = azure_svc_batch::Client::builder(credential)
         .endpoint(endpoint)
         .scopes(scopes)
         .build();

--- a/services/svc/batch/examples/list_jobs.rs
+++ b/services/svc/batch/examples/list_jobs.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let endpoint = format!("https://{}.{}.batch.azure.com", account_name, region);
     let scopes = &["https://batch.core.windows.net/"];
     let credential = Arc::new(AzureCliCredential {});
-    let client = azure_svc_batch::ClientBuilder::new(credential)
+    let client = azure_svc_batch::Client::builder(credential)
         .endpoint(endpoint)
         .scopes(scopes)
         .build();

--- a/services/svc/batch/examples/list_pools.rs
+++ b/services/svc/batch/examples/list_pools.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let endpoint = format!("https://{}.{}.batch.azure.com", account_name, region);
     let scopes = &["https://batch.core.windows.net/"];
     let credential = Arc::new(AzureCliCredential {});
-    let client = azure_svc_batch::ClientBuilder::new(credential)
+    let client = azure_svc_batch::Client::builder(credential)
         .endpoint(endpoint)
         .scopes(scopes)
         .build();

--- a/services/svc/batch/src/package_2019_08_10_0/mod.rs
+++ b/services/svc/batch/src/package_2019_08_10_0/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/batch/src/package_2020_03_11_0/mod.rs
+++ b/services/svc/batch/src/package_2020_03_11_0/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/batch/src/package_2020_09_12_0/mod.rs
+++ b/services/svc/batch/src/package_2020_09_12_0/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/batch/src/package_2021_06_14_0/mod.rs
+++ b/services/svc/batch/src/package_2021_06_14_0/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/batch/src/package_2022_01_15_0/mod.rs
+++ b/services/svc/batch/src/package_2022_01_15_0/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/blobstorage/src/package_2020_10/mod.rs
+++ b/services/svc/blobstorage/src/package_2020_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/blobstorage/src/package_2020_12/mod.rs
+++ b/services/svc/blobstorage/src/package_2020_12/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/blobstorage/src/package_2021_02/mod.rs
+++ b/services/svc/blobstorage/src/package_2021_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/blobstorage/src/package_2021_04/mod.rs
+++ b/services/svc/blobstorage/src/package_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/blobstorage/src/package_2021_08/mod.rs
+++ b/services/svc/blobstorage/src/package_2021_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/containerregistry/src/package_2018_08/mod.rs
+++ b/services/svc/containerregistry/src/package_2018_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://acrapi.azurecr-test.io";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/containerregistry/src/package_2019_07/mod.rs
+++ b/services/svc/containerregistry/src/package_2019_07/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/containerregistry/src/package_2019_08/mod.rs
+++ b/services/svc/containerregistry/src/package_2019_08/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/cosmosdb/src/package_2019_02/mod.rs
+++ b/services/svc/cosmosdb/src/package_2019_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/datalakeanalytics/src/package_catalog_2016_11/mod.rs
+++ b/services/svc/datalakeanalytics/src/package_catalog_2016_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/datalakeanalytics/src/package_job_2015_11_preview/mod.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2015_11_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/datalakeanalytics/src/package_job_2016_03_preview/mod.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2016_03_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/datalakeanalytics/src/package_job_2016_11/mod.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2016_11/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/datalakeanalytics/src/package_job_2017_09_preview/mod.rs
+++ b/services/svc/datalakeanalytics/src/package_job_2017_09_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/deviceprovisioningservices/src/package_2021_10_01/mod.rs
+++ b/services/svc/deviceprovisioningservices/src/package_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://your-dps.azure-devices-provisioning.net";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/deviceupdate/src/package_2020_09_01/mod.rs
+++ b/services/svc/deviceupdate/src/package_2020_09_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/deviceupdate/src/package_2021_06_01_preview/mod.rs
+++ b/services/svc/deviceupdate/src/package_2021_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/deviceupdate/src/package_2022_07_01_preview/mod.rs
+++ b/services/svc/deviceupdate/src/package_2022_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/digitaltwins/src/package_2020_05_31_preview/mod.rs
+++ b/services/svc/digitaltwins/src/package_2020_05_31_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://digitaltwins-name.digitaltwins.azure.net";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/digitaltwins/src/package_2020_10_31/mod.rs
+++ b/services/svc/digitaltwins/src/package_2020_10_31/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://digitaltwins-hostname";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/digitaltwins/src/package_2021_06_30_preview/mod.rs
+++ b/services/svc/digitaltwins/src/package_2021_06_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://digitaltwins-hostname";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/digitaltwins/src/package_2022_05_31/mod.rs
+++ b/services/svc/digitaltwins/src/package_2022_05_31/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://digitaltwins-hostname";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/eventgrid/src/package_2018_01/mod.rs
+++ b/services/svc/eventgrid/src/package_2018_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/filestorage/src/package_2020_10/mod.rs
+++ b/services/svc/filestorage/src/package_2020_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/filestorage/src/package_2021_02/mod.rs
+++ b/services/svc/filestorage/src/package_2021_02/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/filestorage/src/package_2021_04/mod.rs
+++ b/services/svc/filestorage/src/package_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/filestorage/src/package_2021_06/mod.rs
+++ b/services/svc/filestorage/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/graphrbac/src/v1_6/mod.rs
+++ b/services/svc/graphrbac/src/v1_6/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://graph.windows.net";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/imds/src/package_2021_01_01/mod.rs
+++ b/services/svc/imds/src/package_2021_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/imds/src/package_2021_02_01/mod.rs
+++ b/services/svc/imds/src/package_2021_02_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/imds/src/package_2021_03_01/mod.rs
+++ b/services/svc/imds/src/package_2021_03_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/imds/src/package_2021_05_01/mod.rs
+++ b/services/svc/imds/src/package_2021_05_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/imds/src/package_2021_10_01/mod.rs
+++ b/services/svc/imds/src/package_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/iotcentral/src/package_1_1_preview/mod.rs
+++ b/services/svc/iotcentral/src/package_1_1_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/iotcentral/src/package_1_2_preview/mod.rs
+++ b/services/svc/iotcentral/src/package_1_2_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/iotcentral/src/package_2021_04_30_preview/mod.rs
+++ b/services/svc/iotcentral/src/package_2021_04_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/iotcentral/src/package_2022_05_31/mod.rs
+++ b/services/svc/iotcentral/src/package_2022_05_31/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/iotcentral/src/package_2022_06_30_preview/mod.rs
+++ b/services/svc/iotcentral/src/package_2022_06_30_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/keyvault/examples/create_key.rs
+++ b/services/svc/keyvault/examples/create_key.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let key_name = std::env::args().nth(2).expect("please specify the name of the key to create");
     let endpoint = format!("https://{}.vault.azure.net", keyvault_name);
     let scopes = &["https://vault.azure.net"];
-    let client = azure_svc_keyvault::ClientBuilder::new(credential)
+    let client = azure_svc_keyvault::Client::builder(credential)
         .endpoint(endpoint)
         .scopes(scopes)
         .build();

--- a/services/svc/keyvault/src/package_7_1_preview/mod.rs
+++ b/services/svc/keyvault/src/package_7_1_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/keyvault/src/package_7_2/mod.rs
+++ b/services/svc/keyvault/src/package_7_2/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/keyvault/src/package_7_2_preview/mod.rs
+++ b/services/svc/keyvault/src/package_7_2_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/keyvault/src/package_7_3/mod.rs
+++ b/services/svc/keyvault/src/package_7_3/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/keyvault/src/package_preview_7_3_preview/mod.rs
+++ b/services/svc/keyvault/src/package_preview_7_3_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/loadtestservice/src/package_2021_07_01_preview/mod.rs
+++ b/services/svc/loadtestservice/src/package_2021_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/loadtestservice/src/package_2022_06_01_preview/mod.rs
+++ b/services/svc/loadtestservice/src/package_2022_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/marketplacecatalog/src/package_2021_10_01/mod.rs
+++ b/services/svc/marketplacecatalog/src/package_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://catalogapi.azure.com";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/mixedreality/src/package_2021_01_01/mod.rs
+++ b/services/svc/mixedreality/src/package_2021_01_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/monitor/src/package_2018_09_preview/mod.rs
+++ b/services/svc/monitor/src/package_2018_09_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://monitoring.azure.com";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/operationalinsights/src/v1/mod.rs
+++ b/services/svc/operationalinsights/src/v1/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://api.loganalytics.io/v1";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/operationalinsights/src/v20171001/mod.rs
+++ b/services/svc/operationalinsights/src/v20171001/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/operationalinsights/src/v20210519/mod.rs
+++ b/services/svc/operationalinsights/src/v20210519/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://api.loganalytics.io/v1";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/purview/src/package_2021_07_01_preview/mod.rs
+++ b/services/svc/purview/src/package_2021_07_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/purview/src/package_2021_09_01_preview/mod.rs
+++ b/services/svc/purview/src/package_2021_09_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/purview/src/package_2021_10_01_preview/mod.rs
+++ b/services/svc/purview/src/package_2021_10_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://purview.azure.com/scan";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/purview/src/package_2022_02_01_preview/mod.rs
+++ b/services/svc/purview/src/package_2022_02_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://purview.azure.com/scan";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/purview/src/package_preview_2022_03/mod.rs
+++ b/services/svc/purview/src/package_preview_2022_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/quantum/src/package_2019_11_04_preview/mod.rs
+++ b/services/svc/quantum/src/package_2019_11_04_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://quantum.azure.com";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/quantum/src/package_2021_05_06_preview/mod.rs
+++ b/services/svc/quantum/src/package_2021_05_06_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://quantum.azure.com";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/quantum/src/package_2021_11_01_preview/mod.rs
+++ b/services/svc/quantum/src/package_2021_11_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://quantum.azure.com";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/queuestorage/src/package_2018_03/mod.rs
+++ b/services/svc/queuestorage/src/package_2018_03/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/schemaregistry/src/package_2021_10/mod.rs
+++ b/services/svc/schemaregistry/src/package_2021_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/servicefabric/src/v7_1/mod.rs
+++ b/services/svc/servicefabric/src/v7_1/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/servicefabric/src/v7_2/mod.rs
+++ b/services/svc/servicefabric/src/v7_2/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/servicefabric/src/v8_0/mod.rs
+++ b/services/svc/servicefabric/src/v8_0/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/servicefabric/src/v8_1/mod.rs
+++ b/services/svc/servicefabric/src/v8_1/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/servicefabric/src/v8_2/mod.rs
+++ b/services/svc/servicefabric/src/v8_2/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/storagedatalake/src/package_2020_06/mod.rs
+++ b/services/svc/storagedatalake/src/package_2020_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/storagedatalake/src/package_2020_10/mod.rs
+++ b/services/svc/storagedatalake/src/package_2020_10/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/storagedatalake/src/package_2021_04/mod.rs
+++ b/services/svc/storagedatalake/src/package_2021_04/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/storagedatalake/src/package_2021_06/mod.rs
+++ b/services/svc/storagedatalake/src/package_2021_06/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/synapse/src/package_spark_2019_11_01_preview/mod.rs
+++ b/services/svc/synapse/src/package_spark_2019_11_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/synapse/src/package_spark_2020_12_01/mod.rs
+++ b/services/svc/synapse/src/package_spark_2020_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/synapse/src/package_vnet_2019_06_01_preview/mod.rs
+++ b/services/svc/synapse/src/package_vnet_2019_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/synapse/src/package_vnet_2020_12_01/mod.rs
+++ b/services/svc/synapse/src/package_vnet_2020_12_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/synapse/src/package_vnet_2021_06_01_preview/mod.rs
+++ b/services/svc/synapse/src/package_vnet_2021_06_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/timeseriesinsights/src/package_2020_07_31/mod.rs
+++ b/services/svc/timeseriesinsights/src/package_2020_07_31/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/videoanalyzer/src/package_ava_edge_1_0_0_preview/mod.rs
+++ b/services/svc/videoanalyzer/src/package_ava_edge_1_0_0_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/videoanalyzer/src/package_preview_1_1_0/mod.rs
+++ b/services/svc/videoanalyzer/src/package_preview_1_1_0/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/webpubsub/src/package_2021_05_01_preview/mod.rs
+++ b/services/svc/webpubsub/src/package_2021_05_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/webpubsub/src/package_2021_08_01_preview/mod.rs
+++ b/services/svc/webpubsub/src/package_2021_08_01_preview/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );

--- a/services/svc/webpubsub/src/package_2021_10_01/mod.rs
+++ b/services/svc/webpubsub/src/package_2021_10_01/mod.rs
@@ -15,28 +15,50 @@ pub struct ClientBuilder {
     credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
     endpoint: Option<String>,
     scopes: Option<Vec<String>>,
+    options: azure_core::ClientOptions,
 }
 pub const DEFAULT_ENDPOINT: &str = azure_core::resource_manager_endpoint::AZURE_PUBLIC_CLOUD;
 impl ClientBuilder {
+    #[doc = "Create a new instance of `ClientBuilder`."]
+    #[must_use]
     pub fn new(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> Self {
         Self {
             credential,
             endpoint: None,
             scopes: None,
+            options: azure_core::ClientOptions::default(),
         }
     }
+    #[doc = "Set the endpoint."]
+    #[must_use]
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
     }
+    #[doc = "Set the scopes."]
+    #[must_use]
     pub fn scopes(mut self, scopes: &[&str]) -> Self {
         self.scopes = Some(scopes.iter().map(|scope| (*scope).to_owned()).collect());
         self
     }
+    #[doc = "Set the retry options."]
+    #[must_use]
+    pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+        self.options = self.options.retry(retry);
+        self
+    }
+    #[doc = "Set the transport options."]
+    #[must_use]
+    pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+        self.options = self.options.transport(transport);
+        self
+    }
+    #[doc = "Convert the builder into a `Client` instance."]
+    #[must_use]
     pub fn build(self) -> Client {
         let endpoint = self.endpoint.unwrap_or_else(|| DEFAULT_ENDPOINT.to_owned());
         let scopes = self.scopes.unwrap_or_else(|| vec![format!("{}/", endpoint)]);
-        Client::new(endpoint, self.credential, scopes)
+        Client::new(endpoint, self.credential, scopes, self.options)
     }
 }
 impl Client {
@@ -53,16 +75,24 @@ impl Client {
         let mut context = azure_core::Context::default();
         self.pipeline.send(&mut context, request).await
     }
+    #[doc = "Create a new `ClientBuilder`."]
+    #[must_use]
+    pub fn builder(credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>) -> ClientBuilder {
+        ClientBuilder::new(credential)
+    }
+    #[doc = "Create a new `Client`."]
+    #[must_use]
     pub fn new(
         endpoint: impl Into<String>,
         credential: std::sync::Arc<dyn azure_core::auth::TokenCredential>,
         scopes: Vec<String>,
+        options: azure_core::ClientOptions,
     ) -> Self {
         let endpoint = endpoint.into();
         let pipeline = azure_core::Pipeline::new(
             option_env!("CARGO_PKG_NAME"),
             option_env!("CARGO_PKG_VERSION"),
-            azure_core::ClientOptions::default(),
+            options,
             Vec::new(),
             Vec::new(),
         );


### PR DESCRIPTION
This follows #964 for how to set the retry and transport options in the services. It also follows #964 by adding a `Client::builder`.