### PR TITLE
Move most headers to a common headers struct

### DIFF
--- a/sdk/data_cosmos/src/consistency_level.rs
+++ b/sdk/data_cosmos/src/consistency_level.rs
@@ -31,6 +31,21 @@ impl ConsistencyLevel {
         }
     }
 }
+macro_rules! implement_from2 {
+    ($response_type:path) => {
+        impl From<&$response_type> for ConsistencyLevel {
+            fn from(a: &$response_type) -> Self {
+                ConsistencyLevel::Session(a.common.session_token.clone())
+            }
+        }
+
+        impl From<$response_type> for ConsistencyLevel {
+            fn from(a: $response_type) -> Self {
+                ConsistencyLevel::Session(a.common.session_token.clone())
+            }
+        }
+    };
+}
 
 macro_rules! implement_from {
     ($response_type:path) => {
@@ -61,10 +76,10 @@ macro_rules! implement_from {
     };
 }
 
-implement_from!(CreateOrReplaceSlugAttachmentResponse);
-implement_from!(GetCollectionResponse);
-implement_from!(UserResponse);
-implement_from!(DeleteAttachmentResponse);
+implement_from2!(CreateOrReplaceSlugAttachmentResponse);
+implement_from2!(GetCollectionResponse);
+implement_from2!(UserResponse);
+implement_from2!(DeleteAttachmentResponse);
 implement_from!(CreateOrReplaceAttachmentResponse);
 implement_from!(ListAttachmentsResponse);
 implement_from!(GetAttachmentResponse);

--- a/sdk/data_cosmos/src/headers/common_headers.rs
+++ b/sdk/data_cosmos/src/headers/common_headers.rs
@@ -1,0 +1,49 @@
+use azure_core::{
+    headers::{self, Headers},
+    SessionToken,
+};
+use time::OffsetDateTime;
+
+use crate::ResourceQuota;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CommonHeaders {
+    pub content_type: String,
+    pub date: OffsetDateTime,
+    pub etag: Option<String>, // todo: make azure_core::Etag
+    pub activity_id: uuid::Uuid,
+    pub request_charge: f64,
+    pub resource_quota: Vec<ResourceQuota>,
+    pub resource_usage: Vec<ResourceQuota>,
+    pub schema_version: String,
+    pub service_version: String,
+    pub session_token: SessionToken,
+    pub gateway_version: Option<String>,
+    pub alt_content_path: Option<String>,
+    pub last_state_change: Option<OffsetDateTime>,
+    pub lsn: u64,
+}
+
+impl TryFrom<&Headers> for CommonHeaders {
+    type Error = azure_core::error::Error;
+    fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
+        Ok(Self {
+            content_type: headers::content_type_from_headers(headers)?,
+            date: headers::date_from_headers(headers)?,
+            etag: headers::etag_from_headers(headers).ok(),
+            activity_id: super::from_headers::activity_id_from_headers(headers)?,
+            request_charge: super::from_headers::request_charge_from_headers(headers)?,
+            resource_quota: super::from_headers::resource_quota_from_headers(headers)
+                .unwrap_or_default(),
+            resource_usage: super::from_headers::resource_usage_from_headers(headers)
+                .unwrap_or_default(),
+            schema_version: super::from_headers::schema_version_from_headers(headers)?,
+            service_version: super::from_headers::service_version_from_headers(headers)?,
+            session_token: headers::session_token_from_headers(headers)?,
+            gateway_version: super::from_headers::gateway_version_from_headers(headers).ok(),
+            alt_content_path: super::from_headers::alt_content_path_from_headers(&headers).ok(),
+            last_state_change: super::from_headers::last_state_change_from_headers(&headers).ok(),
+            lsn: super::from_headers::lsn_from_headers(headers)?,
+        })
+    }
+}

--- a/sdk/data_cosmos/src/headers/mod.rs
+++ b/sdk/data_cosmos/src/headers/mod.rs
@@ -1,5 +1,6 @@
 use azure_core::headers::HeaderName;
 
+mod common_headers;
 pub(crate) mod from_headers;
 
 pub(crate) const HEADER_DOCUMENTDB_IS_UPSERT: HeaderName =
@@ -69,3 +70,5 @@ pub(crate) const HEADER_MAX_MEDIA_STORAGE_USAGE_MB: HeaderName =
     HeaderName::from_static("x-ms-max-media-storage-usage-mb");
 pub(crate) const HEADER_MEDIA_STORAGE_USAGE_MB: HeaderName =
     HeaderName::from_static("x-ms-media-storage-usage-mb");
