### PR TITLE
Log unrecongnized resource quota parts instead of returning an error

### DIFF
--- a/sdk/data_cosmos/src/resource_quota.rs
+++ b/sdk/data_cosmos/src/resource_quota.rs
@@ -80,12 +80,6 @@ pub(crate) fn resource_quotas_from_str(
             v.push(ResourceQuota::InteropUsers(parseu64(stripped)?));
         } else if let Some(stripped) = token.strip_prefix(AUTH_POLICY_ELEMENTS) {
             v.push(ResourceQuota::AuthPolicyElements(parseu64(stripped)?));
-        } else {
-            return Err(Error::with_message(ErrorKind::DataConversion, || {
-                format!(
-                    "resource quota has an unrecognized part - part: \"{token}\" full string: \"{full_string}\""
-                )
-            }));
         }
 
         trace!("v == {:#?}", v);


### PR DESCRIPTION
Fixes #1137

An alternate solution (or possible addition to this change) would be to capture the resource quota parts that were triggering the error. The parts in question are not useful to me and I'm not sure if they are generally useful so I didn't make that change.