### PR TITLE
Fixed incorrect header name in blob expiry

### DIFF
--- a/sdk/storage_blobs/src/options/blob_expiry.rs
+++ b/sdk/storage_blobs/src/options/blob_expiry.rs
@@ -25,7 +25,7 @@ impl BlobExpiry {
                 headers.insert(EXPIRY_TIME, duration.to_string());
             }
             BlobExpiry::Absolute(date) => {
-                headers.insert(EXPIRY_OPTION, "Abosolute");
+                headers.insert(EXPIRY_OPTION, "Absolute");
                 headers.insert(EXPIRY_TIME, date::to_rfc1123(date));
             }
             BlobExpiry::NeverExpire => {


### PR DESCRIPTION
Fixed incorrect header name