### PR TITLE
address more header names that are not canonicalized before use

### DIFF
--- a/sdk/data_cosmos/src/headers/mod.rs
+++ b/sdk/data_cosmos/src/headers/mod.rs
@@ -11,7 +11,7 @@ pub(crate) const HEADER_CONSISTENCY_LEVEL: HeaderName =
 pub(crate) const HEADER_SESSION_TOKEN: HeaderName = HeaderName::from_static("x-ms-session-token");
 pub(crate) const HEADER_ALLOW_MULTIPLE_WRITES: HeaderName =
     HeaderName::from_static("x-ms-cosmos-allow-tentative-writes");
-pub(crate) const HEADER_A_IM: HeaderName = HeaderName::from_static("A-IM");
+pub(crate) const HEADER_A_IM: HeaderName = HeaderName::from_static("a-im");
 pub(crate) const HEADER_DOCUMENTDB_PARTITIONRANGEID: HeaderName =
     HeaderName::from_static("x-ms-documentdb-partitionkeyrangeid");
 pub(crate) const HEADER_DOCUMENTDB_PARTITIONKEY: HeaderName =

--- a/sdk/data_tables/src/operations/list_tables.rs
+++ b/sdk/data_tables/src/operations/list_tables.rs
@@ -81,7 +81,7 @@ impl TryFrom<CollectedResponse> for ListTablesResponse {
 
         let continuation_next_table_name = response
             .headers()
-            .get_optional_string(&HeaderName::from_static("x-ms-continuation-NextTableName"));
+            .get_optional_string(&HeaderName::from_static("x-ms-continuation-nexttablename"));
 
         Ok(ListTablesResponse {
             common_storage_response_headers: response.headers().try_into()?,

--- a/sdk/data_tables/src/operations/query_entity.rs
+++ b/sdk/data_tables/src/operations/query_entity.rs
@@ -115,11 +115,11 @@ impl<E: DeserializeOwned + Send + Sync> TryFrom<CollectedResponse> for QueryEnti
         let headers = response.headers();
 
         let next_partition_key = headers.get_optional_string(&HeaderName::from_static(
-            "x-ms-continuation-NextPartitionKey",
+            "x-ms-continuation-nextpartitionkey",
         ));
 
         let next_row_key =
-            headers.get_optional_string(&HeaderName::from_static("x-ms-continuation-NextRowKey"));
+            headers.get_optional_string(&HeaderName::from_static("x-ms-continuation-nextrowkey"));
 
         Ok(QueryEntityResponse {
             common_storage_response_headers: response.headers().try_into()?,


### PR DESCRIPTION
Because Header Names are canonicalized to lowercase, use of these headers broke when the headername implementation changed.