### PR TITLE
RetryOptions::custom should take Arc<T> where T: RetryPolicy + Policy

### DIFF
--- a/sdk/core/src/options/mod.rs
+++ b/sdk/core/src/options/mod.rs
@@ -129,9 +129,9 @@ impl RetryOptions {
     }
 
     /// A custom retry using the supplied retry policy.
-    pub fn custom<T: RetryPolicy + Debug + Send + Sync + 'static>(policy: T) -> Self {
+    pub fn custom<T: RetryPolicy + Policy + 'static>(policy: Arc<T>) -> Self {
         Self {
-            mode: RetryMode::Custom(Arc::new(policy)),
+            mode: RetryMode::Custom(policy),
         }
     }
 

--- a/sdk/core/src/options/mod.rs
+++ b/sdk/core/src/options/mod.rs
@@ -129,7 +129,7 @@ impl RetryOptions {
     }
 
     /// A custom retry using the supplied retry policy.
-    pub fn custom<T: RetryPolicy + Policy + 'static>(policy: Arc<T>) -> Self {
+    pub fn custom<T: RetryPolicy + 'static>(policy: Arc<T>) -> Self {
         Self {
             mode: RetryMode::Custom(policy),
         }

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 /// `wait` can be implemented in more complex cases where a simple test of time
 /// is not enough.
 #[async_trait]
-pub trait RetryPolicy: Sync {
+pub trait RetryPolicy: std::fmt::Debug + Send + Sync {
     /// Determine if no more retries should be performed.
     ///
     /// Must return true if no more retries should be attempted.
@@ -48,7 +48,7 @@ const RETRY_STATUSES: &[StatusCode] = &[
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl<T> Policy for T
 where
-    T: RetryPolicy + std::fmt::Debug + Send + Sync,
+    T: RetryPolicy,
 {
     async fn send(
         &self,


### PR DESCRIPTION
Currently we require the user to pass ownership of their `RetryPolicy` only to then wrap it in an Arc. This isn't very helpful. Instead we can just access for an Arc which will let the user hold on to their `RetryPolicy` should they need to. 