### PR TITLE
update mockito to 0.32.0

### DIFF
--- a/sdk/iot_deviceupdate/Cargo.toml
+++ b/sdk/iot_deviceupdate/Cargo.toml
@@ -28,7 +28,7 @@ azure_identity = { path = "../identity", version="0.9", default_features = false
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-mockito = "0.31"
+mockito = "0.32"
 async-trait = "0.1"
 
 [features]

--- a/sdk/iot_deviceupdate/Cargo.toml
+++ b/sdk/iot_deviceupdate/Cargo.toml
@@ -28,7 +28,7 @@ azure_identity = { path = "../identity", version="0.9", default_features = false
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-mockito = "0.32"
+mockito = "0.32.2"
 async-trait = "0.1"
 
 [features]

--- a/sdk/iot_deviceupdate/src/device_update.rs
+++ b/sdk/iot_deviceupdate/src/device_update.rs
@@ -517,7 +517,7 @@ mod tests {
     #[tokio::test]
     async fn can_import_update() -> azure_core::Result<()> {
         let mut server = Server::new_async().await;
-        let m = server
+        let _m = server
             .mock("POST", "/deviceupdate/test-instance/updates")
             .match_query(Matcher::UrlEncoded(
                 "api-version".into(),
@@ -527,7 +527,7 @@ mod tests {
             .with_status(202)
             .create_async()
             .await;
-        let op = server.mock("GET", "/op_location")
+        let _op = server.mock("GET", "/op_location")
             .with_header("content-type", "application/json")
             .with_body(
                 json!({
@@ -567,13 +567,6 @@ mod tests {
             update.last_action_date_time,
             date::parse_rfc3339("1999-09-10T02:05:07.3845533Z").unwrap()
         );
-
-        // `Mock::drop` calls `futures::executor::block_on` which will spin
-        // forever, so we need to avoid this.  Our `Server` will be dropped at
-        // the end of the test, which the mocks are registered, so the impact
-        // here is minimal.  Ref: <https://github.com/lipanski/mockito/issues/155>
-        std::mem::forget(m);
-        std::mem::forget(op);
 
         Ok(())
     }

--- a/sdk/iot_deviceupdate/src/lib.rs
+++ b/sdk/iot_deviceupdate/src/lib.rs
@@ -14,9 +14,9 @@ mod tests {
     use std::sync::Arc;
     use time::OffsetDateTime;
 
-    pub(crate) fn mock_client() -> crate::client::DeviceUpdateClient {
+    pub(crate) fn mock_client(server_url: String) -> crate::client::DeviceUpdateClient {
         crate::client::DeviceUpdateClient {
-            device_update_url: url::Url::parse(&mockito::server_url()).unwrap(),
+            device_update_url: url::Url::parse(&server_url).unwrap(),
             endpoint: "".to_string(),
             token_credential: AutoRefreshingTokenCredential::new(Arc::new(MockCredential)),
         }

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -26,7 +26,6 @@ azure_core = { path = "../core", version = "0.8", default-features = false }
 
 [dev-dependencies]
 azure_identity = { path = "../identity", default-features = false }
-mockito = "0.31"
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 


### PR DESCRIPTION
This updates `mockito` to the latest version. 

Early iterations of this PR called `std::mem::forget` on the `Mock` objects, but the upstream package maintainer addressed the issue we were experiencing.

