### PR TITLE
Fixing build break in using client_certificate credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         run: cargo check --all --features azurite_workaround
 
       - name: sdk tests
-        run: cargo test --all 
+        run: cargo test --all
 
       - name: update readme of sdks
         run: |
@@ -91,6 +91,19 @@ jobs:
           override: true
       - name: check `into_future` feature
         run: cargo check --all --features into_future
+
+  nightly-build:
+    name: Build Nightly
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+      - name: Build Nightly
+        run: cargo +nightly build --all-features
 
   test-services:
     name: Services Tests

--- a/sdk/identity/examples/client_certificate_credentials.rs
+++ b/sdk/identity/examples/client_certificate_credentials.rs
@@ -19,13 +19,13 @@ async fn get_certficate(
     certificate_name: &str,
 ) -> Result<Vec<u8>, Box<dyn Error>> {
     let creds = DefaultAzureCredential::default();
-    let mut client = KeyvaultClient::new(
+    let client = KeyvaultClient::new(
         format!("https://{}.vault.azure.net", vault_name).as_str(),
         std::sync::Arc::new(creds),
     )?
-    .secret_client(certificate_name);
-    let secret = client.get().into_future().await?;
-    let cert = base64::decode(secret.value())?;
+    .secret_client();
+    let secret = client.get(certificate_name).into_future().await?;
+    let cert = base64::decode(secret.value)?;
     Ok(cert)
 }
 

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -3,7 +3,7 @@ use azure_core::{
     auth::{AccessToken, TokenCredential, TokenResponse},
     content_type,
     error::{Error, ErrorKind},
-    headers, new_http_client, Method, Request, StatusCode,
+    headers, new_http_client, Method, Request,
 };
 use base64::{CharacterSet, Config};
 use openssl::{

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -1,8 +1,10 @@
-use super::{authority_hosts, TokenCredential};
-use azure_core::auth::{AccessToken, TokenResponse};
-use azure_core::error::{ErrorKind, ResultExt};
+use super::{authority_hosts};
+use azure_core::{
+    auth::{AccessToken, TokenResponse, TokenCredential},
+    error::{Error, ErrorKind,},
+    headers, Request, content_type, new_http_client, Method, StatusCode
+};
 use base64::{CharacterSet, Config};
-use chrono::Utc;
 use openssl::{
     error::ErrorStack,
     hash::{hash, DigestBytes, MessageDigest},
@@ -14,6 +16,8 @@ use openssl::{
 use serde::Deserialize;
 use std::str;
 use std::time::Duration;
+use time::OffsetDateTime;
+use url::{form_urlencoded, Url};
 
 /// Refresh time to use in seconds
 const DEFAULT_REFRESH_TIME: i64 = 300;
@@ -130,14 +134,21 @@ struct AadTokenResponse {
     access_token: String,
 }
 
-fn get_encoded_cert(cert: &X509) -> Result<String, ClientCertificateCredentialError> {
+fn get_encoded_cert(cert: &X509) -> Result<String, azure_core::error::Error> {
     Ok(format!(
         "\"{}\"",
         base64::encode(
             cert.to_pem()
-                .map_err(ClientCertificateCredentialError::OpensslError)?
+                .map_err(|_| openssl_error())?
         )
     ))
+}
+
+fn openssl_error() -> azure_core::error::Error {
+    Error::message(
+        ErrorKind::Credential,
+        "Openssl decode error",
+    )
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -152,14 +163,17 @@ impl TokenCredential for ClientCertificateCredential {
         );
 
         let certificate = base64::decode(&self.client_certificate)
-            .map_err(ClientCertificateCredentialError::DecodeError)?;
+            .map_err(|_| Error::message(
+                ErrorKind::Credential,
+                "Base64 decode failed",
+            ))?;
         let certificate = Pkcs12::from_der(&certificate)
-            .map_err(ClientCertificateCredentialError::OpensslError)?
+            .map_err(|_| openssl_error())?
             .parse(&self.client_certificate_pass)
-            .map_err(ClientCertificateCredentialError::OpensslError)?;
+            .map_err(|_| openssl_error())?;
 
         let thumbprint = ClientCertificateCredential::get_thumbprint(&certificate.cert)
-            .map_err(ClientCertificateCredentialError::OpensslError)?;
+            .map_err(|_| openssl_error())?;
 
         let uuid = uuid::Uuid::new_v4();
         let current_time = OffsetDateTime::now_utc().unix_timestamp();
@@ -174,7 +188,7 @@ impl TokenCredential for ClientCertificateCredential {
                         let chain = chain
                             .into_iter()
                             .map(|x| get_encoded_cert(&x))
-                            .collect::<Result<Vec<String>, ClientCertificateCredentialError>>()?
+                            .collect::<Result<Vec<String>, azure_core::error::Error>>()?
                             .join(",");
                         format! {"{},{}", base_signature, chain}
                     }
@@ -197,32 +211,42 @@ impl TokenCredential for ClientCertificateCredential {
 
         let jwt = format!("{}.{}", header, payload);
         let signature = ClientCertificateCredential::sign(&jwt, &certificate.pkey)
-            .map_err(ClientCertificateCredentialError::OpensslError)?;
+            .map_err(|_| openssl_error())?;
         let sig = ClientCertificateCredential::as_jwt_part(&signature);
         let client_assertion = format!("{}.{}", jwt, sig);
 
-        let form_data = vec![
-            ("client_id", self.client_id.to_owned()),
-            ("scope", format!("{}/.default", resource)),
-            (
-                "client_assertion_type",
-                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer".to_owned(),
-            ),
-            ("client_assertion", client_assertion),
-            ("grant_type", "client_credentials".to_owned()),
-        ];
+
+        let encoded = {
+            let mut encoded = &mut form_urlencoded::Serializer::new(String::new());
+            encoded = encoded
+                .append_pair("client_id", self.client_id.as_str())
+                .append_pair("scope", format!("{}/.default", resource).as_str())
+                .append_pair(
+                    "client_assertion_type",
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+                .append_pair("client_assertion", client_assertion.as_str())
+                .append_pair("grant_type", "client_credentials");
+            encoded.finish()
+        };
+
+        let url = Url::parse(url)?;
+        let mut req = Request::new(url, Method::Post);
+        req.insert_header(
+            headers::CONTENT_TYPE,
+            content_type::APPLICATION_X_WWW_FORM_URLENCODED,
+        );
+        req.set_body(encoded);
 
         let http_client = new_http_client();
-        let response: AadTokenResponse = client
-            .post(url)
-            .form(&form_data)
-            .send()
-            .await
-            .map_err(ClientCertificateCredentialError::ReqwestError)?
-            .json()
-            .await
-            .map_err(ClientCertificateCredentialError::ReqwestError)?;
+        let rsp = http_client.execute_request(&req).await?;
+        let rsp_status = rsp.status();
+        let rsp_body = rsp.into_body().collect().await?;
 
+        if !rsp_status.is_success() {
+            return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
+        }
+
+        let response: AadTokenResponse = serde_json::from_slice(&rsp_body)?;
         Ok(TokenResponse::new(
             AccessToken::new(response.access_token.to_string()),
             OffsetDateTime::now_utc() + Duration::from_secs(response.expires_in),

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -135,7 +135,7 @@ struct AadTokenResponse {
     access_token: String,
 }
 
-fn get_encoded_cert(cert: &X509) -> Result<String, azure_core::error::Error> {
+fn get_encoded_cert(cert: &X509) -> azure_core::Result<String> {
     Ok(format!(
         "\"{}\"",
         base64::encode(cert.to_pem().map_err(|_| openssl_error())?)


### PR DESCRIPTION
The identity SDK doesn't build anymore when trying to build with feature client_certificate. This PR addresses the issue.

Also added a full build on the SDK