### PR TITLE
add support for `<BlobPrefix>` when listing blobs

### DIFF
--- a/sdk/storage_blobs/examples/anonymous_access.rs
+++ b/sdk/storage_blobs/examples/anonymous_access.rs
@@ -15,7 +15,7 @@ async fn main() -> azure_core::Result<()> {
     let mut blob_stream = container_client.list_blobs().into_stream();
     while let Some(blob_entry) = blob_stream.next().await {
         let blob_entry = blob_entry?;
-        for blob in blob_entry.blobs.blobs {
+        for blob in blob_entry.blobs.blobs() {
             println!("\t{}", blob.name);
         }
     }

--- a/sdk/storage_blobs/examples/connection_string.rs
+++ b/sdk/storage_blobs/examples/connection_string.rs
@@ -59,7 +59,7 @@ async fn main() -> azure_core::Result<()> {
 
     let mut cnt: i32 = 0;
     while let Some(value) = stream.next().await {
-        let len = value?.blobs.blobs.len();
+        let len = value?.blobs.blobs().count();
         println!("received {} blobs", len);
         match cnt {
             0 | 1 | 2 => assert_eq!(len, 3),

--- a/sdk/storage_blobs/examples/container_00.rs
+++ b/sdk/storage_blobs/examples/container_00.rs
@@ -44,8 +44,8 @@ async fn main() -> azure_core::Result<()> {
     let mut count = 0;
     while let Some(result) = stream.next().await {
         let result = result?;
-        count += result.blobs.blobs.len();
-        for blob in result.blobs.blobs.iter() {
+        for blob in result.blobs.blobs() {
+            count += 1;
             println!(
                 "\t{}\t{} MB",
                 blob.name,

--- a/sdk/storage_blobs/examples/count_blobs.rs
+++ b/sdk/storage_blobs/examples/count_blobs.rs
@@ -21,7 +21,7 @@ async fn main() -> azure_core::Result<()> {
     let mut list_blobs = container_client.list_blobs().into_stream();
     while let Some(list_blobs_response) = list_blobs.next().await {
         let list_blobs_response = list_blobs_response?;
-        count += list_blobs_response.blobs.blobs.len();
+        count += list_blobs_response.blobs.blobs().count();
     }
 
     println!("blob count {}", count);

--- a/sdk/storage_blobs/examples/list_blobs_00.rs
+++ b/sdk/storage_blobs/examples/list_blobs_00.rs
@@ -66,8 +66,8 @@ async fn main() -> azure_core::Result<()> {
         .await
         .expect("stream failed")?;
 
-    println!("List blob returned {} blobs.", page.blobs.blobs.len());
-    for cont in page.blobs.blobs.iter() {
+    println!("List blob returned {} blobs.", page.blobs.blobs().count());
+    for cont in page.blobs.blobs() {
         println!("\t{}\t{} bytes", cont.name, cont.properties.content_length);
     }
 
@@ -78,7 +78,7 @@ async fn main() -> azure_core::Result<()> {
 
     let mut cnt: i32 = 0;
     while let Some(value) = stream.next().await {
-        let len = value?.blobs.blobs.len();
+        let len = value?.blobs.blobs().count();
         println!("received {} blobs", len);
         match cnt {
             0 | 1 | 2 => assert_eq!(len, 3),

--- a/sdk/storage_blobs/examples/list_blobs_01.rs
+++ b/sdk/storage_blobs/examples/list_blobs_01.rs
@@ -53,7 +53,7 @@ async fn main() -> azure_core::Result<()> {
         .await
         .expect("stream failed")?;
 
-    assert!(page.blobs.blobs.is_empty());
+    assert!(page.blobs.blobs().next().is_some());
 
     println!("Adding blobs");
 
@@ -131,14 +131,11 @@ async fn main() -> azure_core::Result<()> {
 
     println!(
         "List blob / returned {} blobs with blob_prefix == {:?}",
-        page.blobs.blobs.len(),
-        page.blobs.blob_prefix
+        page.blobs.blobs().count(),
+        page.blobs.prefixes().collect::<Vec<_>>()
     );
-    page.blobs
-        .blobs
-        .iter()
-        .for_each(|b| println!("\t{}", b.name));
-    assert_eq!(page.blobs.blobs.len(), 4);
+    page.blobs.blobs().for_each(|b| println!("\t{}", b.name));
+    assert_eq!(page.blobs.blobs().count(), 4);
 
     let page = container_client
         .list_blobs()
@@ -152,14 +149,11 @@ async fn main() -> azure_core::Result<()> {
 
     println!(
         "List blob firstfolder/ returned {} blobs with blob_prefix == {:?}",
-        page.blobs.blobs.len(),
-        page.blobs.blob_prefix
+        page.blobs.blobs().count(),
+        page.blobs.prefixes().collect::<Vec<_>>()
     );
-    page.blobs
-        .blobs
-        .iter()
-        .for_each(|b| println!("\t{}", b.name));
-    assert_eq!(page.blobs.blobs.len(), 3);
+    page.blobs.blobs().for_each(|b| println!("\t{}", b.name));
+    assert_eq!(page.blobs.blobs().count(), 3);
 
     let mut stream = container_client
         .list_blobs()
@@ -169,7 +163,7 @@ async fn main() -> azure_core::Result<()> {
     println!("Streaming results without prefix");
     let mut cnt: i32 = 0;
     while let Some(value) = stream.next().await {
-        let len = value?.blobs.blobs.len();
+        let len = value?.blobs.blobs().count();
         println!("\treceived {} blobs", len);
         match cnt {
             // we added 21 blobs so 5x4 + 1

--- a/sdk/storage_blobs/examples/list_blobs_02.rs
+++ b/sdk/storage_blobs/examples/list_blobs_02.rs
@@ -27,7 +27,7 @@ async fn main() -> azure_core::Result<()> {
         .next()
         .await
         .expect("stream failed")?;
-    println!("List blob returned {} blobs.", page.blobs.blobs.len());
+    println!("List blob returned {} blobs.", page.blobs.blobs().count());
 
     for i in 0..3 {
         container_client
@@ -46,7 +46,7 @@ async fn main() -> azure_core::Result<()> {
         .next()
         .await
         .expect("stream failed")?;
-    println!("List blob returned {} blobs.", page.blobs.blobs.len());
+    println!("List blob returned {} blobs.", page.blobs.blobs().count());
 
     container_client.delete().into_future().await?;
     println!("Container {} deleted", container_name);

--- a/sdk/storage_blobs/examples/list_containers_and_blobs.rs
+++ b/sdk/storage_blobs/examples/list_containers_and_blobs.rs
@@ -25,7 +25,7 @@ async fn main() -> azure_core::Result<()> {
             let mut blob_stream = container_client.list_blobs().into_stream();
             while let Some(blob_entry) = blob_stream.next().await {
                 let blob_entry = blob_entry?;
-                for blob in blob_entry.blobs.blobs {
+                for blob in blob_entry.blobs.blobs() {
                     println!("\t{}", blob.name);
                 }
             }

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -213,10 +213,11 @@ mod integration_tests {
             .await
             .expect("list blobs next() should return value")
             .expect("list blobs should succeed");
-        assert_eq!(list.blobs.blobs.len(), 1);
-        assert_eq!(list.blobs.blobs[0].name, "hello.txt");
+        let blobs: Vec<_> = list.blobs.blobs().collect();
+        assert_eq!(blobs.len(), 1);
+        assert_eq!(blobs[0].name, "hello.txt");
         assert_eq!(
-            list.blobs.blobs[0]
+            blobs[0]
                 .properties
                 .content_md5
                 .as_ref()

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_xml() {
+    fn parse_xml_with_blob_prefix() {
         const XML: &[u8] = br#"<?xml version="1.0" encoding="utf-8"?>
         <EnumerationResults ServiceEndpoint="https://sisuautomatedtest.blob.core.windows.net/" ContainerName="lowlatencyrequests">
           <Prefix>get-most-recent-key-5/</Prefix>

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -315,4 +315,90 @@ mod tests {
         let bytes = Bytes::from(S);
         let _list_blobs_response_internal: ListBlobsResponseInternal = read_xml(&bytes).unwrap();
     }
+
+    #[test]
+    fn parse_xml() {
+        const XML: &[u8] = br#"<?xml version="1.0" encoding="utf-8"?>
+        <EnumerationResults ServiceEndpoint="https://sisuautomatedtest.blob.core.windows.net/" ContainerName="lowlatencyrequests">
+          <Prefix>get-most-recent-key-5/</Prefix>
+          <Delimiter>/</Delimiter>
+          <Blobs>
+            <Blob>
+              <Name>get-most-recent-key-5/2021-08-04-testfile1</Name>
+              <Properties>
+                <Creation-Time>Tue, 13 Sep 2022 08:20:48 GMT</Creation-Time>
+                <Last-Modified>Tue, 13 Sep 2022 08:20:48 GMT</Last-Modified>
+                <Etag>0x8DA9560DD170CFD</Etag>
+                <Content-Length>19</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-Encoding />
+                <Content-Language />
+                <Content-CRC64 />
+                <Content-MD5>3X/+gWTy92gIJFXx57gLYA==</Content-MD5>
+                <Cache-Control />
+                <Content-Disposition />
+                <BlobType>BlockBlob</BlobType>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+              </Properties>
+              <OrMetadata />
+            </Blob>
+            <BlobPrefix>
+              <Name>get-most-recent-key-5/2021-08-04T21:48:48.592953Z-15839722113750148182/</Name>
+            </BlobPrefix>
+            <Blob>
+              <Name>get-most-recent-key-5/2021-09-04-testfile2</Name>
+              <Properties>
+                <Creation-Time>Tue, 13 Sep 2022 08:07:01 GMT</Creation-Time>
+                <Last-Modified>Tue, 13 Sep 2022 08:19:21 GMT</Last-Modified>
+                <Etag>0x8DA9560A916932D</Etag>
+                <Content-Length>19</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-Encoding />
+                <Content-Language />
+                <Content-CRC64 />
+                <Content-MD5>b0CPJB6eDfKUzzW7dlboKQ==</Content-MD5>
+                <Cache-Control />
+                <Content-Disposition />
+                <BlobType>BlockBlob</BlobType>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+              </Properties>
+              <OrMetadata />
+            </Blob>
+            <Blob>
+              <Name>get-most-recent-key-5/2022-08-04-testfile3</Name>
+              <Properties>
+                <Creation-Time>Tue, 13 Sep 2022 08:07:01 GMT</Creation-Time>
+                <Last-Modified>Tue, 13 Sep 2022 08:19:21 GMT</Last-Modified>
+                <Etag>0x8DA9560A91F9296</Etag>
+                <Content-Length>34</Content-Length>
+                <Content-Type>text/plain</Content-Type>
+                <Content-Encoding />
+                <Content-Language />
+                <Content-CRC64 />
+                <Content-MD5>1F1MssyZOvhY4OZevHWEsw==</Content-MD5>
+                <Cache-Control />
+                <Content-Disposition />
+                <BlobType>BlockBlob</BlobType>
+                <AccessTier>Hot</AccessTier>
+                <AccessTierInferred>true</AccessTierInferred>
+                <LeaseStatus>unlocked</LeaseStatus>
+                <LeaseState>available</LeaseState>
+                <ServerEncrypted>true</ServerEncrypted>
+              </Properties>
+              <OrMetadata />
+            </Blob>
+          </Blobs>
+          <NextMarker />
+        </EnumerationResults>"#;
+
+        let _list_blobs_response_internal: ListBlobsResponseInternal = read_xml(XML).unwrap();
+    }
 }

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -109,12 +109,35 @@ struct ListBlobsResponseInternal {
     pub blobs: Blobs,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Default)]
 #[serde(rename_all = "PascalCase")]
 pub struct Blobs {
-    pub blob_prefix: Option<Vec<BlobPrefix>>,
-    #[serde(rename = "Blob", default)]
-    pub blobs: Vec<Blob>,
+    #[serde(rename = "$value", default)]
+    pub items: Vec<BlobItem>,
+}
+
+impl Blobs {
+    pub fn blobs(&self) -> impl Iterator<Item = &Blob> {
+        self.items.iter().filter_map(|item| match item {
+            BlobItem::Blob(blob) => Some(blob),
+            _ => None,
+        })
+    }
+
+    pub fn prefixes(&self) -> impl Iterator<Item = &BlobPrefix> {
+        self.items.iter().filter_map(|item| match item {
+            BlobItem::BlobPrefix(prefix) => Some(prefix),
+            _ => None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(clippy::large_enum_variant)]
+pub enum BlobItem {
+    Blob(Blob),
+    BlobPrefix(BlobPrefix),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/sdk/storage_blobs/tests/stream_list_blobs.rs
+++ b/sdk/storage_blobs/tests/stream_list_blobs.rs
@@ -59,7 +59,7 @@ async fn stream_list_blobs() {
 
     let mut cnt = 0u32;
     while let Some(value) = stream.next().await {
-        let len = value.unwrap().blobs.blobs.len();
+        let len = value.unwrap().blobs.blobs().count();
         println!("received {} blobs", len);
         match cnt {
             0 | 1 | 2 => assert_eq!(len, 3),


### PR DESCRIPTION
Fix #1092. The `<Blobs>` can contain `<Blob>` or `<BlobPrefix>`. 

https://docs.microsoft.com/en-us/rest/api/storageservices/list-blobs