### PR TITLE
add metadata links to iot_hub requested by `cargo publish`

### DIFF
--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Microsoft Corp."]
 edition = "2021"
 description = "Azure IoT Hub"
 license = "MIT"
+repository = "https://github.com/azure/azure-sdk-for-rust"
+homepage = "https://github.com/azure/azure-sdk-for-rust"
+documentation = "https://docs.rs/azure_iot_hub"
 rust-version = "1.64.0"
 
 [dependencies]


### PR DESCRIPTION
Fixes #1218 