### PR TITLE
Add response headers to PeekLockResponse.

### DIFF
--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -23,9 +23,8 @@ hmac = "0.12"
 sha2 = "0.10"
 ring = "0.16"
 bytes = "1.0"
-serde = "1.0.163"
-serde_json = "1.0.96"
-
+serde = "1.0"
+serde_json = "1.0"
 [dev-dependencies]
 futures = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -16,13 +16,15 @@ edition = "2021"
 
 [dependencies]
 azure_core = { path = "../core", version = "0.12" }
-time = "0.3.10"
+time = { version = "0.3.10", features = ["serde-well-known"] }
 log = "0.4"
 url = "2.2"
 hmac = "0.12"
 sha2 = "0.10"
 ring = "0.16"
 bytes = "1.0"
+serde = "1.0.163"
+serde_json = "1.0.96"
 
 [dev-dependencies]
 futures = "0.3"

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -215,6 +215,11 @@ impl PeekLockResponse {
         self.broker_properties.clone()
     }
 
+    /// Get custom message headers from the message in the lock
+    pub fn custom_properties<T: TryFrom<headers::Headers>>(&self) -> Result<T, T::Error> {
+        self.headers.clone().try_into()
+    }
+
     /// Get the status of the peek
     pub fn status(&self) -> &StatusCode {
         &self.status

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -2,6 +2,8 @@ use azure_core::{
     base64, error::Error, headers, CollectedResponse, HttpClient, Method, Request, StatusCode, Url,
 };
 use ring::hmac;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 use std::time::Duration;
 use std::{ops::Add, sync::Arc};
 use time::OffsetDateTime;
@@ -169,6 +171,9 @@ async fn peek_lock_message2(
 
     let status = res.status();
     let headers = res.headers().clone();
+    let broker_properties = res
+        .headers()
+        .get_optional_as(&headers::HeaderName::from("brokerproperties"))?;
     let lock_location = headers
         .get_optional_string(&headers::LOCATION)
         .unwrap_or_default();
@@ -177,6 +182,7 @@ async fn peek_lock_message2(
     Ok(PeekLockResponse {
         body,
         headers,
+        broker_properties,
         lock_location,
         status,
         http_client: http_client.clone(),
@@ -189,6 +195,7 @@ async fn peek_lock_message2(
 pub struct PeekLockResponse {
     body: String,
     headers: headers::Headers,
+    broker_properties: Option<BrokerProperties>,
     lock_location: String,
     status: StatusCode,
     http_client: Arc<dyn HttpClient>,
@@ -202,9 +209,10 @@ impl PeekLockResponse {
         self.body.clone()
     }
 
-    /// Get the headers from the message in the lock
-    pub fn headers(&self) -> headers::Headers {
-        self.headers.clone()
+    /// Get the broker properties from the message in the lock
+    #[must_use]
+    pub fn broker_properties(&self) -> Option<BrokerProperties> {
+        self.broker_properties.clone()
     }
 
     /// Get the status of the peek
@@ -260,5 +268,30 @@ impl PeekLockResponse {
             .execute_request_check_status(&req)
             .await?;
         Ok(())
+    }
+}
+
+/// `BrokerProperties` object decoded from the message headers
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct BrokerProperties {
+    pub delivery_count: i32,
+    pub enqueued_sequence_number: i32,
+    #[serde(with = "time::serde::rfc2822")]
+    pub enqueued_time_utc: OffsetDateTime,
+    pub lock_token: String,
+    #[serde(with = "time::serde::rfc2822")]
+    pub locked_until_utc: OffsetDateTime,
+    pub message_id: String,
+    pub sequence_number: i32,
+    pub state: String,
+    pub time_to_live: i64,
+}
+
+impl FromStr for BrokerProperties {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -168,14 +168,15 @@ async fn peek_lock_message2(
     let res = http_client.execute_request(&req).await?;
 
     let status = res.status();
-    let lock_location = res
-        .headers()
+    let headers = res.headers().clone();
+    let lock_location = headers
         .get_optional_string(&headers::LOCATION)
         .unwrap_or_default();
     let body = res.into_body().collect_string().await?;
 
     Ok(PeekLockResponse {
         body,
+        headers,
         lock_location,
         status,
         http_client: http_client.clone(),
@@ -187,6 +188,7 @@ async fn peek_lock_message2(
 /// PeekLockResponse object that is returned by `peek_lock_message2`
 pub struct PeekLockResponse {
     body: String,
+    headers: headers::Headers,
     lock_location: String,
     status: StatusCode,
     http_client: Arc<dyn HttpClient>,
@@ -198,6 +200,11 @@ impl PeekLockResponse {
     /// Get the message in the lock
     pub fn body(&self) -> String {
         self.body.clone()
+    }
+
+    /// Get the headers from the message in the lock
+    pub fn headers(&self) -> headers::Headers {
+        self.headers.clone()
     }
 
     /// Get the status of the peek


### PR DESCRIPTION
Service Bus Queue messages can have custom properties set (additionally to the standard properties set by the broker). Those are [mapped to headers](https://learn.microsoft.com/en-us/rest/api/servicebus/introduction) in the rest API.

In order to get those values we need to include the Headers as part of the response.

