### PR TITLE
remove unused packages on github runners

### DIFF
--- a/eng/scripts/check_wasm.sh
+++ b/eng/scripts/check_wasm.sh
@@ -3,6 +3,8 @@
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../
 
+./eng/scripts/github-disk-cleanup.sh
+
 BUILD=${1:-stable}
 
 rustup update --no-self-update ${BUILD}

--- a/eng/scripts/e2e_tests.sh
+++ b/eng/scripts/e2e_tests.sh
@@ -3,6 +3,8 @@
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../
 
+./eng/scripts/github-disk-cleanup.sh
+
 BUILD=${1:-stable}
 
 rustup update --no-self-update ${BUILD}

--- a/eng/scripts/emulator_tests.sh
+++ b/eng/scripts/emulator_tests.sh
@@ -3,6 +3,8 @@
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../
 
+./eng/scripts/github-disk-cleanup.sh
+
 BUILD=${1:-stable}
 
 npm install azurite@3.26.0

--- a/eng/scripts/github-disk-cleanup.sh
+++ b/eng/scripts/github-disk-cleanup.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# avoid running out of disk space on GitHub Runners
+
+set -eux -o pipefail
+
+if [ -v CI ] && [ -v GITHUB_ACTION ] ; then
+    # ref: https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+    # ref: https://github.com/actions/runner-images/issues/2606#issuecomment-772683150
+    # ref: https://github.com/apache/flink/blob/master/tools/azure-pipelines/free_disk_space.sh
+    sudo rm -rf /opt/ghc
+    sudo rm -rf /usr/local/graalvm
+    sudo rm -rf /usr/local/lib/android
+    sudo rm -rf /usr/local/share/boost
+fi

--- a/eng/scripts/sdk_tests.sh
+++ b/eng/scripts/sdk_tests.sh
@@ -3,6 +3,8 @@
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../
 
+./eng/scripts/github-disk-cleanup.sh
+
 BUILD=${1:-stable}
 
 rustup update --no-self-update ${BUILD}

--- a/eng/scripts/services_tests.sh
+++ b/eng/scripts/services_tests.sh
@@ -3,6 +3,8 @@
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../
 
+./eng/scripts/github-disk-cleanup.sh
+
 BUILD=${1:-stable}
 
 rustup update --no-self-update ${BUILD}


### PR DESCRIPTION
We're consistently running short on disk space in multiple jobs during CICD.  This removes some of the unused tools & libraries based on suggestions from someone that worked on Github Actions.

Ref: https://github.com/actions/runner-images/issues/2840#issuecomment-790492173