### PR TITLE
set api-version for keyvault list_secrets

### DIFF
--- a/sdk/security_keyvault/src/account/operations/list_secrets.rs
+++ b/sdk/security_keyvault/src/account/operations/list_secrets.rs
@@ -14,6 +14,7 @@ impl ListSecretsBuilder {
 
             let mut uri = self.client.client.vault_url.clone();
             uri.set_path("secrets");
+            uri.set_query(Some(API_VERSION_PARAM));
 
             loop {
                 let resp_body = self


### PR DESCRIPTION
This is a bug fix. Tested with `cargo run -p azure_security_keyvault --example list_secrets`.