### PR TITLE
remove unnecessary empty serde tag

### DIFF
--- a/services/autorust/openapi/src/autorest.rs
+++ b/services/autorust/openapi/src/autorest.rs
@@ -17,7 +17,6 @@ pub struct MsEnum {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde()]
 pub struct MsEnumValue {
     pub value: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This addresses an issue raised in #1246.  With this change and the aforementioned PR, the update to `syn` rebuilds the generated crates without issue.