### PR TITLE
add "rt-multi-thread" as dev-dependency for services

### DIFF
--- a/services/autorust/codegen/src/cargo_toml.rs
+++ b/services/autorust/codegen/src/cargo_toml.rs
@@ -42,7 +42,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = {{ path = "../../../sdk/identity" }}
-tokio = {{ version = "1.0", features = ["macros"] }}
+tokio = {{ version = "1.0", features = ["macros", "rt-multi-thread"] }}
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/activedirectory/Cargo.toml
+++ b/services/mgmt/activedirectory/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/addons/Cargo.toml
+++ b/services/mgmt/addons/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/adhybridhealthservice/Cargo.toml
+++ b/services/mgmt/adhybridhealthservice/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/adp/Cargo.toml
+++ b/services/mgmt/adp/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/advisor/Cargo.toml
+++ b/services/mgmt/advisor/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/agrifood/Cargo.toml
+++ b/services/mgmt/agrifood/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/alertsmanagement/Cargo.toml
+++ b/services/mgmt/alertsmanagement/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/analysisservices/Cargo.toml
+++ b/services/mgmt/analysisservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/apimanagement/Cargo.toml
+++ b/services/mgmt/apimanagement/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/app/Cargo.toml
+++ b/services/mgmt/app/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/appconfiguration/Cargo.toml
+++ b/services/mgmt/appconfiguration/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/applicationinsights/Cargo.toml
+++ b/services/mgmt/applicationinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/appplatform/Cargo.toml
+++ b/services/mgmt/appplatform/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/arcdata/Cargo.toml
+++ b/services/mgmt/arcdata/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/attestation/Cargo.toml
+++ b/services/mgmt/attestation/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/authorization/Cargo.toml
+++ b/services/mgmt/authorization/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/automanage/Cargo.toml
+++ b/services/mgmt/automanage/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/automation/Cargo.toml
+++ b/services/mgmt/automation/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/baremetalinfrastructure/Cargo.toml
+++ b/services/mgmt/baremetalinfrastructure/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/batch/Cargo.toml
+++ b/services/mgmt/batch/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/billing/Cargo.toml
+++ b/services/mgmt/billing/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/blockchain/Cargo.toml
+++ b/services/mgmt/blockchain/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/blueprint/Cargo.toml
+++ b/services/mgmt/blueprint/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/botservice/Cargo.toml
+++ b/services/mgmt/botservice/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cdn/Cargo.toml
+++ b/services/mgmt/cdn/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/changeanalysis/Cargo.toml
+++ b/services/mgmt/changeanalysis/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/chaos/Cargo.toml
+++ b/services/mgmt/chaos/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cloudshell/Cargo.toml
+++ b/services/mgmt/cloudshell/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cognitiveservices/Cargo.toml
+++ b/services/mgmt/cognitiveservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/commerce/Cargo.toml
+++ b/services/mgmt/commerce/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/communication/Cargo.toml
+++ b/services/mgmt/communication/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/compute/Cargo.toml
+++ b/services/mgmt/compute/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/confidentialledger/Cargo.toml
+++ b/services/mgmt/confidentialledger/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/confluent/Cargo.toml
+++ b/services/mgmt/confluent/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/connectedvmware/Cargo.toml
+++ b/services/mgmt/connectedvmware/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/consumption/Cargo.toml
+++ b/services/mgmt/consumption/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/containerinstance/Cargo.toml
+++ b/services/mgmt/containerinstance/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/containerregistry/Cargo.toml
+++ b/services/mgmt/containerregistry/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/containerservice/Cargo.toml
+++ b/services/mgmt/containerservice/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cosmosdb/Cargo.toml
+++ b/services/mgmt/cosmosdb/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/costmanagement/Cargo.toml
+++ b/services/mgmt/costmanagement/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/cpim/Cargo.toml
+++ b/services/mgmt/cpim/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/customerinsights/Cargo.toml
+++ b/services/mgmt/customerinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/customerlockbox/Cargo.toml
+++ b/services/mgmt/customerlockbox/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/customproviders/Cargo.toml
+++ b/services/mgmt/customproviders/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dashboard/Cargo.toml
+++ b/services/mgmt/dashboard/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/data/Cargo.toml
+++ b/services/mgmt/data/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/databox/Cargo.toml
+++ b/services/mgmt/databox/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/databoxedge/Cargo.toml
+++ b/services/mgmt/databoxedge/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/databricks/Cargo.toml
+++ b/services/mgmt/databricks/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datacatalog/Cargo.toml
+++ b/services/mgmt/datacatalog/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datadog/Cargo.toml
+++ b/services/mgmt/datadog/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datafactory/Cargo.toml
+++ b/services/mgmt/datafactory/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datalakeanalytics/Cargo.toml
+++ b/services/mgmt/datalakeanalytics/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datalakestore/Cargo.toml
+++ b/services/mgmt/datalakestore/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datamigration/Cargo.toml
+++ b/services/mgmt/datamigration/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dataprotection/Cargo.toml
+++ b/services/mgmt/dataprotection/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/datashare/Cargo.toml
+++ b/services/mgmt/datashare/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/deploymentmanager/Cargo.toml
+++ b/services/mgmt/deploymentmanager/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/desktopvirtualization/Cargo.toml
+++ b/services/mgmt/desktopvirtualization/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/devcenter/Cargo.toml
+++ b/services/mgmt/devcenter/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/developerhub/Cargo.toml
+++ b/services/mgmt/developerhub/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/deviceupdate/Cargo.toml
+++ b/services/mgmt/deviceupdate/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/devops/Cargo.toml
+++ b/services/mgmt/devops/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/devspaces/Cargo.toml
+++ b/services/mgmt/devspaces/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/devtestlabs/Cargo.toml
+++ b/services/mgmt/devtestlabs/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dfp/Cargo.toml
+++ b/services/mgmt/dfp/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/digitaltwins/Cargo.toml
+++ b/services/mgmt/digitaltwins/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dnc/Cargo.toml
+++ b/services/mgmt/dnc/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dns/Cargo.toml
+++ b/services/mgmt/dns/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dnsresolver/Cargo.toml
+++ b/services/mgmt/dnsresolver/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/domainservices/Cargo.toml
+++ b/services/mgmt/domainservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/dynatrace/Cargo.toml
+++ b/services/mgmt/dynatrace/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/edgeorder/Cargo.toml
+++ b/services/mgmt/edgeorder/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/edgeorderpartner/Cargo.toml
+++ b/services/mgmt/edgeorderpartner/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/education/Cargo.toml
+++ b/services/mgmt/education/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/elastic/Cargo.toml
+++ b/services/mgmt/elastic/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/elasticsan/Cargo.toml
+++ b/services/mgmt/elasticsan/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/engagementfabric/Cargo.toml
+++ b/services/mgmt/engagementfabric/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/enterpriseknowledgegraph/Cargo.toml
+++ b/services/mgmt/enterpriseknowledgegraph/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/eventgrid/Cargo.toml
+++ b/services/mgmt/eventgrid/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/eventhub/Cargo.toml
+++ b/services/mgmt/eventhub/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/extendedlocation/Cargo.toml
+++ b/services/mgmt/extendedlocation/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/fluidrelay/Cargo.toml
+++ b/services/mgmt/fluidrelay/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/frontdoor/Cargo.toml
+++ b/services/mgmt/frontdoor/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/guestconfiguration/Cargo.toml
+++ b/services/mgmt/guestconfiguration/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hanaon/Cargo.toml
+++ b/services/mgmt/hanaon/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hardwaresecuritymodules/Cargo.toml
+++ b/services/mgmt/hardwaresecuritymodules/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hdinsight/Cargo.toml
+++ b/services/mgmt/hdinsight/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/healthbot/Cargo.toml
+++ b/services/mgmt/healthbot/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/healthcareapis/Cargo.toml
+++ b/services/mgmt/healthcareapis/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridcompute/Cargo.toml
+++ b/services/mgmt/hybridcompute/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridconnectivity/Cargo.toml
+++ b/services/mgmt/hybridconnectivity/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybriddatamanager/Cargo.toml
+++ b/services/mgmt/hybriddatamanager/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridkubernetes/Cargo.toml
+++ b/services/mgmt/hybridkubernetes/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/hybridnetwork/Cargo.toml
+++ b/services/mgmt/hybridnetwork/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/imagebuilder/Cargo.toml
+++ b/services/mgmt/imagebuilder/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/intune/Cargo.toml
+++ b/services/mgmt/intune/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/iotcentral/Cargo.toml
+++ b/services/mgmt/iotcentral/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/iothub/Cargo.toml
+++ b/services/mgmt/iothub/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/iotspaces/Cargo.toml
+++ b/services/mgmt/iotspaces/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/keyvault/Cargo.toml
+++ b/services/mgmt/keyvault/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/kubernetesconfiguration/Cargo.toml
+++ b/services/mgmt/kubernetesconfiguration/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/kusto/Cargo.toml
+++ b/services/mgmt/kusto/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/labservices/Cargo.toml
+++ b/services/mgmt/labservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/loadtestservice/Cargo.toml
+++ b/services/mgmt/loadtestservice/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/logic/Cargo.toml
+++ b/services/mgmt/logic/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/logz/Cargo.toml
+++ b/services/mgmt/logz/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/m365securityandcompliance/Cargo.toml
+++ b/services/mgmt/m365securityandcompliance/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearning/Cargo.toml
+++ b/services/mgmt/machinelearning/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearningcompute/Cargo.toml
+++ b/services/mgmt/machinelearningcompute/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearningexperimentation/Cargo.toml
+++ b/services/mgmt/machinelearningexperimentation/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/machinelearningservices/Cargo.toml
+++ b/services/mgmt/machinelearningservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/maintenance/Cargo.toml
+++ b/services/mgmt/maintenance/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managednetwork/Cargo.toml
+++ b/services/mgmt/managednetwork/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managedservices/Cargo.toml
+++ b/services/mgmt/managedservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managementgroups/Cargo.toml
+++ b/services/mgmt/managementgroups/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/managementpartner/Cargo.toml
+++ b/services/mgmt/managementpartner/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/maps/Cargo.toml
+++ b/services/mgmt/maps/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/mariadb/Cargo.toml
+++ b/services/mgmt/mariadb/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/marketplace/Cargo.toml
+++ b/services/mgmt/marketplace/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/marketplacecatalog/Cargo.toml
+++ b/services/mgmt/marketplacecatalog/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/marketplacenotifications/Cargo.toml
+++ b/services/mgmt/marketplacenotifications/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/marketplaceordering/Cargo.toml
+++ b/services/mgmt/marketplaceordering/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/mediaservices/Cargo.toml
+++ b/services/mgmt/mediaservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/migrate/Cargo.toml
+++ b/services/mgmt/migrate/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/migrateprojects/Cargo.toml
+++ b/services/mgmt/migrateprojects/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/mobilenetwork/Cargo.toml
+++ b/services/mgmt/mobilenetwork/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/monitor/Cargo.toml
+++ b/services/mgmt/monitor/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/msi/Cargo.toml
+++ b/services/mgmt/msi/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/mysql/Cargo.toml
+++ b/services/mgmt/mysql/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/netapp/Cargo.toml
+++ b/services/mgmt/netapp/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/network/Cargo.toml
+++ b/services/mgmt/network/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/networkfunction/Cargo.toml
+++ b/services/mgmt/networkfunction/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/nginx/Cargo.toml
+++ b/services/mgmt/nginx/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/notificationhubs/Cargo.toml
+++ b/services/mgmt/notificationhubs/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/oep/Cargo.toml
+++ b/services/mgmt/oep/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/operationalinsights/Cargo.toml
+++ b/services/mgmt/operationalinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/operationsmanagement/Cargo.toml
+++ b/services/mgmt/operationsmanagement/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/orbital/Cargo.toml
+++ b/services/mgmt/orbital/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/peering/Cargo.toml
+++ b/services/mgmt/peering/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/policyinsights/Cargo.toml
+++ b/services/mgmt/policyinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/portal/Cargo.toml
+++ b/services/mgmt/portal/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/postgresql/Cargo.toml
+++ b/services/mgmt/postgresql/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/postgresqlhsc/Cargo.toml
+++ b/services/mgmt/postgresqlhsc/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerbidedicated/Cargo.toml
+++ b/services/mgmt/powerbidedicated/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerbiembedded/Cargo.toml
+++ b/services/mgmt/powerbiembedded/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerbiprivatelinks/Cargo.toml
+++ b/services/mgmt/powerbiprivatelinks/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/powerplatform/Cargo.toml
+++ b/services/mgmt/powerplatform/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/privatedns/Cargo.toml
+++ b/services/mgmt/privatedns/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/providerhub/Cargo.toml
+++ b/services/mgmt/providerhub/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/purview/Cargo.toml
+++ b/services/mgmt/purview/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/quantum/Cargo.toml
+++ b/services/mgmt/quantum/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/quota/Cargo.toml
+++ b/services/mgmt/quota/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/recommendationsservice/Cargo.toml
+++ b/services/mgmt/recommendationsservice/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/recoveryservices/Cargo.toml
+++ b/services/mgmt/recoveryservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/recoveryservicesbackup/Cargo.toml
+++ b/services/mgmt/recoveryservicesbackup/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/recoveryservicessiterecovery/Cargo.toml
+++ b/services/mgmt/recoveryservicessiterecovery/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/redhatopenshift/Cargo.toml
+++ b/services/mgmt/redhatopenshift/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/redis/Cargo.toml
+++ b/services/mgmt/redis/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/redisenterprise/Cargo.toml
+++ b/services/mgmt/redisenterprise/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/relay/Cargo.toml
+++ b/services/mgmt/relay/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/reservations/Cargo.toml
+++ b/services/mgmt/reservations/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourceconnector/Cargo.toml
+++ b/services/mgmt/resourceconnector/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourcegraph/Cargo.toml
+++ b/services/mgmt/resourcegraph/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourcehealth/Cargo.toml
+++ b/services/mgmt/resourcehealth/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resourcemover/Cargo.toml
+++ b/services/mgmt/resourcemover/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/resources/Cargo.toml
+++ b/services/mgmt/resources/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/saas/Cargo.toml
+++ b/services/mgmt/saas/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/scheduler/Cargo.toml
+++ b/services/mgmt/scheduler/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/scvmm/Cargo.toml
+++ b/services/mgmt/scvmm/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/search/Cargo.toml
+++ b/services/mgmt/search/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/security/Cargo.toml
+++ b/services/mgmt/security/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/securityandcompliance/Cargo.toml
+++ b/services/mgmt/securityandcompliance/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/securityinsights/Cargo.toml
+++ b/services/mgmt/securityinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/serialconsole/Cargo.toml
+++ b/services/mgmt/serialconsole/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicebus/Cargo.toml
+++ b/services/mgmt/servicebus/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicefabricmanagedclusters/Cargo.toml
+++ b/services/mgmt/servicefabricmanagedclusters/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicefabricmesh/Cargo.toml
+++ b/services/mgmt/servicefabricmesh/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicelinker/Cargo.toml
+++ b/services/mgmt/servicelinker/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/servicemap/Cargo.toml
+++ b/services/mgmt/servicemap/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/signalr/Cargo.toml
+++ b/services/mgmt/signalr/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/softwareplan/Cargo.toml
+++ b/services/mgmt/softwareplan/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/solutions/Cargo.toml
+++ b/services/mgmt/solutions/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/sql/Cargo.toml
+++ b/services/mgmt/sql/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/sqlvirtualmachine/Cargo.toml
+++ b/services/mgmt/sqlvirtualmachine/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/stack/Cargo.toml
+++ b/services/mgmt/stack/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storage/Cargo.toml
+++ b/services/mgmt/storage/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storagecache/Cargo.toml
+++ b/services/mgmt/storagecache/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storageimportexport/Cargo.toml
+++ b/services/mgmt/storageimportexport/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storagemover/Cargo.toml
+++ b/services/mgmt/storagemover/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storagepool/Cargo.toml
+++ b/services/mgmt/storagepool/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storagesync/Cargo.toml
+++ b/services/mgmt/storagesync/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storsimple1200series/Cargo.toml
+++ b/services/mgmt/storsimple1200series/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/storsimple8000series/Cargo.toml
+++ b/services/mgmt/storsimple8000series/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/streamanalytics/Cargo.toml
+++ b/services/mgmt/streamanalytics/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/subscription/Cargo.toml
+++ b/services/mgmt/subscription/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/support/Cargo.toml
+++ b/services/mgmt/support/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/synapse/Cargo.toml
+++ b/services/mgmt/synapse/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/testbase/Cargo.toml
+++ b/services/mgmt/testbase/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/timeseriesinsights/Cargo.toml
+++ b/services/mgmt/timeseriesinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/trafficmanager/Cargo.toml
+++ b/services/mgmt/trafficmanager/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/vi/Cargo.toml
+++ b/services/mgmt/vi/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/videoanalyzer/Cargo.toml
+++ b/services/mgmt/videoanalyzer/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/visualstudio/Cargo.toml
+++ b/services/mgmt/visualstudio/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/vmware/Cargo.toml
+++ b/services/mgmt/vmware/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/vmwarecloudsimple/Cargo.toml
+++ b/services/mgmt/vmwarecloudsimple/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/web/Cargo.toml
+++ b/services/mgmt/web/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/webpubsub/Cargo.toml
+++ b/services/mgmt/webpubsub/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/windowsesu/Cargo.toml
+++ b/services/mgmt/windowsesu/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/windowsiot/Cargo.toml
+++ b/services/mgmt/windowsiot/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/workloadmonitor/Cargo.toml
+++ b/services/mgmt/workloadmonitor/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/mgmt/workloads/Cargo.toml
+++ b/services/mgmt/workloads/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/appconfiguration/Cargo.toml
+++ b/services/svc/appconfiguration/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/applicationinsights/Cargo.toml
+++ b/services/svc/applicationinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/attestation/Cargo.toml
+++ b/services/svc/attestation/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/batch/Cargo.toml
+++ b/services/svc/batch/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/blobstorage/Cargo.toml
+++ b/services/svc/blobstorage/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/containerregistry/Cargo.toml
+++ b/services/svc/containerregistry/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/cosmosdb/Cargo.toml
+++ b/services/svc/cosmosdb/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/datalakeanalytics/Cargo.toml
+++ b/services/svc/datalakeanalytics/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/deviceprovisioningservices/Cargo.toml
+++ b/services/svc/deviceprovisioningservices/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/deviceupdate/Cargo.toml
+++ b/services/svc/deviceupdate/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/digitaltwins/Cargo.toml
+++ b/services/svc/digitaltwins/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/eventgrid/Cargo.toml
+++ b/services/svc/eventgrid/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/filestorage/Cargo.toml
+++ b/services/svc/filestorage/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/graphrbac/Cargo.toml
+++ b/services/svc/graphrbac/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/imds/Cargo.toml
+++ b/services/svc/imds/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/iotcentral/Cargo.toml
+++ b/services/svc/iotcentral/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/keyvault/Cargo.toml
+++ b/services/svc/keyvault/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/loadtestservice/Cargo.toml
+++ b/services/svc/loadtestservice/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/marketplacecatalog/Cargo.toml
+++ b/services/svc/marketplacecatalog/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/mixedreality/Cargo.toml
+++ b/services/svc/mixedreality/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/monitor/Cargo.toml
+++ b/services/svc/monitor/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/operationalinsights/Cargo.toml
+++ b/services/svc/operationalinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/purview/Cargo.toml
+++ b/services/svc/purview/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/quantum/Cargo.toml
+++ b/services/svc/quantum/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/queuestorage/Cargo.toml
+++ b/services/svc/queuestorage/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/schemaregistry/Cargo.toml
+++ b/services/svc/schemaregistry/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/servicefabric/Cargo.toml
+++ b/services/svc/servicefabric/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/storagedatalake/Cargo.toml
+++ b/services/svc/storagedatalake/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/synapse/Cargo.toml
+++ b/services/svc/synapse/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/timeseriesinsights/Cargo.toml
+++ b/services/svc/timeseriesinsights/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/videoanalyzer/Cargo.toml
+++ b/services/svc/videoanalyzer/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]

--- a/services/svc/webpubsub/Cargo.toml
+++ b/services/svc/webpubsub/Cargo.toml
@@ -22,7 +22,7 @@ time = "0.3"
 
 [dev-dependencies]
 azure_identity = { path = "../../../sdk/identity" }
-tokio = { version = "1.0", features = ["macros"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This matches the SDKs and avoids this error:

```
error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
  --> mgmt/vmware/examples/private_cloud_list.rs:17:1
   |
17 | #[tokio::main]
   | ^^^^^^^^^^^^^^
   |
   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
```

https://github.com/Azure/azure-sdk-for-rust/runs/7843927677?check_suite_focus=true