### PR TITLE
Always `Send` Futures

### DIFF
--- a/eng/test/mock_transport/src/player_policy.rs
+++ b/eng/test/mock_transport/src/player_policy.rs
@@ -19,8 +19,7 @@ impl MockTransportPlayerPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for MockTransportPlayerPolicy {
     async fn send(
         &self,

--- a/eng/test/mock_transport/src/recorder_policy.rs
+++ b/eng/test/mock_transport/src/recorder_policy.rs
@@ -23,8 +23,7 @@ impl MockTransportRecorderPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for MockTransportRecorderPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/auth.rs
+++ b/sdk/core/src/auth.rs
@@ -37,8 +37,7 @@ impl TokenResponse {
 }
 
 /// Represents a credential capable of providing an OAuth token.
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 pub trait TokenCredential: Send + Sync {
     /// Gets a `TokenResponse` for the specified resource
     async fn get_token(&self, resource: &str) -> crate::Result<TokenResponse>;

--- a/sdk/core/src/bytes_stream.rs
+++ b/sdk/core/src/bytes_stream.rs
@@ -56,8 +56,7 @@ impl Stream for BytesStream {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl SeekableStream for BytesStream {
     async fn reset(&mut self) -> crate::Result<()> {
         self.bytes_read = 0;

--- a/sdk/core/src/http_client/mod.rs
+++ b/sdk/core/src/http_client/mod.rs
@@ -37,8 +37,7 @@ use bytes::Bytes;
 use serde::Serialize;
 
 /// An HTTP client which can send requests.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 pub trait HttpClient: Send + Sync + std::fmt::Debug {
     /// Send out a request using `azure_core`'s types.
     ///

--- a/sdk/core/src/http_client/noop.rs
+++ b/sdk/core/src/http_client/noop.rs
@@ -3,11 +3,7 @@ use async_trait::async_trait;
 #[derive(Debug)]
 pub struct NoopClient;
 
-// TODO(rylev): we probably don't want to limit this to wasm32
-// as there will be wasm environments with threads.
-// This should instead be a feature flag
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl crate::HttpClient for NoopClient {
     async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response> {
         panic!(

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -289,10 +289,6 @@ macro_rules! future {
     };
     ($name:ident<$($generic:ident)?>) => {
         azure_core::__private::paste! {
-        #[cfg(target_arch = "wasm32")]
-        pub type $name<$($generic)*> =
-            std::pin::Pin<std::boxed::Box<dyn std::future::Future<Output = azure_core::Result<[<$name Response>]<$($generic)*>>> + 'static>>;
-        #[cfg(not(target_arch = "wasm32"))]
         pub type $name<$($generic)*> =
             futures::future::BoxFuture<'static, azure_core::Result<[<$name Response>]<$($generic)*>>>;
         }

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -230,8 +230,9 @@ macro_rules! operation {
             @nosetter
             $($nosetter: $nstype),*
         }
-        $crate::future!($name);
+
         azure_core::__private::paste! {
+        pub type $name = futures::future::BoxFuture<'static, azure_core::Result<[<$name Response>]>>;
         #[cfg(feature = "into_future")]
         impl <$($generic: $first_constraint $(+ $constraint)*)* $(+ $lt)*> std::future::IntoFuture for [<$name Builder>]<$($generic),*> {
             type IntoFuture = $name;
@@ -276,23 +277,6 @@ macro_rules! operation {
                 $($nosetter: $nstype),*
             }
     }
-}
-
-/// Declare a `Future` with the given name
-///
-/// `Future::Output` will be set to `azure_core::Result<$NAMEResponse>.
-/// The `Future` will be `Send` for all targets but `wasm32`.
-#[macro_export]
-macro_rules! future {
-    ($name:ident) => {
-        $crate::future!($name<>);
-    };
-    ($name:ident<$($generic:ident)?>) => {
-        azure_core::__private::paste! {
-        pub type $name<$($generic)*> =
-            futures::future::BoxFuture<'static, azure_core::Result<[<$name Response>]<$($generic)*>>>;
-        }
-    };
 }
 
 /// The following macro invocation:

--- a/sdk/core/src/policies/custom_headers_policy.rs
+++ b/sdk/core/src/policies/custom_headers_policy.rs
@@ -15,8 +15,7 @@ impl From<Headers> for CustomHeaders {
 #[derive(Clone, Debug, Default)]
 pub struct CustomHeadersPolicy {}
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for CustomHeadersPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/policies/mod.rs
+++ b/sdk/core/src/policies/mod.rs
@@ -25,8 +25,7 @@ pub type PolicyResult = crate::error::Result<Response>;
 /// The only runtime enforced check is that the last policy must be a Transport policy. It's up to
 /// the implementer to call the following policy.
 /// The `C` generic represents the *contents* of the AuthorizationPolicy specific of this pipeline.
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 pub trait Policy: Send + Sync + std::fmt::Debug {
     async fn send(
         &self,

--- a/sdk/core/src/policies/retry_policies/no_retry.rs
+++ b/sdk/core/src/policies/retry_policies/no_retry.rs
@@ -10,8 +10,7 @@ pub struct NoRetryPolicy {
     _priv: std::marker::PhantomData<u32>,
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for NoRetryPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -34,8 +34,7 @@ const RETRY_STATUSES: &[StatusCode] = &[
     StatusCode::GatewayTimeout,
 ];
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl<T> Policy for T
 where
     T: RetryPolicy + std::fmt::Debug + Send + Sync,

--- a/sdk/core/src/policies/telemetry_policy.rs
+++ b/sdk/core/src/policies/telemetry_policy.rs
@@ -56,8 +56,7 @@ impl<'a> TelemetryPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for TelemetryPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/policies/timeout_policy.rs
+++ b/sdk/core/src/policies/timeout_policy.rs
@@ -13,8 +13,7 @@ impl TimeoutPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for TimeoutPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -15,8 +15,7 @@ impl TransportPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[async_trait]
 impl Policy for TransportPolicy {
     async fn send(
         &self,

--- a/sdk/core/src/seekable_stream.rs
+++ b/sdk/core/src/seekable_stream.rs
@@ -5,8 +5,7 @@ use futures::task::Poll;
 
 /// Enable a type implementing `AsyncRead` to be consumed as if it were
 /// a `Stream` of `Bytes`.
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 pub trait SeekableStream:
     AsyncRead + Unpin + std::fmt::Debug + Send + Sync + dyn_clone::DynClone
 {

--- a/sdk/data_cosmos/examples/query_document.rs
+++ b/sdk/data_cosmos/examples/query_document.rs
@@ -69,15 +69,13 @@ async fn main() -> azure_core::Result<()> {
     // First, we'll look at the results as JSON.
     let mut stream = query.clone().into_stream::<serde_json::Value>();
     while let Some(respo) = stream.next().await {
-        let respo = respo?;
-        println!("JSON: {:#?}", respo.results);
+        println!("JSON: {:#?}", respo?.results);
     }
 
     // Then, we'll look at the results as `Family` structs.
     let mut stream = query.into_stream::<Family>();
     while let Some(respo) = stream.next().await {
-        let respo = respo?;
-        println!("Structs: {:#?}", respo.results);
+        println!("Structs: {:#?}", respo?.results);
     }
 
     Ok(())

--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -38,8 +38,7 @@ impl AuthorizationPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for AuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -91,7 +91,7 @@ impl<T: DeserializeOwned + Send> ExecuteStoredProcedureBuilder<T> {
     }
 }
 
-azure_core::future!(ExecuteStoredProcedure<T>);
+pub type ExecuteStoredProcedure<T> = futures::future::BoxFuture<'static, azure_core::Result<ExecuteStoredProcedureResponse<T>>>;
 
 #[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for ExecuteStoredProcedureBuilder<T> {

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -91,7 +91,8 @@ impl<T: DeserializeOwned + Send> ExecuteStoredProcedureBuilder<T> {
     }
 }
 
-pub type ExecuteStoredProcedure<T> = futures::future::BoxFuture<'static, azure_core::Result<ExecuteStoredProcedureResponse<T>>>;
+pub type ExecuteStoredProcedure<T> =
+    futures::future::BoxFuture<'static, azure_core::Result<ExecuteStoredProcedureResponse<T>>>;
 
 #[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for ExecuteStoredProcedureBuilder<T> {

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -77,7 +77,7 @@ impl<T: DeserializeOwned + Send> GetDocumentBuilder<T> {
     }
 }
 
-azure_core::future!(GetDocument<T>);
+pub type GetDocument<T> = futures::future::BoxFuture<'static, azure_core::Result<GetDocumentResponse<T>>>;
 
 #[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for GetDocumentBuilder<T> {

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -77,7 +77,8 @@ impl<T: DeserializeOwned + Send> GetDocumentBuilder<T> {
     }
 }
 
-pub type GetDocument<T> = futures::future::BoxFuture<'static, azure_core::Result<GetDocumentResponse<T>>>;
+pub type GetDocument<T> =
+    futures::future::BoxFuture<'static, azure_core::Result<GetDocumentResponse<T>>>;
 
 #[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for GetDocumentBuilder<T> {

--- a/sdk/data_tables/src/operations/get_entity.rs
+++ b/sdk/data_tables/src/operations/get_entity.rs
@@ -50,7 +50,8 @@ impl<T: DeserializeOwned + Send> GetEntityBuilder<T> {
     }
 }
 
-azure_core::future!(GetEntity<T>);
+pub type GetEntity<T> =
+    futures::future::BoxFuture<'static, azure_core::Result<GetEntityResponse<T>>>;
 
 #[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for GetEntityBuilder<T> {

--- a/sdk/data_tables/src/operations/insert_entity.rs
+++ b/sdk/data_tables/src/operations/insert_entity.rs
@@ -65,7 +65,8 @@ where
     }
 }
 
-azure_core::future!(InsertEntity<T>);
+pub type InsertEntity<T> =
+    futures::future::BoxFuture<'static, azure_core::Result<InsertEntityResponse<T>>>;
 
 #[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for InsertEntityBuilder<T> {

--- a/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
+++ b/sdk/identity/src/token_credentials/auto_refreshing_credentials.rs
@@ -34,8 +34,7 @@ impl AutoRefreshingTokenCredential {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for AutoRefreshingTokenCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         if let Some(Ok(token)) = self.current_token.read().await.as_ref() {

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -111,8 +111,7 @@ impl AzureCliCredential {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for AzureCliCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let tr = Self::get_access_token(Some(resource))?;

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -140,8 +140,7 @@ fn get_encoded_cert(cert: &X509) -> Result<String, ClientCertificateCredentialEr
     ))
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for ClientCertificateCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let options = self.options();

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -91,8 +91,7 @@ impl ClientSecretCredential {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for ClientSecretCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let options = self.options();

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -77,8 +77,7 @@ pub enum DefaultAzureCredentialEnum {
     AzureCli(AzureCliCredential),
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for DefaultAzureCredentialEnum {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         match self {
@@ -138,8 +137,7 @@ impl Default for DefaultAzureCredential {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for DefaultAzureCredential {
     /// Try to fetch a token using each of the credential sources until one succeeds
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -34,8 +34,7 @@ impl EnvironmentCredential {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for EnvironmentCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let tenant_id =

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -86,8 +86,7 @@ impl ImdsManagedIdentityCredential {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl TokenCredential for ImdsManagedIdentityCredential {
     async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
         let msi_endpoint = std::env::var(MSI_ENDPOINT_ENV_KEY)

--- a/sdk/iot_deviceupdate/src/lib.rs
+++ b/sdk/iot_deviceupdate/src/lib.rs
@@ -24,8 +24,7 @@ mod tests {
 
     pub(crate) struct MockCredential;
 
-    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[async_trait::async_trait]
     impl TokenCredential for MockCredential {
         async fn get_token(
             &self,

--- a/sdk/iot_hub/src/authorization_policy.rs
+++ b/sdk/iot_hub/src/authorization_policy.rs
@@ -19,8 +19,7 @@ impl AuthorizationPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for AuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/security_keyvault/src/lib.rs
+++ b/sdk/security_keyvault/src/lib.rs
@@ -36,8 +36,7 @@ mod tests {
         }
     }
 
-    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    #[async_trait::async_trait]
     impl TokenCredential for MockCredential {
         async fn get_token(
             &self,

--- a/sdk/storage/src/authorization_policy.rs
+++ b/sdk/storage/src/authorization_policy.rs
@@ -19,8 +19,7 @@ impl AuthorizationPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for AuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/storage_datalake/src/authorization_policies/bearer_token.rs
+++ b/sdk/storage_datalake/src/authorization_policies/bearer_token.rs
@@ -16,8 +16,7 @@ impl BearerTokenAuthorizationPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for BearerTokenAuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/storage_datalake/src/authorization_policies/shared_key.rs
+++ b/sdk/storage_datalake/src/authorization_policies/shared_key.rs
@@ -16,8 +16,7 @@ impl SharedKeyAuthorizationPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for SharedKeyAuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/storage_datalake/src/authorization_policies/token_credential.rs
+++ b/sdk/storage_datalake/src/authorization_policies/token_credential.rs
@@ -32,8 +32,7 @@ impl TokenCredentialAuthorizationPolicy {
     }
 }
 
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[async_trait::async_trait]
 impl Policy for TokenCredentialAuthorizationPolicy {
     async fn send(
         &self,

--- a/sdk/storage_datalake/src/operations/file_system_create.rs
+++ b/sdk/storage_datalake/src/operations/file_system_create.rs
@@ -61,7 +61,8 @@ impl CreateFileSystemBuilder {
     }
 }
 
-pub type CreateFileSystem = futures::future::BoxFuture<'static, azure_core::Result<CreateFileSystemResponse>>;
+pub type CreateFileSystem =
+    futures::future::BoxFuture<'static, azure_core::Result<CreateFileSystemResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct CreateFileSystemResponse {

--- a/sdk/storage_datalake/src/operations/file_system_create.rs
+++ b/sdk/storage_datalake/src/operations/file_system_create.rs
@@ -61,7 +61,7 @@ impl CreateFileSystemBuilder {
     }
 }
 
-azure_core::future!(CreateFileSystem);
+pub type CreateFileSystem = futures::future::BoxFuture<'static, azure_core::Result<CreateFileSystemResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct CreateFileSystemResponse {

--- a/sdk/storage_datalake/src/operations/file_system_delete.rs
+++ b/sdk/storage_datalake/src/operations/file_system_delete.rs
@@ -54,7 +54,8 @@ impl DeleteFileSystemBuilder {
     }
 }
 
-pub type DeleteFileSystem = futures::future::BoxFuture<'static, azure_core::Result<DeleteFileSystemResponse>>;
+pub type DeleteFileSystem =
+    futures::future::BoxFuture<'static, azure_core::Result<DeleteFileSystemResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct DeleteFileSystemResponse {

--- a/sdk/storage_datalake/src/operations/file_system_delete.rs
+++ b/sdk/storage_datalake/src/operations/file_system_delete.rs
@@ -54,7 +54,7 @@ impl DeleteFileSystemBuilder {
     }
 }
 
-azure_core::future!(DeleteFileSystem);
+pub type DeleteFileSystem = futures::future::BoxFuture<'static, azure_core::Result<DeleteFileSystemResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct DeleteFileSystemResponse {

--- a/sdk/storage_datalake/src/operations/file_system_get_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_get_properties.rs
@@ -55,7 +55,8 @@ impl GetFileSystemPropertiesBuilder {
     }
 }
 
-pub type GetFileSystemProperties = futures::future::BoxFuture<'static, azure_core::Result<GetFileSystemPropertiesResponse>>;
+pub type GetFileSystemProperties =
+    futures::future::BoxFuture<'static, azure_core::Result<GetFileSystemPropertiesResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct GetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/file_system_get_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_get_properties.rs
@@ -55,7 +55,7 @@ impl GetFileSystemPropertiesBuilder {
     }
 }
 
-azure_core::future!(GetFileSystemProperties);
+pub type GetFileSystemProperties = futures::future::BoxFuture<'static, azure_core::Result<GetFileSystemPropertiesResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct GetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/file_system_set_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_set_properties.rs
@@ -63,7 +63,7 @@ impl SetFileSystemPropertiesBuilder {
     }
 }
 
-azure_core::future!(SetFileSystemProperties);
+pub type SetFileSystemProperties = futures::future::BoxFuture<'static, azure_core::Result<SetFileSystemPropertiesResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct SetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/file_system_set_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_set_properties.rs
@@ -63,7 +63,8 @@ impl SetFileSystemPropertiesBuilder {
     }
 }
 
-pub type SetFileSystemProperties = futures::future::BoxFuture<'static, azure_core::Result<SetFileSystemPropertiesResponse>>;
+pub type SetFileSystemProperties =
+    futures::future::BoxFuture<'static, azure_core::Result<SetFileSystemPropertiesResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct SetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/path_delete.rs
+++ b/sdk/storage_datalake/src/operations/path_delete.rs
@@ -74,7 +74,7 @@ impl<C: PathClient + 'static> DeletePathBuilder<C> {
     }
 }
 
-azure_core::future!(DeletePath);
+pub type DeletePath = futures::future::BoxFuture<'static, azure_core::Result<DeletePathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct DeletePathResponse {

--- a/sdk/storage_datalake/src/operations/path_get.rs
+++ b/sdk/storage_datalake/src/operations/path_get.rs
@@ -73,7 +73,7 @@ impl GetFileBuilder {
     }
 }
 
-azure_core::future!(GetFile);
+pub type GetFile = futures::future::BoxFuture<'static, azure_core::Result<GetFileResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct GetFileResponse {

--- a/sdk/storage_datalake/src/operations/path_head.rs
+++ b/sdk/storage_datalake/src/operations/path_head.rs
@@ -77,7 +77,7 @@ impl<C: PathClient + 'static> HeadPathBuilder<C> {
     }
 }
 
-azure_core::future!(HeadPath);
+pub type HeadPath = futures::future::BoxFuture<'static, azure_core::Result<HeadPathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct HeadPathResponse {

--- a/sdk/storage_datalake/src/operations/path_patch.rs
+++ b/sdk/storage_datalake/src/operations/path_patch.rs
@@ -110,7 +110,7 @@ impl<C: PathClient + 'static> PatchPathBuilder<C> {
     }
 }
 
-azure_core::future!(PatchPath);
+pub type PatchPath = futures::future::BoxFuture<'static, azure_core::Result<PatchPathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct PatchPathResponse {

--- a/sdk/storage_datalake/src/operations/path_put.rs
+++ b/sdk/storage_datalake/src/operations/path_put.rs
@@ -87,7 +87,7 @@ impl<C: PathClient + 'static> PutPathBuilder<C> {
     }
 }
 
-azure_core::future!(PutPath);
+pub type PutPath = futures::future::BoxFuture<'static, azure_core::Result<PutPathResponse>>;
 
 #[derive(Debug, Clone)]
 pub struct PutPathResponse {
@@ -187,6 +187,6 @@ impl<C: PathClient + 'static> RenamePathBuilder<C> {
     }
 }
 
-azure_core::future!(RenamePath);
+pub type RenamePath = futures::future::BoxFuture<'static, azure_core::Result<RenamePathResponse>>;
 
 type RenamePathResponse = ();


### PR DESCRIPTION
This PR removes the distinction between `wasm32` targets and other targets when it comes to whether futures are `Send` or not. This makes it so that futures must always be `Send`. This greatly simplifies the code. 

In order for this to work though, we need to be able to move away from requiring `Reqwest`. This requires two further changes:
* #996 
* #962 

Thoughts?