### PR TITLE
only reset streams when retrying

### DIFF
--- a/sdk/core/src/http_client/reqwest.rs
+++ b/sdk/core/src/http_client/reqwest.rs
@@ -24,14 +24,9 @@ impl HttpClient for ::reqwest::Client {
 
         let reqwest_request = match body {
             Body::Bytes(bytes) => req.body(bytes).build(),
-            Body::SeekableStream(mut seekable_stream) => {
-                seekable_stream.reset().await.context(
-                    ErrorKind::Other,
-                    "failed to reset body stream when building request",
-                )?;
-                req.body(::reqwest::Body::wrap_stream(seekable_stream))
-                    .build()
-            }
+            Body::SeekableStream(seekable_stream) => req
+                .body(::reqwest::Body::wrap_stream(seekable_stream))
+                .build(),
         }
         .context(ErrorKind::Other, "failed to build `reqwest` request")?;
 

--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorKind, HttpError};
+use crate::error::{Error, ErrorKind, HttpError, ResultExt};
 use crate::policies::{Policy, PolicyResult, Request};
 use crate::sleep::sleep;
 use crate::{Context, StatusCode};
@@ -60,6 +60,12 @@ where
         let mut start = None;
 
         loop {
+            if retry_count > 0 {
+                request.body.reset().await.context(
+                    ErrorKind::Other,
+                    "failed to reset body stream before retrying request",
+                )?;
+            }
             let result = next[0].send(ctx, request, &next[1..]).await;
             // only start keeping track of time after the first request is made
             let start = start.get_or_insert_with(OffsetDateTime::now_utc);

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -24,6 +24,13 @@ impl Body {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    pub(crate) async fn reset(&mut self) -> crate::Result<()> {
+        match self {
+            Body::Bytes(_) => Ok(()),
+            Body::SeekableStream(stream) => stream.reset().await,
+        }
+    }
 }
 
 impl<B> From<B> for Body


### PR DESCRIPTION
As is, we always `reset` streams before uploading.  For `SeekableStream` implementations, this includes a `seek`.

This should only occur prior to retrying upon error, rather than before every request.