### PR TITLE
add support to generate documentation for setters

### DIFF
--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -25,11 +25,12 @@
 /// ```
 #[macro_export]
 macro_rules! setters {
-    (@single $name:ident : $typ:ty => $transform:expr) => {
+    (@single $(#[$meta:meta])* $name:ident : $typ:ty => $transform:expr) => {
         #[allow(clippy::redundant_field_names)]
         #[allow(clippy::needless_update)]
         #[allow(missing_docs)]
         #[must_use]
+        $(#[$meta])*
         pub fn $name<P: ::std::convert::Into<$typ>>(self, $name: P) -> Self {
             let $name: $typ = $name.into();
             Self  {
@@ -41,12 +42,12 @@ macro_rules! setters {
     // Terminal condition
     (@recurse) => {};
     // Recurse without transform
-    (@recurse $name:ident : $typ:ty, $($tokens:tt)*) => {
-        $crate::setters! { @recurse $name: $typ => $name, $($tokens)* }
+    (@recurse $(#[$meta:meta])* $name:ident : $typ:ty, $($tokens:tt)*) => {
+        $crate::setters! { @recurse $(#[$meta])* $name: $typ => $name, $($tokens)* }
     };
     // Recurse with transform
-    (@recurse $name:ident : $typ:ty => $transform:expr, $($tokens:tt)*) => {
-        $crate::setters! { @single $name : $typ => $transform }
+    (@recurse $(#[$meta:meta])* $name:ident : $typ:ty => $transform:expr, $($tokens:tt)*) => {
+        $crate::setters! { @single $(#[$meta])* $name : $typ => $transform }
         $crate::setters! { @recurse $($tokens)* }
     };
     ($($tokens:tt)*) => {

--- a/sdk/core/src/options/mod.rs
+++ b/sdk/core/src/options/mod.rs
@@ -249,8 +249,11 @@ pub struct FixedRetryOptions {
 
 impl FixedRetryOptions {
     setters! {
+        #[doc = "Set the delay between retry attempts."]
         delay: Duration => delay,
+        #[doc = "Set the maximum number of retry attempts before giving up."]
         max_retries: u32 => max_retries,
+        #[doc = "Set the maximum permissible elapsed time since starting to retry."]
         max_total_elapsed: Duration => max_total_elapsed,
     }
 }
@@ -268,12 +271,13 @@ impl Default for FixedRetryOptions {
 /// Telemetry options.
 #[derive(Clone, Debug, Default)]
 pub struct TelemetryOptions {
-    /// Optional application ID to telemeter.
+    /// Optional application ID to telemetery.
     pub(crate) application_id: Option<String>,
 }
 
 impl TelemetryOptions {
     setters! {
+        #[doc = "Set the application ID to telemetery."]
         application_id: String => Some(application_id),
     }
 }

--- a/sdk/core/src/options/mod.rs
+++ b/sdk/core/src/options/mod.rs
@@ -271,13 +271,13 @@ impl Default for FixedRetryOptions {
 /// Telemetry options.
 #[derive(Clone, Debug, Default)]
 pub struct TelemetryOptions {
-    /// Optional application ID to telemetery.
+    /// Optional application ID to telemetry.
     pub(crate) application_id: Option<String>,
 }
 
 impl TelemetryOptions {
     setters! {
-        #[doc = "Set the application ID to telemetery."]
+        #[doc = "Set the application ID to telemetry."]
         application_id: String => Some(application_id),
     }
 }


### PR DESCRIPTION
The generated documentation for methods generated by `setters!` do not include documentation.

Consider the documentation for [FixedRetryOptions implementations](https://docs.rs/azure_core/latest/azure_core/struct.FixedRetryOptions.html#implementations).  The methods `delay`, `max_retries`, and `max_total_elapsed` are undocumented.

This change allows the ability to use `#[doc = "msg"]` style meta options, which allows for writing documentation for the generated methods.   