### PR TITLE
Allow support to use vendored openssl

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -47,6 +47,7 @@ enable_reqwest_rustls = [
 development = []
 test_e2e = []
 client_certificate = ["openssl"]
+vendored_openssl = ["openssl/vendored"]
 
 [[example]]
 name="client_certificate_credentials"


### PR DESCRIPTION
Added support to use the vendored version of openssl. This makes it easier to build an app with this crate where the openssl dependencies are not already installed