### PR TITLE
Fix: Avoid passing if-match header for insert_or_replace ops

### DIFF
--- a/sdk/data_tables/examples/table.rs
+++ b/sdk/data_tables/examples/table.rs
@@ -75,12 +75,12 @@ async fn main() -> azure_core::Result<()> {
 
     let response = partition_key_client
         .transaction()
-        .delete(&entity1.surname)?
+        .delete(&entity1.surname, None)?
         .insert(&entity2)?
-        .update(&entity3.surname, &entity3)?
-        .merge(&entity4.surname, &entity4)?
-        .insert_or_replace(&entity5.surname, &entity5, IfMatchCondition::Any)?
-        .insert_or_merge(&entity6.surname, &entity6, IfMatchCondition::Any)?
+        .update(&entity3.surname, &entity3, None)?
+        .merge(&entity4.surname, &entity4, None)?
+        .insert_or_replace(&entity5.surname, &entity5)?
+        .insert_or_merge(&entity6.surname, &entity6)?
         .await?;
 
     // check all the events in the transaction completed successfully.

--- a/sdk/data_tables/src/operations/transaction.rs
+++ b/sdk/data_tables/src/operations/transaction.rs
@@ -51,8 +51,9 @@ impl TransactionBuilder {
         self,
         row_key: RK,
         entity: E,
+        match_condition: Option<IfMatchCondition>,
     ) -> azure_core::Result<Self> {
-        self.entity_operation(row_key, entity, Method::Put, None)
+        self.entity_operation(row_key, entity, Method::Put, match_condition)
     }
 
     /// Replaces an existing entity or inserts a new entity if it does not exist
@@ -77,8 +78,9 @@ impl TransactionBuilder {
         self,
         row_key: RK,
         entity: E,
+        match_condition: Option<IfMatchCondition>,
     ) -> azure_core::Result<Self> {
-        self.entity_operation(row_key, entity, Method::Merge, None)
+        self.entity_operation(row_key, entity, Method::Merge, match_condition)
     }
 
     /// Update an existing entity or inserts a new entity if it does not exist
@@ -97,13 +99,17 @@ impl TransactionBuilder {
     /// Delete an existing entity in a table.
     ///
     /// ref: <https://docs.microsoft.com/en-us/rest/api/storageservices/delete-entity1>
-    pub fn delete<RK: Into<String>>(mut self, row_key: RK) -> azure_core::Result<Self> {
+    pub fn delete<RK: Into<String>>(
+        mut self,
+        row_key: RK,
+        match_condition: Option<IfMatchCondition>,
+    ) -> azure_core::Result<Self> {
         let entity_client = self.client.entity_client(row_key)?;
         let url = entity_client.url()?;
 
         let mut request = Request::new(url, Method::Delete);
         request.insert_header(ACCEPT, "application/json;odata=minimalmetadata");
-        request.insert_header(IF_MATCH, "*");
+        request.add_optional_header(&match_condition);
         request.set_body("");
 
         self.transaction.add(TransactionOperation::new(request));

--- a/sdk/data_tables/src/operations/transaction.rs
+++ b/sdk/data_tables/src/operations/transaction.rs
@@ -64,9 +64,8 @@ impl TransactionBuilder {
         self,
         row_key: RK,
         entity: E,
-        if_match_condition: IfMatchCondition,
     ) -> azure_core::Result<Self> {
-        self.entity_operation(row_key, entity, Method::Put, Some(if_match_condition))
+        self.entity_operation(row_key, entity, Method::Put, None)
     }
 
     /// Update an existing entity by updating the entity's properties. This
@@ -91,9 +90,8 @@ impl TransactionBuilder {
         self,
         row_key: RK,
         entity: E,
-        if_match_condition: IfMatchCondition,
     ) -> azure_core::Result<Self> {
-        self.entity_operation(row_key, entity, Method::Merge, Some(if_match_condition))
+        self.entity_operation(row_key, entity, Method::Merge, None)
     }
 
     /// Delete an existing entity in a table.


### PR DESCRIPTION
#1207 if-match header enforces that the entity already exists whiich breaks the insert new scenarios.