### PR TITLE
address XML parsing issues in generated crates

### DIFF
--- a/sdk/core/src/xml.rs
+++ b/sdk/core/src/xml.rs
@@ -1,4 +1,5 @@
 use crate::error::{ErrorKind, ResultExt};
+pub use quick_xml::serde_helpers::text_content;
 use quick_xml::{
     de::{from_reader, from_str},
     se::to_string,

--- a/services/autorust/codegen/src/codegen.rs
+++ b/services/autorust/codegen/src/codegen.rs
@@ -73,6 +73,10 @@ impl<'a> CodeGen<'a> {
     pub fn should_box_property(&self, prop_nm: &PropertyName) -> bool {
         self.box_properties.contains(prop_nm)
     }
+
+    pub fn has_xml(&self) -> bool {
+        self.spec.has_xml() || self.spec.operations().map_or(false, |f| f.iter().any(|op| op.has_xml()))
+    }
 }
 
 fn id_models() -> Ident {

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -804,15 +804,7 @@ fn create_struct(cg: &CodeGen, schema: &SchemaGen, struct_name: &str, pageable: 
                         impl azure_core::Continuable for #struct_name_code {
                             type Continuation = String;
                             fn continuation(&self) -> Option<Self::Continuation> {
-                                if let Some(value) = self.#field_name.clone() {
-                                    if value.is_empty() {
-                                        None
-                                    } else {
-                                        Some(value)
-                                    }
-                                } else {
-                                    None
-                                }
+                                self.#field_name.clone().filter(|value| !value.is_empty())
                             }
                         }
                     };

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -723,7 +723,7 @@ fn create_struct(cg: &CodeGen, schema: &SchemaGen, struct_name: &str, pageable: 
         if property.schema.is_local_enum() {
             if lowercase_workaround {
                 serde_attrs.push(quote! { deserialize_with = "case_insensitive_deserialize"});
-            } else {
+            } else if cg.has_xml() {
                 serde_attrs.push(quote! { with = "azure_core::xml::text_content"});
             }
         }

--- a/services/autorust/codegen/src/gen.rs
+++ b/services/autorust/codegen/src/gen.rs
@@ -1,7 +1,7 @@
 use crate::{
     autorust_toml, cargo_toml, io, lib_rs,
     readme_md::{self, ReadmeMd},
-    CrateConfig, Error, Result, RunConfig, SpecReadme, WebOperation,
+    CrateConfig, Error, Result, RunConfig, SpecReadme,
 };
 use std::{collections::HashMap, fs};
 
@@ -72,12 +72,7 @@ pub fn gen_crate(package_name: &str, spec: &SpecReadme, run_config: &RunConfig, 
         versions.sort_unstable();
         api_version_totals.insert(tag.name(), versions.len());
         api_versions.insert(tag.name(), versions.iter().map(|v| format!("`{v}`")).collect::<Vec<_>>().join(", "));
-        if !has_xml {
-            has_xml = cg.spec.has_xml()
-        }
-        if !has_xml {
-            has_xml = operations.iter().any(WebOperation::has_xml);
-        }
+        has_xml = cg.has_xml();
     }
 
     let default_tag_name = if let Some(name) = package_config.default_tag() {

--- a/services/svc/blobstorage/data/list_containers.txt
+++ b/services/svc/blobstorage/data/list_containers.txt
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<EnumerationResults ServiceEndpoint="https://bmcrustsdktest.blob.core.windows.net/">
+  <Containers>
+    <Container>
+      <Name>backup</Name>
+      <Properties>
+        <Last-Modified>Tue, 12 Sep 2023 18:18:57 GMT</Last-Modified>
+        <Etag>"0x8DBB3BCBABC4FE8"</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
+        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
+        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
+        <HasLegalHold>false</HasLegalHold>
+        <ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
+      </Properties>
+    </Container>
+    <Container>
+      <Name>test1</Name>
+      <Properties>
+        <Last-Modified>Wed, 06 Sep 2023 20:56:23 GMT</Last-Modified>
+        <Etag>"0x8DBAF1BBAB64687"</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
+        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
+        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
+        <HasLegalHold>false</HasLegalHold>
+        <ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
+      </Properties>
+    </Container>
+    <Container>
+      <Name>test2</Name>
+      <Properties>
+        <Last-Modified>Thu, 07 Sep 2023 16:38:36 GMT</Last-Modified>
+        <Etag>"0x8DBAFC0E2337475"</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
+        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
+        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
+        <HasLegalHold>false</HasLegalHold>
+        <ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
+      </Properties>
+    </Container>
+    <Container>
+      <Name>test3</Name>
+      <Properties>
+        <Last-Modified>Thu, 07 Sep 2023 16:38:54 GMT</Last-Modified>
+        <Etag>"0x8DBAFC0ECD27F8F"</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
+        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
+        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
+        <HasLegalHold>false</HasLegalHold>
+        <ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
+      </Properties>
+    </Container>
+    <Container>
+      <Name>test4</Name>
+      <Properties>
+        <Last-Modified>Thu, 07 Sep 2023 16:41:52 GMT</Last-Modified>
+        <Etag>"0x8DBAFC156F3AE0D"</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
+        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
+        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
+        <HasLegalHold>false</HasLegalHold>
+        <ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
+      </Properties>
+    </Container>
+    <Container>
+      <Name>test5</Name>
+      <Properties>
+        <Last-Modified>Tue, 12 Sep 2023 18:07:11 GMT</Last-Modified>
+        <Etag>"0x8DBB3BB15F4B48F"</Etag>
+        <LeaseStatus>unlocked</LeaseStatus>
+        <LeaseState>available</LeaseState>
+        <DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
+        <DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
+        <HasImmutabilityPolicy>false</HasImmutabilityPolicy>
+        <HasLegalHold>false</HasLegalHold>
+        <ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
+      </Properties>
+    </Container>
+  </Containers>
+  <NextMarker>/bmcrustsdktest/test1</NextMarker>
+</EnumerationResults>

--- a/services/svc/blobstorage/examples/list_containers.rs
+++ b/services/svc/blobstorage/examples/list_containers.rs
@@ -7,32 +7,30 @@ https://docs.microsoft.com/cli/azure/storage/container?view=azure-cli-latest#az-
 */
 
 use azure_identity::AzureCliCredential;
+use azure_svc_blobstorage::Client;
 use futures::stream::StreamExt;
 use std::sync::Arc;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> azure_core::Result<()> {
+    env_logger::init();
+
     let account_name = std::env::args().nth(1).expect("please specify storage account");
 
     let endpoint = format!("https://{account_name}.blob.core.windows.net");
     let scopes = &["https://storage.azure.com/"];
     let credential = Arc::new(AzureCliCredential::new());
-    let client = azure_svc_blobstorage::Client::builder(credential)
-        .endpoint(endpoint)
-        .scopes(scopes)
-        .build();
+    let client = Client::builder(credential).endpoint(endpoint).scopes(scopes).build();
 
-    let mut count = 0;
-    let mut pages = client.service_client().list_containers_segment().into_stream();
-    while let Some(Ok(page)) = pages.next().await {
+    let mut pages = client.service_client().list_containers_segment().maxresults(1).into_stream();
+    while let Some(page) = pages.next().await {
+        let page = page?;
         if let Some(containers) = page.containers {
-            count += containers.items.len();
             for container in containers.items {
                 println!("{}", container.name);
             }
         }
     }
-    println!("# of containers {count}");
 
     Ok(())
 }

--- a/services/svc/blobstorage/src/package_2020_12/models.rs
+++ b/services/svc/blobstorage/src/package_2020_12/models.rs
@@ -1220,15 +1220,7 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1267,15 +1259,7 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1311,15 +1295,7 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListContainersSegmentResponse {
@@ -1428,15 +1404,7 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl PageList {

--- a/services/svc/blobstorage/src/package_2020_12/models.rs
+++ b/services/svc/blobstorage/src/package_2020_12/models.rs
@@ -236,7 +236,7 @@ impl BlobItemInternal {
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobMetadata {
-    #[serde(rename = "Encrypted", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encrypted", default, skip_serializing_if = "Option::is_none")]
     pub encrypted: Option<String>,
 }
 impl BlobMetadata {
@@ -280,17 +280,42 @@ pub struct BlobPropertiesInternal {
     pub cache_control: Option<String>,
     #[serde(rename = "x-ms-blob-sequence-number", default, skip_serializing_if = "Option::is_none")]
     pub x_ms_blob_sequence_number: Option<i64>,
-    #[serde(rename = "BlobType", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "BlobType",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub blob_type: Option<blob_properties_internal::BlobType>,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
     #[serde(rename = "CopyId", default, skip_serializing_if = "Option::is_none")]
     pub copy_id: Option<String>,
-    #[serde(rename = "CopyStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "CopyStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub copy_status: Option<CopyStatus>,
     #[serde(rename = "CopySource", default, skip_serializing_if = "Option::is_none")]
     pub copy_source: Option<String>,
@@ -310,11 +335,21 @@ pub struct BlobPropertiesInternal {
     pub deleted_time: Option<time::OffsetDateTime>,
     #[serde(rename = "RemainingRetentionDays", default, skip_serializing_if = "Option::is_none")]
     pub remaining_retention_days: Option<i64>,
-    #[serde(rename = "AccessTier", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "AccessTier",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub access_tier: Option<AccessTier>,
     #[serde(rename = "AccessTierInferred", default, skip_serializing_if = "Option::is_none")]
     pub access_tier_inferred: Option<bool>,
-    #[serde(rename = "ArchiveStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ArchiveStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub archive_status: Option<ArchiveStatus>,
     #[serde(rename = "CustomerProvidedKeySha256", default, skip_serializing_if = "Option::is_none")]
     pub customer_provided_key_sha256: Option<String>,
@@ -330,13 +365,23 @@ pub struct BlobPropertiesInternal {
     #[serde(rename = "Sealed", default, skip_serializing_if = "Option::is_none")]
     pub sealed: Option<bool>,
     #[doc = "If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High and Standard."]
-    #[serde(rename = "RehydratePriority", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "RehydratePriority",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub rehydrate_priority: Option<RehydratePriority>,
     #[serde(rename = "LastAccessTime", default, with = "azure_core::date::rfc1123::option")]
     pub last_access_time: Option<time::OffsetDateTime>,
     #[serde(rename = "ImmutabilityPolicyUntilDate", default, with = "azure_core::date::rfc1123::option")]
     pub immutability_policy_until_date: Option<time::OffsetDateTime>,
-    #[serde(rename = "ImmutabilityPolicyMode", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ImmutabilityPolicyMode",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub immutability_policy_mode: Option<blob_properties_internal::ImmutabilityPolicyMode>,
     #[serde(rename = "LegalHold", default, skip_serializing_if = "Option::is_none")]
     pub legal_hold: Option<bool>,
@@ -554,13 +599,33 @@ pub struct ContainerProperties {
     pub last_modified: time::OffsetDateTime,
     #[serde(rename = "Etag")]
     pub etag: String,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
-    #[serde(rename = "PublicAccess", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "PublicAccess",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub public_access: Option<PublicAccessType>,
     #[serde(rename = "HasImmutabilityPolicy", default, skip_serializing_if = "Option::is_none")]
     pub has_immutability_policy: Option<bool>,
@@ -993,7 +1058,7 @@ impl FilterBlobItem {
 #[doc = "The result of a Filter Blobs API call"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FilterBlobSegment {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Where")]
     pub where_: String,
@@ -1024,7 +1089,7 @@ pub mod filter_blob_segment {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GeoReplication {
     #[doc = "The status of the secondary location"]
-    #[serde(rename = "Status")]
+    #[serde(rename = "Status", with = "azure_core::xml::text_content")]
     pub status: geo_replication::Status,
     #[doc = "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads."]
     #[serde(rename = "LastSyncTime", with = "azure_core::date::rfc1123")]
@@ -1137,9 +1202,9 @@ pub enum LeaseStatus {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsFlatSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1155,7 +1220,15 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1174,9 +1247,9 @@ impl ListBlobsFlatSegmentResponse {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsHierarchySegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1194,7 +1267,15 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1214,7 +1295,7 @@ impl ListBlobsHierarchySegmentResponse {
 #[doc = "An enumeration of containers"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListContainersSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1230,7 +1311,15 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListContainersSegmentResponse {
@@ -1339,7 +1428,15 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl PageList {
@@ -1408,7 +1505,7 @@ impl Serialize for PublicAccessType {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryFormat {
     #[doc = "The quick query format type."]
-    #[serde(rename = "Type")]
+    #[serde(rename = "Type", with = "azure_core::xml::text_content")]
     pub type_: QueryType,
     #[doc = "Groups the settings used for interpreting the blob data if the blob is delimited text formatted."]
     #[serde(rename = "DelimitedTextConfiguration", default, skip_serializing_if = "Option::is_none")]
@@ -1438,7 +1535,7 @@ impl QueryFormat {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryRequest {
     #[doc = "Required. The type of the provided query expression."]
-    #[serde(rename = "QueryType")]
+    #[serde(rename = "QueryType", with = "azure_core::xml::text_content")]
     pub query_type: query_request::QueryType,
     #[doc = "The query expression in SQL. The maximum size of the query expression is 256KiB."]
     #[serde(rename = "Expression")]

--- a/services/svc/blobstorage/src/package_2021_02/models.rs
+++ b/services/svc/blobstorage/src/package_2021_02/models.rs
@@ -236,7 +236,7 @@ impl BlobItemInternal {
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobMetadata {
-    #[serde(rename = "Encrypted", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encrypted", default, skip_serializing_if = "Option::is_none")]
     pub encrypted: Option<String>,
 }
 impl BlobMetadata {
@@ -247,7 +247,7 @@ impl BlobMetadata {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobName {
     #[doc = "Indicates if the blob name is encoded."]
-    #[serde(rename = "Encoded", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encoded", default, skip_serializing_if = "Option::is_none")]
     pub encoded: Option<bool>,
     #[doc = "The name of the blob."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -294,17 +294,42 @@ pub struct BlobPropertiesInternal {
     pub cache_control: Option<String>,
     #[serde(rename = "x-ms-blob-sequence-number", default, skip_serializing_if = "Option::is_none")]
     pub x_ms_blob_sequence_number: Option<i64>,
-    #[serde(rename = "BlobType", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "BlobType",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub blob_type: Option<blob_properties_internal::BlobType>,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
     #[serde(rename = "CopyId", default, skip_serializing_if = "Option::is_none")]
     pub copy_id: Option<String>,
-    #[serde(rename = "CopyStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "CopyStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub copy_status: Option<CopyStatus>,
     #[serde(rename = "CopySource", default, skip_serializing_if = "Option::is_none")]
     pub copy_source: Option<String>,
@@ -324,11 +349,21 @@ pub struct BlobPropertiesInternal {
     pub deleted_time: Option<time::OffsetDateTime>,
     #[serde(rename = "RemainingRetentionDays", default, skip_serializing_if = "Option::is_none")]
     pub remaining_retention_days: Option<i64>,
-    #[serde(rename = "AccessTier", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "AccessTier",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub access_tier: Option<AccessTier>,
     #[serde(rename = "AccessTierInferred", default, skip_serializing_if = "Option::is_none")]
     pub access_tier_inferred: Option<bool>,
-    #[serde(rename = "ArchiveStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ArchiveStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub archive_status: Option<ArchiveStatus>,
     #[serde(rename = "CustomerProvidedKeySha256", default, skip_serializing_if = "Option::is_none")]
     pub customer_provided_key_sha256: Option<String>,
@@ -344,13 +379,23 @@ pub struct BlobPropertiesInternal {
     #[serde(rename = "Sealed", default, skip_serializing_if = "Option::is_none")]
     pub sealed: Option<bool>,
     #[doc = "If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High and Standard."]
-    #[serde(rename = "RehydratePriority", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "RehydratePriority",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub rehydrate_priority: Option<RehydratePriority>,
     #[serde(rename = "LastAccessTime", default, with = "azure_core::date::rfc1123::option")]
     pub last_access_time: Option<time::OffsetDateTime>,
     #[serde(rename = "ImmutabilityPolicyUntilDate", default, with = "azure_core::date::rfc1123::option")]
     pub immutability_policy_until_date: Option<time::OffsetDateTime>,
-    #[serde(rename = "ImmutabilityPolicyMode", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ImmutabilityPolicyMode",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub immutability_policy_mode: Option<blob_properties_internal::ImmutabilityPolicyMode>,
     #[serde(rename = "LegalHold", default, skip_serializing_if = "Option::is_none")]
     pub legal_hold: Option<bool>,
@@ -568,13 +613,33 @@ pub struct ContainerProperties {
     pub last_modified: time::OffsetDateTime,
     #[serde(rename = "Etag")]
     pub etag: String,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
-    #[serde(rename = "PublicAccess", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "PublicAccess",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub public_access: Option<PublicAccessType>,
     #[serde(rename = "HasImmutabilityPolicy", default, skip_serializing_if = "Option::is_none")]
     pub has_immutability_policy: Option<bool>,
@@ -1007,7 +1072,7 @@ impl FilterBlobItem {
 #[doc = "The result of a Filter Blobs API call"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FilterBlobSegment {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Where")]
     pub where_: String,
@@ -1038,7 +1103,7 @@ pub mod filter_blob_segment {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GeoReplication {
     #[doc = "The status of the secondary location"]
-    #[serde(rename = "Status")]
+    #[serde(rename = "Status", with = "azure_core::xml::text_content")]
     pub status: geo_replication::Status,
     #[doc = "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads."]
     #[serde(rename = "LastSyncTime", with = "azure_core::date::rfc1123")]
@@ -1151,9 +1216,9 @@ pub enum LeaseStatus {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsFlatSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1169,7 +1234,15 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1188,9 +1261,9 @@ impl ListBlobsFlatSegmentResponse {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsHierarchySegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1208,7 +1281,15 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1228,7 +1309,7 @@ impl ListBlobsHierarchySegmentResponse {
 #[doc = "An enumeration of containers"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListContainersSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1244,7 +1325,15 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListContainersSegmentResponse {
@@ -1353,7 +1442,15 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl PageList {
@@ -1422,7 +1519,7 @@ impl Serialize for PublicAccessType {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryFormat {
     #[doc = "The quick query format type."]
-    #[serde(rename = "Type")]
+    #[serde(rename = "Type", with = "azure_core::xml::text_content")]
     pub type_: QueryType,
     #[doc = "Groups the settings used for interpreting the blob data if the blob is delimited text formatted."]
     #[serde(rename = "DelimitedTextConfiguration", default, skip_serializing_if = "Option::is_none")]
@@ -1452,7 +1549,7 @@ impl QueryFormat {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryRequest {
     #[doc = "Required. The type of the provided query expression."]
-    #[serde(rename = "QueryType")]
+    #[serde(rename = "QueryType", with = "azure_core::xml::text_content")]
     pub query_type: query_request::QueryType,
     #[doc = "The query expression in SQL. The maximum size of the query expression is 256KiB."]
     #[serde(rename = "Expression")]

--- a/services/svc/blobstorage/src/package_2021_02/models.rs
+++ b/services/svc/blobstorage/src/package_2021_02/models.rs
@@ -1234,15 +1234,7 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1281,15 +1273,7 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1325,15 +1309,7 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListContainersSegmentResponse {
@@ -1442,15 +1418,7 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl PageList {

--- a/services/svc/blobstorage/src/package_2021_04/models.rs
+++ b/services/svc/blobstorage/src/package_2021_04/models.rs
@@ -236,7 +236,7 @@ impl BlobItemInternal {
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobMetadata {
-    #[serde(rename = "Encrypted", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encrypted", default, skip_serializing_if = "Option::is_none")]
     pub encrypted: Option<String>,
 }
 impl BlobMetadata {
@@ -247,7 +247,7 @@ impl BlobMetadata {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobName {
     #[doc = "Indicates if the blob name is encoded."]
-    #[serde(rename = "Encoded", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encoded", default, skip_serializing_if = "Option::is_none")]
     pub encoded: Option<bool>,
     #[doc = "The name of the blob."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -294,17 +294,42 @@ pub struct BlobPropertiesInternal {
     pub cache_control: Option<String>,
     #[serde(rename = "x-ms-blob-sequence-number", default, skip_serializing_if = "Option::is_none")]
     pub x_ms_blob_sequence_number: Option<i64>,
-    #[serde(rename = "BlobType", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "BlobType",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub blob_type: Option<blob_properties_internal::BlobType>,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
     #[serde(rename = "CopyId", default, skip_serializing_if = "Option::is_none")]
     pub copy_id: Option<String>,
-    #[serde(rename = "CopyStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "CopyStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub copy_status: Option<CopyStatus>,
     #[serde(rename = "CopySource", default, skip_serializing_if = "Option::is_none")]
     pub copy_source: Option<String>,
@@ -324,11 +349,21 @@ pub struct BlobPropertiesInternal {
     pub deleted_time: Option<time::OffsetDateTime>,
     #[serde(rename = "RemainingRetentionDays", default, skip_serializing_if = "Option::is_none")]
     pub remaining_retention_days: Option<i64>,
-    #[serde(rename = "AccessTier", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "AccessTier",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub access_tier: Option<AccessTier>,
     #[serde(rename = "AccessTierInferred", default, skip_serializing_if = "Option::is_none")]
     pub access_tier_inferred: Option<bool>,
-    #[serde(rename = "ArchiveStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ArchiveStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub archive_status: Option<ArchiveStatus>,
     #[serde(rename = "CustomerProvidedKeySha256", default, skip_serializing_if = "Option::is_none")]
     pub customer_provided_key_sha256: Option<String>,
@@ -344,13 +379,23 @@ pub struct BlobPropertiesInternal {
     #[serde(rename = "Sealed", default, skip_serializing_if = "Option::is_none")]
     pub sealed: Option<bool>,
     #[doc = "If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High and Standard."]
-    #[serde(rename = "RehydratePriority", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "RehydratePriority",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub rehydrate_priority: Option<RehydratePriority>,
     #[serde(rename = "LastAccessTime", default, with = "azure_core::date::rfc1123::option")]
     pub last_access_time: Option<time::OffsetDateTime>,
     #[serde(rename = "ImmutabilityPolicyUntilDate", default, with = "azure_core::date::rfc1123::option")]
     pub immutability_policy_until_date: Option<time::OffsetDateTime>,
-    #[serde(rename = "ImmutabilityPolicyMode", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ImmutabilityPolicyMode",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub immutability_policy_mode: Option<blob_properties_internal::ImmutabilityPolicyMode>,
     #[serde(rename = "LegalHold", default, skip_serializing_if = "Option::is_none")]
     pub legal_hold: Option<bool>,
@@ -568,13 +613,33 @@ pub struct ContainerProperties {
     pub last_modified: time::OffsetDateTime,
     #[serde(rename = "Etag")]
     pub etag: String,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
-    #[serde(rename = "PublicAccess", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "PublicAccess",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub public_access: Option<PublicAccessType>,
     #[serde(rename = "HasImmutabilityPolicy", default, skip_serializing_if = "Option::is_none")]
     pub has_immutability_policy: Option<bool>,
@@ -1007,7 +1072,7 @@ impl FilterBlobItem {
 #[doc = "The result of a Filter Blobs API call"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FilterBlobSegment {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Where")]
     pub where_: String,
@@ -1038,7 +1103,7 @@ pub mod filter_blob_segment {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GeoReplication {
     #[doc = "The status of the secondary location"]
-    #[serde(rename = "Status")]
+    #[serde(rename = "Status", with = "azure_core::xml::text_content")]
     pub status: geo_replication::Status,
     #[doc = "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads."]
     #[serde(rename = "LastSyncTime", with = "azure_core::date::rfc1123")]
@@ -1151,9 +1216,9 @@ pub enum LeaseStatus {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsFlatSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1169,7 +1234,15 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1188,9 +1261,9 @@ impl ListBlobsFlatSegmentResponse {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsHierarchySegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1208,7 +1281,15 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1228,7 +1309,7 @@ impl ListBlobsHierarchySegmentResponse {
 #[doc = "An enumeration of containers"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListContainersSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1244,7 +1325,15 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListContainersSegmentResponse {
@@ -1353,7 +1442,15 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl PageList {
@@ -1422,7 +1519,7 @@ impl Serialize for PublicAccessType {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryFormat {
     #[doc = "The quick query format type."]
-    #[serde(rename = "Type")]
+    #[serde(rename = "Type", with = "azure_core::xml::text_content")]
     pub type_: QueryType,
     #[doc = "Groups the settings used for interpreting the blob data if the blob is delimited text formatted."]
     #[serde(rename = "DelimitedTextConfiguration", default, skip_serializing_if = "Option::is_none")]
@@ -1452,7 +1549,7 @@ impl QueryFormat {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryRequest {
     #[doc = "Required. The type of the provided query expression."]
-    #[serde(rename = "QueryType")]
+    #[serde(rename = "QueryType", with = "azure_core::xml::text_content")]
     pub query_type: query_request::QueryType,
     #[doc = "The query expression in SQL. The maximum size of the query expression is 256KiB."]
     #[serde(rename = "Expression")]

--- a/services/svc/blobstorage/src/package_2021_04/models.rs
+++ b/services/svc/blobstorage/src/package_2021_04/models.rs
@@ -1234,15 +1234,7 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1281,15 +1273,7 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1325,15 +1309,7 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListContainersSegmentResponse {
@@ -1442,15 +1418,7 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl PageList {

--- a/services/svc/blobstorage/src/package_2021_08/models.rs
+++ b/services/svc/blobstorage/src/package_2021_08/models.rs
@@ -1240,15 +1240,7 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1287,15 +1279,7 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1331,15 +1315,7 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListContainersSegmentResponse {
@@ -1448,15 +1424,7 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl PageList {

--- a/services/svc/blobstorage/src/package_2021_08/models.rs
+++ b/services/svc/blobstorage/src/package_2021_08/models.rs
@@ -236,7 +236,7 @@ impl BlobItemInternal {
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobMetadata {
-    #[serde(rename = "Encrypted", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encrypted", default, skip_serializing_if = "Option::is_none")]
     pub encrypted: Option<String>,
 }
 impl BlobMetadata {
@@ -247,7 +247,7 @@ impl BlobMetadata {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobName {
     #[doc = "Indicates if the blob name is encoded."]
-    #[serde(rename = "Encoded", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encoded", default, skip_serializing_if = "Option::is_none")]
     pub encoded: Option<bool>,
     #[doc = "The name of the blob."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -294,17 +294,42 @@ pub struct BlobPropertiesInternal {
     pub cache_control: Option<String>,
     #[serde(rename = "x-ms-blob-sequence-number", default, skip_serializing_if = "Option::is_none")]
     pub x_ms_blob_sequence_number: Option<i64>,
-    #[serde(rename = "BlobType", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "BlobType",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub blob_type: Option<blob_properties_internal::BlobType>,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
     #[serde(rename = "CopyId", default, skip_serializing_if = "Option::is_none")]
     pub copy_id: Option<String>,
-    #[serde(rename = "CopyStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "CopyStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub copy_status: Option<CopyStatus>,
     #[serde(rename = "CopySource", default, skip_serializing_if = "Option::is_none")]
     pub copy_source: Option<String>,
@@ -324,11 +349,21 @@ pub struct BlobPropertiesInternal {
     pub deleted_time: Option<time::OffsetDateTime>,
     #[serde(rename = "RemainingRetentionDays", default, skip_serializing_if = "Option::is_none")]
     pub remaining_retention_days: Option<i64>,
-    #[serde(rename = "AccessTier", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "AccessTier",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub access_tier: Option<AccessTier>,
     #[serde(rename = "AccessTierInferred", default, skip_serializing_if = "Option::is_none")]
     pub access_tier_inferred: Option<bool>,
-    #[serde(rename = "ArchiveStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ArchiveStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub archive_status: Option<ArchiveStatus>,
     #[serde(rename = "CustomerProvidedKeySha256", default, skip_serializing_if = "Option::is_none")]
     pub customer_provided_key_sha256: Option<String>,
@@ -344,13 +379,23 @@ pub struct BlobPropertiesInternal {
     #[serde(rename = "Sealed", default, skip_serializing_if = "Option::is_none")]
     pub sealed: Option<bool>,
     #[doc = "If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High and Standard."]
-    #[serde(rename = "RehydratePriority", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "RehydratePriority",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub rehydrate_priority: Option<RehydratePriority>,
     #[serde(rename = "LastAccessTime", default, with = "azure_core::date::rfc1123::option")]
     pub last_access_time: Option<time::OffsetDateTime>,
     #[serde(rename = "ImmutabilityPolicyUntilDate", default, with = "azure_core::date::rfc1123::option")]
     pub immutability_policy_until_date: Option<time::OffsetDateTime>,
-    #[serde(rename = "ImmutabilityPolicyMode", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ImmutabilityPolicyMode",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub immutability_policy_mode: Option<blob_properties_internal::ImmutabilityPolicyMode>,
     #[serde(rename = "LegalHold", default, skip_serializing_if = "Option::is_none")]
     pub legal_hold: Option<bool>,
@@ -568,13 +613,33 @@ pub struct ContainerProperties {
     pub last_modified: time::OffsetDateTime,
     #[serde(rename = "Etag")]
     pub etag: String,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
-    #[serde(rename = "PublicAccess", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "PublicAccess",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub public_access: Option<PublicAccessType>,
     #[serde(rename = "HasImmutabilityPolicy", default, skip_serializing_if = "Option::is_none")]
     pub has_immutability_policy: Option<bool>,
@@ -1013,7 +1078,7 @@ impl FilterBlobItem {
 #[doc = "The result of a Filter Blobs API call"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FilterBlobSegment {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Where")]
     pub where_: String,
@@ -1044,7 +1109,7 @@ pub mod filter_blob_segment {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GeoReplication {
     #[doc = "The status of the secondary location"]
-    #[serde(rename = "Status")]
+    #[serde(rename = "Status", with = "azure_core::xml::text_content")]
     pub status: geo_replication::Status,
     #[doc = "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads."]
     #[serde(rename = "LastSyncTime", with = "azure_core::date::rfc1123")]
@@ -1157,9 +1222,9 @@ pub enum LeaseStatus {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsFlatSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1175,7 +1240,15 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1194,9 +1267,9 @@ impl ListBlobsFlatSegmentResponse {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsHierarchySegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1214,7 +1287,15 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1234,7 +1315,7 @@ impl ListBlobsHierarchySegmentResponse {
 #[doc = "An enumeration of containers"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListContainersSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1250,7 +1331,15 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListContainersSegmentResponse {
@@ -1359,7 +1448,15 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl PageList {
@@ -1428,7 +1525,7 @@ impl Serialize for PublicAccessType {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryFormat {
     #[doc = "The quick query format type."]
-    #[serde(rename = "Type")]
+    #[serde(rename = "Type", with = "azure_core::xml::text_content")]
     pub type_: QueryType,
     #[doc = "Groups the settings used for interpreting the blob data if the blob is delimited text formatted."]
     #[serde(rename = "DelimitedTextConfiguration", default, skip_serializing_if = "Option::is_none")]
@@ -1458,7 +1555,7 @@ impl QueryFormat {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryRequest {
     #[doc = "Required. The type of the provided query expression."]
-    #[serde(rename = "QueryType")]
+    #[serde(rename = "QueryType", with = "azure_core::xml::text_content")]
     pub query_type: query_request::QueryType,
     #[doc = "The query expression in SQL. The maximum size of the query expression is 256KiB."]
     #[serde(rename = "Expression")]

--- a/services/svc/blobstorage/src/package_2021_12/models.rs
+++ b/services/svc/blobstorage/src/package_2021_12/models.rs
@@ -241,7 +241,7 @@ impl BlobItemInternal {
 }
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobMetadata {
-    #[serde(rename = "Encrypted", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encrypted", default, skip_serializing_if = "Option::is_none")]
     pub encrypted: Option<String>,
 }
 impl BlobMetadata {
@@ -252,7 +252,7 @@ impl BlobMetadata {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 pub struct BlobName {
     #[doc = "Indicates if the blob name is encoded."]
-    #[serde(rename = "Encoded", default, skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "@Encoded", default, skip_serializing_if = "Option::is_none")]
     pub encoded: Option<bool>,
     #[doc = "The name of the blob."]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -299,17 +299,42 @@ pub struct BlobPropertiesInternal {
     pub cache_control: Option<String>,
     #[serde(rename = "x-ms-blob-sequence-number", default, skip_serializing_if = "Option::is_none")]
     pub x_ms_blob_sequence_number: Option<i64>,
-    #[serde(rename = "BlobType", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "BlobType",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub blob_type: Option<blob_properties_internal::BlobType>,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
     #[serde(rename = "CopyId", default, skip_serializing_if = "Option::is_none")]
     pub copy_id: Option<String>,
-    #[serde(rename = "CopyStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "CopyStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub copy_status: Option<CopyStatus>,
     #[serde(rename = "CopySource", default, skip_serializing_if = "Option::is_none")]
     pub copy_source: Option<String>,
@@ -329,11 +354,21 @@ pub struct BlobPropertiesInternal {
     pub deleted_time: Option<time::OffsetDateTime>,
     #[serde(rename = "RemainingRetentionDays", default, skip_serializing_if = "Option::is_none")]
     pub remaining_retention_days: Option<i64>,
-    #[serde(rename = "AccessTier", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "AccessTier",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub access_tier: Option<AccessTier>,
     #[serde(rename = "AccessTierInferred", default, skip_serializing_if = "Option::is_none")]
     pub access_tier_inferred: Option<bool>,
-    #[serde(rename = "ArchiveStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ArchiveStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub archive_status: Option<ArchiveStatus>,
     #[serde(rename = "CustomerProvidedKeySha256", default, skip_serializing_if = "Option::is_none")]
     pub customer_provided_key_sha256: Option<String>,
@@ -349,13 +384,23 @@ pub struct BlobPropertiesInternal {
     #[serde(rename = "Sealed", default, skip_serializing_if = "Option::is_none")]
     pub sealed: Option<bool>,
     #[doc = "If an object is in rehydrate pending state then this header is returned with priority of rehydrate. Valid values are High and Standard."]
-    #[serde(rename = "RehydratePriority", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "RehydratePriority",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub rehydrate_priority: Option<RehydratePriority>,
     #[serde(rename = "LastAccessTime", default, with = "azure_core::date::rfc1123::option")]
     pub last_access_time: Option<time::OffsetDateTime>,
     #[serde(rename = "ImmutabilityPolicyUntilDate", default, with = "azure_core::date::rfc1123::option")]
     pub immutability_policy_until_date: Option<time::OffsetDateTime>,
-    #[serde(rename = "ImmutabilityPolicyMode", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "ImmutabilityPolicyMode",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub immutability_policy_mode: Option<blob_properties_internal::ImmutabilityPolicyMode>,
     #[serde(rename = "LegalHold", default, skip_serializing_if = "Option::is_none")]
     pub legal_hold: Option<bool>,
@@ -573,13 +618,33 @@ pub struct ContainerProperties {
     pub last_modified: time::OffsetDateTime,
     #[serde(rename = "Etag")]
     pub etag: String,
-    #[serde(rename = "LeaseStatus", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseStatus",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_status: Option<LeaseStatus>,
-    #[serde(rename = "LeaseState", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseState",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_state: Option<LeaseState>,
-    #[serde(rename = "LeaseDuration", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "LeaseDuration",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub lease_duration: Option<LeaseDuration>,
-    #[serde(rename = "PublicAccess", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "PublicAccess",
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "azure_core::xml::text_content"
+    )]
     pub public_access: Option<PublicAccessType>,
     #[serde(rename = "HasImmutabilityPolicy", default, skip_serializing_if = "Option::is_none")]
     pub has_immutability_policy: Option<bool>,
@@ -1018,7 +1083,7 @@ impl FilterBlobItem {
 #[doc = "The result of a Filter Blobs API call"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FilterBlobSegment {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Where")]
     pub where_: String,
@@ -1049,7 +1114,7 @@ pub mod filter_blob_segment {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GeoReplication {
     #[doc = "The status of the secondary location"]
-    #[serde(rename = "Status")]
+    #[serde(rename = "Status", with = "azure_core::xml::text_content")]
     pub status: geo_replication::Status,
     #[doc = "A GMT date/time value, to the second. All primary writes preceding this value are guaranteed to be available for read operations at the secondary. Primary writes after this point in time may or may not be available for reads."]
     #[serde(rename = "LastSyncTime", with = "azure_core::date::rfc1123")]
@@ -1162,9 +1227,9 @@ pub enum LeaseStatus {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsFlatSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1180,7 +1245,15 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1199,9 +1272,9 @@ impl ListBlobsFlatSegmentResponse {
 #[doc = "An enumeration of blobs"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListBlobsHierarchySegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
-    #[serde(rename = "ContainerName")]
+    #[serde(rename = "@ContainerName")]
     pub container_name: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1219,7 +1292,15 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1239,7 +1320,7 @@ impl ListBlobsHierarchySegmentResponse {
 #[doc = "An enumeration of containers"]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListContainersSegmentResponse {
-    #[serde(rename = "ServiceEndpoint")]
+    #[serde(rename = "@ServiceEndpoint")]
     pub service_endpoint: String,
     #[serde(rename = "Prefix", default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
@@ -1255,7 +1336,15 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl ListContainersSegmentResponse {
@@ -1364,7 +1453,15 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        self.next_marker.clone()
+        if let Some(value) = self.next_marker.clone() {
+            if value.is_empty() {
+                None
+            } else {
+                Some(value)
+            }
+        } else {
+            None
+        }
     }
 }
 impl PageList {
@@ -1433,7 +1530,7 @@ impl Serialize for PublicAccessType {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryFormat {
     #[doc = "The quick query format type."]
-    #[serde(rename = "Type")]
+    #[serde(rename = "Type", with = "azure_core::xml::text_content")]
     pub type_: QueryType,
     #[doc = "Groups the settings used for interpreting the blob data if the blob is delimited text formatted."]
     #[serde(rename = "DelimitedTextConfiguration", default, skip_serializing_if = "Option::is_none")]
@@ -1463,7 +1560,7 @@ impl QueryFormat {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct QueryRequest {
     #[doc = "Required. The type of the provided query expression."]
-    #[serde(rename = "QueryType")]
+    #[serde(rename = "QueryType", with = "azure_core::xml::text_content")]
     pub query_type: query_request::QueryType,
     #[doc = "The query expression in SQL. The maximum size of the query expression is 256KiB."]
     #[serde(rename = "Expression")]

--- a/services/svc/blobstorage/src/package_2021_12/models.rs
+++ b/services/svc/blobstorage/src/package_2021_12/models.rs
@@ -1245,15 +1245,7 @@ pub struct ListBlobsFlatSegmentResponse {
 impl azure_core::Continuable for ListBlobsFlatSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsFlatSegmentResponse {
@@ -1292,15 +1284,7 @@ pub struct ListBlobsHierarchySegmentResponse {
 impl azure_core::Continuable for ListBlobsHierarchySegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListBlobsHierarchySegmentResponse {
@@ -1336,15 +1320,7 @@ pub struct ListContainersSegmentResponse {
 impl azure_core::Continuable for ListContainersSegmentResponse {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl ListContainersSegmentResponse {
@@ -1453,15 +1429,7 @@ pub struct PageList {
 impl azure_core::Continuable for PageList {
     type Continuation = String;
     fn continuation(&self) -> Option<Self::Continuation> {
-        if let Some(value) = self.next_marker.clone() {
-            if value.is_empty() {
-                None
-            } else {
-                Some(value)
-            }
-        } else {
-            None
-        }
+        self.next_marker.clone().filter(|value| !value.is_empty())
     }
 }
 impl PageList {

--- a/services/svc/blobstorage/tests/test_parser.rs
+++ b/services/svc/blobstorage/tests/test_parser.rs
@@ -1,0 +1,19 @@
+use azure_core::{xml::read_xml, Result};
+use azure_svc_blobstorage::models::ListContainersSegmentResponse;
+use std::fs::read;
+
+#[test]
+fn parse_list_container_segment() -> Result<()> {
+    let bytes = read("data/list_containers.txt")?;
+    let body: ListContainersSegmentResponse = read_xml(&bytes)?;
+    assert_eq!(body.next_marker, Some("/bmcrustsdktest/test1".to_owned()));
+    let containers = body
+        .containers
+        .unwrap_or_default()
+        .items
+        .into_iter()
+        .map(|x| x.name)
+        .collect::<Vec<_>>();
+    assert_eq!(containers, ["backup", "test1", "test2", "test3", "test4", "test5"]);
+    Ok(())
+}


### PR DESCRIPTION
This addresses a handful of XML parsing issues in generated crates.
1. Deserializing enum variants with the value being a string content (such as `<field>Value</field>`) needs a serde helper.
2. Deserializing attribute values (such as `<a b="foo"/>`) needs to the attribute name to be prefixed with `@` to indicate it's an attribute
3. Continuation tokens that are strings need to be considered the same as not having a continuation token

Additionally, this PR includes the following:
1. Regenerating the `azure_svc_blobstorage` crate for review
2. A unit test for `azure_svc_blobstorage` that validates the XML parsing works as intended
3. Updates to the `azure_svc_blobstorage` example such that it no longer silently swallows parsing issues

Once this PR is reviewed, I will submit a follow-on PR that includes regenerating the rest of the crates.

Ref: <https://docs.rs/quick-xml/latest/quick_xml/serde_helpers/text_content/index.html>
Ref: <https://docs.rs/quick-xml/latest/quick_xml/de/index.html#mapping-xml-to-rust-types>

NOTE: While this fixes the parsing error indicated by #1366, the `Continuable` functionality used by `azure_svc_storageblob` is currently broken.  That will be addressed in a follow-on PR.