### PR TITLE
cleanup azurite_workaround issues

### DIFF
--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -75,8 +75,14 @@ pub fn delete_type_permanent_from_headers(headers: &Headers) -> crate::Result<bo
 }
 
 #[cfg(feature = "azurite_workaround")]
-pub fn delete_type_permanent_from_headers(headers: &Headers) -> crate::Result<Option<bool>> {
-    headers.get_optional_as(&DELETE_TYPE_PERMANENT)
+pub fn delete_type_permanent_from_headers(headers: &Headers) -> crate::Result<bool> {
+    let result = headers.get_as(&DELETE_TYPE_PERMANENT);
+    if result.is_ok() {
+        result
+    } else {
+       log::warn!("Error receiving delete type permanent.  returning false");
+       Ok(false)
+    }
 }
 
 pub fn sequence_number_from_headers(headers: &Headers) -> crate::Result<u64> {

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -80,8 +80,8 @@ pub fn delete_type_permanent_from_headers(headers: &Headers) -> crate::Result<bo
     if result.is_ok() {
         result
     } else {
-       log::warn!("Error receiving delete type permanent.  returning false");
-       Ok(false)
+        log::warn!("Error receiving delete type permanent.  returning false");
+        Ok(false)
     }
 }
 

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -42,6 +42,5 @@ azure_identity = { path = "../identity", default-features = false }
 default = ["enable_reqwest"]
 test_e2e = []
 test_integration = []
-azurite_workaround = []
 enable_reqwest = ["azure_core/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]

--- a/sdk/storage_blobs/src/blob/operations/delete_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/delete_blob.rs
@@ -37,16 +37,8 @@ impl DeleteBlobBuilder {
     }
 }
 
-#[cfg(not(feature = "azurite_workaround"))]
 azure_storage::response_from_headers!(DeleteBlobResponse ,
     delete_type_permanent_from_headers => delete_type_permanent: bool,
-    request_id_from_headers => request_id: RequestId,
-    date_from_headers => date: OffsetDateTime
-);
-
-#[cfg(feature = "azurite_workaround")]
-azure_storage::response_from_headers!(DeleteBlobResponse ,
-    delete_type_permanent_from_headers => delete_type_permanent: Option<bool>,
     request_id_from_headers => request_id: RequestId,
     date_from_headers => date: OffsetDateTime
 );


### PR DESCRIPTION
1. This removes azurite_workaround feature from azure_storage crate, which isn't used
2. Removes alternate function signatures when using the azurite_workaround feature