### PR TITLE
Change `BlobServiceClientBuilder` to be just a `ClientBuilder`

### DIFF
--- a/sdk/storage_blobs/examples/container_01.rs
+++ b/sdk/storage_blobs/examples/container_01.rs
@@ -17,8 +17,8 @@ async fn main() -> azure_core::Result<()> {
         .expect("please specify container name as command line parameter");
 
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
-    let service_client = BlobServiceClient::new(account, storage_credentials);
-    let container_client = service_client.container_client(container_name);
+    let container_client =
+        ClientBuilder::new(account, storage_credentials).container_client(container_name);
 
     let mut metadata = Metadata::new();
     metadata.insert("prova".to_owned(), "pollo".to_owned());

--- a/sdk/storage_blobs/examples/emulator_00.rs
+++ b/sdk/storage_blobs/examples/emulator_00.rs
@@ -6,7 +6,7 @@ async fn main() -> azure_core::Result<()> {
     env_logger::init();
 
     // this is how you use the emulator.
-    let storage_account = BlobServiceClientBuilder::emulator().build();
+    let storage_account = ClientBuilder::emulator().blob_service_client();
     let container_client = storage_account.container_client("emulcont");
 
     // create container

--- a/sdk/storage_blobs/examples/missing_blob.rs
+++ b/sdk/storage_blobs/examples/missing_blob.rs
@@ -15,8 +15,8 @@ async fn main() -> azure_core::Result<()> {
     let blob_name = format!("missing-{}.txt", Uuid::new_v4());
 
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
-    let service_client = BlobServiceClient::new(account, storage_credentials);
-    let container_client = service_client.container_client(&container_name);
+    let container_client =
+        ClientBuilder::new(account, storage_credentials).container_client(&container_name);
     println!("creating container {}", container_name);
     container_client.create().into_future().await?;
 

--- a/sdk/storage_blobs/examples/put_append_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_append_blob_00.rs
@@ -23,9 +23,8 @@ async fn main() -> azure_core::Result<()> {
         .expect("please specify blob name as command line parameter");
 
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
-    let blob_client = BlobServiceClient::new(account, storage_credentials)
-        .container_client(&container)
-        .blob_client(&blob_name);
+    let blob_client =
+        ClientBuilder::new(account, storage_credentials).blob_client(&container, &blob_name);
 
     //let data = b"something";
 

--- a/sdk/storage_blobs/examples/snapshot_blob.rs
+++ b/sdk/storage_blobs/examples/snapshot_blob.rs
@@ -15,7 +15,7 @@ async fn main() -> azure_core::Result<()> {
     let access_key =
         std::env::var("STORAGE_ACCESS_KEY").expect("Set env variable STORAGE_ACCESS_KEY first!");
 
-    let container = std::env::args()
+    let container_name = std::env::args()
         .nth(1)
         .expect("please specify container name as command line parameter");
     let blob_name = std::env::args()
@@ -23,9 +23,8 @@ async fn main() -> azure_core::Result<()> {
         .expect("please specify blob name as command line parameter");
 
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
-    let blob_client = BlobServiceClient::new(account, storage_credentials)
-        .container_client(&container)
-        .blob_client(&blob_name);
+    let blob_client =
+        ClientBuilder::new(account, storage_credentials).blob_client(&container_name, &blob_name);
 
     let data = Bytes::from_static(b"something");
 

--- a/sdk/storage_blobs/examples/stream_blob_00.rs
+++ b/sdk/storage_blobs/examples/stream_blob_00.rs
@@ -24,9 +24,8 @@ async fn main() -> azure_core::Result<()> {
         .expect("please specify container name as first command line parameter");
 
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
-    let blob_client = BlobServiceClient::new(account, storage_credentials)
-        .container_client(&container_name)
-        .blob_client(file_name);
+    let blob_client =
+        ClientBuilder::new(account, storage_credentials).blob_client(&container_name, file_name);
 
     let string = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
 

--- a/sdk/storage_blobs/examples/stream_blob_01.rs
+++ b/sdk/storage_blobs/examples/stream_blob_01.rs
@@ -23,9 +23,8 @@ async fn main() -> azure_core::Result<()> {
         .expect("please specify container name as first command line parameter");
 
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
-    let blob_client = BlobServiceClient::new(account, storage_credentials)
-        .container_client(container_name)
-        .blob_client(file_name);
+    let blob_client =
+        ClientBuilder::new(account, storage_credentials).blob_client(container_name, file_name);
 
     let mut stream = blob_client.get().into_stream();
     while let Some(res) = stream.next().await {

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -313,7 +313,7 @@ mod tests {
     }
 
     fn build_url(container_name: &str, blob_name: &str, sas: &FakeSas) -> url::Url {
-        let service_client = BlobServiceClientBuilder::emulator().build();
+        let service_client = ClientBuilder::emulator().blob_service_client();
         service_client
             .container_client(container_name)
             .blob_client(blob_name)

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -164,11 +164,11 @@ impl ContainerClient {
 #[cfg(feature = "test_integration")]
 mod integration_tests {
     use super::*;
-    use crate::clients::BlobServiceClientBuilder;
+    use crate::clients::ClientBuilder;
     use futures::StreamExt;
 
     fn get_emulator_client(container_name: &str) -> ContainerClient {
-        let service_client = BlobServiceClientBuilder::emulator().build();
+        let service_client = ClientBuilder::emulator().build();
         service_client.container_client(container_name)
     }
 

--- a/sdk/storage_blobs/src/clients/mod.rs
+++ b/sdk/storage_blobs/src/clients/mod.rs
@@ -6,6 +6,6 @@ mod container_lease_client;
 
 pub use blob_client::BlobClient;
 pub use blob_lease_client::BlobLeaseClient;
-pub use blob_service_client::{BlobServiceClient, BlobServiceClientBuilder};
+pub use blob_service_client::{BlobServiceClient, ClientBuilder};
 pub use container_client::ContainerClient;
 pub use container_lease_client::ContainerLeaseClient;

--- a/sdk/storage_blobs/src/prelude.rs
+++ b/sdk/storage_blobs/src/prelude.rs
@@ -3,7 +3,7 @@ pub use crate::options::*;
 pub use crate::{
     blob::{Blob, BlobBlockType, BlockList, BlockListType},
     clients::{
-        BlobClient, BlobLeaseClient, BlobServiceClient, BlobServiceClientBuilder, ContainerClient,
+        BlobClient, BlobLeaseClient, BlobServiceClient, ClientBuilder, ContainerClient,
         ContainerLeaseClient,
     },
 };

--- a/sdk/storage_blobs/tests/setup.rs
+++ b/sdk/storage_blobs/tests/setup.rs
@@ -18,7 +18,7 @@ pub fn initialize(transaction_name: impl Into<String>) -> azure_core::Result<Blo
     );
     let client = BlobServiceClient::builder(account_name, storage_credentials)
         .transport(transport_options)
-        .build();
+        .blob_service_client();
     Ok(client)
 }
 


### PR DESCRIPTION
*Worked on with @yoshuawuyts 💗*

This is the implementation of #1080 only for `azure_storage_blobs`. Once everyone is happy with this, I can do the other storage SDKs. 

`BlobServiceClientBuilder` is now `ClientBuilder` and can build all of the clients in `azure_storage_blobs`. This makes it slightly more ergonomic to get to the client you need with the right options. 

cc @gorzell 