### PR TITLE
Public response when no response type defined

### DIFF
--- a/services/autorust/openapi/CHANGELOG.md
+++ b/services/autorust/openapi/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.1
+* public Response internals when no response type
+
 # 0.2
 * forked as autorust_openapi
 * removed OpenAPI v3 support. Use openapiv3 crate


### PR DESCRIPTION
Fixes #1348. We want access to the internal response in all cases. It was skipped when a response type wasn't defined in the schema.

Now the generated code includes the following `impl Response` when there are no headers:

```rust
    // azure-sdk-for-rust/services/mgmt/compute/src/package_2022_11_01/mod.rs
    pub mod power_off {
        use super::models;
        pub struct Response(azure_core::Response);
        impl Response {
            pub fn into_raw_response(self) -> azure_core::Response {
                self.0
            }
            pub fn as_raw_response(&self) -> &azure_core::Response {
                &self.0
            }
        }
        impl From<Response> for azure_core::Response {
            fn from(rsp: Response) -> Self {
                rsp.into_raw_response()
            }
        }
        impl AsRef<azure_core::Response> for Response {
            fn as_ref(&self) -> &azure_core::Response {
                self.as_raw_response()
            }
        }
    }
```

and if there are headers, they are included as well:

```rust
    // azure-sdk-for-rust/services/mgmt/alertsmanagement/src/package_preview_2021_08/mod.rs
    pub mod delete {
        use super::models;
        pub struct Response(azure_core::Response);
        impl Response {
            pub fn into_raw_response(self) -> azure_core::Response {
                self.0
            }
            pub fn as_raw_response(&self) -> &azure_core::Response {
                &self.0
            }
            pub fn headers(&self) -> Headers {
                Headers(self.0.headers())
            }
        }
        impl From<Response> for azure_core::Response {
            fn from(rsp: Response) -> Self {
                rsp.into_raw_response()
            }
        }
        impl AsRef<azure_core::Response> for Response {
            fn as_ref(&self) -> &azure_core::Response {
                self.as_raw_response()
            }
        }
        pub struct Headers<'a>(&'a azure_core::headers::Headers);
        impl<'a> Headers<'a> {
            #[doc = "Service generated Request ID."]
            pub fn x_ms_request_id(&self) -> azure_core::Result<&str> {
                self.0.get_str(&azure_core::headers::HeaderName::from_static("x-ms-request-id"))
            }
        }
    }
```

I updated the changelog, even though I'm not generating a new version. I was able to generate updated SDKs locally after adding `package-2023-09-01-preview` to [/svc/devcenter/autorust.toml](https://github.com/Azure/azure-sdk-for-rust/blob/main/services/svc/devcenter/autorust.toml) and removing the `quota` spec.

Let me know if there's something I can do to help with publishing or if I missed anything. I plan to generate the compute for myself and use a patched version.