+
+pub use common_headers::CommonHeaders;

--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -1,9 +1,7 @@
-use crate::headers::from_headers::*;
+use crate::headers::{from_headers::*, CommonHeaders};
 use crate::prelude::*;
 use crate::resources::collection::{IndexingPolicy, PartitionKey};
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use azure_core::Response as HttpResponse;
-use time::OffsetDateTime;
 
 operation! {
     CreateCollection,
@@ -56,15 +54,7 @@ impl CreateCollectionBuilder {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateCollectionResponse {
     pub collection: Collection,
-    pub charge: f64,
-    pub activity_id: uuid::Uuid,
-    pub etag: String,
-    pub session_token: String,
-    pub last_state_change: OffsetDateTime,
-    pub schema_version: String,
-    pub service_version: String,
-    pub gateway_version: String,
-    pub alt_content_path: String,
+    pub common: CommonHeaders,
     pub quorum_acked_lsn: u64,
     pub current_write_quorum: u64,
     pub current_replica_set_size: u64,
@@ -77,15 +67,7 @@ impl CreateCollectionResponse {
 
         Ok(Self {
             collection: serde_json::from_slice(&body)?,
-            charge: request_charge_from_headers(&headers)?,
-            activity_id: activity_id_from_headers(&headers)?,
-            etag: etag_from_headers(&headers)?,
-            session_token: session_token_from_headers(&headers)?,
-            last_state_change: last_state_change_from_headers(&headers)?,
-            schema_version: schema_version_from_headers(&headers)?,
-            service_version: service_version_from_headers(&headers)?,
-            gateway_version: gateway_version_from_headers(&headers)?,
-            alt_content_path: alt_content_path_from_headers(&headers)?,
+            common: CommonHeaders::try_from(&headers)?,
             quorum_acked_lsn: quorum_acked_lsn_from_headers(&headers)?,
             current_write_quorum: current_write_quorum_from_headers(&headers)?,
             current_replica_set_size: current_replica_set_size_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/create_database.rs
+++ b/sdk/data_cosmos/src/operations/create_database.rs
@@ -1,10 +1,7 @@
-use crate::headers::from_headers::*;
+use crate::headers::{from_headers::*, CommonHeaders};
 use crate::prelude::*;
 use crate::resources::Database;
-use crate::ResourceQuota;
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
 use azure_core::Response as HttpResponse;
-use time::OffsetDateTime;
 
 operation! {
     CreateDatabase,
@@ -40,22 +37,13 @@ impl CreateDatabaseBuilder {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct CreateDatabaseResponse {
     pub database: Database,
-    pub charge: f64,
-    pub etag: String,
-    pub session_token: String,
-    pub last_state_change: OffsetDateTime,
-    pub resource_quota: Vec<ResourceQuota>,
-    pub resource_usage: Vec<ResourceQuota>,
+    pub common: CommonHeaders,
     pub quorum_acked_lsn: u64,
     pub current_write_quorum: u64,
     pub current_replica_set_size: u64,
-    pub schema_version: String,
-    pub service_version: String,
-    pub activity_id: uuid::Uuid,
-    pub gateway_version: String,
 }
 
 impl CreateDatabaseResponse {
@@ -65,19 +53,10 @@ impl CreateDatabaseResponse {
 
         Ok(Self {
             database: serde_json::from_slice(&body)?,
-            charge: request_charge_from_headers(&headers)?,
-            etag: etag_from_headers(&headers)?,
-            session_token: session_token_from_headers(&headers)?,
-            last_state_change: last_state_change_from_headers(&headers)?,
-            resource_quota: resource_quota_from_headers(&headers)?,
-            resource_usage: resource_usage_from_headers(&headers)?,
+            common: CommonHeaders::try_from(&headers)?,
             quorum_acked_lsn: quorum_acked_lsn_from_headers(&headers)?,
             current_write_quorum: current_write_quorum_from_headers(&headers)?,
             current_replica_set_size: current_replica_set_size_from_headers(&headers)?,
-            schema_version: schema_version_from_headers(&headers)?,
-            service_version: service_version_from_headers(&headers)?,
-            activity_id: activity_id_from_headers(&headers)?,
-            gateway_version: gateway_version_from_headers(&headers)?,
         })
     }
 }

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -1,17 +1,12 @@
-use crate::headers::from_headers::*;
+use crate::headers::{from_headers::*, CommonHeaders};
 use crate::prelude::*;
 use crate::resources::Attachment;
-use crate::ResourceQuota;
 use azure_core::headers;
-use azure_core::headers::{
-    date_from_headers, etag_from_headers, session_token_from_headers, HeaderValue,
-};
+use azure_core::headers::HeaderValue;
 use azure_core::Method;
 use azure_core::Response as HttpResponse;
-use azure_core::SessionToken;
 use azure_core::{content_type, prelude::*};
 use bytes::Bytes;
-use time::OffsetDateTime;
 
 operation! {
     CreateOrReplaceSlugAttachment,
@@ -77,14 +72,9 @@ impl CreateOrReplaceSlugAttachmentBuilder {
 #[derive(Debug, Clone, PartialEq)]
 pub struct CreateOrReplaceSlugAttachmentResponse {
     pub attachment: Attachment,
+    pub common: CommonHeaders,
     pub max_media_storage_usage_mb: u64,
     pub media_storage_usage_mb: u64,
-    pub last_change: OffsetDateTime,
-    pub etag: String,
-    pub resource_quota: Vec<ResourceQuota>,
-    pub resource_usage: Vec<ResourceQuota>,
-    pub lsn: u64,
-    pub alt_content_path: String,
     pub quorum_acked_lsn: u64,
     pub current_write_quorum: u64,
     pub current_replica_set_size: u64,
@@ -93,12 +83,6 @@ pub struct CreateOrReplaceSlugAttachmentResponse {
     pub transport_request_id: u64,
     pub cosmos_llsn: u64,
     pub cosmos_quorum_acked_llsn: u64,
-    pub session_token: SessionToken,
-    pub request_charge: f64,
-    pub service_version: String,
-    pub activity_id: uuid::Uuid,
-    pub gateway_version: String,
-    pub date: OffsetDateTime,
 }
 
 impl CreateOrReplaceSlugAttachmentResponse {
@@ -110,14 +94,9 @@ impl CreateOrReplaceSlugAttachmentResponse {
 
         Ok(Self {
             attachment,
+            common: CommonHeaders::try_from(&headers)?,
             max_media_storage_usage_mb: max_media_storage_usage_mb_from_headers(&headers)?,
             media_storage_usage_mb: media_storage_usage_mb_from_headers(&headers)?,
-            last_change: last_state_change_from_headers(&headers)?,
-            etag: etag_from_headers(&headers)?,
-            resource_quota: resource_quota_from_headers(&headers)?,
-            resource_usage: resource_usage_from_headers(&headers)?,
-            lsn: lsn_from_headers(&headers)?,
-            alt_content_path: alt_content_path_from_headers(&headers)?,
             quorum_acked_lsn: quorum_acked_lsn_from_headers(&headers)?,
             current_write_quorum: current_write_quorum_from_headers(&headers)?,
             current_replica_set_size: current_replica_set_size_from_headers(&headers)?,
@@ -126,12 +105,6 @@ impl CreateOrReplaceSlugAttachmentResponse {
             transport_request_id: transport_request_id_from_headers(&headers)?,
             cosmos_llsn: cosmos_llsn_from_headers(&headers)?,
             cosmos_quorum_acked_llsn: cosmos_quorum_acked_llsn_from_headers(&headers)?,
-            session_token: session_token_from_headers(&headers)?,
-            request_charge: request_charge_from_headers(&headers)?,
-            service_version: service_version_from_headers(&headers)?,
-            activity_id: activity_id_from_headers(&headers)?,
-            gateway_version: gateway_version_from_headers(&headers)?,
-            date: date_from_headers(&headers)?,
         })
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -1,11 +1,9 @@
 use crate::headers::from_headers::*;
+use crate::headers::CommonHeaders;
 use crate::prelude::*;
-use crate::ResourceQuota;
 
-use azure_core::headers::session_token_from_headers;
 use azure_core::prelude::*;
 use azure_core::Response as HttpResponse;
-use azure_core::SessionToken;
 use time::OffsetDateTime;
 
 operation! {
@@ -45,13 +43,10 @@ impl DeleteAttachmentBuilder {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct DeleteAttachmentResponse {
+    pub common: CommonHeaders,
     pub max_media_storage_usage_mb: u64,
     pub media_storage_usage_mb: u64,
     pub last_change: OffsetDateTime,
-    pub resource_quota: Vec<ResourceQuota>,
-    pub resource_usage: Vec<ResourceQuota>,
-    pub lsn: u64,
-    pub alt_content_path: String,
     pub content_path: String,
     pub quorum_acked_lsn: u64,
     pub current_write_quorum: u64,
@@ -61,12 +56,6 @@ pub struct DeleteAttachmentResponse {
     pub transport_request_id: u64,
     pub cosmos_llsn: u64,
     pub cosmos_quorum_acked_llsn: u64,
-    pub session_token: SessionToken,
-    pub request_charge: f64,
-    pub service_version: String,
-    pub activity_id: uuid::Uuid,
-    pub gateway_version: String,
-    pub date: OffsetDateTime,
 }
 
 impl DeleteAttachmentResponse {
@@ -74,13 +63,10 @@ impl DeleteAttachmentResponse {
         let headers = response.headers();
 
         Ok(Self {
+            common: CommonHeaders::try_from(headers)?,
             max_media_storage_usage_mb: max_media_storage_usage_mb_from_headers(headers)?,
             media_storage_usage_mb: media_storage_usage_mb_from_headers(headers)?,
             last_change: last_state_change_from_headers(headers)?,
-            resource_quota: resource_quota_from_headers(headers)?,
-            resource_usage: resource_usage_from_headers(headers)?,
-            lsn: lsn_from_headers(headers)?,
-            alt_content_path: alt_content_path_from_headers(headers)?,
             content_path: content_path_from_headers(headers)?,
             quorum_acked_lsn: quorum_acked_lsn_from_headers(headers)?,
             current_write_quorum: current_write_quorum_from_headers(headers)?,
@@ -90,12 +76,6 @@ impl DeleteAttachmentResponse {
             transport_request_id: transport_request_id_from_headers(headers)?,
             cosmos_llsn: cosmos_llsn_from_headers(headers)?,
             cosmos_quorum_acked_llsn: cosmos_quorum_acked_llsn_from_headers(headers)?,
-            session_token: session_token_from_headers(headers)?,
-            request_charge: request_charge_from_headers(headers)?,
-            service_version: service_version_from_headers(headers)?,
-            activity_id: activity_id_from_headers(headers)?,
-            gateway_version: gateway_version_from_headers(headers)?,
-            date: date_from_headers(headers)?,
         })
     }
 }

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -1,7 +1,5 @@
-use crate::headers::from_headers::*;
+use crate::headers::CommonHeaders;
 use crate::prelude::*;
-use crate::ResourceQuota;
-use azure_core::headers::session_token_from_headers;
 use azure_core::Response as HttpResponse;
 
 operation! {
@@ -30,26 +28,15 @@ impl DeleteDatabaseBuilder {
 
 #[derive(Debug, Clone)]
 pub struct DeleteDatabaseResponse {
-    pub charge: f64,
-    pub activity_id: uuid::Uuid,
-    pub session_token: String,
-    pub resource_quota: Vec<ResourceQuota>,
-    pub resource_usage: Vec<ResourceQuota>,
+    pub common: CommonHeaders,
 }
 
 impl DeleteDatabaseResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
-        let charge = request_charge_from_headers(headers)?;
-        let activity_id = activity_id_from_headers(headers)?;
-
         Ok(Self {
-            charge,
-            activity_id,
-            session_token: session_token_from_headers(headers)?,
-            resource_quota: resource_quota_from_headers(headers)?,
-            resource_usage: resource_usage_from_headers(headers)?,
+            common: CommonHeaders::try_from(headers)?,
         })
     }
 }

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -1,11 +1,7 @@
 use crate::prelude::*;
 
-use crate::headers::from_headers::*;
-use azure_core::headers::{
-    content_type_from_headers, etag_from_headers, session_token_from_headers,
-};
+use crate::headers::{from_headers::*, CommonHeaders};
 use azure_core::Response as HttpResponse;
-use time::OffsetDateTime;
 
 operation! {
     GetCollection,
@@ -39,13 +35,9 @@ impl GetCollectionBuilder {
 #[derive(Debug, Clone)]
 pub struct GetCollectionResponse {
     pub collection: Collection,
-    pub last_state_change: OffsetDateTime,
-    pub etag: String,
+    pub common: CommonHeaders,
     pub collection_partition_index: u64,
     pub collection_service_index: u64,
-    pub lsn: u64,
-    pub schema_version: String,
-    pub alt_content_path: String,
     pub content_path: String,
     pub global_committed_lsn: u64,
     pub number_of_read_regions: u32,
@@ -53,16 +45,8 @@ pub struct GetCollectionResponse {
     pub transport_request_id: u64,
     pub cosmos_llsn: u64,
     pub cosmos_item_llsn: u64,
-    pub charge: f64,
-    pub service_version: String,
-    pub activity_id: uuid::Uuid,
-    pub session_token: String,
-    pub gateway_version: String,
-    pub server: String,
     pub xp_role: u32,
-    pub content_type: String,
     pub content_location: Option<String>,
-    pub date: OffsetDateTime,
 }
 
 impl GetCollectionResponse {
@@ -72,13 +56,9 @@ impl GetCollectionResponse {
 
         Ok(Self {
             collection: serde_json::from_slice(&body)?,
-            last_state_change: last_state_change_from_headers(&headers)?,
-            etag: etag_from_headers(&headers)?,
+            common: CommonHeaders::try_from(&headers)?,
             collection_partition_index: collection_partition_index_from_headers(&headers)?,
             collection_service_index: collection_service_index_from_headers(&headers)?,
-            lsn: lsn_from_headers(&headers)?,
-            schema_version: schema_version_from_headers(&headers)?,
-            alt_content_path: alt_content_path_from_headers(&headers)?,
             content_path: content_path_from_headers(&headers)?,
             global_committed_lsn: global_committed_lsn_from_headers(&headers)?,
             number_of_read_regions: number_of_read_regions_from_headers(&headers)?,
@@ -86,16 +66,8 @@ impl GetCollectionResponse {
             transport_request_id: transport_request_id_from_headers(&headers)?,
             cosmos_llsn: cosmos_llsn_from_headers(&headers)?,
             cosmos_item_llsn: cosmos_item_llsn_from_headers(&headers)?,
-            charge: request_charge_from_headers(&headers)?,
-            service_version: service_version_from_headers(&headers)?,
-            activity_id: activity_id_from_headers(&headers)?,
-            session_token: session_token_from_headers(&headers)?,
-            gateway_version: gateway_version_from_headers(&headers)?,
-            server: server_from_headers(&headers)?,
             xp_role: role_from_headers(&headers)?,
-            content_type: content_type_from_headers(&headers)?,
             content_location: content_location_from_headers(&headers)?,
-            date: date_from_headers(&headers)?,
         })
     }
 }

--- a/sdk/data_cosmos/src/resources/user.rs
+++ b/sdk/data_cosmos/src/resources/user.rs
@@ -1,11 +1,9 @@
 //! Utilities for interacting with [`User`]s.
 
 use super::Resource;
-use crate::headers::from_headers::*;
-use azure_core::{
-    headers::{etag_from_headers, session_token_from_headers},
-    Response as HttpResponse,
-};
+use crate::headers::CommonHeaders;
+use azure_core::Response as HttpResponse;
+
 /// A logical namespace for scoping permissions on resources.
 ///
 /// You can learn more about users [here](https://docs.microsoft.com/rest/api/cosmos-db/users).
@@ -53,14 +51,8 @@ impl Resource for User {
 pub struct UserResponse {
     /// The Cosmos user
     pub user: User,
-    /// The charge for this request from the Cosmos service
-    pub charge: f64,
-    /// Represents a unique identifier for the operation
-    pub activity_id: uuid::Uuid,
-    /// The etag for the resource retrieved
-    pub etag: String,
-    /// The session token for the request
-    pub session_token: String,
+    /// Common headers that all responses expose
+    pub common: CommonHeaders,
 }
 
 impl UserResponse {
@@ -71,10 +63,7 @@ impl UserResponse {
 
         Ok(Self {
             user: serde_json::from_slice(&body)?,
-            charge: request_charge_from_headers(&headers)?,
-            activity_id: activity_id_from_headers(&headers)?,
-            session_token: session_token_from_headers(&headers)?,
-            etag: etag_from_headers(&headers)?,
+            common: CommonHeaders::try_from(&headers)?,
         })
     }
 }


### PR DESCRIPTION
This change would move most headers that are received back from the Cosmos API to a `CommonHeaders` struct that can be deserialized. The thought behind this is that even for endpoints where it seems like certain headers always come back #1022 showed that this can change. We should probably be pretty lax about what headers we do accept. This allows us to centralize this decision making within Cosmos. 

Thoughts? @ctaggart @bmc-msft