### PR TITLE
Add .bytes() fn to BlockId

### DIFF
--- a/sdk/storage_blobs/src/options/block_id.rs
+++ b/sdk/storage_blobs/src/options/block_id.rs
@@ -5,8 +5,16 @@ use bytes::Bytes;
 pub struct BlockId(Bytes);
 
 impl BlockId {
+    /// Returns a new block id,
+    ///
     pub fn new(block_id: impl Into<Bytes>) -> Self {
         Self(block_id.into())
+    }
+
+    /// Returns clone of bytes,
+    ///
+    pub fn bytes(&self) -> Bytes {
+        self.0.clone()
     }
 }
 

--- a/sdk/storage_blobs/src/options/block_id.rs
+++ b/sdk/storage_blobs/src/options/block_id.rs
@@ -3,7 +3,8 @@ use bytes::Bytes;
 
 /// Struct wrapping the bytes of a block blob block-id,
 ///
-/// A block id cannot exceed 64 bytes. In addition all block id's in a block list must be the same length when converted into a base64 string.
+/// A block id cannot exceed 64 bytes before encoding. In addition all block id's in a block list must be the same length.
+/// Reference: https://learn.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockId(Bytes);

--- a/sdk/storage_blobs/src/options/block_id.rs
+++ b/sdk/storage_blobs/src/options/block_id.rs
@@ -1,6 +1,10 @@
 use azure_core::AppendToUrlQuery;
 use bytes::Bytes;
 
+/// Struct wrapping the bytes of a block blob block-id,
+///
+/// A block id cannot exceed 64 bytes. In addition all block id's in a block list must be the same length when converted into a base64 string.
+///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockId(Bytes);
 


### PR DESCRIPTION
Currently there is not a way to convert `BlockId` into `Bytes`. Constructing a `Bytes` from `AsRef<&[u8]>` requires an allocation (`Bytes::from(.as_ref().to_vec())`). This PR adds a function that returns a clone of `BlockId`'s inner `Bytes`, so that the zero-copy behavior of `Bytes` can be preserved.