### PR TITLE
add `md5` feature to storage_blobs tests

### DIFF
--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -1,4 +1,4 @@
-#![cfg(all(test, feature = "test_e2e"))]
+#![cfg(all(test, feature = "test_e2e", feature = "md5"))]
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
the `md5` feature is used in the integration test, this ensures it's enabled for the test to build