### PR TITLE
move the pipeline to use scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,20 +14,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all
-      - run: cargo doc --all --no-deps
-      - name: check json
-        run: ./eng/scripts/check_json_format.sh
-      - name: check READMEs
-        run: |
-          cargo install cargo-readme
-          ./eng/scripts/cargo_readme.sh
-          if git status sdk | grep -q '.md$'; then
-            echo "Run ./eng/scripts/cargo_readme.sh to update readmes" && exit 1
-          fi
+      - run: eng/scripts/code_style.sh
 
   test-sdk:
     name: SDK Tests
@@ -39,44 +27,16 @@ jobs:
           - nightly
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update --no-self-update ${{ matrix.build }}
-      - run: rustup target add --toolchain ${{ matrix.build }} wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
-
-      - name: check core with --no-default-features
-        run: cargo +${{ matrix.build }} check -p azure_core --no-default-features
-
-      - name: check for wasm
-        run: cargo +${{ matrix.build }} check --target=wasm32-unknown-unknown --no-default-features
-
-      - name: check for azurite_workaround
-        run: cargo +${{ matrix.build }} check --all --features azurite_workaround
-
-      - name: sdk tests
-        run: cargo +${{ matrix.build }} test --all
+      - run: eng/scripts/sdk_tests.sh ${{ matrix.build }}
 
   test-services:
     name: Services Tests
     runs-on: ubuntu-20.04
-    env:
-      RUSTFLAGS: -Dwarnings -Aunreachable-code -Aunused-assignments -Adead-code -Aclippy::new-without-default -Aclippy::unnecessary_to_owned
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
-
-      - name: services check
-        run: cargo check --manifest-path services/Cargo.toml --all
-
-      - name: services check examples
-        run: cargo check --manifest-path services/Cargo.toml --examples
-
-      - name: services clippy
-        run: cargo clippy --manifest-path services/Cargo.toml --all
-
-      - name: services fmt
-        run: cargo fmt --manifest-path services/Cargo.toml --all -- --check
-
+      - run: eng/scripts/services_tests.sh
       - name: display free disk space
         run: df -h /
         if: ${{ always() }}
@@ -104,18 +64,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
-      - run: rustup update --no-self-update stable
       - uses: Swatinem/rust-cache@v2
-
-      - name: e2e tests build
-        run: |
-          PROJECTS=(core  data_cosmos  identity  messaging_servicebus  storage  storage_blobs  storage_queues  storage_datalake  data_tables)
-          for PROJ in ${PROJECTS[@]}
-          do
-            echo "Checking e2e tests for $PROJ"
-            cargo check --tests --features test_e2e --manifest-path sdk/$PROJ/Cargo.toml || exit 1
-          done
-
+      - run: eng/scripts/e2e_tests.sh
       - name: display free disk space
         run: df -h /
         if: ${{ always() }}
@@ -128,13 +78,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: azure-sdk-for-rust
-      - run: rustup update --no-self-update
-      - name: fmt check
-        run: cargo fmt --all --manifest-path azure-sdk-for-rust/services/autorust/Cargo.toml -- --check
-      - name: clippy check
-        run: cargo clippy --all --manifest-path azure-sdk-for-rust/services/autorust/Cargo.toml
-      - name: unit tests
-        run: cargo test --lib --manifest-path azure-sdk-for-rust/services/autorust/Cargo.toml
       - name: git clone Azure/azure-rest-api-specs
         uses: actions/checkout@v3
         with:
@@ -145,9 +88,4 @@ jobs:
         with:
           repository: OAI/OpenAPI-Specification
           path: OpenAPI-Specification
-      - name: integration tests
-        run: |
-          cd azure-sdk-for-rust/services/autorust
-          cargo test --package autorust_openapi --test openapi_spec_examples
-          cargo test --package autorust_openapi --test azure_rest_api_specs
-          cargo test --package autorust_codegen --test azure_rest_api_specs
+      - run: azure-sdk-for-rust/eng/scripts/autorust_tests.sh

--- a/eng/scripts/all_tests.sh
+++ b/eng/scripts/all_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eux -o pipefail
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+BUILD=${1:-stable}
+
+./eng/scripts/code_style.sh ${BUILD}
+./eng/scripts/sdk_tests.sh ${BUILD}
+./eng/scripts/services_tests.sh ${BUILD}
+./eng/scripts/e2e_tests.sh ${BUILD}
+./eng/scripts/autorust_tests.sh ${BUILD}

