### PR TITLE
Change cosmos PartitionKeyRange throughput_fraction to f32

### DIFF
--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -47,7 +47,7 @@ impl GetPartitionKeyRangesBuilder {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct GetPartitionKeyRangesResponse {
     pub rid: String,
     pub content_location: Option<String>,
@@ -111,7 +111,7 @@ impl GetPartitionKeyRangesResponse {
     }
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq, PartialOrd)]
 pub struct PartitionKeyRange {
     #[serde(rename = "_rid")]
     pub rid: String,

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -47,7 +47,7 @@ impl GetPartitionKeyRangesBuilder {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub struct GetPartitionKeyRangesResponse {
     pub rid: String,
     pub content_location: Option<String>,
@@ -111,7 +111,7 @@ impl GetPartitionKeyRangesResponse {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct PartitionKeyRange {
     #[serde(rename = "_rid")]
     pub rid: String,
@@ -126,7 +126,7 @@ pub struct PartitionKeyRange {
     pub rid_prefix: u64,
     pub _self: String,
     #[serde(rename = "throughputFraction")]
-    pub throughput_fraction: u64,
+    pub throughput_fraction: f32,
     pub status: String,
     // TODO: parents
     #[serde(rename = "_ts")]


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-sdk-for-rust/issues/1279

I couldn't find any documentation on the `throughputFraction` field (it doesn't appear in the swagger spec, and I couldn't find it in the online REST documentation).  However, the example response in the issue clearly shows that it is a floating point number.

I've changed the field type from `u64` to `f32` (should it be `f32` or `f64`?  I figured `f32` is sufficient).

This change has a side-effect in that Rust won't derive `Eq` or `Ord` for structs containing floats, due to the difficult nature of comparing floats.  I therefore had to remove these derivations from `PartitionKeyRange` and `GetPartitionKeyRangesResponse` to get the code to build.  I don't think this is a big issue - I think it is unlikely that users will want to directly compare these entire structs.