### PR TITLE
Small Blob cleanup

### DIFF
--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -42,7 +42,7 @@ pub mod xml;
 pub use bytes_stream::*;
 pub use constants::*;
 pub use context::Context;
-pub use error::Result;
+pub use error::{Error, Result};
 #[doc(inline)]
 pub use headers::Header;
 pub use http_client::{new_http_client, to_json, HttpClient};

--- a/sdk/storage_blobs/src/blob/operations/copy_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob.rs
@@ -74,7 +74,7 @@ pub struct CopyBlobResponse {
 }
 
 impl TryFrom<&Headers> for CopyBlobResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> azure_core::Result<Self> {
         Ok(Self {

--- a/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
@@ -72,7 +72,7 @@ pub struct CopyBlobFromUrlResponse {
 }
 
 impl TryFrom<&Headers> for CopyBlobFromUrlResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
     fn try_from(headers: &Headers) -> azure_core::Result<Self> {
         Ok(Self {
             content_md5: content_md5_from_headers_optional(headers)?,

--- a/sdk/storage_blobs/src/blob/operations/get_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_metadata.rs
@@ -48,7 +48,7 @@ pub struct GetMetadataResponse {
 }
 
 impl TryFrom<&Headers> for GetMetadataResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
         Ok(GetMetadataResponse {

--- a/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_blob_tier.rs
@@ -42,7 +42,7 @@ pub struct SetBlobTierResponse {
 }
 
 impl TryFrom<&Headers> for SetBlobTierResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
         Ok(SetBlobTierResponse {

--- a/sdk/storage_blobs/src/blob/operations/set_expiry.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_expiry.rs
@@ -36,7 +36,7 @@ pub struct SetBlobExpiryResponse {
 }
 
 impl TryFrom<Response> for SetBlobExpiryResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(response: Response) -> Result<Self, Self::Error> {
         let headers = response.headers();

--- a/sdk/storage_blobs/src/blob/operations/set_metadata.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_metadata.rs
@@ -50,7 +50,7 @@ pub struct SetMetadataResponse {
 }
 
 impl TryFrom<&Headers> for SetMetadataResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
         Ok(SetMetadataResponse {

--- a/sdk/storage_blobs/src/blob/operations/set_properties.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_properties.rs
@@ -86,7 +86,7 @@ pub struct SetPropertiesResponse {
 }
 
 impl TryFrom<&Headers> for SetPropertiesResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
         Ok(SetPropertiesResponse {

--- a/sdk/storage_blobs/src/blob/operations/set_tags.rs
+++ b/sdk/storage_blobs/src/blob/operations/set_tags.rs
@@ -44,7 +44,7 @@ pub struct SetTagsResponse {
 }
 
 impl TryFrom<&Headers> for SetTagsResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
         Ok(SetTagsResponse {

--- a/sdk/storage_blobs/src/blob/operations/snapshot_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/snapshot_blob.rs
@@ -52,7 +52,7 @@ pub struct SnapshotBlobResponse {
 }
 
 impl TryFrom<&Headers> for SnapshotBlobResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
         Ok(SnapshotBlobResponse {

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -90,6 +90,7 @@ impl BlobServiceClientBuilder {
     }
 }
 
+/// A client for interacting with the blob storage service.
 #[derive(Debug, Clone)]
 pub struct BlobServiceClient {
     pipeline: Pipeline,
@@ -112,14 +113,17 @@ impl BlobServiceClient {
         BlobServiceClientBuilder::new(account, credentials)
     }
 
+    /// Get information about the blob storage account
     pub fn get_account_information(&self) -> GetAccountInformationBuilder {
         GetAccountInformationBuilder::new(self.clone())
     }
 
+    /// Get all the blobs with the given tags in the where expression
     pub fn find_blobs_by_tags(&self, expression: String) -> FindBlobsByTagsBuilder {
         FindBlobsByTagsBuilder::new(self.clone(), expression)
     }
 
+    /// List all the containers in the blob account
     pub fn list_containers(&self) -> ListContainersBuilder {
         ListContainersBuilder::new(self.clone())
     }

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -22,6 +22,7 @@ pub struct ContainerClient {
 }
 
 impl ContainerClient {
+    /// Create a new `ContainerClient` from a `BlobServiceClient` and a container name
     pub(crate) fn new(service_client: BlobServiceClient, container_name: String) -> Self {
         Self {
             service_client,
@@ -29,30 +30,37 @@ impl ContainerClient {
         }
     }
 
+    /// Create a container
     pub fn create(&self) -> CreateBuilder {
         CreateBuilder::new(self.clone())
     }
 
+    /// Delete a container
     pub fn delete(&self) -> DeleteBuilder {
         DeleteBuilder::new(self.clone())
     }
 
+    /// Get a container acl
     pub fn get_acl(&self) -> GetACLBuilder {
         GetACLBuilder::new(self.clone())
     }
 
+    /// Set a container acl
     pub fn set_acl(&self, public_access: PublicAccess) -> SetACLBuilder {
         SetACLBuilder::new(self.clone(), public_access)
     }
 
+    /// Get a container's properties
     pub fn get_properties(&self) -> GetPropertiesBuilder {
         GetPropertiesBuilder::new(self.clone())
     }
 
+    /// List the blobs in a container
     pub fn list_blobs(&self) -> ListBlobsBuilder {
         ListBlobsBuilder::new(self.clone())
     }
 
+    /// Acquite a lease on a container
     pub fn acquire_lease<LD: Into<LeaseDuration>>(
         &self,
         lease_duration: LD,
@@ -60,6 +68,7 @@ impl ContainerClient {
         AcquireLeaseBuilder::new(self.clone(), lease_duration.into())
     }
 
+    /// Break the lease on a container
     pub fn break_lease(&self) -> BreakLeaseBuilder {
         BreakLeaseBuilder::new(self.clone())
     }
@@ -74,10 +83,6 @@ impl ContainerClient {
 
     pub fn container_name(&self) -> &str {
         &self.container_name
-    }
-
-    pub(crate) fn credentials(&self) -> &StorageCredentials {
-        self.service_client.credentials()
     }
 
     /// Create a shared access signature.
@@ -129,6 +134,10 @@ impl ContainerClient {
 
         let url = format!("{}{}{}", self.service_client.url()?, sep, container_name);
         Ok(url::Url::parse(&url)?)
+    }
+
+    pub(crate) fn credentials(&self) -> &StorageCredentials {
+        self.service_client.credentials()
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -23,17 +23,6 @@ impl ContainerLeaseClient {
         RenewLeaseBuilder::new(self.clone())
     }
 
-    pub(crate) fn finalize_request(
-        &self,
-        url: Url,
-        method: Method,
-        headers: Headers,
-        request_body: Option<Body>,
-    ) -> azure_core::Result<Request> {
-        self.container_client
-            .finalize_request(url, method, headers, request_body)
-    }
-
     pub fn lease_id(&self) -> LeaseId {
         self.lease_id
     }
@@ -44,6 +33,17 @@ impl ContainerLeaseClient {
 
     pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
         self.container_client.url()
+    }
+
+    pub(crate) fn finalize_request(
+        &self,
+        url: Url,
+        method: Method,
+        headers: Headers,
+        request_body: Option<Body>,
+    ) -> azure_core::Result<Request> {
+        self.container_client
+            .finalize_request(url, method, headers, request_body)
     }
 
     pub(crate) async fn send(

--- a/sdk/storage_blobs/src/container/operations/get_properties.rs
+++ b/sdk/storage_blobs/src/container/operations/get_properties.rs
@@ -43,7 +43,7 @@ pub struct GetPropertiesResponse {
 }
 
 impl TryFrom<(&str, &Headers)> for GetPropertiesResponse {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from((body, header_map): (&str, &Headers)) -> azure_core::Result<Self> {
         GetPropertiesResponse::from_response(body, header_map)

--- a/sdk/storage_blobs/src/lib.rs
+++ b/sdk/storage_blobs/src/lib.rs
@@ -3,8 +3,6 @@ extern crate serde_derive;
 #[macro_use]
 extern crate azure_core;
 
-pub use azure_core::error::{Error, ErrorKind, ResultExt};
-
 pub mod blob;
 pub mod container;
 pub mod prelude;


### PR DESCRIPTION
Some small clean up in the `azure_storage_blobs` crate:
* Remove some unnecessary public items (the blob crate was exporting `azure_core::{Error, ErrorKind, ResultExt}`)
* Move `pub(crate)` methods to the end of their `impl` blocks
* Add some more basic documentation