### PR TITLE
Exposing public queue api data

### DIFF
--- a/sdk/storage_queues/src/operations/get_messages.rs
+++ b/sdk/storage_queues/src/operations/get_messages.rs
@@ -40,8 +40,8 @@ pub struct GetMessagesResponse {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Message {
-    message_id: String,
-    pop_receipt: String,
+    pub message_id: String,
+    pub pop_receipt: String,
     #[serde(with = "azure_core::date::rfc1123")]
     pub insertion_time: OffsetDateTime,
     #[serde(with = "azure_core::date::rfc1123")]

--- a/sdk/storage_queues/src/operations/mod.rs
+++ b/sdk/storage_queues/src/operations/mod.rs
@@ -19,6 +19,7 @@ pub use clear_messages::ClearMessagesBuilder;
 pub use create_queue::CreateQueueBuilder;
 pub use delete_message::DeleteMessageBuilder;
 pub use delete_queue::DeleteQueueBuilder;
+pub use get_messages::Message;
 pub use get_messages::GetMessagesBuilder;
 pub use get_queue_acl::GetQueueACLBuilder;
 pub use get_queue_metadata::GetQueueMetadataBuilder;

--- a/sdk/storage_queues/src/pop_receipt.rs
+++ b/sdk/storage_queues/src/pop_receipt.rs
@@ -6,7 +6,7 @@ pub struct PopReceipt {
 }
 
 impl PopReceipt {
-    pub(crate) fn new(message_id: impl Into<String>, pop_receipt: impl Into<String>) -> Self {
+    pub fn new(message_id: impl Into<String>, pop_receipt: impl Into<String>) -> Self {
         Self {
             message_id: message_id.into(),
             pop_receipt: pop_receipt.into(),
@@ -15,13 +15,13 @@ impl PopReceipt {
 
     /// These fields are opaque so they should not
     /// be handled by the SDK user.
-    pub(crate) fn message_id(&self) -> &str {
+    pub fn message_id(&self) -> &str {
         &self.message_id
     }
 
     /// These fields are opaque so they should not
     /// be handled by the SDK user.
-    pub(crate) fn pop_receipt(&self) -> &str {
+    pub fn pop_receipt(&self) -> &str {
         &self.pop_receipt
     }
 }


### PR DESCRIPTION
**What**
Making Message, PopReceipt, message_id, and pop_receipt public available.

**Why**
Implementing saga design pattern in an internal Microsoft project where a different node can ack or nack a message.

I believe all of these values must be public because one could use the Rest API and retrieve them, so they aren't necessarily secrets to the SDK user.

It also makes it easier to create abstractions that work with a Storage Account Queue under the hood.

Lastly, although not implemented in this PR, Message could benefit from being `Serialize` as well.