### PR TITLE
make NoopClient feature dependant

### DIFF
--- a/sdk/core/src/http_client/mod.rs
+++ b/sdk/core/src/http_client/mod.rs
@@ -1,26 +1,29 @@
+#[cfg(not(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls")))]
 mod noop;
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 mod reqwest;
 
+#[cfg(not(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls")))]
+use self::noop::NoopClient;
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
-pub use self::reqwest::*;
-pub use noop::*;
-
-use std::sync::Arc;
-
-/// Construct a new `HttpClient`
-pub fn new_http_client() -> Arc<dyn HttpClient> {
-    #[allow(unused)]
-    let http_client: Arc<dyn HttpClient> = Arc::new(NoopClient);
-    #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
-    let http_client = new_reqwest_client();
-    http_client
-}
-
+use self::reqwest::*;
 use crate::error::ErrorKind;
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::Serialize;
+use std::sync::Arc;
+
+/// Construct a new `HttpClient`
+pub fn new_http_client() -> Arc<dyn HttpClient> {
+    #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
+    {
+        new_reqwest_client()
+    }
+    #[cfg(not(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls")))]
+    {
+        Arc::new(NoopClient)
+    }
+}
 
 /// An HTTP client which can send requests.
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]


### PR DESCRIPTION
Instead of always compiling in `NoopClient`, make it something that's only available if the `reqwest` features were not enabled.