### PR TITLE
bump azure_identity version to 0.16.1 to address timezone issue

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_identity"
-version = "0.16.0"
+version = "0.16.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure identity helper crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]


### PR DESCRIPTION
This allows for pushing out a release that addresses #1371 .