### PR TITLE
Do not add timeout header if it has already been added

### DIFF
--- a/sdk/core/src/request_options/timeout.rs
+++ b/sdk/core/src/request_options/timeout.rs
@@ -12,6 +12,10 @@ impl Timeout {
 
 impl AppendToUrlQuery for Timeout {
     fn append_to_url_query(&self, url: &mut url::Url) {
+        if url.query_pairs().any(|(k, _)| k == "timeout") {
+            return;
+        }
+
         url.query_pairs_mut()
             .append_pair("timeout", &format!("{}", self.0.as_secs()));
     }


### PR DESCRIPTION
When an operation is retried, Azure SDK For Rust will re-add parameters to the query url -- this results in multiple values for the same parameter key and, at least in the case of the timeout value, will cause Azure to error out with an invalid value response (http error 400)