### PR TITLE
Prevent the use of uppercase letters in HeaderName::from_static

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -173,6 +173,7 @@ pub struct HeaderName(std::borrow::Cow<'static, str>);
 
 impl HeaderName {
     pub const fn from_static(s: &'static str) -> Self {
+        ensure_no_uppercase(s);
         Self(std::borrow::Cow::Borrowed(s))
     }
 
@@ -190,6 +191,19 @@ impl HeaderName {
 
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
+    }
+}
+
+/// Ensures the supplied string does not contain any uppercase ascii characters
+const fn ensure_no_uppercase(s: &str) {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if byte >= 65u8 && byte <= 90u8 {
+            panic!("header names must not contain any uppercase letters");
+        }
+        i += 1;
     }
 }
 


### PR DESCRIPTION
Hopefully preventing issues like that in #1048 once and for all. 

This is the error you now get if you try to use an uppercase letter in a headername:

```rust
error[E0080]: evaluation of constant value failed
   --> sdk/core/src/headers/mod.rs:204:13
    |
176 |         ensure_no_uppercase(s);
    |         ---------------------- inside `headers::HeaderName::from_static` at sdk/core/src/headers/mod.rs:176:9
...
204 |             panic!("header names must not contain any uppercase letters");
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |             |
    |             the evaluated program panicked at 'header names must not contain any uppercase letters', sdk/core/src/headers/mod.rs:204:13
    |             inside `ensure_no_uppercase` at /home/rylevick/.rustup/toolchains/1.63.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic.rs:57:9
...
265 | pub const ACCEPT: HeaderName = HeaderName::from_static("Accept");
    |                                --------------------------------- inside `headers::ACCEPT` at sdk/core/src/headers/mod.rs:265:32
    |
    = note: this error originates in the macro `$crate::panic::panic_2021` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0080`.
error: could not compile `azure_core` due to previous error
```