### PR TITLE
fix timezone conversion

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_identity"
-version = "0.16.1"
+version = "0.16.2"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure identity helper crate"
 readme = "README.md"
 authors = ["Microsoft Corp."]

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.10"
 serde_test = "1"
 azure_security_keyvault = { path = "../security_keyvault", default-features = false }
+serial_test = "2.0"
 
 [features]
 default = ["development", "enable_reqwest"]

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -188,9 +188,11 @@ impl TokenCredential for AzureCliCredential {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use time::macros::datetime;
 
     #[test]
+    #[serial]
     fn can_parse_expires_on() -> azure_core::Result<()> {
         let expires_on = "2022-07-30 12:12:53.919110";
         assert_eq!(
@@ -203,6 +205,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    #[serial]
     /// test the timezone conversion works as expected on unix platforms
     ///
     /// To validate the timezone conversion works as expected, this test


### PR DESCRIPTION
The original change in #1431 was built & tested on a machine with the timezone of GMT, which is effectively UTC as it relates to the testing.

In addition to fixing the conversion, this adds a unit test for unix platforms that temporarily changes the `TZ` environment variable (used for setting the timezone for libc platforms), performs the conversion, then resets the `TZ` environment variable.

This validates the functionality regardless of the testing environment.