### PR TITLE
update build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: rustup update --no-self-update ${{ matrix.build }}
+      - run: rustup target add --toolchain ${{ matrix.build }} wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
       - name: check core with --no-default-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,69 +9,19 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  fmt:
+  code-style:
     name: Code Style
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt, clippy
-
+      - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
-
-      - name: cargo fmt sdk
-        run: cargo fmt --all -- --check
-
-      - name: cargo clippy sdk
-        run: cargo clippy --all
-
-      - name: cargo doc sdk
-        run: cargo doc --all --no-deps
-
-      - name: cargo fmt services
-        run: |
-          ./eng/scripts/check_json_format.sh
-          cargo fmt --manifest-path services/Cargo.toml --all -- --check
-
-  test-sdk:
-    name: SDK Tests
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt
-          target: wasm32-unknown-unknown
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: fmt
-        run: |
-          cargo fmt --all -- --check
-          ./eng/scripts/check_json_format.sh
-          cargo fmt --manifest-path services/Cargo.toml --all -- --check
-        if: matrix.rust == 'stable'
-
-      - name: check core with --no-default-features
-        run: cargo check -p azure_core --no-default-features
-
-      - name: check for wasm
-        run: cargo check --target=wasm32-unknown-unknown --no-default-features
-
-      - name: check for azurite_workaround
-        run: cargo check --all --features azurite_workaround
-
-      - name: sdk tests
-        run: cargo test --all
-
-      - name: update readme of sdks
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all
+      - run: cargo doc --all --no-deps
+      - name: check json
+        run: ./eng/scripts/check_json_format.sh
+      - name: check READMEs
         run: |
           cargo install cargo-readme
           ./eng/scripts/cargo_readme.sh
@@ -79,31 +29,30 @@ jobs:
             echo "Run ./eng/scripts/cargo_readme.sh to update readmes" && exit 1
           fi
 
-  nightly:
-    name: Test Nightly
+  test-sdk:
+    name: SDK Tests
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        build:
+          - stable
+          - nightly
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-      - name: check `into_future` feature
-        run: cargo check --all --features into_future
+      - run: rustup update --no-self-update ${{ matrix.build }}
+      - uses: Swatinem/rust-cache@v2
 
-  nightly-build:
-    name: Build Nightly
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
-      - name: Build Nightly
-        run: cargo +nightly build --all-features
+      - name: check core with --no-default-features
+        run: cargo +${{ matrix.build }} check -p azure_core --no-default-features
+
+      - name: check for wasm
+        run: cargo +${{ matrix.build }} check --target=wasm32-unknown-unknown --no-default-features
+
+      - name: check for azurite_workaround
+        run: cargo +${{ matrix.build }} check --all --features azurite_workaround
+
+      - name: sdk tests
+        run: cargo +${{ matrix.build }} test --all
 
   test-services:
     name: Services Tests
@@ -112,13 +61,7 @@ jobs:
       RUSTFLAGS: -Dwarnings -Aunreachable-code -Aunused-assignments -Adead-code -Aclippy::new-without-default -Aclippy::unnecessary_to_owned
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt, clippy
-
+      - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
 
       - name: services check
@@ -142,13 +85,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt
-
+      - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
 
       - name: emulator integration tests
@@ -166,13 +103,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt
-
+      - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
 
       - name: e2e tests build
@@ -196,13 +127,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: azure-sdk-for-rust
-      - name: install rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          components: rustfmt, clippy
+      - run: rustup update --no-self-update
       - name: fmt check
         run: cargo fmt --all --manifest-path azure-sdk-for-rust/services/autorust/Cargo.toml -- --check
       - name: clippy check


### PR DESCRIPTION
This PR makes the following changes:
* replaces the use of `actions-rs`, which is no longer being updated, with `rustup update`
* only runs `cargo fmt` for the SDK as part of the code style task
* uses a matrix to test on stable and nightly, rather than manually creating tasks
* removes `into_future` specific testing as IntoFuture is stable