### PR TITLE
security_keyvault: Fix continuation requests

### DIFF
--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault"
-version = "0.12.1"
+version = "0.12.0"
 authors = ["Microsoft Corp."]
 description = "Rust wrapper around Microsoft Azure REST APIs for Azure Key Vault"
 repository = "https://github.com/azure/azure-sdk-for-rust"

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_security_keyvault"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Microsoft Corp."]
 description = "Rust wrapper around Microsoft Azure REST APIs for Azure Key Vault"
 repository = "https://github.com/azure/azure-sdk-for-rust"

--- a/sdk/security_keyvault/src/clients/keyvault_client.rs
+++ b/sdk/security_keyvault/src/clients/keyvault_client.rs
@@ -75,7 +75,7 @@ impl KeyvaultClient {
         let dt = OffsetDateTime::now_utc();
         let time = date::to_rfc1123(&dt);
 
-        if url.query().is_some() && !url.query().unwrap().contains(API_VERSION_PARAM) {
+        if url.query().is_none() || !url.query().unwrap().contains(API_VERSION_PARAM) {
             url.set_query(Some(API_VERSION_PARAM));
         }
 

--- a/sdk/security_keyvault/src/clients/keyvault_client.rs
+++ b/sdk/security_keyvault/src/clients/keyvault_client.rs
@@ -75,7 +75,9 @@ impl KeyvaultClient {
         let dt = OffsetDateTime::now_utc();
         let time = date::to_rfc1123(&dt);
 
-        url.set_query(Some(API_VERSION_PARAM));
+        if url.query().is_some() && !url.query().unwrap().contains(API_VERSION_PARAM) {
+            url.set_query(Some(API_VERSION_PARAM));
+        }
 
         let mut request = Request::new(url, method);
         for (k, v) in headers {


### PR DESCRIPTION
The `set_query` function was overriding the query string when listing enough secrets to be Pageable, so the next_link query string was being replaced. This caused an infinite loop where the `ListSecretsBuilder` stream repeatedly returned the first 25 objects, never completing the subsequent paginated requests.

Please let me know if there are any other changes/suggestions.