### PR TITLE
fix formatting datetime for SAS generation

### DIFF
--- a/sdk/core/src/date/mod.rs
+++ b/sdk/core/src/date/mod.rs
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_rfc3339() -> crate::Result<()> {
-        let s = "2019-10-12T07:20:50.52Z";
+        let s = "2019-10-12T07:20:50Z";
         let dt = parse_rfc3339(s)?;
         assert_eq!(s, to_rfc3339(&dt));
         Ok(())

--- a/sdk/core/src/date/mod.rs
+++ b/sdk/core/src/date/mod.rs
@@ -37,12 +37,8 @@ pub fn parse_rfc3339(s: &str) -> crate::Result<OffsetDateTime> {
 ///
 /// 1985-04-12T23:20:50.52Z
 pub fn to_rfc3339(date: &OffsetDateTime) -> String {
-    date.replace_nanosecond(0)
-        // setting nanonsecond to 0 is also known to not panic.
-        .unwrap()
-        // known format does not panic
-        .format(&Rfc3339)
-        .unwrap()
+    // known format does not panic
+    date.format(&Rfc3339).unwrap()
 }
 
 /// RFC 1123: Requirements for Internet Hosts - Application and Support
@@ -161,7 +157,7 @@ mod tests {
 
     #[test]
     fn test_roundtrip_rfc3339() -> crate::Result<()> {
-        let s = "2019-10-12T07:20:50Z";
+        let s = "2019-10-12T07:20:50.52Z";
         let dt = parse_rfc3339(s)?;
         assert_eq!(s, to_rfc3339(&dt));
         Ok(())

--- a/sdk/core/src/date/mod.rs
+++ b/sdk/core/src/date/mod.rs
@@ -37,8 +37,12 @@ pub fn parse_rfc3339(s: &str) -> crate::Result<OffsetDateTime> {
 ///
 /// 1985-04-12T23:20:50.52Z
 pub fn to_rfc3339(date: &OffsetDateTime) -> String {
-    // known format does not panic
-    date.format(&Rfc3339).unwrap()
+    date.replace_nanosecond(0)
+        // setting nanonsecond to 0 is also known to not panic.
+        .unwrap()
+        // known format does not panic
+        .format(&Rfc3339)
+        .unwrap()
 }
 
 /// RFC 1123: Requirements for Internet Hosts - Application and Support

--- a/sdk/storage/src/core/shared_access_signature/mod.rs
+++ b/sdk/storage/src/core/shared_access_signature/mod.rs
@@ -10,7 +10,8 @@ pub trait SasToken {
 }
 
 pub(crate) fn format_date(d: OffsetDateTime) -> String {
-    azure_core::date::to_rfc3339(&d)
+    // replacing nanosecond with 0 is known to not panic
+    azure_core::date::to_rfc3339(&d.replace_nanosecond(0).unwrap())
 }
 
 pub(crate) fn format_form(d: String) -> String {

--- a/sdk/storage/src/core/shared_access_signature/mod.rs
+++ b/sdk/storage/src/core/shared_access_signature/mod.rs
@@ -9,7 +9,17 @@ pub trait SasToken {
     fn token(&self) -> String;
 }
 
+/// Converts an OffsetDateTime to an RFC3339 formatted string after truncating
+/// any partial seconds.
 pub(crate) fn format_date(d: OffsetDateTime) -> String {
+    // When validating signatures, Azure Storage server creates a canonicalized
+    // version of the request, then verifies the signature from the request with
+    // the canonicalized version.
+    //
+    // The canonicalization at the server truncates the timestamps without
+    // microseconds or nanoseconds.  As such, this needs to be truncated here
+    // too.
+    //
     // replacing nanosecond with 0 is known to not panic
     azure_core::date::to_rfc3339(&d.replace_nanosecond(0).unwrap())
 }
@@ -31,5 +41,18 @@ impl fmt::Display for SasProtocol {
             SasProtocol::Https => write!(f, "https"),
             SasProtocol::HttpHttps => write!(f, "http,https"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::macros::datetime;
+
+    #[test]
+    // verify format_date truncates as expected.
+    fn test_format_date_truncation() {
+        let date = datetime!(2022-08-22 15:11:43.4185122 +00:00:00);
+        assert_eq!(format_date(date), "2022-08-22T15:11:43Z");
     }
 }


### PR DESCRIPTION
Azure uses RFC3339 format, except without microseconds/nanoseconds