### PR TITLE
Allow parsing list blobs response without ServerEncrypted tag

### DIFF
--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -155,6 +155,7 @@ pub struct BlobProperties {
     #[serde(default, with = "azure_core::date::rfc1123::option")]
     pub copy_completion_time: Option<OffsetDateTime>,
     pub copy_status_description: Option<String>,
+    #[serde(default)]
     pub server_encrypted: bool,
     pub customer_provided_key_sha256: Option<String>,
     pub encryption_scope: Option<String>,

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -340,6 +340,38 @@ mod tests {
     }
 
     #[test]
+    fn deserde_azurite_without_server_encrypted() {
+        const S: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+        <EnumerationResults ServiceEndpoint=\"http://127.0.0.1:10000/devstoreaccount1\" ContainerName=\"temp\">
+            <Prefix>b39bc5c9-0f31-459c-a271-828467105470/</Prefix>
+            <Marker/>
+            <MaxResults>5000</MaxResults>
+            <Delimiter/>
+            <Blobs>
+                <Blob>
+                    <Name>b39bc5c9-0f31-459c-a271-828467105470/corrupted_data_2020-01-02T03_04_05.json</Name>
+                    <Properties>
+                        <Creation-Time>Sat, 18 Feb 2023 22:39:00 GMT</Creation-Time>
+                        <Last-Modified>Sat, 18 Feb 2023 22:39:00 GMT</Last-Modified>
+                        <Etag>0x23D9DB658CF7480</Etag>
+                        <Content-Length>64045</Content-Length>
+                        <Content-Type>application/octet-stream</Content-Type>
+                        <BlobType>BlockBlob</BlobType>
+                        <LeaseStatus>unlocked</LeaseStatus>
+                        <LeaseState>available</LeaseState>
+                        <AccessTier>Hot</AccessTier>
+                        <AccessTierInferred>true</AccessTierInferred>
+                    </Properties>
+                </Blob>
+            </Blobs>
+            <NextMarker/>
+        </EnumerationResults>";
+
+        let bytes = Bytes::from(S);
+        let _list_blobs_response_internal: ListBlobsResponseInternal = read_xml(&bytes).unwrap();
+    }
+
+    #[test]
     fn parse_xml_with_blob_prefix() {
         const XML: &[u8] = br#"<?xml version="1.0" encoding="utf-8"?>
         <EnumerationResults ServiceEndpoint="https://sisuautomatedtest.blob.core.windows.net/" ContainerName="lowlatencyrequests">

--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -4,6 +4,7 @@ extern crate log;
 
 use azure_core::date;
 use azure_storage::prelude::*;
+use azure_storage_blobs::container::operations::ListBlobsResponse;
 use azure_storage_blobs::{blob::BlockListType, container::PublicAccess, prelude::*};
 use bytes::Bytes;
 use futures::StreamExt;
@@ -209,6 +210,56 @@ async fn put_and_get_block_list() {
     container.delete().await.unwrap();
 
     println!("container {} deleted!", container_name);
+}
+
+#[tokio::test]
+async fn put_block_list_and_list_files() {
+    let uuid = Uuid::new_v4();
+    let container_name = format!("sdkrust{}", uuid);
+    let name = format!("rustputblock{}.txt", uuid);
+
+    let blob_service = initialize();
+    let container = blob_service.container_client(&container_name);
+    let blob = container.blob_client(name.clone());
+
+    container
+        .create()
+        .public_access(PublicAccess::None)
+        .await
+        .expect("container already present");
+
+    let contents = vec![
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+    ];
+    let mut block_list = BlockList::default();
+    for content in contents {
+        let block_id = format!("sdkrustblock{}", Uuid::new_v4());
+        blob.put_block(block_id.clone(), Bytes::from(content))
+            .await
+            .unwrap_or_else(|e| panic!("Couldn't put block for content: {} - {}", content, e));
+        block_list
+            .blocks
+            .push(BlobBlockType::new_uncommitted(block_id));
+    }
+
+    blob.put_block_list(block_list).await.unwrap();
+
+    let response: ListBlobsResponse = container
+        .list_blobs()
+        .into_stream()
+        .next()
+        .await
+        .expect("stream failed")
+        .unwrap();
+
+    let blobs = response.blobs.blobs().collect::<Vec<_>>();
+
+    assert_eq!(1, blobs.len());
+    assert_eq!(&name, &blobs[0].name);
+
+    container.delete().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
Allow parsing list blobs response without ServerEncrypted tag, which is how Azurite responds when a blob is created by multi-block algorithm.

By default, it will assume this tag is false.

I wasn't able to test this using the e2e provided with my Azurite credentials. But I was able to test this issue independently, and I added a few tests to cover this situation. The payload in `deserde_azurite_without_server_encrypted` is a true payload that happened to me while listing blobs.

I'm not sure if it makes a difference, but this is how my container is setup:
`azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --loose`