### PR TITLE
allow creating LeaseId from Uuid

### DIFF
--- a/sdk/core/src/request_options/lease.rs
+++ b/sdk/core/src/request_options/lease.rs
@@ -11,6 +11,12 @@ impl std::fmt::Display for LeaseId {
     }
 }
 
+impl From<Uuid> for LeaseId {
+    fn from(value: Uuid) -> Self {
+        Self(value)
+    }
+}
+
 impl std::str::FromStr for LeaseId {
     type Err = <Uuid as FromStr>::Err;
 


### PR DESCRIPTION
The documentation of for LeaseId states it must be in the format of a UUID.

> x-ms-proposed-lease-id: <ID>	Optional for acquire, and required for change. Proposed lease ID, in a GUID string format. Blob Storage returns 400 (Invalid request) if the proposed lease ID isn't in the correct format. See Guid Constructor (String) for a list of valid formats.

Right now, users that have a lease id as a Uuid must convert it into a string, then from_str the result.

This allows directly converting to a LeaseId from a Uuid.

ref: https://learn.microsoft.com/en-us/rest/api/storageservices/lease-container?tabs=azure-ad