### PR TITLE
split wasm checks into distinct job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v2
-      - run: eng/scripts/check_wasmsh ${{ matrix.build }}
+      - run: eng/scripts/check_wasm.sh ${{ matrix.build }}
 
   test-services:
     name: Services Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,27 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: eng/scripts/sdk_tests.sh ${{ matrix.build }}
 
+  test-wasm:
+    name: WASM Tests
+    runs-on: ubuntu-20.04
+    needs:
+      - msrv
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      matrix:
+        build:
+          - stable
+          - ${{ needs.msrv.outputs.msrv }}
+        experimental:
+          - false
+        include:
+          - build: nightly
+            experimental: true
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
+      - run: eng/scripts/check_wasmsh ${{ matrix.build }}
+
   test-services:
     name: Services Tests
     runs-on: ubuntu-20.04

--- a/eng/scripts/check_wasm.sh
+++ b/eng/scripts/check_wasm.sh
@@ -6,8 +6,7 @@ cd $(dirname ${BASH_SOURCE[0]})/../../
 BUILD=${1:-stable}
 
 rustup update --no-self-update ${BUILD}
+rustup target add --toolchain ${BUILD} wasm32-unknown-unknown
 
 export RUSTFLAGS="-Dwarnings"
-cargo +${BUILD} check -p azure_core --no-default-features
-cargo +${BUILD} check --all --features azurite_workaround
-cargo +${BUILD} test --all
+cargo +${BUILD} check --target=wasm32-unknown-unknown --no-default-features


### PR DESCRIPTION
Builds are inconsistently failing due to space issues on the build VMs.  Splitting the WASM target checks will reduce the amount of data in `target`, which help both build and cache sizes.