### PR TITLE
Fix #[serde(flatten)] annotation and add ResourceType value

### DIFF
--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -27,6 +27,7 @@ use azure_core::{
 use azure_storage::{ConsistencyCRC64, ConsistencyMD5, CopyId, CopyProgress};
 use serde::{self, Deserialize, Deserializer};
 use std::collections::HashMap;
+use serde_json::Value;
 use time::OffsetDateTime;
 
 #[cfg(feature = "azurite_workaround")]
@@ -174,8 +175,9 @@ pub struct BlobProperties {
     )]
     pub expiry_time: Option<OffsetDateTime>,
     pub blob_committed_block_count: Option<u64>,
+    pub resource_type: Option<String>,
     #[serde(flatten)]
-    extra: HashMap<String, String>, // For debug purposes, should be compiled out in the future
+    extra: HashMap<String, Value>, // For debug purposes, should be compiled out in the future
 }
 
 impl Blob {
@@ -281,6 +283,7 @@ impl Blob {
                 tag_count: None,                    // TODO
                 rehydrate_priority: None,           // TODO
                 expiry_time: None,
+                resource_type: None,
                 blob_committed_block_count,
                 extra: HashMap::new(),
             },

--- a/sdk/storage_blobs/src/blob/mod.rs
+++ b/sdk/storage_blobs/src/blob/mod.rs
@@ -26,8 +26,8 @@ use azure_core::{
 };
 use azure_storage::{ConsistencyCRC64, ConsistencyMD5, CopyId, CopyProgress};
 use serde::{self, Deserialize, Deserializer};
-use std::collections::HashMap;
 use serde_json::Value;
+use std::collections::HashMap;
 use time::OffsetDateTime;
 
 #[cfg(feature = "azurite_workaround")]

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -339,6 +339,47 @@ mod tests {
     }
 
     #[test]
+    fn deserde_properties_with_non_existent_field() {
+        const XML: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
+        <EnumerationResults ServiceEndpoint=\"http://127.0.0.1:10000/devstoreaccount1\" ContainerName=\"temp\">
+            <Prefix>b39bc5c9-0f31-459c-a271-828467105470/</Prefix>
+            <Marker/>
+            <MaxResults>5000</MaxResults>
+            <Delimiter/>
+            <Blobs>
+                <Blob>
+                    <Name>b39bc5c9-0f31-459c-a271-828467105470/corrupted_data_2020-01-02T03_04_05.json</Name>
+                    <Properties>
+                        <Creation-Time>Mon, 02 Oct 2023 20:00:31 GMT</Creation-Time>
+                        <Last-Modified>Mon, 02 Oct 2023 20:00:31 GMT</Last-Modified>
+                        <Etag>0x23D9DB658CF7480</Etag>
+                        <Content-Length>0</Content-Length>
+                        <Content-Type>application/octet-stream</Content-Type>
+                        <Content-Encoding/>
+                        <Content-Language/>
+                        <Content-CRC64/>
+                        <Content-MD5/>
+                        <Cache-Control/>
+                        <Content-Disposition/>
+                        <BlobType>BlockBlob</BlobType>
+                        <AccessTier>Hot</AccessTier>
+                        <AccessTierInferred>true</AccessTierInferred>
+                        <LeaseStatus>unlocked</LeaseStatus>
+                        <LeaseState>available</LeaseState>
+                        <ServerEncrypted>true</ServerEncrypted>
+                        <ResourceType>file</ResourceType>
+                        <NotRealProperty>notRealValue</NotRealProperty> 
+                    </Properties>
+                </Blob>
+            </Blobs>
+            <NextMarker/>
+        </EnumerationResults>";
+
+        let bytes = Bytes::from(XML);
+        let _list_blobs_response_internal: ListBlobsResponseInternal = read_xml(&bytes).unwrap();
+    }
+
+    #[test]
     fn deserde_azurite_without_server_encrypted() {
         const S: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>
         <EnumerationResults ServiceEndpoint=\"http://127.0.0.1:10000/devstoreaccount1\" ContainerName=\"temp\">


### PR DESCRIPTION
Bug 1: When `storage_blobs::blob::BlobProperties` deserializes with an unknown field it errors.
    
Reason: Deserialization is iffy in regard to XMl. This is due to ambiguous typing. Deserialization will interpret the inner field as a map as opposed to a string, thus resulting in a failed conversion with the #[serde(flatten)] annotation and as such, an error.
    
Fix: Change the map to use serde_json::Value
    
Bug 2: List blobs response occasionally can contain a `ResourceType` field. This isn't deserialized to a public field.

Fix: Add the field