### PR TITLE
remove lifetime workaround now that this is fixed

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -25,8 +25,6 @@ log = "0.4"
 async-trait = "0.1"
 openssl = { version = "0.10.46",  optional=true }
 uuid = { version = "1.0",  features = ["v4"] }
-# work around https://github.com/rust-lang/rust/issues/63033
-fix-hidden-lifetime-bug = "0.2"
 pin-project = "1.0"
 
 [dev-dependencies]

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -48,8 +48,6 @@ use std::sync::Arc;
 use url::{form_urlencoded, Url};
 
 /// Perform the client credentials flow
-#[allow(clippy::manual_async_fn)]
-#[fix_hidden_lifetime_bug::fix_hidden_lifetime_bug]
 pub async fn perform(
     http_client: Arc<dyn HttpClient>,
     client_id: &str,

--- a/sdk/identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/src/federated_credentials_flow/mod.rs
@@ -48,8 +48,6 @@ use std::sync::Arc;
 use url::{form_urlencoded, Url};
 
 /// Perform the client credentials flow
-#[allow(clippy::manual_async_fn)]
-#[fix_hidden_lifetime_bug::fix_hidden_lifetime_bug]
 pub async fn perform(
     http_client: Arc<dyn HttpClient>,
     client_id: &str,

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -13,8 +13,6 @@ use std::sync::Arc;
 use url::{form_urlencoded, Url};
 
 /// Exchange a refresh token for a new access token and refresh token
-#[allow(clippy::manual_async_fn)]
-#[fix_hidden_lifetime_bug::fix_hidden_lifetime_bug]
 pub async fn exchange(
     http_client: Arc<dyn HttpClient>,
     tenant_id: &str,


### PR DESCRIPTION
The underlying issue was fixed in rust 1.69.0.  Our minimum supported rust is now 1.70.0 (set in azure_core), which means this workaround is no longer needed.

Ref: https://github.com/rust-lang/rust/issues/63033