### PR TITLE
use default-features rather than default_features

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -34,7 +34,7 @@ reqwest = { version = "0.11", features = ["json"], default-features = false }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.10"
 serde_test = "1"
-azure_security_keyvault = { path = "../security_keyvault", default_features = false }
+azure_security_keyvault = { path = "../security_keyvault", default-features = false }
 
 [features]
 default = ["development", "enable_reqwest"]

--- a/sdk/iot_deviceupdate/Cargo.toml
+++ b/sdk/iot_deviceupdate/Cargo.toml
@@ -14,16 +14,16 @@ edition = "2021"
 publish = false
 
 [dependencies]
-reqwest = { version = "0.11", features = ["json"], default_features = false }
+reqwest = { version = "0.11", features = ["json"], default-features = false }
 time = "0.3.10"
 const_format = "0.2"
 serde_json = "1.0"
 url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
-azure_core = { path = "../core", version = "0.14", default_features = false }
+azure_core = { path = "../core", version = "0.14", default-features = false }
 log = "0.4"
-azure_identity = { path = "../identity", version = "0.14", default_features = false }
+azure_identity = { path = "../identity", version = "0.14", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/azure_iot_hub"
 
 [dependencies]
 async-trait = "0.1"
-azure_core = { path = "../core", version = "0.14", default_features = false }
+azure_core = { path = "../core", version = "0.14", default-features = false }
 bytes = "1.0"
 time = "0.3.10"
 hmac = "0.12"

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["api-bindings"]
 edition = "2021"
 
 [dependencies]
-azure_core = { path = "../core", version = "0.14", default_features = false }
+azure_core = { path = "../core", version = "0.14", default-features = false }
 time = "0.3.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -30,7 +30,7 @@ url = "2.2"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.10"
-azure_identity = { path = "../identity", default_features = false }
+azure_identity = { path = "../identity", default-features = false }
 reqwest = "0.11"
 mock_transport = { path = "../../eng/test/mock_transport" }
 md5 = "0.7"

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.14" }
-azure_storage = { path = "../storage", version = "0.14", default_features = false }
+azure_storage = { path = "../storage", version = "0.14", default-features = false }
 bytes = "1.0"
 time = "0.3.10"
 futures = "0.3"
@@ -27,7 +27,7 @@ uuid = { version = "1.0", features = ["v4"] }
 url = "2.2"
 
 [dev-dependencies]
-azure_identity = { path = "../identity", default_features = false }
+azure_identity = { path = "../identity", default-features = false }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 mock_transport = { path = "../../eng/test/mock_transport" }
 


### PR DESCRIPTION
According to the [cargo reference manual](https://doc.rust-lang.org/cargo/reference/features.html#the-default-feature), we should use `default-features`.  While `default_features` works with `cargo`, it can cause issues with other tools such as `cargo-edit`.