### PR TITLE
propagate azurite_workaround when used

### DIFF
--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -39,7 +39,7 @@ mock_transport = { path = "../../eng/test/mock_transport" }
 default = ["enable_reqwest"]
 test_e2e = []
 test_integration = []
-azurite_workaround = []
+azurite_workaround = ["azure_core/azurite_workaround"]
 enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]
 enable_reqwest_rustls = [
   "azure_core/enable_reqwest_rustls",


### PR DESCRIPTION
When azurite_workaround is set in storage_blobs, it needs to be set in core or the functionality will not work as expected.