### PR TITLE
blob_storage: Make `Snapshot` type consistent.

### DIFF
--- a/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
@@ -1,3 +1,4 @@
+use crate::blob::Snapshot;
 use crate::{blob::operations::DeleteBlobResponse, prelude::*};
 use azure_core::{headers::Headers, prelude::*};
 

--- a/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob_snapshot.rs
@@ -1,4 +1,3 @@
-use crate::blob::Snapshot;
 use crate::{blob::operations::DeleteBlobResponse, prelude::*};
 use azure_core::{headers::Headers, prelude::*};
 

--- a/sdk/storage_blobs/src/blob/operations/snapshot_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/snapshot_blob.rs
@@ -1,4 +1,3 @@
-use crate::blob::{Snapshot, SNAPSHOT};
 use crate::prelude::*;
 use azure_core::headers::etag_from_headers;
 use azure_core::{

--- a/sdk/storage_blobs/src/blob/operations/snapshot_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/snapshot_blob.rs
@@ -1,5 +1,6 @@
+use crate::blob::{Snapshot, SNAPSHOT};
 use crate::prelude::*;
-use azure_core::headers::{etag_from_headers, HeaderName};
+use azure_core::headers::etag_from_headers;
 use azure_core::{
     headers::{date_from_headers, last_modified_from_headers, request_id_from_headers, Headers},
     prelude::*,
@@ -64,5 +65,3 @@ impl TryFrom<&Headers> for SnapshotBlobResponse {
         })
     }
 }
-
-pub const SNAPSHOT: HeaderName = HeaderName::from_static("x-ms-snapshot");

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -1,7 +1,6 @@
-use crate::blob::Snapshot;
 use crate::{
     blob::operations::*,
-    options::{BA512Range, Tags},
+    options::{BA512Range, Snapshot, Tags},
     prelude::*,
 };
 use azure_core::{

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -1,3 +1,4 @@
+use crate::blob::Snapshot;
 use crate::{
     blob::operations::*,
     options::{BA512Range, Tags},

--- a/sdk/storage_blobs/src/options/blob_versioning.rs
+++ b/sdk/storage_blobs/src/options/blob_versioning.rs
@@ -1,4 +1,5 @@
-use super::{Snapshot, VersionId};
+use super::VersionId;
+use crate::blob::Snapshot;
 use azure_core::AppendToUrlQuery;
 
 #[derive(Debug, Clone)]

--- a/sdk/storage_blobs/src/options/blob_versioning.rs
+++ b/sdk/storage_blobs/src/options/blob_versioning.rs
@@ -1,5 +1,5 @@
 use super::VersionId;
-use crate::blob::Snapshot;
+use crate::options::Snapshot;
 use azure_core::AppendToUrlQuery;
 
 #[derive(Debug, Clone)]

--- a/sdk/storage_blobs/src/options/mod.rs
+++ b/sdk/storage_blobs/src/options/mod.rs
@@ -36,6 +36,11 @@ pub use hash::Hash;
 pub use rehydrate_policy::RehydratePriority;
 pub use tags::Tags;
 
+use std::str::FromStr;
+
+use azure_core::error::Error;
+use azure_core::headers::HeaderName;
+
 request_query!(
     /// This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
     ///
@@ -43,3 +48,22 @@ request_query!(
     VersionId,
     "version_id"
 );
+
+request_query!(
+    /// This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
+    ///
+    /// See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]
+    #[derive(PartialEq, Eq, Serialize, Deserialize)]
+    Snapshot,
+    "snapshot"
+);
+
+impl FromStr for Snapshot {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(s.to_string()))
+    }
+}
+
+pub const SNAPSHOT: HeaderName = HeaderName::from_static("x-ms-snapshot");

--- a/sdk/storage_blobs/src/options/mod.rs
+++ b/sdk/storage_blobs/src/options/mod.rs
@@ -43,11 +43,3 @@ request_query!(
     VersionId,
     "version_id"
 );
-
-request_query!(
-    /// This type could also be a DateTime but the docs clearly states to treat is as opaque so we do not convert it in any way.
-    ///
-    /// See: <https://docs.microsoft.com/rest/api/storageservices/get-blob>"]
-    Snapshot,
-    "snapshot"
-);


### PR DESCRIPTION
Previously many things treated `Snapshot` as an opaque type defined by
the `request_query` macro, but the `Blob` type was deserializing it as a
`DateTime` and not reading it from the header at all. Now everything is
using one shared opaque type.

I chose to redefine `Snapshot` without using the macro so that it could
derive Serialize/Deserialize. This is required because in the cases
`Snapshot` is part of a serialized response body. It is otherwise compatible with the
previous definition. The alternative would have been to change the macro
to do derive Serialize/Deserialize, but since that would be a change to
`core` and a number of other types, it felt heavy handed.