### PR TITLE
Improve message from error in retry policy that is no longer retried

### DIFF
--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -133,6 +133,23 @@ impl Error {
         }
     }
 
+    /// Wrap this error in additional `message`
+    pub fn context<C>(self, message: C) -> Self
+    where
+        C: Into<Cow<'static, str>>,
+    {
+        Self::full(self.kind().clone(), self, message)
+    }
+
+    /// Wrap this error in additional message
+    pub fn with_context<F, C>(self, f: F) -> Self
+    where
+        F: FnOnce() -> C,
+        C: Into<Cow<'static, str>>,
+    {
+        self.context(f())
+    }
+
     /// Get the `ErrorKind` of this `Error`
     pub fn kind(&self) -> &ErrorKind {
         match &self.context {


### PR DESCRIPTION
There are two changes in this PR:
* Previously, the retry policy was wrapping all non-200 responses in an error with the message "server returned error status which will not be retried: {status}" even the ones that *are* retired. This change now only uses that message for errors that are definitely retried. 
* Additional context is now added to the error messages that *were* retried but no longer are because the retry limit was reached. 