### PR TITLE
Fix `azure_security_keyvault` handling of optional datetime fields

### DIFF
--- a/sdk/security_keyvault/src/certificates/models.rs
+++ b/sdk/security_keyvault/src/certificates/models.rs
@@ -4,11 +4,9 @@ use time::OffsetDateTime;
 #[derive(Deserialize, Debug)]
 pub(crate) struct KeyVaultCertificateBaseIdentifierAttributedRaw {
     pub enabled: bool,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::timestamp::option")]
+    #[serde(default, with = "azure_core::date::timestamp::option")]
     pub exp: Option<OffsetDateTime>,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::timestamp::option")]
+    #[serde(default, with = "azure_core::date::timestamp::option")]
     pub nbf: Option<OffsetDateTime>,
     #[serde(with = "azure_core::date::timestamp")]
     pub created: OffsetDateTime,
@@ -45,11 +43,9 @@ pub(crate) struct KeyVaultGetCertificateResponse {
 #[derive(Deserialize, Debug)]
 pub(crate) struct KeyVaultGetCertificateResponseAttributes {
     pub enabled: bool,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::timestamp::option")]
+    #[serde(default, with = "azure_core::date::timestamp::option")]
     pub exp: Option<OffsetDateTime>,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::timestamp::option")]
+    #[serde(default, with = "azure_core::date::timestamp::option")]
     pub nbf: Option<OffsetDateTime>,
     #[serde(with = "azure_core::date::timestamp")]
     pub created: OffsetDateTime,

--- a/sdk/security_keyvault/src/certificates/operations/update_properties.rs
+++ b/sdk/security_keyvault/src/certificates/operations/update_properties.rs
@@ -17,9 +17,9 @@ operation! {
 #[serde(rename_all = "camelCase")]
 struct Attributes {
     enabled: Option<bool>,
-    #[serde(with = "azure_core::date::timestamp::option", rename = "exp")]
+    #[serde(default, with = "azure_core::date::timestamp::option", rename = "exp")]
     expiration: Option<OffsetDateTime>,
-    #[serde(with = "azure_core::date::timestamp::option", rename = "nbf")]
+    #[serde(default, with = "azure_core::date::timestamp::option", rename = "nbf")]
     not_before: Option<OffsetDateTime>,
 }
 

--- a/sdk/security_keyvault/src/secrets/models.rs
+++ b/sdk/security_keyvault/src/secrets/models.rs
@@ -33,8 +33,7 @@ pub(crate) struct KeyVaultGetSecretResponse {
 #[derive(Deserialize, Debug)]
 pub(crate) struct KeyVaultGetSecretResponseAttributes {
     pub enabled: bool,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::timestamp::option")]
+    #[serde(default, with = "azure_core::date::timestamp::option")]
     pub exp: Option<OffsetDateTime>,
     #[serde(with = "azure_core::date::timestamp")]
     pub created: OffsetDateTime,

--- a/sdk/security_keyvault/src/secrets/operations/update_secret.rs
+++ b/sdk/security_keyvault/src/secrets/operations/update_secret.rs
@@ -22,9 +22,9 @@ operation! {
 #[serde(rename_all = "camelCase")]
 struct Attributes {
     enabled: Option<bool>,
-    #[serde(with = "azure_core::date::timestamp::option", rename = "exp")]
+    #[serde(default, with = "azure_core::date::timestamp::option", rename = "exp")]
     expiration: Option<OffsetDateTime>,
-    #[serde(with = "azure_core::date::timestamp::option", rename = "nbf")]
+    #[serde(default, with = "azure_core::date::timestamp::option", rename = "nbf")]
     not_before: Option<OffsetDateTime>,
     recovery_level: Option<String>,
 }

--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -101,15 +101,16 @@ pub struct Blob {
 #[serde(rename_all = "PascalCase")]
 pub struct BlobProperties {
     #[cfg(not(feature = "azurite_workaround"))]
-    #[serde(rename = "Creation-Time")]
-    #[serde(with = "azure_core::date::rfc1123")]
+    #[serde(with = "azure_core::date::rfc1123", rename = "Creation-Time")]
     pub creation_time: OffsetDateTime,
     #[cfg(feature = "azurite_workaround")]
-    #[serde(rename = "Creation-Time")]
-    #[serde(default, with = "azure_core::date::rfc1123::option")]
+    #[serde(
+        default,
+        with = "azure_core::date::rfc1123::option",
+        rename = "Creation-Time"
+    )]
     pub creation_time: Option<OffsetDateTime>,
-    #[serde(rename = "Last-Modified")]
-    #[serde(with = "azure_core::date::rfc1123")]
+    #[serde(with = "azure_core::date::rfc1123", rename = "Last-Modified")]
     pub last_modified: OffsetDateTime,
     #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub last_access_time: Option<OffsetDateTime>,
@@ -124,13 +125,17 @@ pub struct BlobProperties {
     pub content_language: Option<String>,
     #[serde(rename = "Content-Disposition")]
     pub content_disposition: Option<String>,
-    #[serde(rename = "Content-MD5")]
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_md5_optional")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_md5_optional",
+        rename = "Content-MD5"
+    )]
     pub content_md5: Option<ConsistencyMD5>,
-    #[serde(rename = "Content-CRC64")]
-    #[serde(default)]
-    #[serde(deserialize_with = "deserialize_crc64_optional")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_crc64_optional",
+        rename = "Content-CRC64"
+    )]
     pub content_crc64: Option<ConsistencyCRC64>,
     #[serde(rename = "Cache-Control")]
     pub cache_control: Option<String>,
@@ -160,8 +165,11 @@ pub struct BlobProperties {
     pub remaining_retention_days: Option<u32>,
     pub tag_count: Option<u32>,
     pub rehydrate_priority: Option<RehydratePriority>,
-    #[serde(rename = "Expiry-Time")]
-    #[serde(default, with = "azure_core::date::rfc1123::option")]
+    #[serde(
+        default,
+        with = "azure_core::date::rfc1123::option",
+        rename = "Expiry-Time"
+    )]
     pub expiry_time: Option<OffsetDateTime>,
     #[serde(flatten)]
     extra: HashMap<String, String>, // For debug purposes, should be compiled out in the future

--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -106,13 +106,12 @@ pub struct BlobProperties {
     pub creation_time: OffsetDateTime,
     #[cfg(feature = "azurite_workaround")]
     #[serde(rename = "Creation-Time")]
-    #[serde(with = "azure_core::date::rfc1123::option")]
+    #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub creation_time: Option<OffsetDateTime>,
     #[serde(rename = "Last-Modified")]
     #[serde(with = "azure_core::date::rfc1123")]
     pub last_modified: OffsetDateTime,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::rfc1123::option")]
+    #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub last_access_time: Option<OffsetDateTime>,
     pub etag: Etag,
     #[serde(rename = "Content-Length")]
@@ -139,8 +138,7 @@ pub struct BlobProperties {
     pub blob_sequence_number: Option<u64>,
     pub blob_type: BlobType,
     pub access_tier: Option<AccessTier>,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::rfc1123::option")]
+    #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub access_tier_change_time: Option<OffsetDateTime>,
     pub lease_status: LeaseStatus,
     pub lease_state: LeaseState,
@@ -149,8 +147,7 @@ pub struct BlobProperties {
     pub copy_status: Option<CopyStatus>,
     pub copy_source: Option<String>,
     pub copy_progress: Option<CopyProgress>,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::rfc1123::option")]
+    #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub copy_completion_time: Option<OffsetDateTime>,
     pub copy_status_description: Option<String>,
     pub server_encrypted: bool,
@@ -158,15 +155,13 @@ pub struct BlobProperties {
     pub encryption_scope: Option<String>,
     pub incremental_copy: Option<bool>,
     pub access_tier_inferred: Option<bool>,
-    #[serde(default)]
-    #[serde(with = "azure_core::date::rfc1123::option")]
+    #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub deleted_time: Option<OffsetDateTime>,
     pub remaining_retention_days: Option<u32>,
     pub tag_count: Option<u32>,
     pub rehydrate_priority: Option<RehydratePriority>,
-    #[serde(default)]
     #[serde(rename = "Expiry-Time")]
-    #[serde(with = "azure_core::date::rfc1123::option")]
+    #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub expiry_time: Option<OffsetDateTime>,
     #[serde(flatten)]
     extra: HashMap<String, String>, // For debug purposes, should be compiled out in the future


### PR DESCRIPTION
Same fix as #1020, but for the SDKs. Fixed by reviewing the changes in #965. Fixes are in:

- sdk/security_keyvault/src/certificates/operations/update_properties.rs
- sdk/security_keyvault/src/secrets/operations/update_secret.rs
- sdk/storage_blobs/src/blob/mod.rs when feature = "azurite_workaround"

This is primarily a azure_security_keyvault fix.