### PR TITLE
use `unwrap_or_default()` rather than `.unwrap_or_else(|| "".to_string())`

### DIFF
--- a/sdk/storage/src/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/shared_access_signature/service_sas.rs
@@ -144,9 +144,7 @@ impl BlobSharedAccessSignature {
                 .unwrap_or(&"".to_string())
                 .to_string(),
             self.ip.as_ref().unwrap_or(&"".to_string()).to_string(),
-            self.protocol
-                .map(|x| x.to_string())
-                .unwrap_or_else(|| "".to_string()),
+            self.protocol.map(|x| x.to_string()).unwrap_or_default(),
             SERVICE_SAS_VERSION.to_string(),
             self.resource.to_string(),
             "".to_string(), // snapshot time


### PR DESCRIPTION
Rather than implement our own `Default`, use `unwrap_or_default`