### PR TITLE
Add a way to override all client options

### DIFF
--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -70,6 +70,13 @@ impl CosmosClientBuilder {
         self.options = self.options.transport(transport);
         self
     }
+
+    /// Override all of the client options.
+    #[must_use]
+    pub fn client_options(mut self, options: impl Into<azure_core::ClientOptions>) -> Self {
+        self.options = options.into();
+        self
+    }
 }
 
 /// A plain Cosmos client.

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -72,6 +72,8 @@ impl CosmosClientBuilder {
     }
 
     /// Override all of the client options.
+    ///
+    /// *Warning!*: This overrides all client options that have been previously set on this builder.
     #[must_use]
     pub fn client_options(mut self, options: impl Into<azure_core::ClientOptions>) -> Self {
         self.options = options.into();

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -79,6 +79,13 @@ impl BlobServiceClientBuilder {
         self.options = self.options.transport(transport);
         self
     }
+
+    /// Override all of the client options.
+    #[must_use]
+    pub fn client_options(mut self, options: impl Into<azure_core::ClientOptions>) -> Self {
+        self.options = options.into();
+        self
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -81,6 +81,8 @@ impl BlobServiceClientBuilder {
     }
 
     /// Override all of the client options.
+    ///
+    /// *Warning!*: This overrides all client options that have been previously set on this builder.
     #[must_use]
     pub fn client_options(mut self, options: impl Into<azure_core::ClientOptions>) -> Self {
         self.options = options.into();


### PR DESCRIPTION
This can be very useful if the user has already created a `ClientOptions` that they want to reuse across many different clients. 