### PR TITLE
azure_mgmt_security - Disable preview tags so composite tags are built

### DIFF
--- a/services/mgmt/security/autorust.toml
+++ b/services/mgmt/security/autorust.toml
@@ -3,3 +3,4 @@ deny = [
     "package-2020-01-preview-only", # duplicate tag https://github.com/Azure/azure-rest-api-specs/pull/13828
     "package-2019-08-only", # defines start_time_utc param twice
   ]
+deny_contains_preview = true


### PR DESCRIPTION
This PR removes preview API versions for the azure_mgmt_security package. The current version of the autorust.toml will only generate the preview API's which are incremental and do not cover all API endpoints. The correct tag to use is probably `package-composite-v3` which will be built after this change.

Previous codegen output:
```
azure_mgmt_security (222)
  package-preview-2022-11
  package-preview-2022-08
  package-preview-2022-07
  package-preview-2022-05
  package-preview-2022-01
```

New codegen output
```
azure_mgmt_security (222)
  package-composite-v3
  package-composite-v2
  package-composite-v1
  package-2022-05
  package-2022-03
```

API spec: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/security/resource-manager/readme.md