### PR TITLE
core: Change the RetryPolicy trait to allow waiting on arbitrary things.

### DIFF
--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -23,7 +23,7 @@ pub trait RetryPolicy {
     /// Determine how long before the next retry should be attempted.
     fn sleep_duration(&self, retry_count: u32) -> Duration;
     /// A Future that will wait until the request can be retried.
-    async fn wait(&self, retry_count: u32) {
+    async fn wait(&self, retry_count: u32, _error: &Error) {
         sleep(self.sleep_duration(retry_count)).await;
     }
 }
@@ -122,7 +122,7 @@ where
             }
             retry_count += 1;
 
-            self.wait(retry_count).await;
+            self.wait(retry_count, &last_error).await;
         }
     }
 }

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -11,9 +11,12 @@ use std::time::Duration;
 
 /// A retry policy.
 ///
-/// All retry policies follow a similar pattern only differing in how
+/// In the simple form, the policies need only differ in how
 /// they determine if the retry has expired and for how long they should
 /// sleep between retries.
+///
+/// `wait` can be implemented in more complex cases where a simple test of time
+/// is not enough.
 #[async_trait]
 pub trait RetryPolicy {
     /// Determine if no more retries should be performed.

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -26,7 +26,7 @@ pub trait RetryPolicy {
     /// Determine how long before the next retry should be attempted.
     fn sleep_duration(&self, retry_count: u32) -> Duration;
     /// A Future that will wait until the request can be retried.
-    /// `error` is the [`Error`] value the led a retry attempt.
+    /// `error` is the [`Error`] value the led to a retry attempt.
     async fn wait(&self, _error: &Error, retry_count: u32) {
         sleep(self.sleep_duration(retry_count)).await;
     }

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -26,7 +26,8 @@ pub trait RetryPolicy {
     /// Determine how long before the next retry should be attempted.
     fn sleep_duration(&self, retry_count: u32) -> Duration;
     /// A Future that will wait until the request can be retried.
-    async fn wait(&self, retry_count: u32, _error: &Error) {
+    /// `error` is the [`Error`] value the led a retry attempt.
+    async fn wait(&self, _error: &Error, retry_count: u32) {
         sleep(self.sleep_duration(retry_count)).await;
     }
 }
@@ -125,7 +126,7 @@ where
             }
             retry_count += 1;
 
-            self.wait(retry_count, &last_error).await;
+            self.wait(&last_error, retry_count).await;
         }
     }
 }

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -3,6 +3,7 @@ use crate::policies::{Policy, PolicyResult, Request};
 use crate::sleep::sleep;
 use crate::{Context, StatusCode};
 
+use async_trait::async_trait;
 use time::OffsetDateTime;
 
 use std::sync::Arc;
@@ -13,6 +14,7 @@ use std::time::Duration;
 /// All retry policies follow a similar pattern only differing in how
 /// they determine if the retry has expired and for how long they should
 /// sleep between retries.
+#[async_trait]
 pub trait RetryPolicy {
     /// Determine if no more retries should be performed.
     ///
@@ -21,11 +23,8 @@ pub trait RetryPolicy {
     /// Determine how long before the next retry should be attempted.
     fn sleep_duration(&self, retry_count: u32) -> Duration;
     /// A Future that will wait until the request can be retried.
-    fn wait(
-        &self,
-        retry_count: u32,
-    ) -> std::pin::Pin<std::boxed::Box<dyn std::future::Future<Output = ()> + Send>> {
-        Box::pin(sleep(self.sleep_duration(retry_count)))
+    async fn wait(&self, retry_count: u32) {
+        sleep(self.sleep_duration(retry_count)).await;
     }
 }
 


### PR DESCRIPTION
Previously the only thing that that a retry would wait for was a period
of time, i.e. `Duration`. This adds another function to the `RetryPolicy` trait
that allows the implementer to wait on any condition they like. The
default implementation of the new method provides backward compatibility
by just sleeping for a period of time.

A real world example of this is flow control. If you are consistently getting errors from the service is too busy, you may want to slow send less requests across multiple threads. Long term it might be better to add a custom policy for this so that you have access to the exact error, but it would also need to be aware of retries that had occurred, and probably sit later in the `Pipeline`. Another option would be to pass the error into this new function.