--- a/eng/scripts/autorust_tests.sh
+++ b/eng/scripts/autorust_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eux -o pipefail
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+BUILD=${1:-stable}
+
+rustup update --no-self-update ${BUILD}
+
+export RUSTFLAGS="-Dwarnings"
+
+cargo +${BUILD} fmt --all --manifest-path services/autorust/Cargo.toml -- --check
+cargo +${BUILD} clippy --all --manifest-path services/autorust/Cargo.toml
+cargo +${BUILD} test --lib --manifest-path services/autorust/Cargo.toml
+
+cd services/autorust
+cargo +${BUILD} test --package autorust_openapi --test openapi_spec_examples
+cargo +${BUILD} test --package autorust_openapi --test azure_rest_api_specs
+cargo +${BUILD} test --package autorust_codegen --test azure_rest_api_specs

--- a/eng/scripts/cargo_readme.sh
+++ b/eng/scripts/cargo_readme.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 
-cd sdk
-for crate in *
-do
+set -eux -o pipefail
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+for crate in sdk/*;  do
   if [ -d "$crate" ]; then
-    cd "$crate"
-    echo Updating README.md for "$crate"
-    cargo readme > README.md
-    cd ..
+    (cd "$crate"; cargo readme > README.md)
   fi
 done
-cd ..

--- a/eng/scripts/code_style.sh
+++ b/eng/scripts/code_style.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eux -o pipefail
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+BUILD=${1:-stable}
+
+export RUSTDOCFLAGS="-D warnings"
+export RUSTFLAGS="-Dwarnings"
+
+rustup update --no-self-update ${BUILD}
+cargo +${BUILD} install cargo-readme
+cargo +${BUILD} fmt --all -- --check
+cargo +${BUILD} clippy --all
+cargo +${BUILD} doc --all --no-deps --all-features
+./eng/scripts/check_json_format.sh
+./eng/scripts/cargo_readme.sh
+if git status sdk | grep -q '.md$'; then
+    echo "Run ./eng/scripts/cargo_readme.sh to update readmes" && exit 1
+fi

--- a/eng/scripts/e2e_tests.sh
+++ b/eng/scripts/e2e_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eux -o pipefail
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+BUILD=${1:-stable}
+
+rustup update --no-self-update ${BUILD}
+
+export RUSTFLAGS="-Dwarnings"
+export PROJECTS=core data_cosmos identity messaging_servicebus storage storage_blobs storage_queues storage_datalake data_tables
+
+for PROJ in ${PROJECTS}; do
+    cargo check --tests --features test_e2e --manifest-path sdk/$PROJ/Cargo.toml
+done

--- a/eng/scripts/sdk_tests.sh
+++ b/eng/scripts/sdk_tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -eux -o pipefail
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+BUILD=${1:-stable}
+
+rustup update --no-self-update ${BUILD}
+rustup target add --toolchain ${BUILD} wasm32-unknown-unknown
+
+export RUSTFLAGS="-Dwarnings"
+cargo +${BUILD} check -p azure_core --no-default-features
+cargo +${BUILD} check --target=wasm32-unknown-unknown --no-default-features
+cargo +${BUILD} check --all --features azurite_workaround
+cargo +${BUILD} test --all

--- a/eng/scripts/services_tests.sh
+++ b/eng/scripts/services_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eux -o pipefail
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+BUILD=${1:-stable}
+
+rustup update --no-self-update ${BUILD}
+export RUSTFLAGS="-Dwarnings -Aunreachable-code -Aunused-assignments -Adead-code -Aclippy::new-without-default -Aclippy::unnecessary_to_owned"
+cargo +${BUILD} check --manifest-path services/Cargo.toml --all
+cargo +${BUILD} check --manifest-path services/Cargo.toml --examples
+cargo +${BUILD} clippy --manifest-path services/Cargo.toml --all
+cargo +${BUILD} fmt --manifest-path services/Cargo.toml --all -- --check


### PR DESCRIPTION
This improves the quality of life for SDK developers by enabling running CICD pipeline checks locally.

For developers that want to test everything, `all_tests.sh` runs each of the scripts.