### PR TITLE
reduce log level on requests that will not be retried

### DIFF
--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -101,8 +101,9 @@ where
                         );
                         error
                     } else {
-                        log::debug!("non-io error occurred which will not be retried: {}", error);
-                        return Err(error);
+                        return Err(
+                            error.context("non-io error occurred which will not be retried")
+                        );
                     }
                 }
             };

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -73,7 +73,7 @@ where
                     );
 
                     if !RETRY_STATUSES.contains(&status) {
-                        log::error!(
+                        log::debug!(
                             "server returned error status which will not be retried: {}",
                             status
                         );

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -101,7 +101,7 @@ where
                         );
                         error
                     } else {
-                        log::error!("non-io error occurred which will not be retried: {}", error);
+                        log::debug!("non-io error occurred which will not be retried: {}", error);
                         return Err(error);
                     }
                 }


### PR DESCRIPTION
This log entry generates errors on multiple common patterns that should not result in the SDK generating error logs.

As an example, the recommended method for checking if a blob exists is to read it's properties.  If a blob does not exist, it generates a 404 response, which causes an error here.

Given the SDK returns an error, this should be left up to the SDK consumer if these warrants logging an error.

