### PR TITLE
address concurrent issue with sleep future 

### DIFF
--- a/sdk/core/src/sleep.rs
+++ b/sdk/core/src/sleep.rs
@@ -21,7 +21,13 @@ impl Future for Sleep {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if self.thread.is_none() {
+        if let Some(thread) = &self.thread {
+            if thread.is_finished() {
+                Poll::Ready(())
+            } else {
+                Poll::Pending
+            }
+        } else {
             let waker = cx.waker().clone();
             let duration = self.duration;
             self.get_mut().thread = Some(thread::spawn(move || {
@@ -29,8 +35,6 @@ impl Future for Sleep {
                 waker.wake();
             }));
             Poll::Pending
-        } else {
-            Poll::Ready(())
         }
     }
 }


### PR DESCRIPTION
As is, the Sleep future relies on the future not getting polled until the waker files, which isn't guaranteed.

This changes the implementation to check if the thread is done.  The waker still triggers the polling to occur.

fixes #1170 