### PR TITLE
Fix: BytesStream failing to set correct slice range

### DIFF
--- a/sdk/core/src/bytes_stream.rs
+++ b/sdk/core/src/bytes_stream.rs
@@ -82,10 +82,11 @@ impl AsyncRead for BytesStream {
             let remaining_bytes = self_mut.bytes.len() - bytes_read;
 
             let bytes_to_copy = std::cmp::min(remaining_bytes, buf.len());
+            let bytes_to_read_end = self_mut.bytes_read + bytes_to_copy;
 
             for (buf_byte, bytes_byte) in buf
                 .iter_mut()
-                .zip(self_mut.bytes.slice(self_mut.bytes_read..bytes_to_copy))
+                .zip(self_mut.bytes.slice(self_mut.bytes_read..bytes_to_read_end))
             {
                 *buf_byte = bytes_byte;
             }


### PR DESCRIPTION
`BytesStream` calls [Bytes::slice](https://docs.rs/bytes/latest/bytes/struct.Bytes.html#method.slice) with incorrect range of `START..SIZE`. Range should be `START..END`.

This results in incorrect slicing or even an assert failure of `"range start must not be greater than end: ` coming from [the slice methnod](https://github.com/tokio-rs/bytes/blob/74b04c7aae5fd7e73f4283774eab0ef72a26a8a7/src/bytes.rs#L255).

I wanted to add a test for this but don't see any tests for this code. If there are some I am happy to add a test for this case.

Tested locally from my fork