### PR TITLE
remove local-offset feature from time in azure_core

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -32,7 +32,7 @@ url = "2.2"
 uuid = { version = "1.0" }
 pin-project = "1.0"
 paste = "1.0"
-time = { version = "0.3.10", features = ["serde-well-known", "macros", "local-offset"] }
+time = { version = "0.3.10", features = ["serde-well-known", "macros"] }
 tokio = {version="1.0", optional=true}
 
 # When target is `wasm32`, include `getrandom` and enable `wasm-bindgen` feature in `time`.

--- a/sdk/core/src/date/mod.rs
+++ b/sdk/core/src/date/mod.rs
@@ -113,11 +113,6 @@ pub fn to_last_state_change(date: &OffsetDateTime) -> String {
     date.format(LAST_STATE_CHANGE_FORMAT).unwrap()
 }
 
-/// Assumes the local offset. Default to UTC if unable to get local offset.
-pub fn assume_local(date: &PrimitiveDateTime) -> OffsetDateTime {
-    date.assume_offset(UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC))
-}
-
 // Create a duration from the number of minutes.
 pub fn duration_from_minutes(minutes: u64) -> Duration {
     Duration::from_secs(minutes * 60)

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -25,7 +25,7 @@ mod az_cli_date_format {
     }
 
     /// Assumes the local offset. Default to UTC if unable to get local offset.
-    pub fn assume_local(date: &PrimitiveDateTime) -> OffsetDateTime {
+    pub(crate) fn assume_local(date: &PrimitiveDateTime) -> OffsetDateTime {
         date.assume_offset(UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC))
     }
 

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -25,7 +25,7 @@ mod az_cli_date_format {
     }
 
     /// Assumes the local offset. Default to UTC if unable to get local offset.
-    fn assume_local(date: &PrimitiveDateTime) -> OffsetDateTime {
+    pub fn assume_local(date: &PrimitiveDateTime) -> OffsetDateTime {
         date.assume_offset(UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC))
     }
 
@@ -135,7 +135,6 @@ impl TokenCredential for AzureCliCredential {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use azure_core::date;
     use time::macros::datetime;
 
     #[test]
@@ -143,7 +142,7 @@ mod tests {
         let expires_on = "2022-07-30 12:12:53.919110";
         assert_eq!(
             az_cli_date_format::parse(expires_on)?,
-            date::assume_local(&datetime!(2022-07-30 12:12:53.919110))
+            az_cli_date_format::assume_local(&datetime!(2022-07-30 12:12:53.919110))
         );
         Ok(())
     }


### PR DESCRIPTION
This moves the `assume_local` function. Once #1371 is addressed, it should be possible to remove the function and `local-offset` from azure_identity as well, but that will be in a later PR.