### PR TITLE
provide helper methods for creating StorageCredentials

### DIFF
--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -21,10 +21,10 @@ const_format = "0.2.13"
 serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
-azure_core = { path = "../core", version = "0.4", no-default-features = true }
+azure_core = { path = "../core", version = "0.4", default-features = false }
 
 [dev-dependencies]
-azure_identity = { path = "../identity", default_features = false }
+azure_identity = { path = "../identity", default-features = false }
 mockito = "0.31"
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 reqwest = "0.11"
 mock_transport = { path = "../../eng/test/mock_transport" }
+azure_identity = { path = "../identity" }
 
 [features]
 default = ["enable_reqwest"]

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -36,7 +36,8 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.9"
 reqwest = "0.11"
 mock_transport = { path = "../../eng/test/mock_transport" }
-azure_identity = { path = "../identity" }
+azure_identity = { path = "../identity", default-features = false }
+
 
 [features]
 default = ["enable_reqwest"]

--- a/sdk/storage/src/clients/storage_client.rs
+++ b/sdk/storage/src/clients/storage_client.rs
@@ -53,11 +53,12 @@ impl StorageCredentials {
 
     /// Create a Shared Access Signature (SAS) token based credential
     ///
-    /// SAS tokens provide delegated access to resources in a storage account
-    /// with granular control over how the client can access data in the
-    /// account.
+    /// SAS token are HTTP query strings that provide delegated access to
+    /// resources in a storage account with granular control over how the client
+    /// can access data in the account.
     ///
-    /// ref: https://docs.microsoft.com/azure/storage/common/storage-sas-overview
+    /// ref: Understanding SAS authentication: https://docs.microsoft.com/azure/storage/common/storage-sas-overview
+    /// ref: Creating a SAS Token: https://docs.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/create-sas-tokens
     pub fn sas_token<S>(token: S) -> azure_core::Result<Self>
     where
         S: AsRef<str>,

--- a/sdk/storage/src/clients/storage_client.rs
+++ b/sdk/storage/src/clients/storage_client.rs
@@ -15,11 +15,11 @@ use time::OffsetDateTime;
 use url::Url;
 
 /// The well-known account used by Azurite and the legacy Azure Storage Emulator.
-/// https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
+/// <https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key>
 pub const EMULATOR_ACCOUNT: &str = "devstoreaccount1";
 
 /// The well-known account key used by Azurite and the legacy Azure Storage Emulator.
-/// https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
+/// <https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key>
 pub const EMULATOR_ACCOUNT_KEY: &str =
     "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
@@ -42,7 +42,7 @@ impl StorageCredentials {
     /// authorize access to data in your storage account via Shared Key
     /// authorization.
     ///
-    /// ref: https://docs.microsoft.com/azure/storage/common/storage-account-keys-manage
+    /// ref: <https://docs.microsoft.com/azure/storage/common/storage-account-keys-manage>
     pub fn access_key<A, K>(account: A, key: K) -> Self
     where
         A: Into<String>,
@@ -57,8 +57,8 @@ impl StorageCredentials {
     /// resources in a storage account with granular control over how the client
     /// can access data in the account.
     ///
-    /// ref: Understanding SAS authentication: https://docs.microsoft.com/azure/storage/common/storage-sas-overview
-    /// ref: Creating a SAS Token: https://docs.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/create-sas-tokens
+    /// * ref: [Grant limited access to Azure Storage resources using shared access signatures (SAS)](https://docs.microsoft.com/azure/storage/common/storage-sas-overview)
+    /// * ref: [Create SAS tokens for storage containers](https://docs.microsoft.com/azure/applied-ai-services/form-recognizer/create-sas-tokens)
     pub fn sas_token<S>(token: S) -> azure_core::Result<Self>
     where
         S: AsRef<str>,
@@ -76,7 +76,7 @@ impl StorageCredentials {
     /// manage access tokens, this method is provided for manual management of
     /// Oauth2 tokens.
     ///
-    /// ref: https://docs.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory
+    /// ref: <https://docs.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory>
     pub fn bearer_token<T>(token: T) -> Self
     where
         T: Into<String>,
@@ -100,7 +100,7 @@ impl StorageCredentials {
     /// let storage_credentials = StorageCredentials::token_credential(token_credential);
     /// ```
     ///
-    /// ref: https://docs.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory
+    /// ref: <https://docs.microsoft.com/rest/api/storageservices/authorize-with-azure-active-directory>
     pub fn token_credential(credential: Arc<dyn TokenCredential>) -> Self {
         Self::TokenCredential(credential)
     }
@@ -115,7 +115,7 @@ impl StorageCredentials {
     /// anonymous access, clients can read data in that container without
     /// authorizing the request.
     ///
-    /// ref: https://docs.microsoft.com/azure/storage/blobs/anonymous-read-access-configure
+    /// ref: <https://docs.microsoft.com/azure/storage/blobs/anonymous-read-access-configure>
     pub fn anonymous() -> Self {
         Self::Anonymous
     }

--- a/sdk/storage/src/clients/storage_client.rs
+++ b/sdk/storage/src/clients/storage_client.rs
@@ -34,6 +34,16 @@ pub enum StorageCredentials {
     Anonymous,
 }
 
+impl StorageCredentials {
+    pub fn new_sas_token<S>(token: S) -> azure_core::Result<Self>
+    where
+        S: AsRef<str>,
+    {
+        let params = get_sas_token_parms(token.as_ref())?;
+        Ok(Self::SASToken(params))
+    }
+}
+
 impl std::fmt::Debug for StorageCredentials {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
@@ -181,8 +191,7 @@ impl StorageClient {
     {
         let account = account.into();
 
-        let storage_credentials =
-            StorageCredentials::SASToken(get_sas_token_parms(sas_token.as_ref())?);
+        let storage_credentials = StorageCredentials::new_sas_token(sas_token)?;
         let pipeline =
             new_pipeline_from_options(ClientOptions::default(), storage_credentials.clone());
 
@@ -270,9 +279,7 @@ impl StorageClient {
             } => {
                 log::warn!("Both account key and SAS defined in connection string. Using only the provided SAS.");
 
-                let storage_credentials =  StorageCredentials::SASToken(get_sas_token_parms(
-                    sas_token,
-                )?);
+                let storage_credentials =  StorageCredentials::new_sas_token(sas_token)?;
                 let pipeline = new_pipeline_from_options(ClientOptions::default(), storage_credentials.clone());
 
                 Ok(Self {
@@ -295,7 +302,7 @@ impl StorageClient {
                 file_endpoint,
                 ..
             } => {
-                let storage_credentials = StorageCredentials::SASToken(get_sas_token_parms(sas_token)?);
+                let storage_credentials = StorageCredentials::new_sas_token(sas_token)?;
                 let pipeline =
                 new_pipeline_from_options(ClientOptions::default(), storage_credentials.clone());
                 Ok(Self {


### PR DESCRIPTION
One of the side effects of #1057 is that users now must create `StorageCredentials`.  For SAS tokens, this was previously handled for the user.

I'm not 100% sold on needing helper methods for anything but SAS Tokens, but I added them for completeness.