### PR TITLE
Make `azure_data_cosmos::clients::CloudLocation` public

### DIFF
--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -179,19 +179,30 @@ fn new_pipeline_from_options(
 pub enum CloudLocation {
     /// Azure public cloud
     Public {
+        /// The account name
         account: String,
+        /// The auth token
         auth_token: AuthorizationToken,
     },
     /// Azure China cloud
     China {
+        /// The account name
         account: String,
+        /// The auth token
         auth_token: AuthorizationToken,
     },
     /// Use the well-known Cosmos emulator
-    Emulator { address: String, port: u16 },
+    Emulator {
+        /// The emulator's address
+        address: String,
+        /// The emulator's port
+        port: u16,
+    },
     /// A custom base URL
     Custom {
+        /// The uri
         uri: String,
+        /// The auth token
         auth_token: AuthorizationToken,
     },
 }

--- a/sdk/data_cosmos/src/clients/mod.rs
+++ b/sdk/data_cosmos/src/clients/mod.rs
@@ -34,7 +34,7 @@ mod user_defined_function;
 
 pub use attachment::AttachmentClient;
 pub use collection::CollectionClient;
-pub use cosmos::{CosmosClient, CosmosClientBuilder};
+pub use cosmos::{CloudLocation, CosmosClient, CosmosClientBuilder};
 pub use database::DatabaseClient;
 pub use document::DocumentClient;
 pub use permission::PermissionClient;


### PR DESCRIPTION
I was trying to use the SDK against the CosmosDB emulator, and it looks like `CosmosClientBuilder` has a few public methods which aren't usable right now as `CloudLocation` is not public. This one-liner exports `CloudLocation` as public to allow those methods to be used.