### PR TITLE
Fix SAS token generation for directory-scoped access

### DIFF
--- a/sdk/storage/src/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/shared_access_signature/service_sas.rs
@@ -100,7 +100,7 @@ pub struct BlobSharedAccessSignature {
     identifier: Option<String>,
     ip: Option<String>,
     protocol: Option<SasProtocol>,
-    signed_directory_depth: Option<u32>, // sdd
+    signed_directory_depth: Option<usize>, // sdd
 }
 
 impl BlobSharedAccessSignature {
@@ -130,7 +130,7 @@ impl BlobSharedAccessSignature {
         identifier: String => Some(identifier),
         ip: String => Some(ip),
         protocol: SasProtocol => Some(protocol),
-        signed_directory_depth: u32 => Some(signed_directory_depth),
+        signed_directory_depth: usize => Some(signed_directory_depth),
     }
 
     fn sign(&self) -> String {
@@ -234,7 +234,7 @@ mod test {
             OffsetDateTime::UNIX_EPOCH + Duration::days(7),
             BlobSignedResource::Directory,
         )
-        .signed_directory_depth(2_u32)
+        .signed_directory_depth(2_usize)
         .token();
         // BlobSignedResource::Blob
         assert!(signed_token.contains("sr=d"));

--- a/sdk/storage/src/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/shared_access_signature/service_sas.rs
@@ -100,6 +100,7 @@ pub struct BlobSharedAccessSignature {
     identifier: Option<String>,
     ip: Option<String>,
     protocol: Option<SasProtocol>,
+    signed_directory_depth: Option<u32>, // sdd
 }
 
 impl BlobSharedAccessSignature {
@@ -120,6 +121,7 @@ impl BlobSharedAccessSignature {
             identifier: None,
             ip: None,
             protocol: None,
+            signed_directory_depth: None,
         }
     }
 
@@ -128,6 +130,7 @@ impl BlobSharedAccessSignature {
         identifier: String => Some(identifier),
         ip: String => Some(ip),
         protocol: SasProtocol => Some(protocol),
+        signed_directory_depth: u32 => Some(signed_directory_depth),
     }
 
     fn sign(&self) -> String {
@@ -177,6 +180,10 @@ impl SasToken for BlobSharedAccessSignature {
 
         if let Some(protocol) = &self.protocol {
             elements.push(format!("spr={protocol}"))
+        }
+
+        if let Some(signed_directory_depth) = &self.signed_directory_depth {
+            elements.push(format!("sdd={signed_directory_depth}"))
         }
 
         let sig = self.sign();


### PR DESCRIPTION
Directory scoped SAS tokens require `signedDirectoryDepth` field to work. This adds it as an optional element.

Docs say "The value of the sdd field must be a non-negative integer." so I went with a u32 assuming no one would need a higher directory depth than that. Is that a sensible assumption?

I also added some tests but they aren't particularly inspired so I am happy to change/remove them

Links:
About directory scoped access: https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#service-sas-support-for-directory-scoped-access
Directory depth field: https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#specify-the-directory-depth