### PR TITLE
make IntoFuture broadly usable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.64.0"
 components = [ "rustfmt", "clippy" ]

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -103,7 +103,6 @@ macro_rules! setters {
 ///     }
 /// }
 ///
-/// #[cfg(feature = "into_future")]
 /// impl std::future::IntoFuture for CreateCollectionBuilder {
 ///     type IntoFuture = CreateCollection;
 ///     type Output = <CreateCollection as std::future::Future>::Output;
@@ -232,7 +231,6 @@ macro_rules! operation {
         }
         $crate::future!($name);
         azure_core::__private::paste! {
-        #[cfg(feature = "into_future")]
         impl <$($generic: $first_constraint $(+ $constraint)*)* $(+ $lt)*> std::future::IntoFuture for [<$name Builder>]<$($generic),*> {
             type IntoFuture = $name;
             type Output = <$name as std::future::Future>::Output;

--- a/sdk/data_cosmos/examples/attachments.rs
+++ b/sdk/data_cosmos/examples/attachments.rs
@@ -54,7 +54,7 @@ async fn main() -> azure_core::Result<()> {
     };
 
     // let's add an entity.
-    match client.create_document(doc.clone()).into_future().await {
+    match client.create_document(doc.clone()).await {
         Ok(_) => {
             println!("document created");
         }
@@ -83,7 +83,6 @@ async fn main() -> azure_core::Result<()> {
             "image/jpeg",
         )
         .consistency_level(ret)
-        .into_future()
         .await?;
     println!("create reference == {:#?}", resp);
 
@@ -91,11 +90,7 @@ async fn main() -> azure_core::Result<()> {
     // sure to find the just created attachment
     let session_token: ConsistencyLevel = resp.into();
 
-    let resp = attachment
-        .get()
-        .consistency_level(session_token)
-        .into_future()
-        .await?;
+    let resp = attachment.get().consistency_level(session_token).await?;
 
     println!("get attachment == {:#?}", resp);
     let session_token: ConsistencyLevel = resp.into();
@@ -108,16 +103,11 @@ async fn main() -> azure_core::Result<()> {
             "image/jpeg",
         )
         .consistency_level(session_token)
-        .into_future()
         .await?;
     println!("replace reference == {:#?}", resp);
 
     println!("deleting");
-    let resp_delete = attachment
-        .delete()
-        .consistency_level(&resp)
-        .into_future()
-        .await?;
+    let resp_delete = attachment.delete().consistency_level(&resp).await?;
     println!("delete attachment == {:#?}", resp_delete);
 
     // slug attachment
@@ -127,17 +117,12 @@ async fn main() -> azure_core::Result<()> {
         .create_slug("FFFFF".into())
         .consistency_level(&resp_delete)
         .content_type("text/plain")
-        .into_future()
         .await?;
 
     println!("create slug == {:#?}", resp);
 
     println!("deleting");
-    let resp_delete = attachment
-        .delete()
-        .consistency_level(&resp)
-        .into_future()
-        .await?;
+    let resp_delete = attachment.delete().consistency_level(&resp).await?;
     println!("delete attachment == {:#?}", resp_delete);
 
     Ok(())

--- a/sdk/data_cosmos/examples/collection.rs
+++ b/sdk/data_cosmos/examples/collection.rs
@@ -44,11 +44,7 @@ async fn main() -> azure_core::Result<()> {
     // try get on the first database (if any)
     if let Some(db) = databases.databases.first() {
         println!("getting info of database {}", &db.id);
-        let db = client
-            .database_client(db.id.clone())
-            .get_database()
-            .into_future()
-            .await?;
+        let db = client.database_client(db.id.clone()).get_database().await?;
         println!("db {} found == {:?}", &db.database.id, &db);
     }
 
@@ -75,7 +71,6 @@ async fn main() -> azure_core::Result<()> {
             let collection_response = database
                 .collection_client(collection.id)
                 .get_collection()
-                .into_future()
                 .await?;
 
             println!("\tcollection_response {:?}", collection_response);

--- a/sdk/data_cosmos/examples/create_delete_database.rs
+++ b/sdk/data_cosmos/examples/create_delete_database.rs
@@ -46,19 +46,13 @@ async fn main() -> azure_core::Result<()> {
     }
     drop(list_databases_stream);
 
-    let db = client
-        .create_database(&args.database_name)
-        .into_future()
-        .await?;
+    let db = client.create_database(&args.database_name).await?;
     println!("created database = {:#?}", db);
 
     // create collection!
     {
         let database = client.database_client(args.database_name.clone());
-        let create_collection_response = database
-            .create_collection("panzadoro", "/id")
-            .into_future()
-            .await?;
+        let create_collection_response = database.create_collection("panzadoro", "/id").await?;
 
         println!(
             "create_collection_response == {:#?}",
@@ -67,7 +61,7 @@ async fn main() -> azure_core::Result<()> {
 
         let db_collection = database.collection_client("panzadoro");
 
-        let get_collection_response = db_collection.get_collection().into_future().await?;
+        let get_collection_response = db_collection.get_collection().await?;
         println!("get_collection_response == {:#?}", get_collection_response);
 
         let mut stream = database.list_collections().into_stream();
@@ -76,14 +70,13 @@ async fn main() -> azure_core::Result<()> {
             println!("res == {:#?}", res);
         }
 
-        let delete_response = db_collection.delete_collection().into_future().await?;
+        let delete_response = db_collection.delete_collection().await?;
         println!("collection deleted: {:#?}", delete_response);
     }
 
     let resp = client
         .database_client(args.database_name)
         .delete_database()
-        .into_future()
         .await?;
     println!("database deleted. resp == {:#?}", resp);
 

--- a/sdk/data_cosmos/examples/database.rs
+++ b/sdk/data_cosmos/examples/database.rs
@@ -66,17 +66,12 @@ async fn main() -> azure_core::Result<()> {
                     .create_document(document)
                     .is_upsert(true)
                     .partition_key(&43u32)?
-                    .into_future()
                     .await?;
 
                 println!("`create_document` response: {:?}", create_document);
 
                 // Alternatively, we can just fetch a specific collection directly
-                let _ = database
-                    .collection_client("cnt")
-                    .get_collection()
-                    .into_future()
-                    .await?;
+                let _ = database.collection_client("cnt").get_collection().await?;
 
                 // Replace the collection's indexing policy
                 indexing_policy_new
@@ -87,7 +82,6 @@ async fn main() -> azure_core::Result<()> {
                 let replace_collection_response = collection
                     .replace_collection("/age")
                     .indexing_policy(indexing_policy_new)
-                    .into_future()
                     .await?;
                 println!(
                     "`replace_collection` response: {:#?}",

--- a/sdk/data_cosmos/examples/document.rs
+++ b/sdk/data_cosmos/examples/document.rs
@@ -74,13 +74,7 @@ async fn main() -> azure_core::Result<()> {
     // If the requested database is not found we create it.
     let database = match db {
         Some(db) => db,
-        None => {
-            client
-                .create_database(DATABASE)
-                .into_future()
-                .await?
-                .database
-        }
+        None => client.create_database(DATABASE).await?.database,
     };
     println!("database == {:?}", database);
 
@@ -107,7 +101,6 @@ async fn main() -> azure_core::Result<()> {
                 .clone()
                 .database_client(database.id.clone())
                 .create_collection(COLLECTION, "/id")
-                .into_future()
                 .await?
                 .collection
         }
@@ -136,10 +129,7 @@ async fn main() -> azure_core::Result<()> {
     // The method create_document will return, upon success,
     // the document attributes.
 
-    let create_document_response = collection
-        .create_document(doc.clone())
-        .into_future()
-        .await?;
+    let create_document_response = collection.create_document(doc.clone()).await?;
     println!(
         "create_document_response == {:#?}",
         create_document_response
@@ -165,7 +155,6 @@ async fn main() -> azure_core::Result<()> {
         .clone()
         .document_client(doc.id.clone(), &doc.id)?
         .get_document::<MySampleStruct>()
-        .into_future()
         .await?;
     println!("get_document_response == {:#?}", get_document_response);
 
@@ -184,7 +173,6 @@ async fn main() -> azure_core::Result<()> {
             .document_client(doc.id.clone(), &doc.id)?
             .replace_document(doc)
             .if_match_condition(IfMatchCondition::Match(document.etag))
-            .into_future()
             .await?;
         println!(
             "replace_document_response == {:#?}",
@@ -197,7 +185,6 @@ async fn main() -> azure_core::Result<()> {
         .database_client(DATABASE.to_owned())
         .collection_client(COLLECTION.to_owned())
         .delete_collection()
-        .into_future()
         .await?;
     println!("collection deleted");
 
@@ -205,7 +192,6 @@ async fn main() -> azure_core::Result<()> {
     client
         .database_client(database.id)
         .delete_database()
-        .into_future()
         .await?;
     println!("database deleted");
 

--- a/sdk/data_cosmos/examples/document_entries.rs
+++ b/sdk/data_cosmos/examples/document_entries.rs
@@ -59,7 +59,7 @@ async fn main() -> azure_core::Result<()> {
         };
 
         // let's add an entity.
-        response = Some(client.create_document(doc.clone()).into_future().await?);
+        response = Some(client.create_document(doc.clone()).await?);
     }
 
     println!("Created 5 documents.");
@@ -117,7 +117,6 @@ async fn main() -> azure_core::Result<()> {
     let response: GetDocumentResponse<MySampleStruct> = client
         .document_client(id.clone(), partition_key)?
         .get_document()
-        .into_future()
         .await?;
 
     assert!(matches!(response, GetDocumentResponse::Found(_)));
@@ -135,7 +134,6 @@ async fn main() -> azure_core::Result<()> {
         .replace_document(doc.document)
         .consistency_level(ConsistencyLevel::from(&response))
         .if_match_condition(IfMatchCondition::Match(doc.etag)) // use optimistic concurrency check
-        .into_future()
         .await?;
 
     println!(
@@ -151,7 +149,6 @@ async fn main() -> azure_core::Result<()> {
         .document_client(id.clone(), &id)?
         .get_document()
         .consistency_level(&response)
-        .into_future()
         .await?;
 
     assert!(matches!(response, GetDocumentResponse::NotFound(_)));
@@ -162,7 +159,6 @@ async fn main() -> azure_core::Result<()> {
         client
             .document_client(id.clone(), &id)?
             .delete_document()
-            .into_future()
             .await?;
     }
     println!("Cleaned up");

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -39,11 +39,7 @@ async fn main() -> azure_core::Result<()> {
 
     context.insert(custom_headers);
 
-    let response = database
-        .get_database()
-        .context(context)
-        .into_future()
-        .await?;
+    let response = database.get_database().context(context).await?;
     println!("response == {:?}", response);
 
     Ok(())

--- a/sdk/data_cosmos/examples/key_ranges.rs
+++ b/sdk/data_cosmos/examples/key_ranges.rs
@@ -24,7 +24,7 @@ async fn main() -> azure_core::Result<()> {
         .database_client(args.database_name)
         .collection_client(args.collection_name);
 
-    let resp = client.get_partition_key_ranges().into_future().await?;
+    let resp = client.get_partition_key_ranges().await?;
     println!("resp == {:#?}", resp);
 
     Ok(())

--- a/sdk/data_cosmos/examples/permission.rs
+++ b/sdk/data_cosmos/examples/permission.rs
@@ -34,19 +34,19 @@ async fn main() -> azure_core::Result<()> {
     let collection2 = database.collection_client(args.collection_name2);
     let user = database.user_client(args.user_name);
 
-    let get_database_response = database.get_database().into_future().await?;
+    let get_database_response = database.get_database().await?;
     println!("get_database_response == {:#?}", get_database_response);
 
-    let get_collection_response = collection.get_collection().into_future().await?;
+    let get_collection_response = collection.get_collection().await?;
     println!("get_collection_response == {:#?}", get_collection_response);
 
-    let get_collection2_response = collection2.get_collection().into_future().await?;
+    let get_collection2_response = collection2.get_collection().await?;
     println!(
         "get_collection2_response == {:#?}",
         get_collection2_response
     );
 
-    let create_user_response = user.create_user().into_future().await?;
+    let create_user_response = user.create_user().await?;
     println!("create_user_response == {:#?}", create_user_response);
 
     // create the first permission!
@@ -57,7 +57,6 @@ async fn main() -> azure_core::Result<()> {
         .create_permission(permission_mode)
         .consistency_level(&create_user_response)
         .expiry_seconds(18000u64)
-        .into_future()
         .await
         .unwrap();
     println!(
@@ -72,7 +71,6 @@ async fn main() -> azure_core::Result<()> {
     let create_permission2_response = permission
         .create_permission(permission_mode)
         .consistency_level(&create_user_response)
-        .into_future()
         .await
         .unwrap();
 
@@ -101,7 +99,6 @@ async fn main() -> azure_core::Result<()> {
         .consistency_level(ConsistencyLevel::Session(
             list_permissions_response.session_token,
         ))
-        .into_future()
         .await
         .unwrap();
     println!("get_permission_response == {:#?}", get_permission_response);
@@ -115,7 +112,6 @@ async fn main() -> azure_core::Result<()> {
         .consistency_level(ConsistencyLevel::Session(
             get_permission_response.session_token,
         ))
-        .into_future()
         .await
         .unwrap();
     println!(
@@ -128,7 +124,6 @@ async fn main() -> azure_core::Result<()> {
         .consistency_level(ConsistencyLevel::Session(
             replace_permission_response.session_token,
         ))
-        .into_future()
         .await
         .unwrap();
 
@@ -142,7 +137,6 @@ async fn main() -> azure_core::Result<()> {
         .consistency_level(ConsistencyLevel::Session(
             delete_permission_response.session_token,
         ))
-        .into_future()
         .await?;
     println!("delete_user_response == {:#?}", delete_user_response);
 

--- a/sdk/data_cosmos/examples/readme.rs
+++ b/sdk/data_cosmos/examples/readme.rs
@@ -82,7 +82,6 @@ async fn main() -> azure_core::Result<()> {
             collection
                 .create_document(document_to_insert)
                 .is_upsert(true)
-                .into_future()
                 .await?
                 .session_token, // get only the session token, if everything else was ok!
         );
@@ -139,7 +138,6 @@ async fn main() -> azure_core::Result<()> {
             .delete_document()
             .consistency_level(session_token.clone())
             .if_match_condition(&document_attributes.unwrap())
-            .into_future()
             .await?;
     }
 

--- a/sdk/data_cosmos/examples/remove_all_documents.rs
+++ b/sdk/data_cosmos/examples/remove_all_documents.rs
@@ -72,7 +72,6 @@ async fn main() -> azure_core::Result<()> {
         collection
             .document_client(id.clone(), &partition_key)?
             .delete_document()
-            .into_future()
             .await?;
     }
 

--- a/sdk/data_cosmos/examples/stored_proc.rs
+++ b/sdk/data_cosmos/examples/stored_proc.rs
@@ -52,7 +52,6 @@ async fn main() -> azure_core::Result<()> {
 
     let create_stored_procedure_response = stored_procedure
         .create_stored_procedure(FUNCTION_BODY)
-        .into_future()
         .await?;
     println!(
         "create_stored_procedure_response == {:#?}",
@@ -62,7 +61,6 @@ async fn main() -> azure_core::Result<()> {
     let execute_stored_procedure_response = stored_procedure
         .execute_stored_procedure::<serde_json::Value>()
         .parameters(["Robert"])
-        .into_future()
         .await?;
 
     println!(
@@ -74,10 +72,7 @@ async fn main() -> azure_core::Result<()> {
         execute_stored_procedure_response.payload
     );
 
-    let delete_stored_procedure_response = stored_procedure
-        .delete_stored_procedure()
-        .into_future()
-        .await?;
+    let delete_stored_procedure_response = stored_procedure.delete_stored_procedure().await?;
     println!(
         "delete_stored_procedure_response == {:#?}",
         delete_stored_procedure_response

--- a/sdk/data_cosmos/examples/trigger.rs
+++ b/sdk/data_cosmos/examples/trigger.rs
@@ -61,14 +61,12 @@ async fn main() -> azure_core::Result<()> {
 
     let ret = trigger
         .create_trigger("something", TriggerType::Post, TriggerOperation::All)
-        .into_future()
         .await?;
     println!("Create response object:\n{:#?}", ret);
 
     let ret = trigger
         .replace_trigger(TRIGGER_BODY, TriggerType::Post, TriggerOperation::All)
         .consistency_level(ret)
-        .into_future()
         .await?;
     println!("Replace response object:\n{:#?}", ret);
 
@@ -91,7 +89,6 @@ async fn main() -> azure_core::Result<()> {
     let ret = trigger
         .delete_trigger()
         .consistency_level(last_session_token.unwrap())
-        .into_future()
         .await?;
     println!("Delete response object:\n{:#?}", ret);
 

--- a/sdk/data_cosmos/examples/user.rs
+++ b/sdk/data_cosmos/examples/user.rs
@@ -27,24 +27,24 @@ async fn main() -> azure_core::Result<()> {
     let database = client.database_client(args.database_name);
     let user = database.user_client(args.user_name.clone());
 
-    let create_user_response = user.create_user().into_future().await?;
+    let create_user_response = user.create_user().await?;
     println!("create_user_response == {:#?}", create_user_response);
 
     let users = database.list_users().into_stream().next().await.unwrap()?;
 
     println!("list_users_response == {:#?}", users);
 
-    let get_user_response = user.get_user().into_future().await?;
+    let get_user_response = user.get_user().await?;
     println!("get_user_response == {:#?}", get_user_response);
 
     let new_user = format!("{}replaced", args.user_name);
 
-    let replace_user_response = user.replace_user(new_user.clone()).into_future().await?;
+    let replace_user_response = user.replace_user(new_user.clone()).await?;
     println!("replace_user_response == {:#?}", replace_user_response);
 
     let user = database.user_client(new_user);
 
-    let delete_user_response = user.delete_user().into_future().await?;
+    let delete_user_response = user.delete_user().await?;
     println!("delete_user_response == {:#?}", delete_user_response);
 
     Ok(())

--- a/sdk/data_cosmos/examples/user_defined_function.rs
+++ b/sdk/data_cosmos/examples/user_defined_function.rs
@@ -40,7 +40,6 @@ async fn main() -> azure_core::Result<()> {
 
     let ret = user_defined_function
         .create_user_defined_function("body")
-        .into_future()
         .await?;
     println!("Creeate response object:\n{:#?}", ret);
 
@@ -60,7 +59,6 @@ async fn main() -> azure_core::Result<()> {
     let ret = user_defined_function
         .replace_user_defined_function(FN_BODY)
         .consistency_level(&ret)
-        .into_future()
         .await?;
     println!("Replace response object:\n{:#?}", ret);
 
@@ -91,7 +89,6 @@ async fn main() -> azure_core::Result<()> {
     let ret = user_defined_function
         .delete_user_defined_function()
         .consistency_level(&ret)
-        .into_future()
         .await?;
 
     println!("Delete response object:\n{:#?}", ret);

--- a/sdk/data_cosmos/examples/user_permission_token.rs
+++ b/sdk/data_cosmos/examples/user_permission_token.rs
@@ -31,10 +31,10 @@ async fn main() -> azure_core::Result<()> {
     let collection = database.collection_client(args.collection_name.clone());
     let user = database.user_client(args.user_name);
 
-    let get_collection_response = collection.get_collection().into_future().await?;
+    let get_collection_response = collection.get_collection().await?;
     println!("get_collection_response == {:#?}", get_collection_response);
 
-    let create_user_response = user.create_user().into_future().await?;
+    let create_user_response = user.create_user().await?;
     println!("create_user_response == {:#?}", create_user_response);
 
     // test list documents
@@ -57,7 +57,6 @@ async fn main() -> azure_core::Result<()> {
     let create_permission_response = permission
         .create_permission(permission_mode)
         .expiry_seconds(18000u64) // 5 hours, max!
-        .into_future()
         .await
         .unwrap();
     println!(
@@ -113,21 +112,19 @@ async fn main() -> azure_core::Result<()> {
         .create_document(document.clone())
         .is_upsert(true)
         .partition_key(&"Gianluigi Bombatomica")?
-        .into_future()
         .await
     {
         Ok(_) => panic!("this should not happen!"),
         Err(error) => println!("Insert failed: {:#?}", error),
     }
 
-    permission.delete_permission().into_future().await?;
+    permission.delete_permission().await?;
 
     // All includes read and write.
     let permission_mode = get_collection_response.collection.all_permission();
     let create_permission_response = permission
         .create_permission(permission_mode)
         .expiry_seconds(18000u64)
-        .into_future()
         .await
         .unwrap();
     println!(
@@ -154,7 +151,6 @@ async fn main() -> azure_core::Result<()> {
         .create_document(document)
         .is_upsert(true)
         .partition_key(&"Gianluigi Bombatomica")?
-        .into_future()
         .await?;
     println!(
         "create_document_response == {:#?}",
@@ -162,7 +158,7 @@ async fn main() -> azure_core::Result<()> {
     );
 
     println!("Cleaning up user.");
-    let delete_user_response = user.delete_user().into_future().await?;
+    let delete_user_response = user.delete_user().await?;
     println!("delete_user_response == {:#?}", delete_user_response);
 
     Ok(())

--- a/sdk/data_cosmos/src/lib.rs
+++ b/sdk/data_cosmos/src/lib.rs
@@ -75,7 +75,7 @@ async fn main() -> azure_core::Result<()> {
         collection
             .create_document(document_to_insert)
             .is_upsert(true)
-            .into_future()
+
             .await?;
     }
 

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -93,7 +93,6 @@ impl<T: DeserializeOwned + Send> ExecuteStoredProcedureBuilder<T> {
 
 azure_core::future!(ExecuteStoredProcedure<T>);
 
-#[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for ExecuteStoredProcedureBuilder<T> {
     type IntoFuture = ExecuteStoredProcedure<T>;
     type Output = <ExecuteStoredProcedure<T> as std::future::Future>::Output;

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -79,7 +79,6 @@ impl<T: DeserializeOwned + Send> GetDocumentBuilder<T> {
 
 azure_core::future!(GetDocument<T>);
 
-#[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for GetDocumentBuilder<T> {
     type IntoFuture = GetDocument<T>;
     type Output = <GetDocument<T> as std::future::Future>::Output;

--- a/sdk/data_cosmos/tests/attachment_operations.rs
+++ b/sdk/data_cosmos/tests/attachment_operations.rs
@@ -36,11 +36,7 @@ async fn attachment_operations() -> azure_core::Result<()> {
     let client = setup::initialize().unwrap();
 
     // create a temp database
-    let _create_database_response = client
-        .create_database(DATABASE_NAME)
-        .into_future()
-        .await
-        .unwrap();
+    let _create_database_response = client.create_database(DATABASE_NAME).await.unwrap();
 
     let database = client.database_client(DATABASE_NAME);
 
@@ -68,7 +64,6 @@ async fn attachment_operations() -> azure_core::Result<()> {
             .create_collection(COLLECTION_NAME, "/id")
             .offer(Offer::Throughput(400))
             .indexing_policy(ip)
-            .into_future()
             .await
             .unwrap()
     };
@@ -85,11 +80,7 @@ async fn attachment_operations() -> azure_core::Result<()> {
     };
 
     // let's add an entity.
-    let session_token: ConsistencyLevel = collection
-        .create_document(doc.clone())
-        .into_future()
-        .await?
-        .into();
+    let session_token: ConsistencyLevel = collection.create_document(doc.clone()).await?.into();
 
     let document = collection.document_client(id.clone(), &doc.id)?;
 
@@ -108,14 +99,12 @@ async fn attachment_operations() -> azure_core::Result<()> {
     let resp = attachment
         .create_attachment("https://www.bing.com", "image/jpeg")
         .consistency_level(&ret)
-        .into_future()
         .await?;
 
     // replace reference attachment
     let resp = attachment
         .replace_attachment("https://www.microsoft.com", "image/jpeg")
         .consistency_level(&resp)
-        .into_future()
         .await?;
 
     // create slug attachment
@@ -124,7 +113,6 @@ async fn attachment_operations() -> azure_core::Result<()> {
         .create_slug("something cool here".into())
         .consistency_level(&resp)
         .content_type("text/plain")
-        .into_future()
         .await?;
 
     // list attachments, there must be two.
@@ -142,7 +130,6 @@ async fn attachment_operations() -> azure_core::Result<()> {
         .attachment_client("reference")
         .get()
         .consistency_level(&ret)
-        .into_future()
         .await?;
     assert_eq!(
         "https://www.microsoft.com",
@@ -155,7 +142,6 @@ async fn attachment_operations() -> azure_core::Result<()> {
         .attachment_client("slug")
         .get()
         .consistency_level(&reference_attachment)
-        .into_future()
         .await
         .unwrap();
     assert_eq!("text/plain", slug_attachment.attachment.content_type);
@@ -164,7 +150,6 @@ async fn attachment_operations() -> azure_core::Result<()> {
     let resp_delete = attachment
         .delete()
         .consistency_level(&slug_attachment)
-        .into_future()
         .await?;
 
     // list attachments, there must be one.
@@ -178,7 +163,7 @@ async fn attachment_operations() -> azure_core::Result<()> {
     assert_eq!(1, ret.attachments.len());
 
     // delete the database
-    database.delete_database().into_future().await?;
+    database.delete_database().await?;
 
     Ok(())
 }

--- a/sdk/data_cosmos/tests/collection_operations.rs
+++ b/sdk/data_cosmos/tests/collection_operations.rs
@@ -11,7 +11,7 @@ async fn collection_operations() -> azure_core::Result<()> {
     let database_name = "test-collection-operations";
 
     log::info!("Creating a database with name '{}'...", database_name);
-    client.create_database(database_name).into_future().await?;
+    client.create_database(database_name).await?;
     log::info!("Successfully created a database");
 
     // create collection!
@@ -20,10 +20,7 @@ async fn collection_operations() -> azure_core::Result<()> {
     let collection_name = "sample_collection";
     log::info!("Creating a collection with name '{}'...", collection_name);
 
-    let create_collection_response = database
-        .create_collection(collection_name, "/id")
-        .into_future()
-        .await?;
+    let create_collection_response = database.create_collection(collection_name, "/id").await?;
 
     assert_eq!(create_collection_response.collection.id, collection_name);
 
@@ -36,7 +33,7 @@ async fn collection_operations() -> azure_core::Result<()> {
     let collection = database.collection_client(collection_name);
 
     // get collection!
-    let get_collection = collection.get_collection().into_future().await?;
+    let get_collection = collection.get_collection().await?;
 
     assert_eq!(get_collection.collection.id, collection_name);
 
@@ -81,7 +78,6 @@ async fn collection_operations() -> azure_core::Result<()> {
     let replace_collection_response = collection
         .replace_collection("/id")
         .indexing_policy(new_indexing_policy)
-        .into_future()
         .await?;
 
     assert_eq!(replace_collection_response.collection.id, collection_name);
@@ -110,7 +106,7 @@ async fn collection_operations() -> azure_core::Result<()> {
     );
 
     // delete collection!
-    let delete_collection_response = collection.delete_collection().into_future().await?;
+    let delete_collection_response = collection.delete_collection().await?;
 
     log::info!("Successfully deleted collection");
     log::debug!(
@@ -119,7 +115,7 @@ async fn collection_operations() -> azure_core::Result<()> {
     );
 
     // delete database
-    database.delete_database().into_future().await?;
+    database.delete_database().await?;
     log::info!("Successfully deleted database");
 
     Ok(())

--- a/sdk/data_cosmos/tests/database_operations.rs
+++ b/sdk/data_cosmos/tests/database_operations.rs
@@ -18,7 +18,7 @@ async fn database_operations() -> azure_core::Result<()> {
     let database_count_before = databases.databases.len();
 
     // create a new database and check if the number of DBs increased
-    let database = client.create_database(DATABASE_NAME).into_future().await?;
+    let database = client.create_database(DATABASE_NAME).await?;
 
     let databases = client
         .list_databases()
@@ -30,11 +30,7 @@ async fn database_operations() -> azure_core::Result<()> {
     assert!(databases.databases.len() == database_count_before + 1);
 
     // get the previously created database
-    let database_after_get = client
-        .database_client(DATABASE_NAME)
-        .get_database()
-        .into_future()
-        .await?;
+    let database_after_get = client.database_client(DATABASE_NAME).get_database().await?;
 
     assert!(database.database.rid == database_after_get.database.rid);
 
@@ -42,7 +38,6 @@ async fn database_operations() -> azure_core::Result<()> {
     client
         .database_client(DATABASE_NAME)
         .delete_database()
-        .into_future()
         .await?;
 
     let databases = client

--- a/sdk/data_cosmos/tests/document_operations.rs
+++ b/sdk/data_cosmos/tests/document_operations.rs
@@ -29,11 +29,7 @@ async fn document_operations() {
 
     let client = setup_mock::initialize("document_operations").unwrap();
 
-    client
-        .create_database(DATABASE_NAME)
-        .into_future()
-        .await
-        .unwrap();
+    client.create_database(DATABASE_NAME).await.unwrap();
 
     let database = client.database_client(DATABASE_NAME);
 
@@ -49,7 +45,6 @@ async fn document_operations() {
         .create_collection(COLLECTION_NAME, "/id")
         .offer(Offer::Throughput(400))
         .indexing_policy(indexing_policy)
-        .into_future()
         .await
         .unwrap();
 
@@ -62,7 +57,6 @@ async fn document_operations() {
     };
     collection
         .create_document(document_data.clone())
-        .into_future()
         .await
         .unwrap();
 
@@ -97,11 +91,7 @@ async fn document_operations() {
         .document_client(DOCUMENT_NAME, &DOCUMENT_NAME)
         .unwrap();
 
-    let document_after_get = document
-        .get_document::<MyDocument>()
-        .into_future()
-        .await
-        .unwrap();
+    let document_after_get = document.get_document::<MyDocument>().await.unwrap();
 
     if let GetDocumentResponse::Found(document) = document_after_get {
         assert_eq!(document.document.document, document_data);
@@ -122,7 +112,6 @@ async fn document_operations() {
                 .etag()
                 .to_string(),
         ))
-        .into_future()
         .await
         .unwrap();
 
@@ -130,11 +119,7 @@ async fn document_operations() {
     let document = collection
         .document_client(DOCUMENT_NAME, &DOCUMENT_NAME)
         .unwrap();
-    let document_after_get = document
-        .get_document::<MyDocument>()
-        .into_future()
-        .await
-        .unwrap();
+    let document_after_get = document.get_document::<MyDocument>().await.unwrap();
 
     if let GetDocumentResponse::Found(document) = document_after_get {
         assert!(document.document.document.hello == 190);
@@ -143,7 +128,7 @@ async fn document_operations() {
     }
 
     // delete document
-    document.delete_document().into_future().await.unwrap();
+    document.delete_document().await.unwrap();
 
     let mut documents = collection.list_documents().into_stream::<MyDocument>();
 
@@ -156,5 +141,5 @@ async fn document_operations() {
     .unwrap();
     assert!(result, "Documents length was not 0");
 
-    database.delete_database().into_future().await.unwrap();
+    database.delete_database().await.unwrap();
 }

--- a/sdk/data_cosmos/tests/permission_operations.rs
+++ b/sdk/data_cosmos/tests/permission_operations.rs
@@ -15,24 +15,19 @@ async fn permission_operations() {
     let client = setup_mock::initialize("permission_operations").unwrap();
 
     // create a temp database
-    let _ = client
-        .create_database(DATABASE_NAME)
-        .into_future()
-        .await
-        .unwrap();
+    let _ = client.create_database(DATABASE_NAME).await.unwrap();
 
     let database = client.database_client(DATABASE_NAME);
 
     // create two users
     let user1 = database.user_client(USER_NAME1);
-    let _create_user_response = user1.create_user().into_future().await.unwrap();
+    let _create_user_response = user1.create_user().await.unwrap();
     let user2 = database.user_client(USER_NAME2);
-    let _create_user_response = user2.create_user().into_future().await.unwrap();
+    let _create_user_response = user2.create_user().await.unwrap();
 
     // create a temp collection
     let create_collection_response = database
         .create_collection(COLLECTION_NAME, "/id")
-        .into_future()
         .await
         .unwrap();
 
@@ -43,14 +38,12 @@ async fn permission_operations() {
     let _ = permission_user1
         .create_permission(create_collection_response.collection.all_permission())
         .expiry_seconds(18000u64) // 5 hours, max!
-        .into_future()
         .await
         .unwrap();
 
     let _ = permission_user2
         .create_permission(create_collection_response.collection.read_permission())
         .expiry_seconds(18000u64) // 5 hours, max!
-        .into_future()
         .await
         .unwrap();
 
@@ -73,5 +66,5 @@ async fn permission_operations() {
     assert_eq!(list_permissions_response.permissions.len(), 1);
 
     // delete the database
-    database.delete_database().into_future().await.unwrap();
+    database.delete_database().await.unwrap();
 }

--- a/sdk/data_cosmos/tests/permission_token_usage.rs
+++ b/sdk/data_cosmos/tests/permission_token_usage.rs
@@ -31,11 +31,7 @@ async fn permission_token_usage() {
     let client = setup::initialize().unwrap();
 
     // create a temp database
-    let _create_database_response = client
-        .create_database(DATABASE_NAME)
-        .into_future()
-        .await
-        .unwrap();
+    let _create_database_response = client.create_database(DATABASE_NAME).await.unwrap();
 
     let database = client.database_client(DATABASE_NAME);
 
@@ -51,12 +47,11 @@ async fn permission_token_usage() {
         .create_collection(COLLECTION_NAME, "/id")
         .offer(Offer::Throughput(400))
         .indexing_policy(indexing_policy)
-        .into_future()
         .await
         .unwrap();
 
     let user = database.user_client(USER_NAME);
-    user.create_user().into_future().await.unwrap();
+    user.create_user().await.unwrap();
 
     // create the RO permission
     let permission = user.permission_client(PERMISSION);
@@ -65,7 +60,6 @@ async fn permission_token_usage() {
     let create_permission_response = permission
         .create_permission(permission_mode)
         .expiry_seconds(18000u64) // 5 hours, max!
-        .into_future()
         .await
         .unwrap();
 
@@ -102,18 +96,16 @@ async fn permission_token_usage() {
     new_collection
         .create_document(document.clone())
         .is_upsert(true)
-        .into_future()
         .await
         .unwrap_err();
 
-    permission.delete_permission().into_future().await.unwrap();
+    permission.delete_permission().await.unwrap();
 
     // All includes read and write.
     let permission_mode = create_collection_response.collection.all_permission();
     let create_permission_response = permission
         .create_permission(permission_mode)
         .expiry_seconds(18000u64) // 5 hours, max!
-        .into_future()
         .await
         .unwrap();
 
@@ -130,7 +122,6 @@ async fn permission_token_usage() {
     let create_document_response = new_collection
         .create_document(document)
         .is_upsert(true)
-        .into_future()
         .await
         .unwrap();
     println!(
@@ -139,5 +130,5 @@ async fn permission_token_usage() {
     );
 
     // cleanup
-    database.delete_database().into_future().await.unwrap();
+    database.delete_database().await.unwrap();
 }

--- a/sdk/data_cosmos/tests/trigger_operations.rs
+++ b/sdk/data_cosmos/tests/trigger_operations.rs
@@ -42,15 +42,12 @@ async fn trigger_operations() -> azure_core::Result<()> {
     let client = setup_mock::initialize("trigger_operations")?;
 
     // create a temp database
-    let _create_database_response = client.create_database(DATABASE_NAME).into_future().await?;
+    let _create_database_response = client.create_database(DATABASE_NAME).await?;
 
     let database = client.database_client(DATABASE_NAME);
 
     // create a temp collection
-    let _ = database
-        .create_collection(COLLECTION_NAME, "/id")
-        .into_future()
-        .await?;
+    let _ = database.create_collection(COLLECTION_NAME, "/id").await?;
 
     let collection = database.collection_client(COLLECTION_NAME);
     let trigger = collection.trigger_client(TRIGGER_NAME);
@@ -61,7 +58,6 @@ async fn trigger_operations() -> azure_core::Result<()> {
             trigger::TriggerType::Post,
             trigger::TriggerOperation::All,
         )
-        .into_future()
         .await?;
 
     let ret = trigger
@@ -71,7 +67,6 @@ async fn trigger_operations() -> azure_core::Result<()> {
             trigger::TriggerOperation::All,
         )
         .consistency_level(ret)
-        .into_future()
         .await?;
 
     let mut last_session_token: Option<ConsistencyLevel> = None;
@@ -89,11 +84,10 @@ async fn trigger_operations() -> azure_core::Result<()> {
     let _ = trigger
         .delete_trigger()
         .consistency_level(last_session_token.expect("no triggers were found in collection"))
-        .into_future()
         .await?;
 
     // delete the database
-    database.delete_database().into_future().await?;
+    database.delete_database().await?;
 
     Ok(())
 }

--- a/sdk/data_cosmos/tests/user_defined_function_operations.rs
+++ b/sdk/data_cosmos/tests/user_defined_function_operations.rs
@@ -26,17 +26,14 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
 
     log::info!("creating database");
     // create a temp database
-    let _ = client.create_database(DATABASE_NAME).into_future().await?;
+    let _ = client.create_database(DATABASE_NAME).await?;
     log::info!("created database");
 
     let database = client.database_client(DATABASE_NAME);
 
     // create a temp collection
     log::info!("creating collection");
-    let _ = database
-        .create_collection(COLLECTION_NAME, "/id")
-        .into_future()
-        .await?;
+    let _ = database.create_collection(COLLECTION_NAME, "/id").await?;
     log::info!("created collection");
 
     let collection = database.collection_client(COLLECTION_NAME);
@@ -45,7 +42,6 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
     log::info!("creating user defined function");
     let ret = user_defined_function
         .create_user_defined_function("body")
-        .into_future()
         .await?;
     log::info!("created user defined function");
 
@@ -64,7 +60,6 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
     let ret = user_defined_function
         .replace_user_defined_function(FN_BODY)
         .consistency_level(&ret)
-        .into_future()
         .await?;
     log::info!("replaced user defined functions");
 
@@ -115,11 +110,10 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
     let _ret = user_defined_function
         .delete_user_defined_function()
         .consistency_level(&ret)
-        .into_future()
         .await?;
 
     // delete the database
-    database.delete_database().into_future().await?;
+    database.delete_database().await?;
     log::info!("deleted test resources");
 
     Ok(())

--- a/sdk/data_cosmos/tests/user_operations.rs
+++ b/sdk/data_cosmos/tests/user_operations.rs
@@ -11,16 +11,12 @@ async fn user_operations() {
     let client = setup_mock::initialize("user_operations").unwrap();
 
     // create a temp database
-    let _ = client
-        .create_database(DATABASE_NAME)
-        .into_future()
-        .await
-        .unwrap();
+    let _ = client.create_database(DATABASE_NAME).await.unwrap();
 
     let database = client.database_client(DATABASE_NAME);
     let user = database.user_client(USER_NAME);
 
-    let _ = user.create_user().into_future().await.unwrap();
+    let _ = user.create_user().await.unwrap();
 
     let list_users_response = database
         .list_users()
@@ -32,14 +28,10 @@ async fn user_operations() {
 
     assert_eq!(list_users_response.users.len(), 1);
 
-    let retrieved_user = user.get_user().into_future().await.unwrap();
+    let retrieved_user = user.get_user().await.unwrap();
     assert_eq!(retrieved_user.user.id, USER_NAME);
 
-    let _ = user
-        .replace_user(USER_NAME_REPLACED)
-        .into_future()
-        .await
-        .unwrap();
+    let _ = user.replace_user(USER_NAME_REPLACED).await.unwrap();
 
     let list_users_response = database
         .list_users()
@@ -52,7 +44,7 @@ async fn user_operations() {
 
     let user = database.user_client(USER_NAME_REPLACED);
 
-    let _ = user.delete_user().into_future().await.unwrap();
+    let _ = user.delete_user().await.unwrap();
 
     let list_users_response = database
         .list_users()
@@ -67,7 +59,6 @@ async fn user_operations() {
     client
         .database_client(DATABASE_NAME)
         .delete_database()
-        .into_future()
         .await
         .unwrap();
 }

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -157,14 +157,10 @@ mod integration_tests {
         let table = table_client.table_client("EntityClientUpdate");
 
         println!("Delete the table (if it exists)");
-        let _ = table.delete().into_future().await;
+        let _ = table.delete().await;
 
         println!("Create the table");
-        table
-            .create()
-            .into_future()
-            .await
-            .expect("the table should be created");
+        table.create().await.expect("the table should be created");
 
         let entity = TestEntity {
             city: "Milan".to_owned(),
@@ -180,14 +176,12 @@ mod integration_tests {
         entity_client
             .update(&entity, IfMatchCondition::Any)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect_err("the update should fail if the entity doesn't exist");
 
         table
             .insert::<&TestEntity, TestEntity>(&entity)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the entity should be inserted");
 
@@ -196,7 +190,6 @@ mod integration_tests {
         entity_client
             .update(&entity, IfMatchCondition::Any)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the update operation should complete");
 
@@ -210,14 +203,10 @@ mod integration_tests {
         let table = table_client.table_client("EntityClientMerge");
 
         println!("Delete the table (if it exists)");
-        let _ = table.delete().into_future().await;
+        let _ = table.delete().await;
 
         println!("Create the table");
-        table
-            .create()
-            .into_future()
-            .await
-            .expect("the table should be created");
+        table.create().await.expect("the table should be created");
 
         let entity = TestEntity {
             city: "Milan".to_owned(),
@@ -239,14 +228,12 @@ mod integration_tests {
         entity_client
             .merge(&entity2, IfMatchCondition::Any)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect_err("the merge should fail if the entity doesn't exist");
 
         table
             .insert::<&TestEntity, TestEntity>(&entity)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the entity should be inserted");
 
@@ -255,7 +242,6 @@ mod integration_tests {
         entity_client
             .merge(&entity2, IfMatchCondition::Any)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the merge operation should complete");
 
@@ -269,14 +255,10 @@ mod integration_tests {
         let table = table_client.table_client("EntityClientInsertOrReplace");
 
         println!("Delete the table (if it exists)");
-        let _ = table.delete().into_future().await;
+        let _ = table.delete().await;
 
         println!("Create the table");
-        table
-            .create()
-            .into_future()
-            .await
-            .expect("the table should be created");
+        table.create().await.expect("the table should be created");
 
         let mut entity = TestEntity {
             city: "Milan".to_owned(),
@@ -291,7 +273,6 @@ mod integration_tests {
         entity_client
             .insert_or_replace(&entity)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the insert or replace operation should complete");
 
@@ -301,7 +282,6 @@ mod integration_tests {
         entity_client
             .insert_or_replace(&entity)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the insert or replace operation should complete");
 
@@ -315,14 +295,10 @@ mod integration_tests {
         let table = table_client.table_client("EntityClientInsertOrMerge");
 
         println!("Delete the table (if it exists)");
-        let _ = table.delete().into_future().await;
+        let _ = table.delete().await;
 
         println!("Create the table");
-        table
-            .create()
-            .into_future()
-            .await
-            .expect("the table should be created");
+        table.create().await.expect("the table should be created");
 
         let mut entity = TestEntity {
             city: "Milan".to_owned(),
@@ -337,7 +313,6 @@ mod integration_tests {
         entity_client
             .insert_or_merge(&entity)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the insert or replace operation should complete");
 
@@ -347,7 +322,6 @@ mod integration_tests {
         entity_client
             .insert_or_merge(&entity)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the insert or replace operation should complete");
 
@@ -362,7 +336,6 @@ mod integration_tests {
         entity_client
             .insert_or_merge(&entity2)
             .expect("entity could not be serialized")
-            .into_future()
             .await
             .expect("the insert or merge operation should complete");
 

--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -82,14 +82,10 @@ mod integration_tests {
         let table = table_service.table_client("PartitionKeyClientTransaction");
 
         println!("Delete the table (if it exists)");
-        let _ = table.delete().into_future().await;
+        let _ = table.delete().await;
 
         println!("Create the table");
-        table
-            .create()
-            .into_future()
-            .await
-            .expect("the table should be created");
+        table.create().await.expect("the table should be created");
 
         let partition_client = table.partition_key_client("Milan");
 
@@ -113,7 +109,6 @@ mod integration_tests {
             .unwrap()
             .insert(&entity2)
             .unwrap()
-            .into_future()
             .await
             .expect("transaction compete");
 

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -101,7 +101,7 @@ mod integration_tests {
         );
 
         println!("Create the table");
-        let _ = table.create().into_future().await.unwrap();
+        let _ = table.create().await.unwrap();
 
         println!("Validate that the table was created");
         let mut stream = table_client.list().into_stream();
@@ -118,7 +118,6 @@ mod integration_tests {
         println!("Delete the table");
         table
             .delete()
-            .into_future()
             .await
             .expect("we should be able to delete the table");
 
@@ -149,14 +148,10 @@ mod integration_tests {
         );
 
         println!("Delete the table (if it exists)");
-        let _ = table.delete().into_future().await;
+        let _ = table.delete().await;
 
         println!("Create the table");
-        table
-            .create()
-            .into_future()
-            .await
-            .expect("the table should be created");
+        table.create().await.expect("the table should be created");
 
         let entity = TestEntity {
             city: "Milan".to_owned(),
@@ -169,7 +164,6 @@ mod integration_tests {
             .insert(&entity)
             .unwrap()
             .return_entity(true)
-            .into_future()
             .await
             .expect("the insert operation should succeed");
 

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -150,7 +150,7 @@ mod integration_tests {
 
         println!("Create a table in the storage account");
         let table_client = service_client.table_client("TableServiceClientList");
-        let _ = table_client.create().into_future().await;
+        let _ = table_client.create().await;
 
         println!("Check that the table is listed correctly");
         let mut stream = service_client.list().into_stream();

--- a/sdk/data_tables/src/operations/get_entity.rs
+++ b/sdk/data_tables/src/operations/get_entity.rs
@@ -52,7 +52,6 @@ impl<T: DeserializeOwned + Send> GetEntityBuilder<T> {
 
 azure_core::future!(GetEntity<T>);
 
-#[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for GetEntityBuilder<T> {
     type IntoFuture = GetEntity<T>;
     type Output = <GetEntity<T> as std::future::Future>::Output;

--- a/sdk/data_tables/src/operations/insert_entity.rs
+++ b/sdk/data_tables/src/operations/insert_entity.rs
@@ -67,7 +67,6 @@ where
 
 azure_core::future!(InsertEntity<T>);
 
-#[cfg(feature = "into_future")]
 impl<T: DeserializeOwned + Send> std::future::IntoFuture for InsertEntityBuilder<T> {
     type IntoFuture = InsertEntity<T>;
     type Output = <InsertEntity<T> as std::future::Future>::Output;

--- a/sdk/identity/examples/client_certificate_credentials.rs
+++ b/sdk/identity/examples/client_certificate_credentials.rs
@@ -24,7 +24,7 @@ async fn get_certficate(
         std::sync::Arc::new(creds),
     )?
     .secret_client();
-    let secret = client.get(certificate_name).into_future().await?;
+    let secret = client.get(certificate_name).await?;
     let cert = base64::decode(secret.value)?;
     Ok(cert)
 }

--- a/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
+++ b/sdk/iot_hub/examples/apply_configuration_on_edge_device.rs
@@ -60,7 +60,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     service_client
         .apply_on_edge_device(device_id)
         .modules_content(modules_content)
-        .into_future()
         .await?;
 
     println!("Successfully applied the configuration");

--- a/sdk/iot_hub/examples/configuration.rs
+++ b/sdk/iot_hub/examples/configuration.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             "metric1",
             "SELECT deviceId FROM devices WHERE properties.reported.lastDesiredStatus.code = 200",
         )
-        .into_future()
         .await?;
 
     println!(
@@ -36,10 +35,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     );
 
     println!("Getting configuration: {}", configuration_id);
-    let configuration = service_client
-        .get_configuration(configuration_id)
-        .into_future()
-        .await?;
+    let configuration = service_client.get_configuration(configuration_id).await?;
 
     println!(
         "Successfully retrieved the new configuration '{:?}'",
@@ -66,10 +62,9 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         }))
         .labels(configuration.labels)
         .metrics(configuration.metrics.queries)
-        .into_future()
         .await?;
 
-    let multiple_configurations = service_client.get_configurations().into_future().await?;
+    let multiple_configurations = service_client.get_configurations().await?;
     println!(
         "Successfully retrieved all configurations '{:?}'",
         multiple_configurations
@@ -87,7 +82,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     service_client
         .delete_configuration(&configuration.id, configuration.etag)
-        .into_future()
         .await?;
 
     println!(

--- a/sdk/iot_hub/examples/device_identity.rs
+++ b/sdk/iot_hub/examples/device_identity.rs
@@ -23,7 +23,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 "6YS6w5wqkpdfkEW7iOP1NvituehFlFRfPko2n7KY4Gk",
             ),
         )
-        .into_future()
         .await?;
     let device: DeviceIdentityResponse = device.try_into()?;
 
@@ -44,21 +43,16 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             device.etag,
         )
         .device_capability(DesiredCapability::IotEdge)
-        .into_future()
         .await?;
 
     println!("Getting device identity of '{}'", device.device_id);
-    let device = service_client
-        .get_device_identity(device.device_id)
-        .into_future()
-        .await?;
+    let device = service_client.get_device_identity(device.device_id).await?;
     let device: DeviceIdentityResponse = device.try_into()?;
     println!("Identity is: {:?}", device);
 
     println!("Deleting device '{}'", device.device_id);
     service_client
         .delete_device_identity(device.device_id, device.etag)
-        .into_future()
         .await?;
 
     Ok(())

--- a/sdk/iot_hub/examples/directmethod.rs
+++ b/sdk/iot_hub/examples/directmethod.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         serde_json::from_str(&payload)?,
     );
 
-    let response = direct_method.into_future().await?;
+    let response = direct_method.await?;
 
     println!(
         "Received a response from the direct method with status code {} and payload {:?}",

--- a/sdk/iot_hub/examples/gettwin.rs
+++ b/sdk/iot_hub/examples/gettwin.rs
@@ -13,10 +13,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("Getting device twin for device: {}", device_id);
 
     let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
-    let twin = service_client
-        .get_device_twin(device_id)
-        .into_future()
-        .await?;
+    let twin = service_client.get_device_twin(device_id).await?;
 
     println!("Received device twin: {:?}", twin);
 

--- a/sdk/iot_hub/examples/module_identity.rs
+++ b/sdk/iot_hub/examples/module_identity.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
                 "6YS6w5wqkpdfkEW7iOP1NvituehFlFRfPko2n7KY4Gk",
             ),
         )
-        .into_future()
         .await?;
 
     println!(
@@ -50,7 +49,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
             ),
             module.etag,
         )
-        .into_future()
         .await?;
 
     println!(
@@ -59,7 +57,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     );
     let module = service_client
         .get_module_identity(module.device_id, module.module_id)
-        .into_future()
         .await?;
     let module: ModuleIdentityResponse = module.try_into()?;
     println!("Identity is: {:?}", module);
@@ -70,7 +67,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     );
     service_client
         .delete_module_identity(module.device_id, module.module_id, module.etag)
-        .into_future()
         .await?;
 
     Ok(())

--- a/sdk/iot_hub/examples/query_iothub.rs
+++ b/sdk/iot_hub/examples/query_iothub.rs
@@ -13,11 +13,7 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
 
     let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
 
-    let response = service_client
-        .query(query)
-        .max_item_count(1)
-        .into_future()
-        .await?;
+    let response = service_client.query(query).max_item_count(1).await?;
 
     println!(
         "Response of first result: {}",
@@ -33,7 +29,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
         .query(query)
         .max_item_count(1)
         .continuation(token)
-        .into_future()
         .await?;
 
     println!(

--- a/sdk/iot_hub/examples/updatetwin.rs
+++ b/sdk/iot_hub/examples/updatetwin.rs
@@ -21,7 +21,6 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let updated_twin = service_client
         .update_device_twin(device_id)
         .desired_properties(serde_json::from_str(&payload)?)
-        .into_future()
         .await?;
 
     println!("Received device twin: {:?}", updated_twin);

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -400,7 +400,7 @@ impl ServiceClient {
     /// let twin = iot_hub.update_module_twin("some-device", "some-module")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
-    ///              .into_future();
+    ///              ;
     /// ```
     pub fn update_module_twin<S, T>(&self, device_id: S, module_id: T) -> UpdateOrReplaceTwinBuilder
     where
@@ -421,7 +421,7 @@ impl ServiceClient {
     /// let twin = iot_hub.replace_module_twin("some-device", "some-module")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
-    ///              .into_future();
+    ///              ;
     /// ```
     pub fn replace_module_twin<S, T>(
         &self,
@@ -446,7 +446,7 @@ impl ServiceClient {
     /// let twin = iot_hub.update_device_twin("some-device")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
-    ///              .into_future();
+    ///              ;
     /// ```
     pub fn update_device_twin<S>(&self, device_id: S) -> UpdateOrReplaceTwinBuilder
     where
@@ -465,7 +465,7 @@ impl ServiceClient {
     /// let twin = iot_hub.replace_device_twin("some-device")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
-    ///              .into_future();
+    ///              ;
     /// ```
     pub fn replace_device_twin<S>(&self, device_id: S) -> UpdateOrReplaceTwinBuilder
     where
@@ -499,7 +499,7 @@ impl ServiceClient {
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     /// let iot_hub = ServiceClient::new_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let device = iot_hub.create_device_identity("some-existing-device", Status::Enabled, AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key"))
-    ///     .into_future();
+    ///     ;
     /// ```
     pub fn create_device_identity<S>(
         &self,
@@ -596,7 +596,7 @@ impl ServiceClient {
     ///
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     /// let iot_hub = ServiceClient::new_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
-    /// let device = iot_hub.create_module_identity("some-existing-device", "some-existing-module", "IoTEdge", AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key")).into_future();
+    /// let device = iot_hub.create_module_identity("some-existing-device", "some-existing-module", "IoTEdge", AuthenticationMechanism::new_using_symmetric_key("first-key", "second-key"));
     /// ```
     pub fn create_module_identity<S1, S2, S3>(
         &self,
@@ -757,7 +757,7 @@ impl ServiceClient {
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     /// let iot_hub = ServiceClient::new_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let configuration = iot_hub.create_configuration("some-configuration-id", 10, "tags.environment='test'")
-    ///     .into_future();
+    ///     ;
     /// ```
     pub fn create_configuration<S, T>(
         &self,
@@ -787,7 +787,7 @@ impl ServiceClient {
     /// # let connection_string = "HostName=cool-iot-hub.azure-devices.net;SharedAccessKeyName=iot_hubowner;SharedAccessKey=YSB2ZXJ5IHNlY3VyZSBrZXkgaXMgaW1wb3J0YW50Cg==";
     /// let iot_hub = ServiceClient::new_connection_string(connection_string, 3600).expect("Failed to create the ServiceClient!");
     /// let configuration = iot_hub.update_configuration("some-configuration-id", 10, "tags.environment='test'", "some-etag-value")
-    ///     .into_future();
+    ///     ;
     /// ```
     pub fn update_configuration<S, T, U>(
         &self,

--- a/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
+++ b/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
@@ -54,7 +54,7 @@ impl UpdateOrReplaceTwinBuilder {
     /// let twin = iot_hub.update_device_twin("some-device")
     ///              .tag("TagName", "TagValue")
     ///              .desired_properties(serde_json::json!({"PropertyName": "PropertyValue"}))
-    ///              .into_future();
+    ///              ;
     /// ```
     pub fn into_future(mut self) -> UpdateOrReplaceTwin {
         Box::pin(async move {

--- a/sdk/security_keyvault/examples/backup_secret.rs
+++ b/sdk/security_keyvault/examples/backup_secret.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let client = SecretClient::new(&keyvault_url, creds)?;
-    let backup_response = client.backup(secret_name).into_future().await?;
+    let backup_response = client.backup(secret_name).await?;
     dbg!(&backup_response);
 
     Ok(())

--- a/sdk/security_keyvault/examples/delete_secret.rs
+++ b/sdk/security_keyvault/examples/delete_secret.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let client = SecretClient::new(&keyvault_url, creds)?;
-    client.delete(secret_name).into_future().await?;
+    client.delete(secret_name).await?;
 
     Ok(())
 }

--- a/sdk/security_keyvault/examples/get_secret.rs
+++ b/sdk/security_keyvault/examples/get_secret.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("{:?}", version?);
     }
 
-    let secret = client.get(secret_name).into_future().await?;
+    let secret = client.get(secret_name).await?;
     dbg!(secret.value);
 
     Ok(())

--- a/sdk/security_keyvault/examples/pass_client.rs
+++ b/sdk/security_keyvault/examples/pass_client.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 async fn get_secret(client: &SecretClient) -> Result<(), Box<dyn std::error::Error>> {
     let secret_name = env::var("SECRET_NAME").expect("Missing SECRET_NAME environment variable.");
-    let secrets = client.get(secret_name).into_future().await?;
+    let secrets = client.get(secret_name).await?;
     dbg!(&secrets);
 
     Ok(())

--- a/sdk/security_keyvault/examples/restore_secret.rs
+++ b/sdk/security_keyvault/examples/restore_secret.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client = SecretClient::new(&keyvault_url, creds)?;
 
-    client.restore_secret(&backup_blob).into_future().await?;
+    client.restore_secret(&backup_blob).await?;
 
     Ok(())
 }

--- a/sdk/security_keyvault/examples/set_secret.rs
+++ b/sdk/security_keyvault/examples/set_secret.rs
@@ -18,9 +18,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client = SecretClient::new(&keyvault_url, creds)?;
 
-    client.set(&secret_name, secret_value).into_future().await?;
+    client.set(&secret_name, secret_value).await?;
 
-    let secret = client.get(secret_name).into_future().await?;
+    let secret = client.get(secret_name).await?;
     assert_eq!(secret.value, "whatup");
 
     Ok(())

--- a/sdk/security_keyvault/examples/update_secret.rs
+++ b/sdk/security_keyvault/examples/update_secret.rs
@@ -27,7 +27,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .enabled(false)
         .recovery_level("Purgeable")
         .expiration(OffsetDateTime::now_utc() + date::duration_from_days(14))
-        .into_future()
         .await?;
 
     Ok(())

--- a/sdk/security_keyvault/src/clients/certificate_client.rs
+++ b/sdk/security_keyvault/src/clients/certificate_client.rs
@@ -36,7 +36,7 @@ impl CertificateClient {
     ///         &"KEYVAULT_URL",
     ///         Arc::new(creds),
     ///     ).unwrap().certificate_client();
-    ///     let certificate = client.get("NAME").into_future().await.unwrap();
+    ///     let certificate = client.get("NAME").await.unwrap();
     ///     dbg!(&certificate);
     /// }
     ///
@@ -103,7 +103,7 @@ impl CertificateClient {
     ///         &"KEYVAULT_URL",
     ///         Arc::new(creds),
     ///     ).unwrap().certificate_client();
-    ///     client.backup("NAME").into_future().await.unwrap();
+    ///     client.backup("NAME").await.unwrap();
     /// }
     ///
     /// Runtime::new().unwrap().block_on(example());
@@ -198,7 +198,7 @@ impl CertificateClient {
     ///         &"KEYVAULT_URL",
     ///         Arc::new(creds),
     ///     ).unwrap().certificate_client();
-    ///     client.restore_certificate("KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taW").into_future().await.unwrap();
+    ///     client.restore_certificate("KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taW").await.unwrap();
     /// }
     ///
     /// Runtime::new().unwrap().block_on(example());

--- a/sdk/security_keyvault/src/clients/secret_client.rs
+++ b/sdk/security_keyvault/src/clients/secret_client.rs
@@ -36,7 +36,7 @@ impl SecretClient {
     ///     &"KEYVAULT_URL",
     ///     Arc::new(creds),
     ///     ).unwrap().secret_client();
-    ///     let secret = client.get("SECRET_NAME").into_future().await.unwrap();
+    ///     let secret = client.get("SECRET_NAME").await.unwrap();
     ///     dbg!(&secret);
     /// }
     ///
@@ -65,7 +65,7 @@ impl SecretClient {
     ///     &"KEYVAULT_URL",
     ///     Arc::new(creds),
     ///     ).unwrap().secret_client();
-    ///     client.set("SECRET_NAME", "NEW_VALUE").into_future().await.unwrap();
+    ///     client.set("SECRET_NAME", "NEW_VALUE").await.unwrap();
     /// }
     ///
     /// Runtime::new().unwrap().block_on(example());
@@ -94,7 +94,7 @@ impl SecretClient {
     ///     &"KEYVAULT_URL",
     ///     Arc::new(creds),
     ///     ).unwrap().secret_client();
-    ///     client.update("SECRET_NAME").enabled(false).into_future().await.unwrap();
+    ///     client.update("SECRET_NAME").enabled(false).await.unwrap();
     /// }
     ///
     /// Runtime::new().unwrap().block_on(example());
@@ -153,7 +153,7 @@ impl SecretClient {
     ///     &"KEYVAULT_URL",
     ///     Arc::new(creds),
     ///     ).unwrap().secret_client();
-    ///     client.backup("SECRET_NAME").into_future().await.unwrap();
+    ///     client.backup("SECRET_NAME").await.unwrap();
     /// }
     ///
     /// Runtime::new().unwrap().block_on(example());
@@ -181,7 +181,7 @@ impl SecretClient {
     ///     &"KEYVAULT_URL",
     ///     Arc::new(creds),
     ///     ).unwrap().secret_client();
-    ///     client.delete("SECRET_NAME").into_future().await.unwrap();
+    ///     client.delete("SECRET_NAME").await.unwrap();
     /// }
     ///
     /// Runtime::new().unwrap().block_on(example());
@@ -233,7 +233,7 @@ impl SecretClient {
     ///     &"KEYVAULT_URL",
     ///     std::sync::Arc::new(creds),
     ///     ).unwrap().secret_client();
-    ///     client.restore_secret("KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taW").into_future().await.unwrap();
+    ///     client.restore_secret("KUF6dXJlS2V5VmF1bHRTZWNyZXRCYWNrdXBWMS5taW").await.unwrap();
     /// }
     ///
     /// Runtime::new().unwrap().block_on(example());

--- a/sdk/storage_blobs/examples/account.rs
+++ b/sdk/storage_blobs/examples/account.rs
@@ -13,10 +13,7 @@ async fn main() -> azure_core::Result<()> {
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
     let service_client = BlobServiceClient::new(account, storage_credentials);
 
-    let account = service_client
-        .get_account_information()
-        .into_future()
-        .await?;
+    let account = service_client.get_account_information().await?;
     println!("Account info:");
     println!("\tKind: {}", account.account_kind);
     println!("\tSku: {}", account.sku_name);

--- a/sdk/storage_blobs/examples/blob_04.rs
+++ b/sdk/storage_blobs/examples/blob_04.rs
@@ -43,11 +43,7 @@ async fn main() -> azure_core::Result<()> {
         block_ids.push(block_id.clone());
         let hash = md5::compute(slice.clone());
 
-        let put_block_response = blob_client
-            .put_block(block_id, slice)
-            .hash(hash)
-            .into_future()
-            .await?;
+        let put_block_response = blob_client.put_block(block_id, slice).hash(hash).await?;
 
         println!("put_block_response == {:#?}", put_block_response);
     }
@@ -60,7 +56,6 @@ async fn main() -> azure_core::Result<()> {
     let res = blob_client
         .put_block_list(block_list)
         .content_md5(md5::compute(data))
-        .into_future()
         .await?;
     println!("PutBlockList == {:?}", res);
 

--- a/sdk/storage_blobs/examples/blob_range.rs
+++ b/sdk/storage_blobs/examples/blob_range.rs
@@ -17,16 +17,13 @@ async fn main() -> azure_core::Result<()> {
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
     let container_client =
         BlobServiceClient::new(account, storage_credentials).container_client(container_name);
-    container_client.create().into_future().await?;
+    container_client.create().await?;
 
     let blob_client = container_client.blob_client(&blob_name);
 
     let buf = b"0123456789".repeat(1000);
 
-    blob_client
-        .put_block_blob(buf.clone())
-        .into_future()
-        .await?;
+    blob_client.put_block_blob(buf.clone()).await?;
 
     // if we get the entire content, it should match
     let blob = blob_client.get_content().await?;
@@ -100,7 +97,7 @@ async fn main() -> azure_core::Result<()> {
         "streamed blob content should match original buf"
     );
 
-    container_client.delete().into_future().await?;
+    container_client.delete().await?;
 
     Ok(())
 }

--- a/sdk/storage_blobs/examples/blob_tags.rs
+++ b/sdk/storage_blobs/examples/blob_tags.rs
@@ -18,29 +18,25 @@ async fn main() -> azure_core::Result<()> {
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
     let container_client =
         BlobServiceClient::new(account, storage_credentials).container_client(container_name);
-    container_client.create().into_future().await?;
+    container_client.create().await?;
 
     let blob_client = container_client.blob_client(&blob_name);
 
     let mut tags = Tags::new();
     tags.insert("tag1", "value1");
 
-    blob_client
-        .put_block_blob("hello world")
-        .tags(tags)
-        .into_future()
-        .await?;
+    blob_client.put_block_blob("hello world").tags(tags).await?;
 
-    let result = blob_client.get_tags().into_future().await?;
+    let result = blob_client.get_tags().await?;
     println!("get tags result: {:?}", result);
 
     let mut new_tags = HashMap::new();
     new_tags.insert("tag2", "value2");
     new_tags.insert("tag3", "value3");
-    let result = blob_client.set_tags(new_tags).into_future().await?;
+    let result = blob_client.set_tags(new_tags).await?;
     println!("set tags result: {:?}", result);
 
-    let result = blob_client.get_tags().into_future().await?;
+    let result = blob_client.get_tags().await?;
     println!("get tags result: {:?}", result);
 
     for (key, value) in result.tags.into_iter() {
@@ -48,14 +44,11 @@ async fn main() -> azure_core::Result<()> {
     }
 
     let blob_client = container_client.blob_client(&blob_notags_name);
-    blob_client
-        .put_block_blob("hello world")
-        .into_future()
-        .await?;
-    let result = blob_client.get_tags().into_future().await?;
+    blob_client.put_block_blob("hello world").await?;
+    let result = blob_client.get_tags().await?;
     println!("get tags without tags result: {:?}", result);
 
-    container_client.delete().into_future().await?;
+    container_client.delete().await?;
 
     Ok(())
 }

--- a/sdk/storage_blobs/examples/connection_string.rs
+++ b/sdk/storage_blobs/examples/connection_string.rs
@@ -35,7 +35,6 @@ async fn main() -> azure_core::Result<()> {
     container_client
         .create()
         .public_access(PublicAccess::None)
-        .into_future()
         .await?;
     println!("Container {} created", container_name);
 
@@ -45,7 +44,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
         println!("\tAdded blob {}", i);
     }
@@ -69,7 +67,7 @@ async fn main() -> azure_core::Result<()> {
         cnt += 1;
     }
 
-    container_client.delete().into_future().await?;
+    container_client.delete().await?;
     println!("Container {} deleted", container_name);
 
     Ok(())

--- a/sdk/storage_blobs/examples/container_01.rs
+++ b/sdk/storage_blobs/examples/container_01.rs
@@ -32,11 +32,10 @@ async fn main() -> azure_core::Result<()> {
         .create()
         .public_access(PublicAccess::Container)
         .metadata(metadata)
-        .into_future()
         .await?;
 
     // get acl without stored access policy list
-    let result = container_client.get_acl().into_future().await?;
+    let result = container_client.get_acl().await?;
     println!("\nget_acl() == {:?}", result);
 
     // set stored access policy list
@@ -50,11 +49,10 @@ async fn main() -> azure_core::Result<()> {
     let _result = container_client
         .set_acl(PublicAccess::Blob)
         .stored_access_policy_list(sapl.clone())
-        .into_future()
         .await?;
 
     // now we get back the acess policy list and compare to the one created
-    let result = container_client.get_acl().into_future().await?;
+    let result = container_client.get_acl().await?;
 
     println!("\nget_acl() == {:?}", result);
 
@@ -78,19 +76,17 @@ async fn main() -> azure_core::Result<()> {
         assert!(i1.permission == i2.permission);
     }
 
-    let res = container_client.get_properties().into_future().await?;
+    let res = container_client.get_properties().await?;
     println!("\nget_properties() == {:?}", res);
 
     let res = container_client
         .acquire_lease(Duration::from_secs(15))
-        .into_future()
         .await?;
     println!("\nacquire_lease() == {:?}", res);
 
     container_client
         .delete()
         .lease_id(res.lease_id) // we need to specify the lease or it won't work!
-        .into_future()
         .await?;
 
     Ok(())

--- a/sdk/storage_blobs/examples/container_and_blob.rs
+++ b/sdk/storage_blobs/examples/container_and_blob.rs
@@ -24,7 +24,6 @@ async fn main() -> azure_core::Result<()> {
     container_client
         .create()
         .public_access(PublicAccess::None)
-        .into_future()
         .await?;
 
     let data = Bytes::from_static(b"something");
@@ -38,7 +37,6 @@ async fn main() -> azure_core::Result<()> {
         .put_block_blob(data.clone())
         .content_type("text/plain")
         .hash(hash)
-        .into_future()
         .await?;
     println!("{:?}", res);
 
@@ -47,7 +45,6 @@ async fn main() -> azure_core::Result<()> {
         .put_block_blob(data.clone())
         .content_type("text/plain")
         .hash(hash)
-        .into_future()
         .await?;
     println!("{:?}", res);
 
@@ -56,7 +53,6 @@ async fn main() -> azure_core::Result<()> {
         .put_block_blob(data)
         .content_type("text/plain")
         .hash(hash)
-        .into_future()
         .await?;
     println!("{:?}", res);
 

--- a/sdk/storage_blobs/examples/copy_blob.rs
+++ b/sdk/storage_blobs/examples/copy_blob.rs
@@ -65,7 +65,7 @@ async fn main() -> azure_core::Result<()> {
     };
     println!("read only SAS url: '{}'", sas_url);
 
-    let response = destination_blob.copy(sas_url).into_future().await?;
+    let response = destination_blob.copy(sas_url).await?;
     println!("copy response == {:#?}", response);
 
     Ok(())

--- a/sdk/storage_blobs/examples/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/examples/copy_blob_from_url.rs
@@ -36,7 +36,6 @@ async fn main() -> azure_core::Result<()> {
     let response = blob_client
         .copy_from_url(source_url)
         .is_synchronous(true)
-        .into_future()
         .await?;
 
     println!("response == {:?}", response);

--- a/sdk/storage_blobs/examples/emulator_00.rs
+++ b/sdk/storage_blobs/examples/emulator_00.rs
@@ -12,7 +12,6 @@ async fn main() -> azure_core::Result<()> {
     container_client
         .create()
         .public_access(PublicAccess::None)
-        .into_future()
         .await?;
 
     let res = container_client

--- a/sdk/storage_blobs/examples/list_blobs_00.rs
+++ b/sdk/storage_blobs/examples/list_blobs_00.rs
@@ -43,7 +43,6 @@ async fn main() -> azure_core::Result<()> {
         .create()
         .public_access(PublicAccess::None)
         .context(context)
-        .into_future()
         .await?;
     println!("Container {} created", container_name);
 
@@ -53,7 +52,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
         println!("\tAdded blob {}", i);
     }
@@ -88,7 +86,7 @@ async fn main() -> azure_core::Result<()> {
         cnt += 1;
     }
 
-    container_client.delete().into_future().await?;
+    container_client.delete().await?;
     println!("Container {} deleted", container_name);
 
     Ok(())

--- a/sdk/storage_blobs/examples/list_blobs_01.rs
+++ b/sdk/storage_blobs/examples/list_blobs_01.rs
@@ -38,7 +38,6 @@ async fn main() -> azure_core::Result<()> {
     container_client
         .create()
         .public_access(PublicAccess::None)
-        .into_future()
         .await?;
     println!("Container {} created", container_name);
 
@@ -63,7 +62,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("blob_at_root{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
     }
 
@@ -73,7 +71,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("firstfolder/blob_at_1stfolder{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
     }
 
@@ -83,7 +80,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("secondroot/blobsd{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
     }
 
@@ -93,7 +89,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("firstfolder/secondfolder/blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
     }
 
@@ -103,7 +98,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("firstfolder/thirdfolder/blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
     }
 
@@ -116,7 +110,6 @@ async fn main() -> azure_core::Result<()> {
             ))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
     }
 
@@ -174,7 +167,7 @@ async fn main() -> azure_core::Result<()> {
         cnt += 1;
     }
 
-    container_client.delete().into_future().await?;
+    container_client.delete().await?;
     println!("Container {} deleted", container_name);
 
     Ok(())

--- a/sdk/storage_blobs/examples/list_blobs_02.rs
+++ b/sdk/storage_blobs/examples/list_blobs_02.rs
@@ -18,7 +18,7 @@ async fn main() -> azure_core::Result<()> {
     let blob_service = BlobServiceClient::new(account, storage_credentials);
     let container_client = blob_service.container_client(&container_name);
 
-    container_client.create().into_future().await?;
+    container_client.create().await?;
 
     // list empty container
     let page = container_client
@@ -34,7 +34,6 @@ async fn main() -> azure_core::Result<()> {
             .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await?;
         println!("\tAdded blob {}", i);
     }
@@ -48,7 +47,7 @@ async fn main() -> azure_core::Result<()> {
         .expect("stream failed")?;
     println!("List blob returned {} blobs.", page.blobs.blobs().count());
 
-    container_client.delete().into_future().await?;
+    container_client.delete().await?;
     println!("Container {} deleted", container_name);
 
     Ok(())

--- a/sdk/storage_blobs/examples/missing_blob.rs
+++ b/sdk/storage_blobs/examples/missing_blob.rs
@@ -18,12 +18,12 @@ async fn main() -> azure_core::Result<()> {
     let container_client =
         ClientBuilder::new(account, storage_credentials).container_client(&container_name);
     println!("creating container {}", container_name);
-    container_client.create().into_future().await?;
+    container_client.create().await?;
 
     let blob_client = container_client.blob_client(&blob_name);
 
     println!("getting properties for {}/{}", container_name, blob_name);
-    let result = blob_client.get_properties().into_future().await;
+    let result = blob_client.get_properties().await;
     let error = result.expect_err("get_properties on missing blob should fail");
     if let ErrorKind::HttpResponse {
         status: StatusCode::NotFound,
@@ -36,7 +36,7 @@ async fn main() -> azure_core::Result<()> {
     }
 
     // cleanup
-    container_client.delete().into_future().await?;
+    container_client.delete().await?;
 
     Ok(())
 }

--- a/sdk/storage_blobs/examples/put_append_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_append_blob_00.rs
@@ -47,13 +47,12 @@ async fn main() -> azure_core::Result<()> {
         .content_type("text/plain")
         .content_language("en/us")
         .metadata(metadata)
-        .into_future()
         .await?;
 
     println!("{:?}", res);
 
     // let get back the metadata
-    let res = blob_client.get_metadata().into_future().await?;
+    let res = blob_client.get_metadata().await?;
     println!("{:?}", res);
 
     Ok(())

--- a/sdk/storage_blobs/examples/put_block_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_block_blob_00.rs
@@ -42,7 +42,6 @@ async fn main() -> azure_core::Result<()> {
         .put_block_blob(data.clone())
         .content_type("text/plain")
         .hash(hash)
-        .into_future()
         .await?;
     println!("1-put_block_blob {:?}", res);
 
@@ -54,22 +53,15 @@ async fn main() -> azure_core::Result<()> {
         .blocks
         .push(BlobBlockType::new_uncommitted("pollastro"));
 
-    let res = blob_client
-        .put_block("satanasso", data.clone())
-        .into_future()
-        .await?;
+    let res = blob_client.put_block("satanasso", data.clone()).await?;
     println!("2-put_block {:?}", res);
 
-    let res = blob_client
-        .put_block("pollastro", data)
-        .into_future()
-        .await?;
+    let res = blob_client.put_block("pollastro", data).await?;
     println!("3-put_block {:?}", res);
 
     let ret = blob_client
         .get_block_list()
         .block_list_type(BlockListType::All)
-        .into_future()
         .await?;
 
     println!("GetBlockList == {:?}", ret);
@@ -77,34 +69,29 @@ async fn main() -> azure_core::Result<()> {
     let bl = ret.block_with_size_list.into();
     println!("bl == {:?}", bl);
 
-    let res = blob_client.put_block_list(bl).into_future().await?;
+    let res = blob_client.put_block_list(bl).await?;
     println!("PutBlockList == {:?}", res);
 
-    let res = blob_client
-        .acquire_lease(Duration::from_secs(60))
-        .into_future()
-        .await?;
+    let res = blob_client.acquire_lease(Duration::from_secs(60)).await?;
     println!("Acquire lease == {:?}", res);
 
     let lease = blob_client.blob_lease_client(res.lease_id);
 
-    let res = lease.renew().into_future().await?;
+    let res = lease.renew().await?;
     println!("Renew lease == {:?}", res);
 
     let res = blob_client
         .break_lease()
         .lease_break_period(Duration::from_secs(15))
-        .into_future()
         .await?;
     println!("Break lease == {:?}", res);
 
-    let res = lease.release().into_future().await?;
+    let res = lease.release().await?;
     println!("Release lease == {:?}", res);
 
     let res = blob_client
         .delete()
         .delete_snapshots_method(DeleteSnapshotsMethod::Include)
-        .into_future()
         .await?;
     println!("Delete blob == {:?}", res);
 

--- a/sdk/storage_blobs/examples/put_multi_block_blob.rs
+++ b/sdk/storage_blobs/examples/put_multi_block_blob.rs
@@ -45,7 +45,7 @@ async fn main() -> azure_core::Result<()> {
     try_join_all(upload_block_futures).await?;
 
     // Commit uploaded blocks.
-    let resp = blob_client.put_block_list(block_list).into_future().await?;
+    let resp = blob_client.put_block_list(block_list).await?;
     println!("PutBlockListResponse: {:?}", resp);
 
     Ok(())

--- a/sdk/storage_blobs/examples/put_page_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_page_blob_00.rs
@@ -49,7 +49,6 @@ async fn main() -> azure_core::Result<()> {
         .content_type("text/plain")
         .metadata(metadata)
         .sequence_number(100)
-        .into_future()
         .await?;
     println!("put_page_blob == {:?}", res);
 
@@ -59,7 +58,6 @@ async fn main() -> azure_core::Result<()> {
     let res = blob_client
         .put_page(BA512Range::new(0, 511)?, slice.clone())
         .hash(digest)
-        .into_future()
         .await?;
     println!("update first page == {:?}", res);
 
@@ -67,7 +65,6 @@ async fn main() -> azure_core::Result<()> {
     let res = blob_client
         .put_page(BA512Range::new(512, 1023)?, slice.clone())
         .hash(digest)
-        .into_future()
         .await?;
     println!("update second page == {:?}", res);
 
@@ -76,23 +73,19 @@ async fn main() -> azure_core::Result<()> {
         .put_page(BA512Range::new(512, 1023)?, slice)
         .hash(digest)
         .if_sequence_number(IfSequenceNumber::Equal(100))
-        .into_future()
         .await?;
     println!("update sequence number condition == {:?}", res);
 
     // let's get page ranges
-    let res = blob_client.get_page_ranges().into_future().await?;
+    let res = blob_client.get_page_ranges().await?;
     println!("get page ranges == {:?}", res);
 
     // let's clear a page
-    let res = blob_client
-        .clear_page(BA512Range::new(0, 511)?)
-        .into_future()
-        .await?;
+    let res = blob_client.clear_page(BA512Range::new(0, 511)?).await?;
     println!("clear first page {:?}", res);
 
     // let's get page ranges again
-    let res = blob_client.get_page_ranges().into_future().await?;
+    let res = blob_client.get_page_ranges().await?;
     println!("get page ranges == {:?}", res);
 
     Ok(())

--- a/sdk/storage_blobs/examples/set_blob_properties_00.rs
+++ b/sdk/storage_blobs/examples/set_blob_properties_00.rs
@@ -29,18 +29,12 @@ async fn main() -> azure_core::Result<()> {
 
     trace!("Requesting blob properties");
 
-    let properties = blob_client
-        .get_properties()
-        .into_future()
-        .await?
-        .blob
-        .properties;
+    let properties = blob_client.get_properties().await?.blob.properties;
 
     blob_client
         .set_properties()
         .set_from_blob_properties(properties)
         .content_md5(md5::compute("howdy"))
-        .into_future()
         .await?;
 
     Ok(())

--- a/sdk/storage_blobs/examples/snapshot_blob.rs
+++ b/sdk/storage_blobs/examples/snapshot_blob.rs
@@ -40,17 +40,15 @@ async fn main() -> azure_core::Result<()> {
         .put_block_blob(data.clone())
         .content_type("text/plain")
         .hash(hash)
-        .into_future()
         .await?;
     println!("put_blob {:?}", res);
 
-    let res = blob_client.snapshot().into_future().await?;
+    let res = blob_client.snapshot().await?;
     println!("blob snapshot: {:?}", res.snapshot);
 
     let res = blob_client
         .delete()
         .delete_snapshots_method(DeleteSnapshotsMethod::Include)
-        .into_future()
         .await?;
     println!("Delete blob == {:?}", res);
 

--- a/sdk/storage_blobs/examples/stream_blob_00.rs
+++ b/sdk/storage_blobs/examples/stream_blob_00.rs
@@ -32,7 +32,6 @@ async fn main() -> azure_core::Result<()> {
     let _response = blob_client
         .put_block_blob(string)
         .content_type("text/plain")
-        .into_future()
         .await?;
 
     println!("{}/{} blob created!", container_name, file_name);
@@ -86,7 +85,6 @@ async fn main() -> azure_core::Result<()> {
     blob_client
         .delete()
         .delete_snapshots_method(DeleteSnapshotsMethod::Include)
-        .into_future()
         .await?;
 
     Ok(())

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -240,7 +240,7 @@ impl BlobClient {
 
     /// Check whether blob exists.
     pub async fn exists(&self) -> azure_core::Result<bool> {
-        let result = self.get_properties().into_future().await.map(|_| true);
+        let result = self.get_properties().await.map(|_| true);
         if let Err(err) = result {
             if let ErrorKind::HttpResponse { status, .. } = err.kind() {
                 return Ok(status != &StatusCode::NotFound);

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -178,12 +178,10 @@ mod integration_tests {
 
         container_client
             .create()
-            .into_future()
             .await
             .expect("create container should succeed");
         container_client
             .delete()
-            .into_future()
             .await
             .expect("delete container should succeed");
     }
@@ -195,7 +193,6 @@ mod integration_tests {
 
         container_client
             .create()
-            .into_future()
             .await
             .expect("create container should succeed");
 
@@ -203,7 +200,6 @@ mod integration_tests {
         container_client
             .blob_client("hello.txt")
             .put_block_blob("world")
-            .into_future()
             .await
             .expect("put block blob should succeed");
         let list = container_client
@@ -228,7 +224,6 @@ mod integration_tests {
 
         container_client
             .delete()
-            .into_future()
             .await
             .expect("delete container should succeed");
     }

--- a/sdk/storage_blobs/tests/account.rs
+++ b/sdk/storage_blobs/tests/account.rs
@@ -12,9 +12,5 @@ async fn get_account_information() {
     let storage_credentials = StorageCredentials::Key(account.clone(), access_key);
     let blob_service = BlobServiceClient::new(account, storage_credentials);
 
-    blob_service
-        .get_account_information()
-        .into_future()
-        .await
-        .unwrap();
+    blob_service.get_account_information().await.unwrap();
 }

--- a/sdk/storage_blobs/tests/append_blob.rs
+++ b/sdk/storage_blobs/tests/append_blob.rs
@@ -38,7 +38,6 @@ async fn put_append_blob() {
         container
             .create()
             .public_access(PublicAccess::None)
-            .into_future()
             .await
             .unwrap();
     }
@@ -50,13 +49,12 @@ async fn put_append_blob() {
     blob.put_append_blob()
         .content_type("text/plain")
         .metadata(metadata)
-        .into_future()
         .await
         .unwrap();
 
     trace!("created {:?}", blob_name);
 
-    let resp = blob.get_metadata().into_future().await.unwrap();
+    let resp = blob.get_metadata().await.unwrap();
 
     assert_eq!(resp.metadata.len(), 2);
 

--- a/sdk/storage_blobs/tests/blob_operations.rs
+++ b/sdk/storage_blobs/tests/blob_operations.rs
@@ -30,7 +30,6 @@ async fn put_block_blob_and_snapshot() {
         container
             .create()
             .public_access(PublicAccess::None)
-            .into_future()
             .await
             .unwrap();
     }
@@ -41,17 +40,16 @@ async fn put_block_blob_and_snapshot() {
     blob.put_block_blob(data)
         .content_type("text/plain")
         .hash(digest)
-        .into_future()
         .await
         .unwrap();
 
     trace!("created {:?}", BLOB_NAME);
 
-    let snapshot = blob.snapshot().into_future().await.unwrap().snapshot;
+    let snapshot = blob.snapshot().await.unwrap().snapshot;
 
     trace!("crated snapshot: {:?} of {:?}", snapshot, BLOB_NAME);
 
     // Clean-up test
-    container.delete().into_future().await.unwrap();
+    container.delete().await.unwrap();
     trace!("container {} deleted!", CONTAINER_NAME);
 }

--- a/sdk/storage_blobs/tests/container.rs
+++ b/sdk/storage_blobs/tests/container.rs
@@ -13,22 +13,20 @@ async fn lease() {
     container
         .create()
         .public_access(PublicAccess::None)
-        .into_future()
         .await
         .unwrap();
 
     let res = container
         .acquire_lease(Duration::from_secs(30))
-        .into_future()
         .await
         .unwrap();
     let lease_id = res.lease_id;
     let lease = container.container_lease_client(lease_id);
 
-    let _res = lease.renew().into_future().await.unwrap();
-    let _res = lease.release().into_future().await.unwrap();
+    let _res = lease.renew().await.unwrap();
+    let _res = lease.release().await.unwrap();
 
-    container.delete().into_future().await.unwrap();
+    container.delete().await.unwrap();
 }
 
 #[tokio::test]
@@ -41,28 +39,25 @@ async fn break_lease() {
     container
         .create()
         .public_access(PublicAccess::None)
-        .into_future()
         .await
         .unwrap();
 
     let res = container
         .acquire_lease(Duration::from_secs(30))
-        .into_future()
         .await
         .unwrap();
 
     let lease = container.container_lease_client(res.lease_id);
-    lease.renew().into_future().await.unwrap();
+    lease.renew().await.unwrap();
 
     let res = container
         .break_lease()
         .lease_break_period(Duration::from_secs(0))
-        .into_future()
         .await
         .unwrap();
     assert!(res.lease_time == 0);
 
-    container.delete().into_future().await.unwrap();
+    container.delete().await.unwrap();
 }
 
 fn initialize() -> BlobServiceClient {

--- a/sdk/storage_blobs/tests/page_blob.rs
+++ b/sdk/storage_blobs/tests/page_blob.rs
@@ -29,7 +29,6 @@ async fn put_page_blob() {
         container
             .create()
             .public_access(PublicAccess::None)
-            .into_future()
             .await
             .unwrap();
     }
@@ -41,7 +40,6 @@ async fn put_page_blob() {
     blob.put_page_blob(1024 * 64)
         .content_type("text/plain")
         .metadata(metadata)
-        .into_future()
         .await
         .unwrap();
 

--- a/sdk/storage_blobs/tests/stream_blob00.rs
+++ b/sdk/storage_blobs/tests/stream_blob00.rs
@@ -37,11 +37,7 @@ async fn code() -> azure_core::Result<()> {
         .any(|x| x.name == container_name)
     {
         println!("create container");
-        container
-            .create()
-            .public_access(PublicAccess::None)
-            .into_future()
-            .await?;
+        container.create().public_access(PublicAccess::None).await?;
     }
 
     let string = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
@@ -49,7 +45,6 @@ async fn code() -> azure_core::Result<()> {
 
     blob.put_block_blob(string)
         .content_type("text/plain")
-        .into_future()
         .await?;
 
     println!("{}/{} blob created!", container_name, file_name);
@@ -75,11 +70,10 @@ async fn code() -> azure_core::Result<()> {
 
     blob.delete()
         .delete_snapshots_method(DeleteSnapshotsMethod::Include)
-        .into_future()
         .await?;
 
     println!("{}/{} blob deleted!", container_name, file_name);
 
-    container.delete().into_future().await?;
+    container.delete().await?;
     Ok(())
 }

--- a/sdk/storage_blobs/tests/stream_list_blobs.rs
+++ b/sdk/storage_blobs/tests/stream_list_blobs.rs
@@ -37,7 +37,6 @@ async fn stream_list_blobs() {
     container
         .create()
         .public_access(PublicAccess::None)
-        .into_future()
         .await
         .unwrap();
 
@@ -47,7 +46,6 @@ async fn stream_list_blobs() {
             .blob_client(format!("blob{}.txt", i))
             .put_block_blob("somedata")
             .content_type("text/plain")
-            .into_future()
             .await
             .unwrap();
     }
@@ -69,5 +67,5 @@ async fn stream_list_blobs() {
         cnt += 1;
     }
 
-    container.delete().into_future().await.unwrap();
+    container.delete().await.unwrap();
 }

--- a/sdk/storage_datalake/examples/directory.rs
+++ b/sdk/storage_datalake/examples/directory.rs
@@ -19,7 +19,6 @@ async fn main() -> azure_core::Result<()> {
     let create_fs_response = file_system_client
         .create()
         .properties(fs_properties.clone())
-        .into_future()
         .await?;
     println!("create file system response == {:?}\n", create_fs_response);
 
@@ -29,7 +28,6 @@ async fn main() -> azure_core::Result<()> {
     let create_directory_response = directory_client
         .create()
         .properties(fs_properties.clone())
-        .into_future()
         .await?;
     println!(
         "create directory response == {:?}\n",
@@ -37,8 +35,7 @@ async fn main() -> azure_core::Result<()> {
     );
 
     println!("creating directory '{}' if not exists...", directory_name);
-    let create_directory_if_not_exists_result =
-        directory_client.create_if_not_exists().into_future().await;
+    let create_directory_if_not_exists_result = directory_client.create_if_not_exists().await;
     println!(
         "create directory result (should fail) == {:?}\n",
         create_directory_if_not_exists_result
@@ -52,11 +49,10 @@ async fn main() -> azure_core::Result<()> {
     directory_client
         .rename(new_directory_name)
         .properties(fs_properties)
-        .into_future()
         .await?;
 
     println!("deleting file system...");
-    let delete_fs_response = file_system_client.delete().into_future().await?;
+    let delete_fs_response = file_system_client.delete().await?;
     println!("delete file system response == {:?}\n", delete_fs_response);
 
     Ok(())

--- a/sdk/storage_datalake/examples/file_create_delete.rs
+++ b/sdk/storage_datalake/examples/file_create_delete.rs
@@ -13,7 +13,7 @@ async fn main() -> azure_core::Result<()> {
     let file_system_client = data_lake_client.file_system_client(file_system_name.to_string());
 
     println!("creating file system '{}'...", &file_system_name);
-    let create_fs_response = file_system_client.create().into_future().await?;
+    let create_fs_response = file_system_client.create().await?;
     println!("create file system response == {:?}\n", create_fs_response);
 
     let file_path = "some/path/example-file.txt";
@@ -25,12 +25,11 @@ async fn main() -> azure_core::Result<()> {
     let create_file_response = file_client
         .create()
         .properties(file_properties.clone())
-        .into_future()
         .await?;
     println!("create file response == {:?}\n", create_file_response);
 
     println!("getting properties for file '{}'...", file_path);
-    let get_properties_response = file_client.get_properties().into_future().await?;
+    let get_properties_response = file_client.get_properties().await?;
     println!(
         "get file properties response == {:?}\n",
         get_properties_response
@@ -38,32 +37,29 @@ async fn main() -> azure_core::Result<()> {
 
     println!("setting properties for file '{}'...", file_path);
     file_properties.insert("ModifiedBy", "Iota");
-    let set_properties_response = file_client
-        .set_properties(file_properties)
-        .into_future()
-        .await?;
+    let set_properties_response = file_client.set_properties(file_properties).await?;
     println!(
         "set file properties response == {:?}\n",
         set_properties_response
     );
 
     println!("creating file '{}' if not exists...", file_path);
-    let create_file_if_not_exists_result = file_client.create_if_not_exists().into_future().await;
+    let create_file_if_not_exists_result = file_client.create_if_not_exists().await;
     println!(
         "create file result (should fail) == {:?}\n",
         create_file_if_not_exists_result
     );
 
     println!("creating file '{}' (overwrite)...", file_path);
-    let create_file_response = file_client.create().into_future().await?;
+    let create_file_response = file_client.create().await?;
     println!("create file response == {:?}\n", create_file_response);
 
     println!("deleting file '{}'...", file_path);
-    let delete_file_response = file_client.delete().into_future().await?;
+    let delete_file_response = file_client.delete().await?;
     println!("delete_file file response == {:?}\n", delete_file_response);
 
     println!("deleting file system...");
-    let delete_fs_response = file_system_client.delete().into_future().await?;
+    let delete_fs_response = file_system_client.delete().await?;
     println!("delete file system response == {:?}\n", delete_fs_response);
 
     Ok(())

--- a/sdk/storage_datalake/examples/file_rename.rs
+++ b/sdk/storage_datalake/examples/file_rename.rs
@@ -13,7 +13,7 @@ async fn main() -> azure_core::Result<()> {
     let file_system_client = data_lake_client.file_system_client(file_system_name.to_string());
 
     println!("creating file system '{}'...", &file_system_name);
-    let create_fs_response = file_system_client.create().into_future().await?;
+    let create_fs_response = file_system_client.create().await?;
     println!("create file system response == {:?}\n", create_fs_response);
 
     let file_path1 = "some/path/example-file1.txt";
@@ -22,38 +22,35 @@ async fn main() -> azure_core::Result<()> {
     let file_client2 = file_system_client.get_file_client(file_path2);
 
     println!("creating file '{}'...", file_path1);
-    let create_file_response1 = file_client1.create().into_future().await?;
+    let create_file_response1 = file_client1.create().await?;
     println!("create file response == {:?}\n", create_file_response1);
 
     println!("creating file '{}'...", file_path2);
-    let create_file_response2 = file_client2.create().into_future().await?;
+    let create_file_response2 = file_client2.create().await?;
     println!("create file response == {:?}\n", create_file_response2);
 
     println!(
         "renaming file '{}' to '{}' if not exists...",
         file_path1, file_path2
     );
-    let rename_file_if_not_exists_result = file_client1
-        .rename_if_not_exists(file_path2)
-        .into_future()
-        .await;
+    let rename_file_if_not_exists_result = file_client1.rename_if_not_exists(file_path2).await;
     println!(
         "rename file result (should fail) == {:?}\n",
         rename_file_if_not_exists_result
     );
 
     println!("renaming file '{}' to '{}'...", file_path1, file_path2);
-    file_client1.rename(file_path2).into_future().await?;
-    let renamed_file_properties = file_client2.get_properties().into_future().await?;
+    file_client1.rename(file_path2).await?;
+    let renamed_file_properties = file_client2.get_properties().await?;
     println!("renamed file properties == {:?}\n", renamed_file_properties);
 
     // getting properties for the source file should fail, when the file no longer exists
     // Eventually we will implement the `exists` method, which internally employs a similar check
-    let source_file_properties_result = file_client1.get_properties().into_future().await;
+    let source_file_properties_result = file_client1.get_properties().await;
     assert!(source_file_properties_result.is_err());
 
     println!("deleting file system...");
-    let delete_fs_response = file_system_client.delete().into_future().await?;
+    let delete_fs_response = file_system_client.delete().await?;
     println!("delete file system response == {:?}\n", delete_fs_response);
 
     Ok(())

--- a/sdk/storage_datalake/examples/file_upload.rs
+++ b/sdk/storage_datalake/examples/file_upload.rs
@@ -13,14 +13,14 @@ async fn main() -> azure_core::Result<()> {
     let file_system_client = data_lake_client.file_system_client(file_system_name.to_string());
 
     println!("creating file system '{}'...", &file_system_name);
-    let create_fs_response = file_system_client.create().into_future().await?;
+    let create_fs_response = file_system_client.create().await?;
     println!("create file system response == {:?}\n", create_fs_response);
 
     let file_path = "some/path/example-file.txt";
     let file_client = file_system_client.get_file_client(file_path);
 
     println!("creating file '{}'...", file_path);
-    let create_file_response = file_client.create().into_future().await?;
+    let create_file_response = file_client.create().await?;
     println!("create file response == {:?}\n", create_file_response);
 
     let string1 = "some data";
@@ -32,30 +32,26 @@ async fn main() -> azure_core::Result<()> {
     let data2_length = data2.len() as i64;
 
     println!("appending '{}' to file '{}'...", string1, file_path);
-    let append_to_file_response = file_client.append(0, data1).into_future().await?;
+    let append_to_file_response = file_client.append(0, data1).await?;
     println!("append to file response == {:?}\n", append_to_file_response);
 
     println!("appending '{}' to file '{}'...", string2, file_path);
-    let append_to_file_response = file_client
-        .append(data1_length, data2)
-        .into_future()
-        .await?;
+    let append_to_file_response = file_client.append(data1_length, data2).await?;
     println!("append to file response == {:?}\n", append_to_file_response);
 
     println!("flushing file '{}'...", file_path);
     let flush_file_response = file_client
         .flush(data1_length + data2_length)
         .close(true)
-        .into_future()
         .await?;
     println!("flush file response == {:?}\n", flush_file_response);
 
     println!("reading file '{}'...", file_path);
-    let read_file_response = file_client.read().into_future().await?;
+    let read_file_response = file_client.read().await?;
     println!("read file response == {:?}\n", read_file_response);
 
     println!("deleting file system...");
-    let delete_fs_response = file_system_client.delete().into_future().await?;
+    let delete_fs_response = file_system_client.delete().await?;
     println!("delete file system response == {:?}\n", delete_fs_response);
 
     Ok(())

--- a/sdk/storage_datalake/examples/filesystem.rs
+++ b/sdk/storage_datalake/examples/filesystem.rs
@@ -21,7 +21,6 @@ async fn main() -> azure_core::Result<()> {
     let create_fs_response = file_system_client
         .create()
         .properties(fs_properties.clone())
-        .into_future()
         .await?;
     println!("create file system response == {:?}\n", create_fs_response);
 
@@ -35,7 +34,7 @@ async fn main() -> azure_core::Result<()> {
     }
 
     println!("getting file system properties...");
-    let get_fs_props_response = file_system_client.get_properties().into_future().await?;
+    let get_fs_props_response = file_system_client.get_properties().await?;
     println!(
         "get file system properties response == {:?}\n",
         get_fs_props_response
@@ -43,24 +42,21 @@ async fn main() -> azure_core::Result<()> {
 
     println!("setting file system properties...");
     fs_properties.insert("ModifiedBy", "Iota");
-    let set_fs_props_response = file_system_client
-        .set_properties(fs_properties)
-        .into_future()
-        .await?;
+    let set_fs_props_response = file_system_client.set_properties(fs_properties).await?;
     println!(
         "set file system properties response == {:?}\n",
         set_fs_props_response
     );
 
     println!("getting file system properties...");
-    let get_fs_props_response = file_system_client.get_properties().into_future().await?;
+    let get_fs_props_response = file_system_client.get_properties().await?;
     println!(
         "get file system properties response == {:?}\n",
         get_fs_props_response
     );
 
     println!("deleting file system...");
-    let delete_fs_response = file_system_client.delete().into_future().await?;
+    let delete_fs_response = file_system_client.delete().await?;
     println!("delete file system response == {:?}\n", delete_fs_response);
 
     Ok(())

--- a/sdk/storage_datalake/tests/file_system.rs
+++ b/sdk/storage_datalake/tests/file_system.rs
@@ -21,7 +21,6 @@ async fn file_system_create_delete() -> azure_core::Result<()> {
     let create_fs_response = file_system_client
         .create()
         .properties(fs_properties.clone())
-        .into_future()
         .await?;
     assert!(
         create_fs_response.namespace_enabled,
@@ -44,7 +43,7 @@ async fn file_system_create_delete() -> azure_core::Result<()> {
     }
     assert!(found, "did not find created file system");
 
-    let get_fs_props_response = file_system_client.get_properties().into_future().await?;
+    let get_fs_props_response = file_system_client.get_properties().await?;
     let added_via_option = get_fs_props_response.properties.get("AddedVia");
     assert!(
         added_via_option.is_some(),
@@ -57,12 +56,9 @@ async fn file_system_create_delete() -> azure_core::Result<()> {
     );
 
     fs_properties.insert("ModifiedBy", "Iota");
-    file_system_client
-        .set_properties(fs_properties)
-        .into_future()
-        .await?;
+    file_system_client.set_properties(fs_properties).await?;
 
-    let get_fs_props_response = file_system_client.get_properties().into_future().await?;
+    let get_fs_props_response = file_system_client.get_properties().await?;
     let modified_by_option = get_fs_props_response.properties.get("ModifiedBy");
     assert!(
         modified_by_option.is_some(),
@@ -74,7 +70,7 @@ async fn file_system_create_delete() -> azure_core::Result<()> {
         "did not find expected property value for: ModifiedBy"
     );
 
-    file_system_client.delete().into_future().await?;
+    file_system_client.delete().await?;
 
     Ok(())
 }
@@ -90,19 +86,19 @@ async fn file_system_list_paths() -> azure_core::Result<()> {
         .clone()
         .file_system_client(file_system_name.to_string());
 
-    file_system_client.create().into_future().await?;
+    file_system_client.create().await?;
 
     let file_path = "some/path/file1.txt";
     let file_client = file_system_client.get_file_client(file_path);
-    file_client.create().into_future().await?;
+    file_client.create().await?;
 
     let file_path = "some/path/file2.txt";
     let file_client = file_system_client.get_file_client(file_path);
-    file_client.create().into_future().await?;
+    file_client.create().await?;
 
     let file_path = "some/other_path/file3.txt";
     let file_client = file_system_client.get_file_client(file_path);
-    file_client.create().into_future().await?;
+    file_client.create().await?;
 
     // by default all paths are listed
     let paths = file_system_client
@@ -134,7 +130,7 @@ async fn file_system_list_paths() -> azure_core::Result<()> {
         .unwrap()?;
     assert_eq!(paths.paths.len(), 2);
 
-    file_system_client.delete().into_future().await?;
+    file_system_client.delete().await?;
 
     Ok(())
 }

--- a/sdk/storage_queues/examples/delete_message.rs
+++ b/sdk/storage_queues/examples/delete_message.rs
@@ -28,7 +28,6 @@ async fn main() -> azure_core::Result<()> {
         .get_messages()
         .number_of_messages(2)
         .visibility_timeout(Duration::from_secs(5)) // the message will become visible again after 5 secs
-        .into_future()
         .await?;
 
     println!("get_response == {:#?}", get_response);
@@ -39,11 +38,7 @@ async fn main() -> azure_core::Result<()> {
         for message_to_delete in get_response.messages {
             println!("deleting message {:?}", message_to_delete);
 
-            let delete_response = queue
-                .pop_receipt_client(message_to_delete)
-                .delete()
-                .into_future()
-                .await?;
+            let delete_response = queue.pop_receipt_client(message_to_delete).delete().await?;
 
             println!("delete_response == {:#?}", delete_response);
         }

--- a/sdk/storage_queues/examples/get_messages.rs
+++ b/sdk/storage_queues/examples/get_messages.rs
@@ -29,7 +29,6 @@ async fn main() -> azure_core::Result<()> {
         .get_messages()
         .number_of_messages(2)
         .visibility_timeout(Duration::from_secs(5)) // the message will become visible again after 5 secs
-        .into_future()
         .await?;
 
     println!("response == {:#?}", response);
@@ -38,7 +37,6 @@ async fn main() -> azure_core::Result<()> {
         .get_messages()
         .number_of_messages(2)
         .visibility_timeout(Duration::from_secs(10)) // the message will become visible again after 10 secs
-        .into_future()
         .await?;
     println!("get_messages_response == {:#?}", get_messages_response);
 
@@ -53,7 +51,6 @@ async fn main() -> azure_core::Result<()> {
                 format!("new body at {}", OffsetDateTime::now_utc()),
                 Duration::from_secs(4),
             )
-            .into_future()
             .await?;
         println!("response == {:#?}", response);
     }

--- a/sdk/storage_queues/examples/list_queues.rs
+++ b/sdk/storage_queues/examples/list_queues.rs
@@ -15,17 +15,11 @@ async fn main() -> azure_core::Result<()> {
     let queue_service = QueueServiceClient::new(account, storage_credentials);
 
     println!("getting service stats");
-    let response = queue_service
-        .get_queue_service_stats()
-        .into_future()
-        .await?;
+    let response = queue_service.get_queue_service_stats().await?;
     println!("get_queue_service_properties.response == {:#?}", response);
 
     println!("getting service properties");
-    let response = queue_service
-        .get_queue_service_properties()
-        .into_future()
-        .await?;
+    let response = queue_service.get_queue_service_properties().await?;
     println!("get_queue_service_stats.response == {:#?}", response);
 
     println!("enumerating queues starting with a");

--- a/sdk/storage_queues/examples/peek_messages.rs
+++ b/sdk/storage_queues/examples/peek_messages.rs
@@ -24,11 +24,7 @@ async fn main() -> azure_core::Result<()> {
 
     trace!("peeking messages");
 
-    let response = queue
-        .peek_messages()
-        .number_of_messages(2)
-        .into_future()
-        .await?;
+    let response = queue.peek_messages().number_of_messages(2).await?;
 
     println!("response == {:#?}", response);
 

--- a/sdk/storage_queues/examples/put_message.rs
+++ b/sdk/storage_queues/examples/put_message.rs
@@ -28,7 +28,6 @@ async fn main() -> azure_core::Result<()> {
             "Azure SDK for Rust rocks! {}",
             OffsetDateTime::now_utc()
         ))
-        .into_future()
         .await?;
 
     println!("response == {:#?}", response);

--- a/sdk/storage_queues/examples/queue_create.rs
+++ b/sdk/storage_queues/examples/queue_create.rs
@@ -35,11 +35,7 @@ async fn main() -> azure_core::Result<()> {
         format!("{:?}", OffsetDateTime::now_utc()).into(),
     );
 
-    let response = queue
-        .create()
-        .metadata(metadata.clone())
-        .into_future()
-        .await?;
+    let response = queue.create().metadata(metadata.clone()).await?;
     println!("response == {:#?}", response);
 
     // let's add some more metadata
@@ -51,11 +47,11 @@ async fn main() -> azure_core::Result<()> {
 
     println!("metadata == {:#?}", metadata);
 
-    let response = queue.set_metadata(metadata).into_future().await?;
+    let response = queue.set_metadata(metadata).await?;
     println!("response == {:#?}", response);
 
     // let's get back the metadata
-    let response = queue.get_metadata().into_future().await?;
+    let response = queue.get_metadata().await?;
     println!("response == {:#?}", response);
 
     // use two queue stored access policies
@@ -75,15 +71,15 @@ async fn main() -> azure_core::Result<()> {
         .enable_all(),
     ];
 
-    let response = queue.set_acl(policies).into_future().await?;
+    let response = queue.set_acl(policies).await?;
     println!("response == {:#?}", response);
 
     // get the queue ACL
-    let response = queue.get_acl().into_future().await?;
+    let response = queue.get_acl().await?;
     println!("response == {:#?}", response);
 
     // now let's delete it
-    let response = queue.delete().into_future().await?;
+    let response = queue.delete().await?;
     println!("response == {:#?}", response);
 
     Ok(())

--- a/sdk/storage_queues/src/clients/queue_client.rs
+++ b/sdk/storage_queues/src/clients/queue_client.rs
@@ -150,12 +150,10 @@ mod integration_tests {
 
         queue_client
             .create()
-            .into_future()
             .await
             .expect("create container should succeed");
         queue_client
             .delete()
-            .into_future()
             .await
             .expect("delete container should succeed");
     }
@@ -167,19 +165,16 @@ mod integration_tests {
 
         queue_client
             .create()
-            .into_future()
             .await
             .expect("create container should succeed");
 
         queue_client
             .put_message("Hello")
-            .into_future()
             .await
             .expect("put message should succeed");
 
         let mut messages = queue_client
             .peek_messages()
-            .into_future()
             .await
             .expect("peek messages should succeed");
         assert_eq!(
@@ -189,7 +184,6 @@ mod integration_tests {
 
         let mut messages = queue_client
             .get_messages()
-            .into_future()
             .await
             .expect("get messages should succeed");
         assert_eq!(
@@ -199,7 +193,6 @@ mod integration_tests {
 
         queue_client
             .delete()
-            .into_future()
             .await
             .expect("delete container should succeed");
     }

--- a/sdk/storage_queues/tests/queue.rs
+++ b/sdk/storage_queues/tests/queue.rs
@@ -34,11 +34,7 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
         format!("{:?}", OffsetDateTime::now_utc()).into(),
     );
 
-    let response = queue
-        .create()
-        .metadata(metadata.clone())
-        .into_future()
-        .await?;
+    let response = queue.create().metadata(metadata.clone()).await?;
     println!("response == {:#?}", response);
 
     // let's add some more metadata
@@ -50,11 +46,11 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
 
     println!("metadata == {:#?}", metadata);
 
-    let response = queue.set_metadata(metadata).into_future().await?;
+    let response = queue.set_metadata(metadata).await?;
     println!("response == {:#?}", response);
 
     // let's get back the metadata
-    let response = queue.get_metadata().into_future().await?;
+    let response = queue.get_metadata().await?;
     println!("response == {:#?}", response);
 
     // create two queue stored access policies
@@ -74,11 +70,11 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
         .enable_all(),
     ];
 
-    let response = queue.set_acl(policies).into_future().await?;
+    let response = queue.set_acl(policies).await?;
     println!("response == {:#?}", response);
 
     // get the queue ACL
-    let response = queue.get_acl().into_future().await?;
+    let response = queue.get_acl().await?;
     println!("response == {:#?}", response);
 
     let mut stream = queue_service.list_queues().into_stream();
@@ -92,7 +88,6 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
 
         let response = queue
             .put_message(format!("Azure SDK for Rust {}", OffsetDateTime::now_utc()))
-            .into_future()
             .await?;
 
         println!("response == {:#?}", response);
@@ -102,7 +97,6 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
         .get_messages()
         .number_of_messages(2)
         .visibility_timeout(Duration::from_secs(10))
-        .into_future()
         .await?;
     println!("get_messages_response == {:#?}", get_messages_response);
 
@@ -114,7 +108,6 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
                 format!("new body at {}", OffsetDateTime::now_utc()),
                 Duration::from_secs(4),
             )
-            .into_future()
             .await?;
         println!("response == {:#?}", response);
     }
@@ -123,7 +116,6 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
         .get_messages()
         .number_of_messages(2)
         .visibility_timeout(Duration::from_secs(5))
-        .into_future()
         .await?;
 
     println!("get_response == {:#?}", get_response);
@@ -131,17 +123,13 @@ async fn queue_create_put_and_get() -> azure_core::Result<()> {
     for message_to_delete in get_response.messages {
         println!("deleting message {:?}", message_to_delete);
 
-        let delete_response = queue
-            .pop_receipt_client(message_to_delete)
-            .delete()
-            .into_future()
-            .await?;
+        let delete_response = queue.pop_receipt_client(message_to_delete).delete().await?;
 
         println!("delete_response == {:#?}", delete_response);
     }
 
     // now let's delete the queue
-    let response = queue.delete().into_future().await?;
+    let response = queue.delete().await?;
     println!("response == {:#?}", response);
 
     Ok(())


### PR DESCRIPTION
With 1.64, IntoFuture is now stable.  Therefore, most of our calls to .into_future() are no longer needed.