### PR TITLE
Make content_location optional

### DIFF
--- a/sdk/data_cosmos/src/headers/from_headers.rs
+++ b/sdk/data_cosmos/src/headers/from_headers.rs
@@ -152,8 +152,10 @@ pub(crate) fn service_version_from_headers(headers: &Headers) -> azure_core::Res
     headers.get_as(&HEADER_SERVICE_VERSION)
 }
 
-pub(crate) fn content_location_from_headers(headers: &Headers) -> azure_core::Result<String> {
-    headers.get_as(&headers::CONTENT_LOCATION)
+pub(crate) fn content_location_from_headers(
+    headers: &Headers,
+) -> azure_core::Result<Option<String>> {
+    headers.get_optional_as(&headers::CONTENT_LOCATION)
 }
 
 pub(crate) fn gateway_version_from_headers(headers: &Headers) -> azure_core::Result<String> {

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -57,7 +57,7 @@ pub struct DeleteCollectionResponse {
     pub xp_role: u32,
     pub server: String,
     pub cosmos_quorum_acked_llsn: u64,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub content_type: String,
 }
 

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -37,7 +37,7 @@ impl DeleteTriggerBuilder {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteTriggerResponse {
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub server: String,
     pub last_state_change: OffsetDateTime,
     pub resource_quota: Vec<ResourceQuota>,

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -39,7 +39,7 @@ impl DeleteUserDefinedFunctionBuilder {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteUserDefinedFunctionResponse {
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub server: String,
     pub last_state_change: OffsetDateTime,
     pub resource_quota: Vec<ResourceQuota>,

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -50,7 +50,7 @@ pub struct GetAttachmentResponse {
     pub attachment: Attachment,
 
     pub content_type: String,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub last_change: OffsetDateTime,
     pub etag: String,
     pub resource_quota: Vec<ResourceQuota>,

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -61,7 +61,7 @@ pub struct GetCollectionResponse {
     pub server: String,
     pub xp_role: u32,
     pub content_type: String,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub date: OffsetDateTime,
 }
 

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -124,7 +124,7 @@ where
 #[derive(Debug, Clone)]
 pub struct FoundDocumentResponse<T> {
     pub document: Document<T>,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub last_state_change: OffsetDateTime,
     pub etag: String,
     pub resource_quota: Vec<ResourceQuota>,
@@ -184,7 +184,7 @@ where
 
 #[derive(Debug, Clone)]
 pub struct NotFoundDocumentResponse {
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub last_state_change: OffsetDateTime,
     pub lsn: u64,
     pub schema_version: String,

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -50,7 +50,7 @@ impl GetPartitionKeyRangesBuilder {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GetPartitionKeyRangesResponse {
     pub rid: String,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub server: String,
     pub last_state_change: OffsetDateTime,
     pub lsn: u64,

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -77,7 +77,7 @@ pub struct ListDocumentsResponseAttributes {
 pub struct ListDocumentsResponse<T> {
     pub rid: String,
     pub documents: Vec<Document<T>>,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub last_state_change: OffsetDateTime,
     pub resource_quota: Vec<ResourceQuota>,
     pub resource_usage: Vec<ResourceQuota>,

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -61,7 +61,7 @@ pub type ListTriggers = Pageable<ListTriggersResponse, azure_core::error::Error>
 pub struct ListTriggersResponse {
     pub rid: String,
     pub triggers: Vec<Trigger>,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub server: String,
     pub last_state_change: OffsetDateTime,
     pub continuation_token: Option<Continuation>,

--- a/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
+++ b/sdk/data_cosmos/src/operations/list_user_defined_functions.rs
@@ -65,7 +65,7 @@ pub type ListUserDefinedFunctions =
 pub struct ListUserDefinedFunctionsResponse {
     pub rid: String,
     pub user_defined_functions: Vec<UserDefinedFunction>,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub server: String,
     pub last_state_change: OffsetDateTime,
     pub continuation_token: Option<Continuation>,

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -80,7 +80,7 @@ pub struct ReplaceCollectionResponse {
     pub quorum_acked_lsn: u64,
     pub last_state_change: OffsetDateTime,
     pub date: OffsetDateTime,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub activity_id: uuid::Uuid,
     pub schema_version: String,
 }

--- a/sdk/data_cosmos/src/operations/replace_document.rs
+++ b/sdk/data_cosmos/src/operations/replace_document.rs
@@ -69,7 +69,7 @@ impl<D: Serialize + Send + 'static> ReplaceDocumentBuilder<D> {
 #[derive(Debug, Clone)]
 pub struct ReplaceDocumentResponse {
     pub document_attributes: DocumentAttributes,
-    pub content_location: String,
+    pub content_location: Option<String>,
     pub last_state_change: OffsetDateTime,
     pub resource_quota: Vec<ResourceQuota>,
     pub resource_usage: Vec<ResourceQuota>,


### PR DESCRIPTION
Fixes #1022 

This is likely not the only header that is not guaranteed to be there. We should make all headers that are not part of the [common response headers](https://docs.microsoft.com/en-us/rest/api/cosmos-db/common-cosmosdb-rest-response-headers) list optional. 