### PR TITLE
move the rest of datalake operations to use the operations macro

### DIFF
--- a/sdk/storage_datalake/src/operations/mod.rs
+++ b/sdk/storage_datalake/src/operations/mod.rs
@@ -13,6 +13,7 @@ mod path_head;
 mod path_list;
 mod path_patch;
 mod path_put;
+mod path_rename;
 
 pub use file_system_create::*;
 pub use file_system_delete::*;
@@ -25,3 +26,4 @@ pub use path_head::*;
 pub use path_list::*;
 pub use path_patch::*;
 pub use path_put::*;
+pub use path_rename::*;

--- a/sdk/storage_datalake/src/operations/path_put.rs
+++ b/sdk/storage_datalake/src/operations/path_put.rs
@@ -1,89 +1,51 @@
-use crate::clients::PathClient;
-use crate::request_options::*;
-use crate::Properties;
-use azure_core::headers::{etag_from_headers, last_modified_from_headers};
-use azure_core::prelude::*;
-use azure_core::Request;
-use azure_core::{AppendToUrlQuery, Response as HttpResponse};
+use crate::{clients::PathClient, request_options::*, Properties};
+use azure_core::{
+    headers::{etag_from_headers, last_modified_from_headers},
+    prelude::*,
+    AppendToUrlQuery, Request, Response,
+};
 use azure_storage::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 use time::OffsetDateTime;
 
-#[derive(Debug, Clone)]
-pub struct PutPathBuilder<C>
-where
-    C: PathClient,
-{
+operation! {
+    PutPath<C: PathClient + 'static>,
     client: C,
-    mode: Option<PathRenameMode>,
-    resource: Option<ResourceType>,
-    continuation: Option<NextMarker>,
-    if_match_condition: Option<IfMatchCondition>,
-    if_modified_since: Option<IfModifiedSinceCondition>,
-    client_request_id: Option<ClientRequestId>,
-    properties: Option<Properties>,
-    timeout: Option<Timeout>,
-    context: Context,
+    ?mode: PathRenameMode,
+    ?resource: ResourceType,
+    ?continuation: NextMarker,
+    ?if_match_condition: IfMatchCondition,
+    ?if_modified_since: IfModifiedSince,
+    ?properties: Properties,
 }
 
 impl<C: PathClient + 'static> PutPathBuilder<C> {
-    pub(crate) fn new(client: C) -> Self {
-        Self {
-            client,
-            mode: None,
-            continuation: None,
-            resource: None,
-            if_match_condition: None,
-            if_modified_since: None,
-            client_request_id: None,
-            properties: None,
-            timeout: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        mode: PathRenameMode => Some(mode),
-        resource: ResourceType => Some(resource),
-        continuation: NextMarker => Some(continuation),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        if_modified_since: IfModifiedSinceCondition => Some(if_modified_since),
-        client_request_id: ClientRequestId => Some(client_request_id),
-        properties: Properties => Some(properties),
-        timeout: Timeout => Some(timeout),
-        context: Context => context,
-    }
-
     pub fn into_future(self) -> PutPath {
-        let this = self.clone();
-        let mut ctx = self.context.clone();
-
         Box::pin(async move {
-            let mut url = this.client.url()?;
+            let mut url = self.client.url()?;
 
             if let Some(continuation) = self.continuation {
                 continuation.append_to_url_query_as_continuation(&mut url);
             };
             self.resource.append_to_url_query(&mut url);
             self.mode.append_to_url_query(&mut url);
-            self.timeout.append_to_url_query(&mut url);
 
             let mut request = Request::new(url, azure_core::Method::Put);
 
-            request.insert_headers(&this.client_request_id);
-            request.insert_headers(&this.properties);
-            request.insert_headers(&this.if_match_condition);
-            request.insert_headers(&this.if_modified_since);
+            request.insert_headers(&self.properties);
+            request.insert_headers(&self.if_match_condition);
+            request.insert_headers(&self.if_modified_since);
             request.insert_headers(&ContentLength::new(0));
 
-            let response = self.client.send(&mut ctx, &mut request).await?;
+            let response = self
+                .client
+                .send(&mut self.context.clone(), &mut request)
+                .await?;
 
             PutPathResponse::try_from(response).await
         })
     }
 }
-
-azure_core::future!(PutPath);
 
 #[derive(Debug, Clone)]
 pub struct PutPathResponse {
@@ -94,7 +56,7 @@ pub struct PutPathResponse {
 }
 
 impl PutPathResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {
@@ -105,81 +67,3 @@ impl PutPathResponse {
         })
     }
 }
