### PR TITLE
Fix: Authorization Policy does applies SAS token twice on retry requests 

### DIFF
--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -52,6 +52,7 @@ impl Policy for AuthorizationPolicy {
                 request
             }
             StorageCredentials::SASToken(query_pairs) => {
+                // Ensure the signature param is not already present
                 if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
                     request
                         .url_mut()
@@ -224,4 +225,78 @@ fn lexy_sort<'a>(
         .collect::<Vec<_>>();
     values.sort_unstable();
     values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use azure_core::{BytesStream, Response};
+
+    #[derive(Debug, Clone)]
+    struct AssertSigHeaderUniqueMockPolicy;
+
+    #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+    impl Policy for AssertSigHeaderUniqueMockPolicy {
+        async fn send(
+            &self,
+            _ctx: &Context,
+            request: &mut Request,
+            _next: &[Arc<dyn Policy>],
+        ) -> PolicyResult {
+            let sig_header_count = request
+                .url()
+                .query_pairs()
+                .filter(|param| param.0 == "sig")
+                .count();
+            assert_eq!(sig_header_count, 1);
+
+            Ok(Response::new(
+                azure_core::StatusCode::Accepted,
+                Headers::new(),
+                Box::pin(BytesStream::new(vec![])),
+            ))
+        }
+    }
+
+    const SAMPLE_SAS_TOKEN: &str = "sp=r&st=1970-01-01T00:00:00Z&se=1970-01-01T00:00:00Z&spr=https&sv=1970-01-01&sr=c&sig=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    #[tokio::test]
+    async fn authorization_policy_applies_sas_token() {
+        let ctx = Context::default();
+        let storage_credentials = StorageCredentials::sas_token(SAMPLE_SAS_TOKEN).unwrap();
+        let auth_policy = AuthorizationPolicy::new(storage_credentials);
+        let mut request = Request::new(Url::parse("https://example.com").unwrap(), Method::Get);
+
+        let assert_sig_header_unique_mock_policy = Arc::new(AssertSigHeaderUniqueMockPolicy);
+
+        auth_policy
+            .send(&ctx, &mut request, &[assert_sig_header_unique_mock_policy])
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn authorization_policy_with_sas_token_does_not_apply_twice() {
+        let ctx = Context::default();
+        let storage_credentials = StorageCredentials::sas_token(SAMPLE_SAS_TOKEN).unwrap();
+        let auth_policy = AuthorizationPolicy::new(storage_credentials);
+        let mut request = Request::new(Url::parse("https://example.com").unwrap(), Method::Get);
+
+        let assert_sig_header_unique_mock_policy = Arc::new(AssertSigHeaderUniqueMockPolicy);
+
+        // apply policy twice
+        auth_policy
+            .send(
+                &ctx,
+                &mut request,
+                &[assert_sig_header_unique_mock_policy.clone()],
+            )
+            .await
+            .unwrap();
+        auth_policy
+            .send(&ctx, &mut request, &[assert_sig_header_unique_mock_policy])
+            .await
+            .unwrap();
+    }
 }

--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -52,11 +52,12 @@ impl Policy for AuthorizationPolicy {
                 request
             }
             StorageCredentials::SASToken(query_pairs) => {
-                request
-                    .url_mut()
-                    .query_pairs_mut()
-                    .extend_pairs(query_pairs);
-
+                if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
+                    request
+                        .url_mut()
+                        .query_pairs_mut()
+                        .extend_pairs(query_pairs);
+                }
                 request
             }
             StorageCredentials::BearerToken(token) => {


### PR DESCRIPTION
# Background 

I encountered a bug where `put_block` operations would sporadically fail with http status code `403 - Forbidden` when authenticating using a SAS token.
 
Detailed of the error were:
`"AuthenticationFailed"`
`"Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature."`
`<AuthenticationErrorDetail>Signature fields not well formed.</AuthenticationErrorDetail>`

Upon investigating I narrowed it down to the Authorization Policy applying SAS token params multiple times for retry requests.

Simple way to diagnose this issues when using `reqwest` as the url library is to run Env Logger filter with `"azure_core::http_client::reqwest=debug"` which will cause `reqwest` to print the full URL for all requests.


# Details

I used the same approach as the Access Key policy already uses and simply check the presence of `sig` param in the path. This doesn't feel like a very foolproof solution but it fixes the issue for now.

It seems that the python SDK suffered from a similar issues and they chose the same approach for resolving it https://github.com/Azure/azure-storage-python/pull/304

The tests I added feel a little awkward because I had to mock the policy setup. If there is an already existing mock that would allow me to test this easily I am happy to update the PR!

I don't believe this should be an issue for header based authentication since `insert_header` would override an existing header if it was present 