### PR TITLE
Add None option to IndexingMode for Cosmos

### DIFF
--- a/sdk/data_cosmos/src/resources/collection/mod.rs
+++ b/sdk/data_cosmos/src/resources/collection/mod.rs
@@ -89,6 +89,8 @@ pub enum IndexingMode {
     Consistent,
     /// indexing occurs asynchronously during insertion, replacment or deletion of documents
     Lazy,
+    /// indexing is disabled on the container
+    None,
 }
 
 /// Path to be indexed


### PR DESCRIPTION
Add None option for IndexingMode from https://learn.microsoft.com/en-us/azure/cosmos-db/index-policy