### PR TITLE
Simplify example blob_05_default_credential.rs

### DIFF
--- a/sdk/storage_blobs/examples/blob_05_default_credential.rs
+++ b/sdk/storage_blobs/examples/blob_05_default_credential.rs
@@ -8,7 +8,6 @@ use azure_core::{
     error::{ErrorKind, ResultExt},
 };
 use azure_identity::DefaultAzureCredential;
-use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 
 #[tokio::main]

--- a/sdk/storage_blobs/examples/blob_05_default_credential.rs
+++ b/sdk/storage_blobs/examples/blob_05_default_credential.rs
@@ -26,8 +26,7 @@ async fn main() -> azure_core::Result<()> {
         .nth(3)
         .expect("please specify the blob name as third command line parameter");
 
-    let storage_credentials: Arc<dyn TokenCredential> =
-        Arc::<azure_identity::DefaultAzureCredential>::default();
+    let storage_credentials: Arc<dyn TokenCredential> = Arc::new(DefaultAzureCredential::default());
     let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob);

--- a/sdk/storage_blobs/examples/blob_05_default_credential.rs
+++ b/sdk/storage_blobs/examples/blob_05_default_credential.rs
@@ -1,6 +1,8 @@
 #[macro_use]
 extern crate log;
 
+use std::sync::Arc;
+
 use azure_core::{
     auth::TokenCredential,
     error::{ErrorKind, ResultExt},
@@ -24,11 +26,8 @@ async fn main() -> azure_core::Result<()> {
         .nth(3)
         .expect("please specify the blob name as third command line parameter");
 
-    let bearer_token = DefaultAzureCredential::default()
-        .get_token("https://storage.azure.com/")
-        .await?;
-
-    let storage_credentials = StorageCredentials::BearerToken(bearer_token.token.secret().into());
+    let storage_credentials: Arc<dyn TokenCredential> =
+        Arc::<azure_identity::DefaultAzureCredential>::default();
     let blob_client = BlobServiceClient::new(account, storage_credentials)
         .container_client(&container)
         .blob_client(&blob);


### PR DESCRIPTION
Updated to use the to DefaultAzureCredential directly rather than fetching a token manually.