### PR TITLE
Add ContainerClient::exists method

### DIFF
--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -240,15 +240,18 @@ impl BlobClient {
 
     /// Check whether blob exists.
     pub async fn exists(&self) -> azure_core::Result<bool> {
-        let result = self.get_properties().await.map(|_| true);
-        if let Err(err) = result {
-            if let ErrorKind::HttpResponse { status, .. } = err.kind() {
-                return Ok(status != &StatusCode::NotFound);
-            } else {
-                return Err(err);
+        match self.get_properties().await {
+            Ok(_) => Ok(true),
+            Err(err)
+                if err
+                    .as_http_error()
+                    .map(|e| e.status() == StatusCode::NotFound)
+                    .unwrap_or_default() =>
+            {
+                Ok(false)
             }
+            Err(err) => Err(err),
         }
-        result
     }
 
     /// Create a blob snapshot


### PR DESCRIPTION
Fixes #1123 

In addition to adding the method, it also refactors `BlobClient::exits` to return an error on any http error code that is not a 404. Previously this method would have return false even if the blob existed, but the endpoint returned a 5xx.