### PR TITLE
fix bare URLs in documentation

### DIFF
--- a/sdk/core/src/util.rs
+++ b/sdk/core/src/util.rs
@@ -17,7 +17,7 @@ where
 }
 
 /// Deserialize JSON null as default
-/// https://github.com/serde-rs/serde/issues/1098
+/// <https://github.com/serde-rs/serde/issues/1098>
 pub fn deserialize_null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
     T: Default + Deserialize<'de>,

--- a/sdk/storage_blobs/src/options/block_id.rs
+++ b/sdk/storage_blobs/src/options/block_id.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 /// Struct wrapping the bytes of a block blob block-id,
 ///
 /// A block id cannot exceed 64 bytes before encoding. In addition all block id's in a block list must be the same length.
-/// Reference: https://learn.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters
+/// Reference: <https://learn.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters>
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BlockId(Bytes);


### PR DESCRIPTION
This addresses a warning seen when building crate documentation

```
 --> sdk/storage_blobs/src/options/block_id.rs:7:16
  |
7 | /// Reference:
https://learn.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters
  |
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
help: use an automatic link instead:
`<https://learn.microsoft.com/en-us/rest/api/storageservices/put-block#uri-parameters>`
  |
  = note: bare URLs are not automatically turned into clickable links
```