### PR TITLE
Implement Cosmos AAD authentication

### DIFF
--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -140,7 +140,7 @@ fn generate_resource_link(request: &Request) -> String {
 
 /// The `CosmosDB` authorization can either be:
 /// - "primary": one of the two service-level tokens
-/// - "resource: e.g. a single database
+/// - "resource": e.g. a single database
 /// - "aad": Azure Active Directory token
 /// In the "primary" case the signature must be constructed by signing the HTTP method,
 /// resource type, resource link (the relative URI) and the current time.
@@ -193,9 +193,7 @@ async fn generate_authorization(
 fn scope_from_url(url: &Url) -> String {
     let scheme = url.scheme();
     let hostname = url.host_str().unwrap();
-    // TODO: Investigate why this did not work in testing...
-    //return format!("{scheme}://{hostname}/.default");
-    return format!("{scheme}://{hostname}");
+    format!("{scheme}://{hostname}")
 }
 
 /// This function generates a valid authorization string, according to the documentation.

--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -193,7 +193,9 @@ async fn generate_authorization(
 fn scope_from_url(url: &Url) -> String {
     let scheme = url.scheme();
     let hostname = url.host_str().unwrap();
-    return format!("{scheme}://{hostname}/.default");
+    // TODO: Investigate why this did not work in testing...
+    //return format!("{scheme}://{hostname}/.default");
+    return format!("{scheme}://{hostname}");
 }
 
 /// This function generates a valid authorization string, according to the documentation.
@@ -385,6 +387,6 @@ mon, 01 jan 1900 01:00:00 gmt
         let scope = scope_from_url(
             &azure_core::Url::parse("https://.documents.azure.com/dbs/test_db/colls").unwrap(),
         );
-        assert_eq!(scope, "https://.documents.azure.com/.default");
+        assert_eq!(scope, "https://.documents.azure.com");
     }
 }

--- a/sdk/data_cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/authorization_token.rs
@@ -20,21 +20,6 @@ pub enum AuthorizationToken {
     TokenCredential(Arc<dyn TokenCredential>),
 }
 
-impl PartialEq for AuthorizationToken {
-    fn eq(&self, other: &Self) -> bool {
-        use AuthorizationToken::*;
-        match (self, other) {
-            (Primary(a), Primary(b)) => a == b,
-            (Resource(a), Resource(b)) => a == b,
-            // Consider two token credentials equal if they point to the same object.
-            (TokenCredential(a), TokenCredential(b)) => Arc::ptr_eq(a, b),
-            _ => false,
-        }
-    }
-}
-
-impl Eq for AuthorizationToken {}
-
 impl AuthorizationToken {
     /// Create a primary `AuthorizationToken` from base64 encoded data
     ///

--- a/sdk/data_cosmos/src/resources/permission/permission.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission.rs
@@ -10,7 +10,8 @@ use std::borrow::Cow;
 /// access to a specific resource. It is used to manage access to collections, documents,
 /// attachments, stored procedures, triggers, and user-defined functions for a particular user.
 /// You can learn more about permissions [here](https://docs.microsoft.com/rest/api/cosmos-db/permissions).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+//#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Permission {
     ///  The unique name that identifies the permission.
     pub id: String,

--- a/sdk/data_cosmos/src/resources/permission/permission_response.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission_response.rs
@@ -5,7 +5,7 @@ use azure_core::Response as HttpResponse;
 
 use super::Permission;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct PermissionResponse {
     pub permission: Permission,
     pub charge: f64,

--- a/sdk/data_cosmos/src/resources/permission/permission_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission_token.rs
@@ -30,6 +30,11 @@ impl std::fmt::Display for PermissionToken {
         let (permission_type, signature) = match &self.token {
             AuthorizationToken::Resource(s) => ("resource", Cow::Borrowed(s)),
             AuthorizationToken::Primary(s) => ("master", Cow::Owned(base64::encode(s))),
+            // @@@TODO: Do we need to support TokenCredential for PermissionToken?
+            // It is painful to implement because we can't easily get the
+            // token string from the TokenCredential (the function is async and fallible,
+            // and fmt() is neither!).
+            AuthorizationToken::TokenCredential(_s) => ("aad", Cow::Owned("xxx".to_string())),
         };
         write!(
             f,

--- a/sdk/data_cosmos/src/resources/permission/permission_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission_token.rs
@@ -9,11 +9,24 @@ const SIGNATURE_PREFIX: &str = "sig=";
 ///
 /// This field is a url encoded string with the type of permission, the signature, and the version (currently only 1.0)
 /// This type is a wrapper around `AuthorizationToken`.
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(try_from = "String")]
 pub struct PermissionToken {
     pub(crate) token: AuthorizationToken,
 }
+
+impl PartialEq for PermissionToken {
+    fn eq(&self, other: &Self) -> bool {
+        use AuthorizationToken::*;
+        match (&self.token, &other.token) {
+            (Primary(a), Primary(b)) => a == b,
+            (Resource(a), Resource(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for PermissionToken {}
 
 impl serde::Serialize for PermissionToken {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -30,11 +43,9 @@ impl std::fmt::Display for PermissionToken {
         let (permission_type, signature) = match &self.token {
             AuthorizationToken::Resource(s) => ("resource", Cow::Borrowed(s)),
             AuthorizationToken::Primary(s) => ("master", Cow::Owned(base64::encode(s))),
-            // @@@TODO: Do we need to support TokenCredential for PermissionToken?
-            // It is painful to implement because we can't easily get the
-            // token string from the TokenCredential (the function is async and fallible,
-            // and fmt() is neither!).
-            AuthorizationToken::TokenCredential(_s) => ("aad", Cow::Owned("xxx".to_string())),
+            AuthorizationToken::TokenCredential(_) => {
+                panic!("TokenCredential not supported for PermissionToken")
+            }
         };
         write!(
             f,


### PR DESCRIPTION
Add support for Cosmos AAD authentication via `TokenCredential`:
- Extended `AuthorizationToken` enum to add `TokenCredential` variant
- Added new `AuthorizationToken::from_token_credential(...)` constructor
- Removed `PartialEq` and `Eq` implementations from `AuthorizationToken`, as it is difficult to compare `dyn TokenCredential` instances, and I'm going to assert that users probably don't need to compare `AuthorizationToken`s.
- Updated `generate_authorization(...)` to be `async` and return a `Result<...>`, as it now has to be able to call `token_credential.get_token(...)`
- Did not implement `TokenCredential` support for `PermissionToken`s, as it doesn't seem to make sense to support AAD for these.

Added new example `document_entries_aad.rs` to demonstrate and test the new function (I've tested it and it works).

Fixes: https://github.com/Azure/azure-sdk-for-rust/issues/1230