### PR TITLE
actively avoid panic at runtime in keyvault crate

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/sdk/security_keyvault/src/keys/operations/decrypt.rs
+++ b/sdk/security_keyvault/src/keys/operations/decrypt.rs
@@ -28,8 +28,7 @@ impl DecryptBuilder {
 
             let algorithm = match self.decrypt_parameters.decrypt_parameters_encryption {
                 CryptographParamtersEncryption::Rsa(RsaEncryptionParameters { algorithm }) => {
-                    request_body
-                        .insert("alg".to_owned(), serde_json::to_value(&algorithm).unwrap());
+                    request_body.insert("alg".to_owned(), serde_json::to_value(&algorithm)?);
                     algorithm
                 }
                 CryptographParamtersEncryption::AesGcm(AesGcmEncryptionParameters {
@@ -38,15 +37,12 @@ impl DecryptBuilder {
                     authentication_tag,
                     additional_authenticated_data,
                 }) => {
+                    request_body.insert("alg".to_owned(), serde_json::to_value(&algorithm)?);
+                    request_body.insert("iv".to_owned(), serde_json::to_value(iv)?);
                     request_body
-                        .insert("alg".to_owned(), serde_json::to_value(&algorithm).unwrap());
-                    request_body.insert("iv".to_owned(), serde_json::to_value(iv).unwrap());
-                    request_body.insert(
-                        "tag".to_owned(),
-                        serde_json::to_value(authentication_tag).unwrap(),
-                    );
+                        .insert("tag".to_owned(), serde_json::to_value(authentication_tag)?);
                     if let Some(aad) = additional_authenticated_data {
-                        request_body.insert("aad".to_owned(), serde_json::to_value(aad).unwrap());
+                        request_body.insert("aad".to_owned(), serde_json::to_value(aad)?);
                     };
                     algorithm
                 }
@@ -54,9 +50,8 @@ impl DecryptBuilder {
                     algorithm,
                     iv,
                 }) => {
-                    request_body
-                        .insert("alg".to_owned(), serde_json::to_value(&algorithm).unwrap());
-                    request_body.insert("iv".to_owned(), serde_json::to_value(iv).unwrap());
+                    request_body.insert("alg".to_owned(), serde_json::to_value(&algorithm)?);
+                    request_body.insert("iv".to_owned(), serde_json::to_value(iv)?);
                     algorithm
                 }
             };

--- a/sdk/security_keyvault/src/keys/operations/encrypt.rs
+++ b/sdk/security_keyvault/src/keys/operations/encrypt.rs
@@ -28,8 +28,7 @@ impl EncryptBuilder {
 
             let algorithm = match self.encrypt_parameters.encrypt_parameters_encryption {
                 CryptographParamtersEncryption::Rsa(RsaEncryptionParameters { algorithm }) => {
-                    request_body
-                        .insert("alg".to_owned(), serde_json::to_value(&algorithm).unwrap());
+                    request_body.insert("alg".to_owned(), serde_json::to_value(&algorithm)?);
                     algorithm
                 }
                 CryptographParamtersEncryption::AesGcm(AesGcmEncryptionParameters {
@@ -38,15 +37,12 @@ impl EncryptBuilder {
                     authentication_tag,
                     additional_authenticated_data,
                 }) => {
+                    request_body.insert("alg".to_owned(), serde_json::to_value(&algorithm)?);
+                    request_body.insert("iv".to_owned(), serde_json::to_value(iv)?);
                     request_body
-                        .insert("alg".to_owned(), serde_json::to_value(&algorithm).unwrap());
-                    request_body.insert("iv".to_owned(), serde_json::to_value(iv).unwrap());
-                    request_body.insert(
-                        "tag".to_owned(),
-                        serde_json::to_value(authentication_tag).unwrap(),
-                    );
+                        .insert("tag".to_owned(), serde_json::to_value(authentication_tag)?);
                     if let Some(aad) = additional_authenticated_data {
-                        request_body.insert("aad".to_owned(), serde_json::to_value(aad).unwrap());
+                        request_body.insert("aad".to_owned(), serde_json::to_value(aad)?);
                     };
                     algorithm
                 }
@@ -54,9 +50,8 @@ impl EncryptBuilder {
                     algorithm,
                     iv,
                 }) => {
-                    request_body
-                        .insert("alg".to_owned(), serde_json::to_value(&algorithm).unwrap());
-                    request_body.insert("iv".to_owned(), serde_json::to_value(iv).unwrap());
+                    request_body.insert("alg".to_owned(), serde_json::to_value(&algorithm)?);
+                    request_body.insert("iv".to_owned(), serde_json::to_value(iv)?);
                     algorithm
                 }
             };

--- a/sdk/security_keyvault/src/lib.rs
+++ b/sdk/security_keyvault/src/lib.rs
@@ -4,6 +4,8 @@
 //! information on the project, and an overview of other crates, please refer to
 //! [our GitHub repository](https://github.com/azure/azure-sdk-for-rust).
 
+#![deny(clippy::unwrap_used, clippy::expect_used)]
+
 #[macro_use]
 extern crate azure_core;
 


### PR DESCRIPTION
This PR updates a handful of operations to not use `unwrap` in the operations and adds clippy configuration to deny the use of `unwrap` or `expect` (with the exception of unit tests) in the crate moving forward.

This also adds a top level clippy.toml that explicitly allows `unwrap` and `expect` when used within `#[cfg(test)]` blocks.