### PR TITLE
use scheme from specification in generated crates

### DIFF
--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -93,14 +93,23 @@ impl Spec {
         self.docs.values().find_map(|doc| doc.host.as_deref())
     }
 
+    fn scheme(&self) -> String {
+        self.docs
+            .values()
+            .find_map(|doc| doc.schemes.first().cloned())
+            .unwrap_or_default()
+            .to_string()
+    }
+
     pub fn base_path(&self) -> Option<&str> {
         self.docs.values().find_map(|doc| doc.base_path.as_deref())
     }
 
     pub fn endpoint(&self) -> Option<String> {
+        let scheme = self.scheme();
         match (self.host(), self.base_path()) {
-            (Some(host), Some(base_path)) => Some(format!("https://{host}{base_path}").trim_end_matches('/').to_owned()),
-            (Some(host), None) => Some(format!("https://{host}")),
+            (Some(host), Some(base_path)) => Some(format!("{scheme}://{host}{base_path}").trim_end_matches('/').to_owned()),
+            (Some(host), None) => Some(format!("{scheme}://{host}")),
             _ => None,
         }
     }

--- a/services/autorust/openapi/src/schema.rs
+++ b/services/autorust/openapi/src/schema.rs
@@ -1,8 +1,7 @@
-use std::fmt::Display;
-
 use crate::*;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 // http://json.schemastore.org/swagger-2.0
 

--- a/services/autorust/openapi/src/schema.rs
+++ b/services/autorust/openapi/src/schema.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::*;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -13,6 +15,17 @@ pub enum Scheme {
     Https,
     Ws,
     Wss,
+}
+
+impl Display for Scheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Scheme::Http => write!(f, "http"),
+            Scheme::Https => write!(f, "https"),
+            Scheme::Ws => write!(f, "ws"),
+            Scheme::Wss => write!(f, "wss"),
+        }
+    }
 }
 
 impl Default for Scheme {

--- a/services/svc/imds/src/package_2021_05_01/mod.rs
+++ b/services/svc/imds/src/package_2021_05_01/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
+pub const DEFAULT_ENDPOINT: &str = "http://169.254.169.254/metadata";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/imds/src/package_2021_10_01/mod.rs
+++ b/services/svc/imds/src/package_2021_10_01/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
+pub const DEFAULT_ENDPOINT: &str = "http://169.254.169.254/metadata";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/imds/src/package_2021_11_01/mod.rs
+++ b/services/svc/imds/src/package_2021_11_01/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
+pub const DEFAULT_ENDPOINT: &str = "http://169.254.169.254/metadata";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/imds/src/package_2021_11_15/mod.rs
+++ b/services/svc/imds/src/package_2021_11_15/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
+pub const DEFAULT_ENDPOINT: &str = "http://169.254.169.254/metadata";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/imds/src/package_2021_12_13/mod.rs
+++ b/services/svc/imds/src/package_2021_12_13/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://169.254.169.254/metadata";
+pub const DEFAULT_ENDPOINT: &str = "http://169.254.169.254/metadata";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/servicefabric/src/v7_1/mod.rs
+++ b/services/svc/servicefabric/src/v7_1/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:19080";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/servicefabric/src/v7_2/mod.rs
+++ b/services/svc/servicefabric/src/v7_2/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:19080";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/servicefabric/src/v8_0/mod.rs
+++ b/services/svc/servicefabric/src/v8_0/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:19080";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/servicefabric/src/v8_1/mod.rs
+++ b/services/svc/servicefabric/src/v8_1/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:19080";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]

--- a/services/svc/servicefabric/src/v8_2/mod.rs
+++ b/services/svc/servicefabric/src/v8_2/mod.rs
@@ -17,7 +17,7 @@ pub struct ClientBuilder {
     scopes: Option<Vec<String>>,
     options: azure_core::ClientOptions,
 }
-pub const DEFAULT_ENDPOINT: &str = "https://localhost:19080";
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:19080";
 impl ClientBuilder {
     #[doc = "Create a new instance of `ClientBuilder`."]
     #[must_use]


### PR DESCRIPTION
This PR moves from hard-coding the scheme from `https` to using the first scheme defined in the specification.