### PR TITLE
Make `url` on BlobClient pub.

### DIFF
--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -272,7 +272,8 @@ impl BlobClient {
         &self.container_client
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    /// Full URL for the blob.
+    pub fn url(&self) -> azure_core::Result<url::Url> {
         StorageClient::url_with_segments(self.container_client.url()?, self.blob_name.split('/'))
     }
 

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -120,7 +120,8 @@ impl ContainerClient {
         Ok(url)
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    /// Full URL for the container.
+    pub fn url(&self) -> azure_core::Result<url::Url> {
         self.storage_client
             .blob_url_with_segments(Some(self.container_name.as_str()).into_iter())
     }


### PR DESCRIPTION
Making this pub so that it can be used with the `copy` function which
requires a URL as an argument. Ideally this probably shouldn't be
fallible given that if you have a BlobClient it should have a valid URL,
but that can be changed later.