-
-#[derive(Debug, Clone)]
-pub struct RenamePathBuilder<C>
-where
-    C: PathClient,
-{
-    client: C,
-    mode: Option<PathRenameMode>,
-    continuation: Option<NextMarker>,
-    if_match_condition: Option<IfMatchCondition>,
-    if_modified_since: Option<IfModifiedSinceCondition>,
-    client_request_id: Option<ClientRequestId>,
-    rename_source: Option<RenameSource>,
-    properties: Option<Properties>,
-    timeout: Option<Timeout>,
-    context: Context,
-}
-
-impl<C: PathClient + 'static> RenamePathBuilder<C> {
-    pub(crate) fn new(client: C) -> Self {
-        Self {
-            client,
-            mode: None,
-            continuation: None,
-            if_match_condition: None,
-            if_modified_since: None,
-            client_request_id: None,
-            rename_source: None,
-            properties: None,
-            timeout: None,
-            context: Context::new(),
-        }
-    }
-
-    setters! {
-        mode: PathRenameMode => Some(mode),
-        continuation: NextMarker => Some(continuation),
-        if_match_condition: IfMatchCondition => Some(if_match_condition),
-        if_modified_since: IfModifiedSinceCondition => Some(if_modified_since),
-        client_request_id: ClientRequestId => Some(client_request_id),
-        rename_source: RenameSource => Some(rename_source),
-        properties: Properties => Some(properties),
-        timeout: Timeout => Some(timeout),
-        context: Context => context,
-    }
-
-    pub fn into_future(self) -> RenamePath {
-        let this = self.clone();
-        let mut ctx = self.context.clone();
-
-        Box::pin(async move {
-            let mut url = this.client.url()?;
-
-            if let Some(continuation) = self.continuation {
-                continuation.append_to_url_query_as_continuation(&mut url);
-            };
-            self.mode.append_to_url_query(&mut url);
-            self.timeout.append_to_url_query(&mut url);
-
-            let mut request = Request::new(url, azure_core::Method::Put);
-
-            request.insert_headers(&this.client_request_id);
-            request.insert_headers(&this.properties);
-            request.insert_headers(&this.if_match_condition);
-            request.insert_headers(&this.if_modified_since);
-            request.insert_headers(&this.rename_source);
-            request.insert_headers(&ContentLength::new(0));
-
-            self.client.send(&mut ctx, &mut request).await?;
-
-            Ok(())
-        })
-    }
-}
-
-azure_core::future!(RenamePath);
-
-type RenamePathResponse = ();

--- a/sdk/storage_datalake/src/operations/path_rename.rs
+++ b/sdk/storage_datalake/src/operations/path_rename.rs
@@ -1,0 +1,42 @@
+use crate::{clients::PathClient, request_options::*, Properties};
+use azure_core::{prelude::*, AppendToUrlQuery, Request};
+
+operation! {
+    RenamePath<C: PathClient + 'static>,
+    client: C,
+    ?mode: PathRenameMode,
+    ?continuation: NextMarker,
+    ?if_match_condition: IfMatchCondition,
+    ?if_modified_since: IfModifiedSince,
+    ?rename_source: RenameSource,
+    ?properties: Properties,
+}
+
+impl<C: PathClient + 'static> RenamePathBuilder<C> {
+    pub fn into_future(self) -> RenamePath {
+        let mut ctx = self.context.clone();
+
+        Box::pin(async move {
+            let mut url = self.client.url()?;
+
+            if let Some(continuation) = self.continuation {
+                continuation.append_to_url_query_as_continuation(&mut url);
+            };
+            self.mode.append_to_url_query(&mut url);
+
+            let mut request = Request::new(url, azure_core::Method::Put);
+
+            request.insert_headers(&self.properties);
+            request.insert_headers(&self.if_match_condition);
+            request.insert_headers(&self.if_modified_since);
+            request.insert_headers(&self.rename_source);
+            request.insert_headers(&ContentLength::new(0));
+
+            self.client.send(&mut ctx, &mut request).await?;
+
+            Ok(())
+        })
+    }
+}
+
+type RenamePathResponse = ();


### PR DESCRIPTION
In the previous PR, these were missed.  Additionally, this splits out the rename operation off of the `path_put` into it's own file.