### PR TITLE
remove rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.65.0"
-components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Instead of specifying the toolchain via `rust-toolchain.toml`, our CI pipelines specify the intended toolchain.  For contributor's purposes, this is out of sync with what we verify against for PRs and has contributed to confusion over time.

For users of the SDK, this isn't applied.  For those, we specify the toolchain needed via setting MSRV in the `Cargo.toml` for the specific crate.