### PR TITLE
require rust 1.65.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.64.0"
+channel = "1.65.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
#1185 uses generic associate types. This separates out the rust version change.