### PR TITLE
Wrap DeviceCodePhaseOneResponse::stream response in `Pin<Box>>`

### DIFF
--- a/sdk/identity/examples/device_code_flow.rs
+++ b/sdk/identity/examples/device_code_flow.rs
@@ -1,41 +1,41 @@
-use azure_core::new_http_client;
+use azure_core::{
+    error::{Error, ErrorKind},
+    new_http_client,
+};
 use azure_identity::device_code_flow::start;
-use futures::{future::ready, StreamExt};
-use oauth2::ClientId;
-use std::{env, error::Error};
+use futures::StreamExt;
+use std::env::var;
 
 const SCOPES: &[&str; 2] = &[".default", "offline_access"];
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
-    let tenant_id = env::var("TENANT_ID").expect("Missing TENANT_ID environment variable.");
-    let client_id =
-        ClientId::new(env::var("CLIENT_ID").expect("Missing CLIENT_ID environment variable."));
+async fn main() -> azure_core::Result<()> {
+    let tenant_id = var("TENANT_ID").expect("Missing TENANT_ID environment variable");
+    let client_id = var("CLIENT_ID").expect("Missing CLIENT_ID environment variable");
 
     let client = new_http_client();
 
-    match start(client.clone(), tenant_id, client_id.as_str(), SCOPES).await {
-        Ok(response) => {
-            println!("{:?}", response.message());
+    let response = start(client, tenant_id, &client_id, SCOPES).await?;
+    println!("{}", response.message());
 
-            response
-                .stream()
-                .for_each(|result| {
-                    match result {
-                        Ok(value) => {
-                            println!("access token: {:?}", value.access_token().secret());
-                            match value.refresh_token() {
-                                None => {}
-                                Some(tk) => println!("refresh token: {:?}", tk.secret()),
-                            }
-                        }
-                        Err(_) => println!("waiting..."),
-                    }
-                    ready(())
-                })
-                .await
+    let mut stream = response.stream();
+    let authorization = loop {
+        match stream.next().await {
+            Some(Ok(authorization)) => break authorization,
+            Some(Err(_)) => continue,
+            None => {
+                return Err(Error::with_message(ErrorKind::Credential, || {
+                    "device flow stream ended unexpectedly"
+                }))
+            }
         }
-        Err(err) => println!("error: {:?}", err),
+    };
+
+    println!("access token: {:?}", authorization.access_token().secret());
+
+    match authorization.refresh_token() {
+        None => {}
+        Some(tk) => println!("refresh token: {:?}", tk.secret()),
     }
 
     Ok(())

--- a/sdk/storage_blobs/examples/blob_device_code_flow.rs
+++ b/sdk/storage_blobs/examples/blob_device_code_flow.rs
@@ -1,15 +1,16 @@
+use azure_core::{Error, error::ErrorKind};
 use azure_identity::{device_code_flow, refresh_token};
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
-use std::env;
+use std::env::{var, args};
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    let client_id = env::var("CLIENT_ID").expect("Missing CLIENT_ID environment variable.");
-    let tenant_id = env::var("TENANT_ID").expect("Missing TENANT_ID environment variable.");
+    let client_id = var("CLIENT_ID").expect("Missing CLIENT_ID environment variable.");
+    let tenant_id = var("TENANT_ID").expect("Missing TENANT_ID environment variable.");
 
-    let storage_account_name = std::env::args()
+    let storage_account_name = args()
         .nth(1)
         .expect("please specify the storage account name as first command line parameter");
 
@@ -42,36 +43,25 @@ async fn main() -> azure_core::Result<()> {
     // return, besides errors, a success meaning either
     // Success or Pending. The loop will continue until we
     // get either a Success or an error.
-    let mut stream = Box::pin(device_code_flow.stream());
-
+    let mut stream = device_code_flow.stream();
     let authorization = loop {
-        let response = stream.next().await.expect("device code flow stream failed");
-        if let Ok(auth) = response {
-            break auth;
+        match stream.next().await {
+            Some(Ok(authorization)) => break authorization,
+            Some(Err(_)) => continue,
+            None => {
+                return Err(Error::with_message(ErrorKind::Credential, || {
+                    "device flow stream ended unexpectedly"
+                }))
+            }
         }
     };
-
-    println!("{authorization:?}");
-
-    println!(
-        "\nReceived valid bearer token: {}",
-        &authorization.access_token().secret()
-    );
-
-    if let Some(refresh_token) = authorization.refresh_token().as_ref() {
-        println!("Received valid refresh token: {}", &refresh_token.secret());
-    }
-
-    // we can now spend the access token in other crates. In
-    // this example we are creating an Azure Storage client
-    // using the access token.
-
-    let storage_credentials =
-        StorageCredentials::BearerToken(authorization.access_token().secret().to_owned());
+    
+    // we can now spend the access token in other crates. In this example we are
+    // creating an Azure Storage client using the access token.
+    let storage_credentials = StorageCredentials::bearer_token(authorization.access_token().secret());
     let blob_service_client = BlobServiceClient::new(storage_account_name, storage_credentials);
 
-    // now we enumerate the containers in the
-    // specified storage account.
+    // now we enumerate the containers in the specified storage account.
     let containers = blob_service_client
         .list_containers()
         .into_stream()
@@ -80,7 +70,9 @@ async fn main() -> azure_core::Result<()> {
         .expect("stream failed")?;
     println!("\nList containers completed succesfully: {containers:?}");
 
-    // now let's refresh the token, if available
+    // If we want to use the refresh token to get a new access token (such as if
+    // we wanted to bump the expiry window on the token), we can do the
+    // following
     if let Some(refresh_token) = authorization.refresh_token() {
         let refreshed_token =
             refresh_token::exchange(http_client, &tenant_id, &client_id, None, refresh_token)

--- a/sdk/storage_blobs/examples/blob_device_code_flow.rs
+++ b/sdk/storage_blobs/examples/blob_device_code_flow.rs
@@ -1,9 +1,9 @@
-use azure_core::{Error, error::ErrorKind};
+use azure_core::{error::ErrorKind, Error};
 use azure_identity::{device_code_flow, refresh_token};
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::stream::StreamExt;
-use std::env::{var, args};
+use std::env::{args, var};
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
@@ -55,10 +55,11 @@ async fn main() -> azure_core::Result<()> {
             }
         }
     };
-    
+
     // we can now spend the access token in other crates. In this example we are
     // creating an Azure Storage client using the access token.
-    let storage_credentials = StorageCredentials::bearer_token(authorization.access_token().secret());
+    let storage_credentials =
+        StorageCredentials::bearer_token(authorization.access_token().secret());
     let blob_service_client = BlobServiceClient::new(storage_account_name, storage_credentials);
 
     // now we enumerate the containers in the specified storage account.


### PR DESCRIPTION
In order to use the stream, it needs to be a Pinned box.

This change aligns the code with other places in the SDK that return Streams, where we handle pinning the stream for the caller.