### PR TITLE
Add blob committed block count for append blobs.

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -364,3 +364,4 @@ pub const WWW_AUTHENTICATE: HeaderName = HeaderName::from_static("www-authentica
 pub const ENCRYPTION_ALGORITHM: HeaderName = HeaderName::from_static("x-ms-encryption-algorithm");
 pub const ENCRYPTION_KEY: HeaderName = HeaderName::from_static("x-ms-encryption-key");
 pub const ENCRYPTION_KEY_SHA256: HeaderName = HeaderName::from_static("x-ms-encryption-key-sha256");
+pub const BLOB_COMMITTED_BLOCK_COUNT: HeaderName = HeaderName::from_static("x-ms-blob-committed-block-count");

--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -364,4 +364,5 @@ pub const WWW_AUTHENTICATE: HeaderName = HeaderName::from_static("www-authentica
 pub const ENCRYPTION_ALGORITHM: HeaderName = HeaderName::from_static("x-ms-encryption-algorithm");
 pub const ENCRYPTION_KEY: HeaderName = HeaderName::from_static("x-ms-encryption-key");
 pub const ENCRYPTION_KEY_SHA256: HeaderName = HeaderName::from_static("x-ms-encryption-key-sha256");
-pub const BLOB_COMMITTED_BLOCK_COUNT: HeaderName = HeaderName::from_static("x-ms-blob-committed-block-count");
+pub const BLOB_COMMITTED_BLOCK_COUNT: HeaderName =
+    HeaderName::from_static("x-ms-blob-committed-block-count");

--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -173,6 +173,7 @@ pub struct BlobProperties {
         rename = "Expiry-Time"
     )]
     pub expiry_time: Option<OffsetDateTime>,
+    pub blob_committed_block_count: Option<u64>,
     #[serde(flatten)]
     extra: HashMap<String, String>, // For debug purposes, should be compiled out in the future
 }
@@ -219,6 +220,7 @@ impl Blob {
             .and_then(|cct| date::parse_rfc1123(cct).ok());
         let copy_status_description = h.get_optional_string(&headers::COPY_STATUS_DESCRIPTION);
         let server_encrypted = h.get_as(&headers::SERVER_ENCRYPTED)?;
+        let blob_committed_block_count = h.get_optional_as(&headers::BLOB_COMMITTED_BLOCK_COUNT)?;
 
         let mut metadata = HashMap::new();
         for (name, value) in h.iter() {
@@ -279,6 +281,7 @@ impl Blob {
                 tag_count: None,                    // TODO
                 rehydrate_priority: None,           // TODO
                 expiry_time: None,
+                blob_committed_block_count,
                 extra: HashMap::new(),
             },
             metadata,


### PR DESCRIPTION
Add `x-ms-blob-committed-block-count` response header for use with append blobs.