### PR TITLE
Add `content_range` to `GetBlobResponse`

### DIFF
--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -66,6 +66,7 @@ pub struct GetBlobResponse {
     pub blob: Blob,
     pub data: ResponseBody,
     pub date: OffsetDateTime,
+    pub content_range: Option<Range>,
     pub remaining_range: Option<Range>,
 }
 
@@ -94,6 +95,7 @@ impl GetBlobResponse {
             blob,
             data,
             date,
+            content_range: content_range.map(|cr| Range::new(cr.start(), cr.end())),
             remaining_range,
         })
     }
@@ -106,7 +108,7 @@ impl Continuable for GetBlobResponse {
     }
 }
 
-// caclculate the first Range for use at the beginning of the Pageable.
+// calculate the first Range for use at the beginning of the Pageable.
 fn initial_range(chunk_size: u64, request_range: Option<Range>) -> Range {
     match request_range {
         Some(range) => {


### PR DESCRIPTION
This adds `content_range` to `GetBlobResponse`. This can help in situations as described in #1140. 

In such a situation the user can use `content_range` to create the right range for the call to getting a blob. 

For instance, if the user finds that reading `GetBlobResponse.data` fails, they can call `BlobClient::get` again and set `range` to `Range::new(content_range.unwrap_or(0), original_range_end)`.  This will restart the blob download starting with at the blob chunk that failed (instead of having to start from the very beginning). 

cc @gorzell 