### PR TITLE
fix URL link generation

### DIFF
--- a/sdk/core/src/date/mod.rs
+++ b/sdk/core/src/date/mod.rs
@@ -1,7 +1,7 @@
 //! Azure date and time parsing and formatting
 
 // RFC 3339 vs ISO 8601
-// https://ijmacd.github.io/rfc3339-iso8601/
+// <https://ijmacd.github.io/rfc3339-iso8601/>
 
 use crate::error::{ErrorKind, ResultExt};
 use std::time::Duration;
@@ -18,7 +18,7 @@ pub mod rfc1123;
 
 /// RFC 3339: Date and Time on the Internet: Timestamps
 ///
-/// https://www.rfc-editor.org/rfc/rfc3339
+/// <https://www.rfc-editor.org/rfc/rfc3339>
 ///
 /// In Azure REST API specifications it is specified as `"format": "date-time"`.
 ///
@@ -31,7 +31,7 @@ pub fn parse_rfc3339(s: &str) -> crate::Result<OffsetDateTime> {
 
 /// RFC 3339: Date and Time on the Internet: Timestamps
 ///
-/// https://www.rfc-editor.org/rfc/rfc3339
+/// <https://www.rfc-editor.org/rfc/rfc3339>
 ///
 /// In Azure REST API specifications it is specified as `"format": "date-time"`.
 ///
@@ -43,15 +43,15 @@ pub fn to_rfc3339(date: &OffsetDateTime) -> String {
 
 /// RFC 1123: Requirements for Internet Hosts - Application and Support
 ///
-/// https://www.rfc-editor.org/rfc/rfc1123
+/// <https://www.rfc-editor.org/rfc/rfc1123>
 ///
 /// In Azure REST API specifications it is specified as `"format": "date-time-rfc1123"`.
 ///
 /// In .NET it is the `rfc1123pattern`.
-/// https://docs.microsoft.com/dotnet/api/system.globalization.datetimeformatinfo.rfc1123pattern
+/// <https://docs.microsoft.com/dotnet/api/system.globalization.datetimeformatinfo.rfc1123pattern>
 ///
 /// This format is also the preferred HTTP date format.
-/// https://httpwg.org/specs/rfc9110.html#http.date
+/// <https://httpwg.org/specs/rfc9110.html#http.date>
 ///
 /// Sun, 06 Nov 1994 08:49:37 GMT
 pub fn parse_rfc1123(s: &str) -> crate::Result<OffsetDateTime> {
@@ -68,15 +68,15 @@ const RFC1123_FORMAT: &[FormatItem] = format_description!(
 
 /// RFC 1123: Requirements for Internet Hosts - Application and Support
 ///
-/// https://www.rfc-editor.org/rfc/rfc1123
+/// <https://www.rfc-editor.org/rfc/rfc1123>
 ///
 /// In Azure REST API specifications it is specified as `"format": "date-time-rfc1123"`.
 ///
 /// In .NET it is the `rfc1123pattern`.
-/// https://docs.microsoft.com/dotnet/api/system.globalization.datetimeformatinfo.rfc1123pattern
+/// <https://docs.microsoft.com/dotnet/api/system.globalization.datetimeformatinfo.rfc1123pattern>
 ///
 /// This format is also the preferred HTTP date format.
-/// https://httpwg.org/specs/rfc9110.html#http.date
+/// <https://httpwg.org/specs/rfc9110.html#http.date>
 ///
 /// Sun, 06 Nov 1994 08:49:37 GMT
 pub fn to_rfc1123(date: &OffsetDateTime) -> String {
@@ -87,7 +87,7 @@ pub fn to_rfc1123(date: &OffsetDateTime) -> String {
 
 /// Similar to RFC 1123, but includes milliseconds.
 ///
-/// https://docs.microsoft.com/rest/api/cosmos-db/patch-a-document
+/// <https://docs.microsoft.com/rest/api/cosmos-db/patch-a-document>
 ///
 /// x-ms-last-state-change-utc: Fri, 25 Mar 2016 21:27:20.035 GMT
 pub fn parse_last_state_change(s: &str) -> crate::Result<OffsetDateTime> {
@@ -104,7 +104,7 @@ const LAST_STATE_CHANGE_FORMAT: &[FormatItem] = format_description!(
 
 /// Similar to preferred HTTP date format, but includes milliseconds
 ///
-/// https://docs.microsoft.com/rest/api/cosmos-db/patch-a-document
+/// <https://docs.microsoft.com/rest/api/cosmos-db/patch-a-document>
 ///
 /// x-ms-last-state-change-utc: Fri, 25 Mar 2016 21:27:20.035 GMT
 pub fn to_last_state_change(date: &OffsetDateTime) -> String {

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 /// The well-known account key used by Azure Cosmos DB Emulator.
-/// https://docs.microsoft.com/azure/cosmos-db/local-emulator?tabs=ssl-netstd21#connect-with-emulator-apis
+/// <https://docs.microsoft.com/azure/cosmos-db/local-emulator?tabs=ssl-netstd21#connect-with-emulator-apis>
 pub const EMULATOR_ACCOUNT_KEY: &str =
     "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 

--- a/sdk/data_tables/src/operations/transaction.rs
+++ b/sdk/data_tables/src/operations/transaction.rs
@@ -24,7 +24,7 @@ operation! {
 impl TransactionBuilder {
     /// Insert a new entity into a table
     ///
-    /// Ref: https://docs.microsoft.com/en-us/rest/api/storageservices/insert-entity
+    /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/insert-entity>
     pub fn insert<E: Serialize>(mut self, entity: E) -> azure_core::Result<Self> {
         let body = serde_json::to_string(&entity)?;
 
@@ -47,7 +47,7 @@ impl TransactionBuilder {
     /// Update an existing entity in a table. The Update Entity operation
     /// replaces the entire entity and can be used to remove properties.
     ///
-    /// Ref: https://docs.microsoft.com/en-us/rest/api/storageservices/update-entity2
+    /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/update-entity2>
     pub fn update<RK: Into<String>, E: Serialize>(
         self,
         row_key: RK,
@@ -60,7 +60,7 @@ impl TransactionBuilder {
     /// in the table. Because this operation can insert or update an entity, it
     /// is also known as an upsert operation.
     ///
-    /// Ref: https://docs.microsoft.com/en-us/rest/api/storageservices/insert-or-replace-entity
+    /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/insert-or-replace-entity>
     pub fn insert_or_replace<RK: Into<String>, E: Serialize>(
         self,
         row_key: RK,
@@ -74,7 +74,7 @@ impl TransactionBuilder {
     /// operation does not replace the existing entity, as the Update Entity
     /// operation does.
     ///
-    /// ref: https://docs.microsoft.com/en-us/rest/api/storageservices/merge-entity
+    /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/merge-entity>
     pub fn merge<RK: Into<String>, E: Serialize>(
         self,
         row_key: RK,
@@ -87,7 +87,7 @@ impl TransactionBuilder {
     /// in the table. Because this operation can insert or update an entity, it
     /// is also known as an upsert operation.
     ///
-    /// ref: https://docs.microsoft.com/en-us/rest/api/storageservices/insert-or-merge-entity
+    /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/insert-or-merge-entity>
     pub fn insert_or_merge<RK: Into<String>, E: Serialize>(
         self,
         row_key: RK,
@@ -99,7 +99,7 @@ impl TransactionBuilder {
 
     /// Delete an existing entity in a table.
     ///
-    /// ref: https://docs.microsoft.com/en-us/rest/api/storageservices/delete-entity1
+    /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/delete-entity1>
     pub fn delete<RK: Into<String>>(mut self, row_key: RK) -> azure_core::Result<Self> {
         let client = Arc::new(self.client.clone());
         let entity_client = client.entity_client(row_key)?;

--- a/sdk/identity/src/oauth2_http_client.rs
+++ b/sdk/identity/src/oauth2_http_client.rs
@@ -1,5 +1,5 @@
 //! Implements the oauth2 crate http client interface using an `azure_core::HttpClient` instance.
-//! https://docs.rs/oauth2/latest/oauth2/#importing-oauth2-selecting-an-http-client-interface
+//! <https://docs.rs/oauth2/latest/oauth2/#importing-oauth2-selecting-an-http-client-interface>
 
 use azure_core::{
     error::{Error, ErrorKind, ResultExt},

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -57,7 +57,7 @@ impl CertificateCredentialOptions {
     }
 
     /// The authority host to use for authentication requests.  The default is
-    /// https://login.microsoftonline.com.
+    /// <https://login.microsoftonline.com>.
     pub fn authority_host(&self) -> &str {
         &self.authority_host
     }

--- a/sdk/storage/src/clients/storage_client.rs
+++ b/sdk/storage/src/clients/storage_client.rs
@@ -15,11 +15,11 @@ use time::OffsetDateTime;
 use url::Url;
 
 /// The well-known account used by Azurite and the legacy Azure Storage Emulator.
-/// https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
+/// <https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key>
 pub const EMULATOR_ACCOUNT: &str = "devstoreaccount1";
 
 /// The well-known account key used by Azurite and the legacy Azure Storage Emulator.
-/// https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
+/// <https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key>
 pub const EMULATOR_ACCOUNT_KEY: &str =
     "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
 
@@ -341,7 +341,7 @@ impl StorageClient {
 
     /// Create a new anonymous storage client
     ///
-    /// Ref: https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure?tabs=portal
+    /// ref: <https://docs.microsoft.com/en-us/azure/storage/blobs/anonymous-read-access-configure?tabs=portal>
     pub fn new_anonymous<A>(account: A) -> Self
     where
         A: Into<String>,

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -93,7 +93,7 @@ impl BlobClient {
     /// This operation is only allowed on Hierarchical Namespace enabled
     /// accounts.
     ///
-    /// Ref: https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-expiry
+    /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/set-blob-expiry>
     pub fn set_blob_expiry(&self, blob_expiry: BlobExpiry) -> SetBlobExpiryBuilder {
         SetBlobExpiryBuilder::new(self.clone(), blob_expiry)
     }

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -219,10 +219,10 @@ pub static EMULATOR_CREDENTIALS: Lazy<StorageCredentials> = Lazy::new(|| {
 });
 
 /// The well-known account used by Azurite and the legacy Azure Storage Emulator.
-/// https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
+/// <https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key>
 pub const EMULATOR_ACCOUNT: &str = "devstoreaccount1";
 
 /// The well-known account key used by Azurite and the legacy Azure Storage Emulator.
-/// https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key
+/// <https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key>
 pub const EMULATOR_ACCOUNT_KEY: &str =
     "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";

--- a/sdk/storage_blobs/src/options/tags.rs
+++ b/sdk/storage_blobs/src/options/tags.rs
@@ -28,7 +28,7 @@ use url::form_urlencoded;
 ///           * 0 through 9 (numbers)
 ///           * Valid special characters: space, plus, minus, period, colon, equals, underscore, forward slash ( +-.:=_/)
 ///
-/// Ref: https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs
+/// ref: <https://docs.microsoft.com/en-us/azure/storage/blobs/storage-manage-find-blobs>
 pub struct Tags {
     pub tag_set: TagSet,
 }


### PR DESCRIPTION
Per `cargo doc`, "bare URLs are not automatically turned into clickable links".  

This updates the links to be clickable.