### PR TITLE
Stop using `StorageClient` in blob storage

### DIFF
--- a/sdk/storage/src/clients/mod.rs
+++ b/sdk/storage/src/clients/mod.rs
@@ -1,3 +1,6 @@
 mod storage_client;
 
-pub use storage_client::{ServiceType, StorageClient, StorageCredentials, StorageOptions};
+pub use storage_client::{
+    finalize_request, new_pipeline_from_options, ServiceType, StorageClient, StorageCredentials,
+    StorageOptions,
+};

--- a/sdk/storage/src/prelude.rs
+++ b/sdk/storage/src/prelude.rs
@@ -1,5 +1,5 @@
 pub use crate::{
-    clients::StorageClient,
+    clients::{StorageClient, StorageCredentials},
     consistency::{ConsistencyCRC64, ConsistencyMD5},
     shared_access_signature::{
         account_sas::{AccountSasPermissions, AccountSasResource, AccountSasResourceType},

--- a/sdk/storage_blobs/examples/account.rs
+++ b/sdk/storage_blobs/examples/account.rs
@@ -10,10 +10,10 @@ async fn main() -> azure_core::Result<()> {
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_service_client = storage_client.blob_service_client();
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
 
-    let account = blob_service_client
+    let account = service_client
         .get_account_information()
         .into_future()
         .await?;

--- a/sdk/storage_blobs/examples/anonymous_access.rs
+++ b/sdk/storage_blobs/examples/anonymous_access.rs
@@ -8,8 +8,9 @@ async fn main() -> azure_core::Result<()> {
     let account = std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT");
     let container = std::env::var("STORAGE_CONTAINER").expect("Set env variable STORAGE_CONTAINER");
 
-    let storage_client = StorageClient::new_anonymous(&account);
-    let container_client = storage_client.container_client(container);
+    let storage_credentials = StorageCredentials::Anonymous;
+    let container_client =
+        BlobServiceClient::new(account, storage_credentials).container_client(container);
 
     let mut blob_stream = container_client.list_blobs().into_stream();
     while let Some(blob_entry) = blob_stream.next().await {

--- a/sdk/storage_blobs/examples/blob_00.rs
+++ b/sdk/storage_blobs/examples/blob_00.rs
@@ -20,13 +20,14 @@ async fn main() -> azure_core::Result<()> {
         .nth(2)
         .expect("please specify blob name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
 
     // this is how you would use the SAS token:
     // let storage_client = StorageAccountClient::new_sas_token(http_client.clone(), &account,
     //      "sv=2018-11-09&ss=b&srt=o&se=2021-01-15T12%3A09%3A01Z&sp=r&st=2021-01-15T11%3A09%3A01Z&spr=http,https&sig=some_signature")?;
 
-    let blob_client = storage_client
+    let blob_client = service_client
         .container_client(&container)
         .blob_client(&blob);
 

--- a/sdk/storage_blobs/examples/blob_01.rs
+++ b/sdk/storage_blobs/examples/blob_01.rs
@@ -16,8 +16,9 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let container_client = storage_client.container_client(&container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
+    let container_client = service_client.container_client(&container_name);
     let blob_client = container_client.blob_client("SorgeniaReorganizeRebuildIndexes.zip");
 
     // only get the first chunk

--- a/sdk/storage_blobs/examples/blob_02_bearer_token.rs
+++ b/sdk/storage_blobs/examples/blob_02_bearer_token.rs
@@ -21,7 +21,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(4)
         .expect("please specify the bearer token as fourth command line parameter");
 
-    let blob_client = StorageClient::new_bearer_token(&account, bearer_token)
+    let storage_credentials = StorageCredentials::BearerToken(bearer_token);
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob);
 

--- a/sdk/storage_blobs/examples/blob_04.rs
+++ b/sdk/storage_blobs/examples/blob_04.rs
@@ -17,7 +17,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container_name)
         .blob_client("test1");
 

--- a/sdk/storage_blobs/examples/blob_05_default_credential.rs
+++ b/sdk/storage_blobs/examples/blob_05_default_credential.rs
@@ -28,7 +28,8 @@ async fn main() -> azure_core::Result<()> {
         .get_token("https://storage.azure.com/")
         .await?;
 
-    let blob_client = StorageClient::new_bearer_token(&account, bearer_token.token.secret())
+    let storage_credentials = StorageCredentials::BearerToken(bearer_token.token.secret().into());
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob);
 

--- a/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
+++ b/sdk/storage_blobs/examples/blob_06_auto_refreshing_credentials.rs
@@ -25,7 +25,8 @@ async fn main() -> azure_core::Result<()> {
     let creds = Arc::new(DefaultAzureCredential::default());
     let auto_creds = Arc::new(AutoRefreshingTokenCredential::new(creds));
 
-    let blob_client = StorageClient::new_token_credential(&account, auto_creds)
+    let storage_credentials = StorageCredentials::TokenCredential(token_credential);
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob);
 

--- a/sdk/storage_blobs/examples/blob_range.rs
+++ b/sdk/storage_blobs/examples/blob_range.rs
@@ -14,8 +14,9 @@ async fn main() -> azure_core::Result<()> {
     let container_name = format!("range-example-{}", Uuid::new_v4());
     let blob_name = format!("blob-{}.txt", Uuid::new_v4());
 
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
     let container_client =
-        StorageClient::new_access_key(&account, &access_key).container_client(&container_name);
+        BlobServiceClient::new(&account, storage_credentials).container_client(&container_name);
     container_client.create().into_future().await?;
 
     let blob_client = container_client.blob_client(&blob_name);

--- a/sdk/storage_blobs/examples/blob_tags.rs
+++ b/sdk/storage_blobs/examples/blob_tags.rs
@@ -15,9 +15,9 @@ async fn main() -> azure_core::Result<()> {
     let blob_name = format!("file-{}.txt", Uuid::new_v4());
     let blob_notags_name = format!("file-{}.txt", Uuid::new_v4());
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-
-    let container_client = storage_client.container_client(&container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let container_client =
+        BlobServiceClient::new(&account, storage_credentials).container_client(&container_name);
     container_client.create().into_future().await?;
 
     let blob_client = container_client.blob_client(&blob_name);

--- a/sdk/storage_blobs/examples/container_00.rs
+++ b/sdk/storage_blobs/examples/container_00.rs
@@ -15,12 +15,12 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_service_client = storage_client.blob_service_client();
-    let container_client = storage_client.container_client(container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
+    let container_client = service_client.container_client(container_name);
 
     let max_results = NonZeroU32::new(3).unwrap();
-    let mut iv = blob_service_client
+    let mut iv = service_client
         .list_containers()
         .max_results(max_results)
         .into_stream();

--- a/sdk/storage_blobs/examples/container_01.rs
+++ b/sdk/storage_blobs/examples/container_01.rs
@@ -16,8 +16,9 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let container_client = storage_client.container_client(container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
+    let container_client = service_client.container_client(container_name);
 
     let mut metadata = Metadata::new();
     metadata.insert("prova".to_owned(), "pollo".to_owned());

--- a/sdk/storage_blobs/examples/container_and_blob.rs
+++ b/sdk/storage_blobs/examples/container_and_blob.rs
@@ -16,8 +16,9 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let container_client = storage_client.container_client(&container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let container_client =
+        BlobServiceClient::new(&account, storage_credentials).container_client(&container_name);
 
     // create container
     container_client

--- a/sdk/storage_blobs/examples/copy_blob.rs
+++ b/sdk/storage_blobs/examples/copy_blob.rs
@@ -1,5 +1,5 @@
 use azure_core::date;
-use azure_storage::prelude::*;
+use azure_storage::{clients::StorageCredentials, prelude::*};
 use azure_storage_blobs::prelude::*;
 use time::OffsetDateTime;
 
@@ -29,15 +29,18 @@ async fn main() -> azure_core::Result<()> {
         .nth(4)
         .expect("please specify destination blob name as fourth command line parameter");
 
-    let source_storage_client = StorageClient::new_access_key(&source_account, &source_access_key);
-    let source_blob = source_storage_client
+    let storage_credentials = StorageCredentials::Key(source_account.clone(), source_access_key);
+    let service_client = BlobServiceClient::new(source_account, storage_credentials);
+    let source_blob = service_client
         .container_client(&source_container_name)
         .blob_client(&source_blob_name);
 
-    let destination_blob =
-        StorageClient::new_access_key(&destination_account, &destination_access_key)
-            .container_client(&destination_container_name)
-            .blob_client(&destination_blob_name);
+    let storage_credentials =
+        StorageCredentials::Key(destination_account.clone(), destination_access_key);
+    let source_storage_client = BlobServiceClient::new(destination_account, storage_credentials);
+    let destination_blob = service_client
+        .container_client(&source_container_name)
+        .blob_client(&source_blob_name);
 
     // let's get a SAS key for the source
     let sas_url = {

--- a/sdk/storage_blobs/examples/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/examples/copy_blob_from_url.rs
@@ -22,8 +22,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(4)
         .expect("please specify destination blob name as fourth command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_client = storage_client
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(&account, storage_credentials)
         .container_client(&destination_container)
         .blob_client(&destination_blob);
 

--- a/sdk/storage_blobs/examples/count_blobs.rs
+++ b/sdk/storage_blobs/examples/count_blobs.rs
@@ -13,8 +13,9 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
     let container_client =
-        StorageClient::new_access_key(&account, &access_key).container_client(&container);
+        BlobServiceClient::new(&account, storage_credentials).container_client(&container);
 
     let mut count: usize = 0;
     let mut list_blobs = container_client.list_blobs().into_stream();

--- a/sdk/storage_blobs/examples/device_code_flow.rs
+++ b/sdk/storage_blobs/examples/device_code_flow.rs
@@ -69,11 +69,9 @@ async fn main() -> azure_core::Result<()> {
     // this example we are creating an Azure Storage client
     // using the access token.
 
-    let storage_client = StorageClient::new_bearer_token(
-        &storage_account_name,
-        authorization.access_token().secret(),
-    );
-    let blob_service_client = storage_client.blob_service_client();
+    let storage_credentials =
+        StorageCredentials::BearerToken(authorization.access_token().secret().to_owned());
+    let blob_service_client = BlobServiceClient::new(account, storage_credentials);
 
     // now we enumerate the containers in the
     // specified storage account.

--- a/sdk/storage_blobs/examples/emulator_00.rs
+++ b/sdk/storage_blobs/examples/emulator_00.rs
@@ -7,7 +7,11 @@ async fn main() -> azure_core::Result<()> {
     env_logger::init();
 
     // this is how you use the emulator.
-    let storage_account = StorageClient::new_emulator_default();
+    let storage_account = BlobServiceClientBuilder::with_location(CloudLocation::Emulator {
+        address: "".into(),
+        port: 1000, // TODO: provide constructors for this
+    })
+    .build();
     let container_client = storage_account.container_client("emulcont");
 
     // create container

--- a/sdk/storage_blobs/examples/list_blobs_00.rs
+++ b/sdk/storage_blobs/examples/list_blobs_00.rs
@@ -17,9 +17,9 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_service = storage_client.blob_service_client();
-    let container_client = storage_client.container_client(&container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_service = BlobServiceClient::new(account, storage_credentials);
+    let container_client = blob_service.container_client(&container_name);
 
     let page = blob_service
         .list_containers()

--- a/sdk/storage_blobs/examples/list_blobs_01.rs
+++ b/sdk/storage_blobs/examples/list_blobs_01.rs
@@ -15,11 +15,11 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_service_client = storage_client.blob_service_client();
-    let container_client = storage_client.container_client(&container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_service = BlobServiceClient::new(account, storage_credentials);
+    let container_client = blob_service.container_client(&container_name);
 
-    let page = blob_service_client
+    let page = blob_service
         .list_containers()
         .into_stream()
         .next()

--- a/sdk/storage_blobs/examples/list_blobs_02.rs
+++ b/sdk/storage_blobs/examples/list_blobs_02.rs
@@ -14,21 +14,9 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify a non-existing container name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-
-    create_container_and_list(storage_client, &container_name).await?;
-
-    let storage_client = StorageClient::new_emulator_default();
-    create_container_and_list(storage_client, &container_name).await?;
-
-    Ok(())
-}
-
-async fn create_container_and_list(
-    storage_client: StorageClient,
-    container_name: &str,
-) -> azure_core::Result<()> {
-    let container_client = storage_client.container_client(container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_service = BlobServiceClient::new(account, storage_credentials);
+    let container_client = blob_service.container_client(&container_name);
 
     container_client.create().into_future().await?;
 

--- a/sdk/storage_blobs/examples/list_containers2.rs
+++ b/sdk/storage_blobs/examples/list_containers2.rs
@@ -17,10 +17,10 @@ async fn main() -> azure_core::Result<()> {
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_service_client = storage_client.blob_service_client();
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
 
-    let response = blob_service_client
+    let response = service_client
         .list_containers()
         .into_stream()
         .next()
@@ -28,7 +28,7 @@ async fn main() -> azure_core::Result<()> {
         .expect("stream failed")?;
     println!("response = {:#?}", response);
 
-    let response = storage_client
+    let response = service_client
         .container_client("$logs")
         .list_blobs()
         .into_stream()

--- a/sdk/storage_blobs/examples/list_containers_and_blobs.rs
+++ b/sdk/storage_blobs/examples/list_containers_and_blobs.rs
@@ -10,17 +10,17 @@ async fn main() -> azure_core::Result<()> {
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_service_client = storage_client.blob_service_client();
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
 
-    let mut stream = blob_service_client.list_containers().into_stream();
+    let mut stream = service_client.list_containers().into_stream();
 
     while let Some(entry) = stream.next().await {
         let entry = entry?;
         for container in entry.containers {
             println!("container: {}", container.name);
 
-            let container_client = storage_client.container_client(container.name);
+            let container_client = service_client.container_client(container.name);
 
             let mut blob_stream = container_client.list_blobs().into_stream();
             while let Some(blob_entry) = blob_stream.next().await {

--- a/sdk/storage_blobs/examples/missing_blob.rs
+++ b/sdk/storage_blobs/examples/missing_blob.rs
@@ -14,8 +14,9 @@ async fn main() -> azure_core::Result<()> {
     let container_name = format!("example-{}", Uuid::new_v4());
     let blob_name = format!("missing-{}.txt", Uuid::new_v4());
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let container_client = storage_client.container_client(&container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let service_client = BlobServiceClient::new(&account, storage_credentials);
+    let container_client = service_client.container_client(&container_name);
     println!("creating container {}", container_name);
     container_client.create().into_future().await?;
 

--- a/sdk/storage_blobs/examples/put_append_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_append_blob_00.rs
@@ -22,7 +22,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(2)
         .expect("please specify blob name as command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob_name);
 

--- a/sdk/storage_blobs/examples/put_block_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_block_blob_00.rs
@@ -23,7 +23,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(2)
         .expect("please specify blob name as command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob_name);
 

--- a/sdk/storage_blobs/examples/put_multi_block_blob.rs
+++ b/sdk/storage_blobs/examples/put_multi_block_blob.rs
@@ -24,7 +24,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(2)
         .expect("please specify blob name as command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob_name);
 

--- a/sdk/storage_blobs/examples/put_page_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_page_blob_00.rs
@@ -23,7 +23,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(2)
         .expect("please specify blob name as command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(&account, storage_credentials)
         .container_client(&container_name)
         .blob_client(&blob_name);
 

--- a/sdk/storage_blobs/examples/set_blob_properties_00.rs
+++ b/sdk/storage_blobs/examples/set_blob_properties_00.rs
@@ -8,7 +8,7 @@ async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
-    let master_key =
+    let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
     let container = std::env::args()
@@ -18,15 +18,14 @@ async fn main() -> azure_core::Result<()> {
         .nth(2)
         .expect("please specify blob name as command line parameter");
 
-    let storage_client = StorageClient::new_access_key(&account, &master_key);
-
     // this is how you would use the SAS token:
     // let storage_client = StorageAccountClient::new_sas_token(http_client.clone(), &account,
     //      "sv=2018-11-09&ss=b&srt=o&se=2021-01-15T12%3A09%3A01Z&sp=r&st=2021-01-15T11%3A09%3A01Z&spr=http,https&sig=some_signature")?;
 
-    let blob_client = storage_client
+    let storage_credentials = StorageCredentials::Key(account, access_key);
+    let blob_client = BlobServiceClient::new(&account, storage_credentials)
         .container_client(&container)
-        .blob_client(&blob);
+        .blob_client(blob);
 
     trace!("Requesting blob properties");
 

--- a/sdk/storage_blobs/examples/snapshot_blob.rs
+++ b/sdk/storage_blobs/examples/snapshot_blob.rs
@@ -22,7 +22,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(2)
         .expect("please specify blob name as command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob_name);
 

--- a/sdk/storage_blobs/examples/stream_blob_00.rs
+++ b/sdk/storage_blobs/examples/stream_blob_00.rs
@@ -23,7 +23,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as first command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(&account, storage_credentials)
         .container_client(&container_name)
         .blob_client(file_name);
 

--- a/sdk/storage_blobs/examples/stream_blob_01.rs
+++ b/sdk/storage_blobs/examples/stream_blob_01.rs
@@ -1,4 +1,4 @@
-use azure_storage::prelude::*;
+use azure_storage::clients::StorageCredentials;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
 
@@ -22,7 +22,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(1)
         .expect("please specify container name as first command line parameter");
 
-    let blob_client = StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_client = BlobServiceClient::new(&account, storage_credentials)
         .container_client(&container_name)
         .blob_client(file_name);
 

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -204,28 +204,28 @@ impl BlobClient {
         ClearPageBuilder::new(self.clone(), ba512_range)
     }
 
-    /// Create a shared access signature.
-    pub fn shared_access_signature(
-        &self,
-        permissions: BlobSasPermissions,
-        expiry: OffsetDateTime,
-    ) -> azure_core::Result<BlobSharedAccessSignature> {
-        let canonicalized_resource = format!(
-            "/blob/{}/{}/{}",
-            self.container_client.storage_client().account(),
-            self.container_client.container_name(),
-            self.blob_name()
-        );
+    // /// Create a shared access signature.
+    // pub fn shared_access_signature(
+    //     &self,
+    //     permissions: BlobSasPermissions,
+    //     expiry: OffsetDateTime,
+    // ) -> azure_core::Result<BlobSharedAccessSignature> {
+    //     let canonicalized_resource = format!(
+    //         "/blob/{}/{}/{}",
+    //         self.container_client.storage_client().account(),
+    //         self.container_client.container_name(),
+    //         self.blob_name()
+    //     );
 
-        match self.storage_client().storage_credentials() {
-            StorageCredentials::Key(ref _account, ref key) => Ok(
-                BlobSharedAccessSignature::new(key.to_string(), canonicalized_resource, permissions, expiry, BlobSignedResource::Blob)
-            ),
-            _ => Err(Error::message(ErrorKind::Credential,
-                "Shared access signature generation - SAS can be generated only from key and account clients",
-            )),
-        }
-    }
+    //     match self.storage_client().storage_credentials() {
+    //         StorageCredentials::Key(ref _account, ref key) => Ok(
+    //             BlobSharedAccessSignature::new(key.to_string(), canonicalized_resource, permissions, expiry, BlobSignedResource::Blob)
+    //         ),
+    //         _ => Err(Error::message(ErrorKind::Credential,
+    //             "Shared access signature generation - SAS can be generated only from key and account clients",
+    //         )),
+    //     }
+    // }
 
     /// Create a signed blob url
     pub fn generate_signed_blob_url<T>(&self, signature: &T) -> azure_core::Result<url::Url>
@@ -262,10 +262,6 @@ impl BlobClient {
     /// Turn into a `BlobLeaseClient`
     pub fn blob_lease_client(&self, lease_id: LeaseId) -> BlobLeaseClient {
         BlobLeaseClient::new(self.clone(), lease_id)
-    }
-
-    pub fn storage_client(&self) -> &StorageClient {
-        self.container_client.storage_client()
     }
 
     pub fn container_client(&self) -> &ContainerClient {
@@ -311,12 +307,13 @@ mod tests {
     }
 
     fn build_url(container_name: &str, blob_name: &str, sas: &FakeSas) -> url::Url {
-        let storage_account = StorageClient::new_emulator_default();
-        storage_account
-            .container_client(container_name)
-            .blob_client(blob_name)
-            .generate_signed_blob_url(sas)
-            .expect("build url failed")
+        todo!("replace the following code")
+        // let storage_account = StorageClient::new_emulator_default();
+        // storage_account
+        //     .container_client(container_name)
+        //     .blob_client(blob_name)
+        //     .generate_signed_blob_url(sas)
+        //     .expect("build url failed")
     }
 
     #[test]

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -1,6 +1,5 @@
 use crate::{blob::operations::*, prelude::*};
 use azure_core::{headers::Headers, prelude::*, Body, Context, Method, Request, Response, Url};
-use azure_storage::prelude::*;
 
 #[derive(Debug, Clone)]
 pub struct BlobLeaseClient {
@@ -30,10 +29,6 @@ impl BlobLeaseClient {
 
     pub fn lease_id(&self) -> LeaseId {
         self.lease_id
-    }
-
-    pub fn storage_client(&self) -> &StorageClient {
-        self.blob_client.storage_client()
     }
 
     pub fn container_client(&self) -> &ContainerClient {

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -1,25 +1,89 @@
 use crate::service::operations::*;
-use azure_core::{Context, Request, Response};
-use azure_storage::clients::{ServiceType, StorageClient};
+use azure_core::{headers::Headers, Body, Context, Method, Pipeline, Request, Response, Url};
+use azure_storage::clients::{
+    new_pipeline_from_options, ServiceType, StorageCredentials, StorageOptions,
+};
 
-pub trait AsBlobServiceClient {
-    fn blob_service_client(&self) -> BlobServiceClient;
+use super::ContainerClient;
+
+/// A builder for the cosmos client.
+#[derive(Debug, Clone)]
+pub struct BlobServiceClientBuilder {
+    cloud_location: CloudLocation,
+    options: StorageOptions,
 }
 
-impl AsBlobServiceClient for StorageClient {
-    fn blob_service_client(&self) -> BlobServiceClient {
-        BlobServiceClient::new(self.clone())
+impl BlobServiceClientBuilder {
+    /// Create a new instance of `BlobServiceClientBuilder`.
+    #[must_use]
+    pub fn new(account: impl Into<String>, credentials: StorageCredentials) -> Self {
+        Self::with_location(CloudLocation::Public {
+            account: account.into(),
+            credentials,
+        })
     }
+
+    /// Create a new instance of `BlobServiceClientBuilder` with a cloud location.
+    #[must_use]
+    pub fn with_location(cloud_location: CloudLocation) -> Self {
+        Self {
+            options: StorageOptions::default(),
+            cloud_location,
+        }
+    }
+
+    /// Convert the builder into a `BlobServiceClient` instance.
+    #[must_use]
+    pub fn build(self) -> BlobServiceClient {
+        let auth_token = self.cloud_location.credentials();
+        BlobServiceClient {
+            pipeline: new_pipeline_from_options(self.options, auth_token),
+            cloud_location: self.cloud_location,
+        }
+    }
+
+    /// Set the cloud location.
+    #[must_use]
+    pub fn cloud_location(mut self, cloud_location: CloudLocation) -> Self {
+        self.cloud_location = cloud_location;
+        self
+    }
+
+    // /// Set the retry options.
+    // #[must_use]
+    // pub fn retry(mut self, retry: impl Into<azure_core::RetryOptions>) -> Self {
+    //     self.options = self.options.retry(retry);
+    //     self
+    // }
+
+    // /// Set the transport options.
+    // #[must_use]
+    // pub fn transport(mut self, transport: impl Into<azure_core::TransportOptions>) -> Self {
+    //     self.options = self.options.transport(transport);
+    //     self
+    // }
 }
 
 #[derive(Debug, Clone)]
 pub struct BlobServiceClient {
-    pub(crate) storage_client: StorageClient,
+    pipeline: Pipeline,
+    cloud_location: CloudLocation,
 }
 
 impl BlobServiceClient {
-    pub(crate) fn new(storage_client: StorageClient) -> Self {
-        Self { storage_client }
+    /// Create a new `BlobServiceClient` which connects to the account's instance in the public Azure cloud.
+    #[must_use]
+    pub fn new(account: impl Into<String>, credentials: StorageCredentials) -> Self {
+        BlobServiceClientBuilder::new(account, credentials).build()
+    }
+
+    /// Create a new `BlobServiceClientBuilder`.
+    #[must_use]
+    pub fn builder(
+        account: impl Into<String>,
+        credentials: StorageCredentials,
+    ) -> BlobServiceClientBuilder {
+        BlobServiceClientBuilder::new(account, credentials)
     }
 
     pub fn get_account_information(&self) -> GetAccountInformationBuilder {
@@ -34,13 +98,81 @@ impl BlobServiceClient {
         ListContainersBuilder::new(self.clone())
     }
 
+    pub fn url(&self) -> url::Url {
+        self.cloud_location.url()
+    }
+
+    pub fn container_client<S: Into<String>>(&self, container_name: S) -> ContainerClient {
+        ContainerClient::new(self.clone(), container_name.into())
+    }
+
+    pub(crate) fn finalize_request(
+        &self,
+        url: Url,
+        method: Method,
+        headers: Headers,
+        request_body: Option<Body>,
+    ) -> azure_core::Result<Request> {
+        azure_storage::clients::finalize_request(url, method, headers, request_body)
+    }
+
     pub(crate) async fn send(
         &self,
         context: &mut Context,
         request: &mut Request,
     ) -> azure_core::Result<Response> {
-        self.storage_client
-            .send(context, request, ServiceType::Blob)
+        self.pipeline
+            .send(context.insert(ServiceType::Blob), request)
             .await
+    }
+}
+
+/// The cloud with which you want to interact.
+// TODO: Other govt clouds?
+#[derive(Debug, Clone)]
+pub enum CloudLocation {
+    /// Azure public cloud
+    Public {
+        account: String,
+        credentials: StorageCredentials,
+    },
+    /// Azure China cloud
+    China {
+        account: String,
+        credentials: StorageCredentials,
+    },
+    /// Use the well-known Cosmos emulator
+    Emulator { address: String, port: u16 },
+    /// A custom base URL
+    Custom {
+        uri: String,
+        credentials: StorageCredentials,
+    },
+}
+
+impl CloudLocation {
+    /// the base URL for a given cloud location
+    fn url(&self) -> url::Url {
+        // match self {
+        //     CloudLocation::Public { account, .. } => {
+        //         format!("https://{account}.documents.azure.com")
+        //     }
+        //     CloudLocation::China { account, .. } => format!("https://{account}.documents.azure.cn"),
+        //     CloudLocation::Custom { uri, .. } => uri.clone(),
+        //     CloudLocation::Emulator { address, port } => format!("https://{address}:{port}"),
+        // }
+        todo!()
+    }
+
+    fn credentials(&self) -> StorageCredentials {
+        match self {
+            CloudLocation::Public { credentials, .. } => credentials.clone(),
+            CloudLocation::China { credentials, .. } => credentials.clone(),
+            CloudLocation::Emulator { .. } => {
+                todo!()
+                // AuthorizationToken::primary_from_base64(EMULATOR_ACCOUNT_KEY).unwrap()
+            }
+            CloudLocation::Custom { credentials, .. } => credentials.clone(),
+        }
     }
 }

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -1,6 +1,5 @@
 use crate::{container::operations::*, prelude::*};
 use azure_core::{headers::Headers, prelude::*, Body, Context, Method, Request, Response, Url};
-use azure_storage::prelude::*;
 
 #[derive(Debug, Clone)]
 pub struct ContainerLeaseClient {
@@ -37,10 +36,6 @@ impl ContainerLeaseClient {
 
     pub fn lease_id(&self) -> LeaseId {
         self.lease_id
-    }
-
-    pub fn storage_client(&self) -> &StorageClient {
-        self.container_client.storage_client()
     }
 
     pub fn container_client(&self) -> &ContainerClient {

--- a/sdk/storage_blobs/src/clients/mod.rs
+++ b/sdk/storage_blobs/src/clients/mod.rs
@@ -6,6 +6,6 @@ mod container_lease_client;
 
 pub use blob_client::BlobClient;
 pub use blob_lease_client::BlobLeaseClient;
-pub use blob_service_client::{AsBlobServiceClient, BlobServiceClient};
-pub use container_client::{AsContainerClient, ContainerClient};
+pub use blob_service_client::{BlobServiceClient, BlobServiceClientBuilder, CloudLocation};
+pub use container_client::ContainerClient;
 pub use container_lease_client::ContainerLeaseClient;

--- a/sdk/storage_blobs/src/prelude.rs
+++ b/sdk/storage_blobs/src/prelude.rs
@@ -3,7 +3,7 @@ pub use crate::options::*;
 pub use crate::{
     blob::{Blob, BlobBlockType, BlockList, BlockListType},
     clients::{
-        AsBlobServiceClient, AsContainerClient, BlobClient, BlobLeaseClient, BlobServiceClient,
+        BlobClient, BlobLeaseClient, BlobServiceClient, BlobServiceClientBuilder, CloudLocation,
         ContainerClient, ContainerLeaseClient,
     },
 };

--- a/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
+++ b/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
@@ -18,7 +18,7 @@ impl FindBlobsByTagsBuilder {
             let this = self.clone();
             let mut ctx = self.context.clone();
             async move {
-                let mut url = this.client.storage_client.blob_storage_url().clone();
+                let mut url = this.client.url().clone();
 
                 url.query_pairs_mut().append_pair("comp", "blobs");
                 if let Some(next_marker) = next_marker {
@@ -26,7 +26,7 @@ impl FindBlobsByTagsBuilder {
                         .append_pair("next", next_marker.as_str());
                 }
                 url.query_pairs_mut().append_pair("where", &this.expression);
-                let mut request = this.client.storage_client.finalize_request(
+                let mut request = this.client.finalize_request(
                     url,
                     azure_core::Method::Get,
                     azure_core::headers::Headers::new(),

--- a/sdk/storage_blobs/src/service/operations/get_account_information.rs
+++ b/sdk/storage_blobs/src/service/operations/get_account_information.rs
@@ -11,17 +11,14 @@ operation! {
 impl GetAccountInformationBuilder {
     pub fn into_future(mut self) -> GetAccountInformation {
         Box::pin(async move {
-            let mut url = self.client.storage_client.blob_storage_url().clone();
+            let mut url = self.client.url().clone();
 
             for (k, v) in [("restype", "account"), ("comp", "properties")].iter() {
                 url.query_pairs_mut().append_pair(k, v);
             }
-            let mut request = self.client.storage_client.finalize_request(
-                url,
-                Method::Get,
-                Headers::new(),
-                None,
-            )?;
+            let mut request =
+                self.client
+                    .finalize_request(url, Method::Get, Headers::new(), None)?;
 
             let response = self.client.send(&mut self.context, &mut request).await?;
 

--- a/sdk/storage_blobs/src/service/operations/list_containers.rs
+++ b/sdk/storage_blobs/src/service/operations/list_containers.rs
@@ -44,7 +44,7 @@ impl ListContainersBuilder {
             let this = self.clone();
             let mut ctx = self.context.clone();
             async move {
-                let mut url = this.client.storage_client.blob_storage_url().clone();
+                let mut url = this.client.url().clone();
 
                 url.query_pairs_mut().append_pair("comp", "list");
 
@@ -64,12 +64,9 @@ impl ListContainersBuilder {
                 }
                 this.max_results.append_to_url_query(&mut url);
 
-                let mut request = this.client.storage_client.finalize_request(
-                    url,
-                    Method::Get,
-                    Headers::new(),
-                    None,
-                )?;
+                let mut request =
+                    this.client
+                        .finalize_request(url, Method::Get, Headers::new(), None)?;
 
                 let response = this.client.send(&mut ctx, &mut request).await?;
 

--- a/sdk/storage_blobs/tests/account.rs
+++ b/sdk/storage_blobs/tests/account.rs
@@ -9,10 +9,10 @@ async fn get_account_information() {
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    let storage_client = StorageClient::new_access_key(&account, &access_key);
-    let blob_service_client = storage_client.blob_service_client();
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_service = BlobServiceClient::new(account, storage_credentials);
 
-    blob_service_client
+    blob_service
         .get_account_information()
         .into_future()
         .await

--- a/sdk/storage_blobs/tests/append_blob.rs
+++ b/sdk/storage_blobs/tests/append_blob.rs
@@ -19,9 +19,9 @@ async fn put_append_blob() {
     let container_name: &'static str = "rust-upload-test";
     let _data = b"abcdef";
 
-    let storage = StorageClient::new_access_key(&account, &access_key);
-    let blob_service = storage.blob_service_client();
-    let container = storage.container_client(container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_service = BlobServiceClient::new(account, storage_credentials);
+    let container = blob_service.container_client(container_name);
     let blob = container.blob_client(blob_name);
 
     if !blob_service

--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -529,11 +529,12 @@ fn send_check() {
     );
 }
 
-fn initialize() -> StorageClient {
+fn initialize() -> BlobServiceClient {
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    BlobServiceClient::new(account, storage_credentials)
 }

--- a/sdk/storage_blobs/tests/container.rs
+++ b/sdk/storage_blobs/tests/container.rs
@@ -65,11 +65,12 @@ async fn break_lease() {
     container.delete().into_future().await.unwrap();
 }
 
-fn initialize() -> StorageClient {
+fn initialize() -> BlobServiceClient {
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    BlobServiceClient::new(account, storage_credentials)
 }

--- a/sdk/storage_blobs/tests/page_blob.rs
+++ b/sdk/storage_blobs/tests/page_blob.rs
@@ -11,9 +11,8 @@ async fn put_page_blob() {
     let blob_name: &'static str = "page_blob.txt";
     let container_name: &'static str = "rust-upload-test";
 
-    let storage = initialize();
-    let blob_service = storage.blob_service_client();
-    let container = storage.container_client(container_name);
+    let blob_service = initialize();
+    let container = blob_service.container_client(container_name);
     let blob = container.blob_client(blob_name);
 
     if !blob_service
@@ -49,11 +48,12 @@ async fn put_page_blob() {
     trace!("created {:?}", blob_name);
 }
 
-fn initialize() -> StorageClient {
+fn initialize() -> BlobServiceClient {
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    StorageClient::new_access_key(&account, &access_key)
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    BlobServiceClient::new(account, storage_credentials)
 }

--- a/sdk/storage_blobs/tests/stream_blob00.rs
+++ b/sdk/storage_blobs/tests/stream_blob00.rs
@@ -21,9 +21,9 @@ async fn code() -> azure_core::Result<()> {
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    let storage = StorageClient::new_access_key(&account, &access_key);
-    let blob_service = storage.blob_service_client();
-    let container = storage.container_client(&container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_service = BlobServiceClient::new(account, storage_credentials);
+    let container = blob_service.container_client(container_name);
     let blob = container.blob_client(file_name);
 
     if !blob_service

--- a/sdk/storage_blobs/tests/stream_list_blobs.rs
+++ b/sdk/storage_blobs/tests/stream_list_blobs.rs
@@ -1,5 +1,5 @@
 #![cfg(all(test, feature = "test_e2e"))]
-use azure_storage::prelude::*;
+use azure_storage::{clients::StorageCredentials, prelude::*};
 use azure_storage_blobs::prelude::*;
 use futures::StreamExt;
 
@@ -13,9 +13,9 @@ async fn stream_list_blobs() {
 
     let container_name = "streamlistblobs235xx752zdve";
 
-    let storage = StorageClient::new_access_key(&account, &access_key);
-    let blob_service = storage.blob_service_client();
-    let container = storage.container_client(container_name);
+    let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
+    let blob_service = BlobServiceClient::new(&account, storage_credentials);
+    let container = service.container_client(container_name);
 
     let page = blob_service
         .list_containers()


### PR DESCRIPTION
*Note: This builds on work done by @gorzell.*

This change is also a fairly simple one but has far reaching effects.

This removes the use of `StorageClient` from `azure_blob_stroage`. `StorageClient` now has no operations of its own and so is effectively just a helper. This ditches using that type in favor of the hierarchy starting at `BlobServiceClient`. Instead of a whole mess of constructors, construction of clients follows the pattern established in `azure_cosmos`. 

```rust
let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
let service_client = BlobServiceClient::new(account, storage_credentials);
```

`BlobServiceClient` can easily be instantiated with an account name and some sort of `StorageCredentials`. We also offer `BlobServiceClientBuilder` which allows for more advanced creation of a `BlobServiceClient` through tuning of various options such as retry policy, transport policy, etc. This is the same pattern followed in `azure_cosmos`. 

I was not able to fully finish moving everything over, so I'm marking this as a draft for now, but I wanted to make everyone aware. 