### PR TITLE
add `models` to autorust's reserved words

### DIFF
--- a/services/autorust/codegen/src/codegen.rs
+++ b/services/autorust/codegen/src/codegen.rs
@@ -1,4 +1,8 @@
-use crate::{identifier::parse_ident, spec::TypeName, CrateConfig, PropertyName, Spec};
+use crate::{
+    identifier::{parse_ident, raw_str_to_ident},
+    spec::TypeName,
+    CrateConfig, PropertyName, Spec,
+};
 use crate::{Error, Result};
 use camino::Utf8Path;
 use camino::Utf8PathBuf;
@@ -80,7 +84,7 @@ impl<'a> CodeGen<'a> {
 }
 
 fn id_models() -> Ident {
-    parse_ident("models").unwrap()
+    raw_str_to_ident("models").unwrap()
 }
 
 // any word character or `-` between curly braces

--- a/services/autorust/codegen/src/identifier.rs
+++ b/services/autorust/codegen/src/identifier.rs
@@ -65,6 +65,10 @@ pub fn parse_ident(text: &str) -> Result<Ident> {
     syn::parse_str::<Ident>(&id(text)).with_context(ErrorKind::Parse, || format!("parse ident {text}"))
 }
 
+pub fn raw_str_to_ident(text: &str) -> Result<Ident> {
+    syn::parse_str::<Ident>(text).with_context(ErrorKind::Parse, || format!("parse ident {text}"))
+}
+
 fn remove_spaces(text: &str) -> String {
     text.replace(' ', "")
 }
@@ -179,6 +183,8 @@ fn is_keyword(word: &str) -> bool {
             | "where"
             | "while"
             | "yield"
+            // names used by autorust that we shouldn't stomp on
+            | "models"
     )
 }
 

--- a/services/mgmt/cognitiveservices/autorust.toml
+++ b/services/mgmt/cognitiveservices/autorust.toml
@@ -1,5 +1,0 @@
-[tags]
-deny = [
-    # duplicate clients
-    "package-2023-05"
-  ]


### PR DESCRIPTION
Because we use `models` heavily throughout to describe where the generated structs are stored, services that use `models` as a identifier name will cause issues.

By adding `models` to the pre-existing `is_keyword` and using a something that doesn't check `is_keyword` for when we _actually_ want `models`, we can generate code for services that use the keyword `models`.

Fixes #1382 (once the services are re-generated after this PR is merged).