### PR TITLE
use newer workspace resolver

### DIFF
--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -272,3 +272,5 @@ members = [
   "svc/videoanalyzer",
   "svc/webpubsub",
 ]
+
+resolver = "2"

--- a/services/autorust/codegen/templates/WorkspaceCargo.toml.jinja
+++ b/services/autorust/codegen/templates/WorkspaceCargo.toml.jinja
@@ -4,3 +4,5 @@ members = [
   "{{dir}}",
 {%- endfor %}
 ]
+
+resolver = "2"


### PR DESCRIPTION
As we use `edition=2021` in a handful of places, we should align the resolver in the Cargo.toml for the workspace to use the same resolver.

Ref: https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html