### PR TITLE
Key Vault Certificate Delete

### DIFF
--- a/sdk/security_keyvault/src/certificates/operations/delete.rs
+++ b/sdk/security_keyvault/src/certificates/operations/delete.rs
@@ -1,0 +1,36 @@
+use crate::prelude::*;
+use azure_core::{headers::Headers, CollectedResponse, Method};
+
+operation! {
+    DeleteCertificate,
+    client: CertificateClient,
+    name: String,
+}
+
+impl DeleteCertificateBuilder {
+    pub fn into_future(mut self) -> DeleteCertificate {
+        Box::pin(async move {
+            let mut uri = self.client.keyvault_client.vault_url.clone();
+            uri.set_path(&format!("certificates/{}", self.name));
+
+            let headers = Headers::new();
+            let mut request =
+                self.client
+                    .keyvault_client
+                    .finalize_request(uri, Method::Delete, headers, None)?;
+
+            let response = self
+                .client
+                .keyvault_client
+                .send(&mut self.context, &mut request)
+                .await?;
+
+            let response = CollectedResponse::from_response(response).await?;
+            let body = response.body();
+            let response = serde_json::from_slice::<KeyVaultGetCertificateResponse>(body)?;
+            Ok(response)
+        })
+    }
+}
+
+type DeleteCertificateResponse = KeyVaultGetCertificateResponse;

--- a/sdk/security_keyvault/src/certificates/operations/mod.rs
+++ b/sdk/security_keyvault/src/certificates/operations/mod.rs
@@ -1,5 +1,6 @@
 mod backup;
 mod create;
+mod delete;
 mod get_certificate;
 mod get_versions;
 mod import;
@@ -7,6 +8,7 @@ mod merge;
 mod update_properties;
 pub use backup::*;
 pub use create::*;
+pub use delete::*;
 pub use get_certificate::*;
 pub use get_versions::*;
 pub use import::*;

--- a/sdk/security_keyvault/src/clients/certificate_client.rs
+++ b/sdk/security_keyvault/src/clients/certificate_client.rs
@@ -243,20 +243,11 @@ impl CertificateClient {
     ///
     /// Runtime::new().unwrap().block_on(example());
     /// ```
-    pub async fn delete<N>(&self, name: N) -> azure_core::Result<()>
+    pub fn delete<N>(&self, name: N) -> DeleteCertificateBuilder
     where
         N: Into<String>,
     {
-        // let mut uri = self.vault_url.clone();
-        // uri.set_path(&format!("certificates/{}", certificate_name));
-
-        // self.delete_authed(uri.to_string()).await?;
-
-        // Ok(())
-
-        let _name = name.into();
-
-        todo!("See issue #174 at: https://github.com/Azure/azure-sdk-for-rust/issues/174.")
+        DeleteCertificateBuilder::new(self.clone(), name.into())
     }
 
     /// Lists all the certificates in the Key Vault.


### PR DESCRIPTION
Adds Key Vault certificate delete operation. Noticed that there was a placeholder for delete which mentions issue 174. 
```rust
todo!("See issue #174 at: https://github.com/Azure/azure-sdk-for-rust/issues/174.")
```
Issue 174 talks about long running operations. As far as I can tell from the API docs certificate deletion is not a long running operation. I tested it on my computer and delete took less time to return than a Get. 
