### PR TITLE
allow wasm32 for `azure_identity`

### DIFF
--- a/sdk/identity/src/lib.rs
+++ b/sdk/identity/src/lib.rs
@@ -42,6 +42,7 @@
 //!
 //! This crate also includes utilities for handling refresh tokens and accessing token credentials from many different sources.
 
+#[cfg(feature = "enable_reqwest")]
 pub mod authorization_code_flow;
 pub mod client_credentials_flow;
 #[cfg(feature = "development")]

--- a/sdk/identity/src/token_credentials/mod.rs
+++ b/sdk/identity/src/token_credentials/mod.rs
@@ -9,8 +9,10 @@ mod auto_refreshing_credentials;
 mod azure_cli_credentials;
 #[cfg(feature = "client_certificate")]
 mod client_certificate_credentials;
+#[cfg(feature = "enable_reqwest")]
 mod client_secret_credentials;
 mod default_credentials;
+#[cfg(feature = "enable_reqwest")]
 mod environment_credentials;
 mod imds_managed_identity_credentials;
 
@@ -18,7 +20,9 @@ pub use auto_refreshing_credentials::*;
 pub use azure_cli_credentials::*;
 #[cfg(feature = "client_certificate")]
 pub use client_certificate_credentials::*;
+#[cfg(feature = "enable_reqwest")]
 pub use client_secret_credentials::*;
 pub use default_credentials::*;
+#[cfg(feature = "enable_reqwest")]
 pub use environment_credentials::*;
 pub use imds_managed_identity_credentials::*;

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -38,7 +38,7 @@ oauth2 = { version = "4.0.0", default-features = false }
 mock_transport = { path = "../../eng/test/mock_transport" }
 
 [features]
-default = ["enable_reqwest", "azure_identity/default"]
+default = ["enable_reqwest"]
 test_e2e = []
 azurite_workaround = []
 enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -32,7 +32,7 @@ url = "2.2"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
-azure_identity = { path = "../identity", default_features = false }
+azure_identity = { path = "../identity" }
 reqwest = "0.11"
 oauth2 = { version = "4.0.0", default-features = false }
 mock_transport = { path = "../../eng/test/mock_transport" }

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -32,7 +32,7 @@ url = "2.2"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
-azure_identity = { path = "../identity" }
+azure_identity = { path = "../identity", default_features = false }
 reqwest = "0.11"
 oauth2 = { version = "4.0.0", default-features = false }
 mock_transport = { path = "../../eng/test/mock_transport" }

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.4" }
-azure_identity = { path = "../identity", default_features = false }
 azure_storage = { path = "../storage", version = "0.5", default_features = false }
 base64 = "0.13"
 bytes = "1.0"
@@ -30,11 +29,12 @@ uuid = { version = "1.0", features = ["v4"] }
 url = "2.2"
 
 [dev-dependencies]
+azure_identity = { path = "../identity", default_features = false }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 mock_transport = { path = "../../eng/test/mock_transport" }
 
 [features]
 default = ["enable_reqwest"]
 test_e2e = []
-enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest", "azure_identity/enable_reqwest"]
+enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "1.0", features = ["v4"] }
 url = "2.2"
 
 [dev-dependencies]
-azure_identity = { path = "../identity", default_features = false }
+azure_identity = { path = "../identity" }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 mock_transport = { path = "../../eng/test/mock_transport" }
 

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "1.0", features = ["v4"] }
 url = "2.2"
 
 [dev-dependencies]
-azure_identity = { path = "../identity" }
+azure_identity = { path = "../identity", default_features = false }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 mock_transport = { path = "../../eng/test/mock_transport" }
 


### PR DESCRIPTION
This makes all of these checks to work:

- cargo check --target=wasm32-unknown-unknown --no-default-features
- cargo check --tests --features test_e2e --manifest-path sdk/storage_blobs/Cargo.toml
- cargo check --tests --features test_e2e --manifest-path sdk/storage_datalake/Cargo.toml

The storage_blobs & storage_datalake dependency changes were included in yesterday's release.