### PR TITLE
fix manual XML Byte Order Marker removal

### DIFF
--- a/sdk/storage_blobs/src/blob/operations/get_block_list.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_block_list.rs
@@ -64,7 +64,7 @@ impl GetBlockListResponse {
         let date = date_from_headers(headers)?;
 
         let body = from_utf8(body)?;
-        let block_with_size_list = BlockWithSizeList::try_from_xml(&body[3..] as &str)?;
+        let block_with_size_list = BlockWithSizeList::try_from_xml(body)?;
 
         Ok(GetBlockListResponse {
             etag,

--- a/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_page_ranges.rs
@@ -60,7 +60,7 @@ impl GetPageRangesResponse {
         let date = date_from_headers(headers)?;
 
         let body = from_utf8(body)?;
-        let page_list = PageRangeList::try_from_xml(&body[3..] as &str)?;
+        let page_list = PageRangeList::try_from_xml(body)?;
 
         Ok(GetPageRangesResponse {
             etag,


### PR DESCRIPTION
The `azure_cored::xml::read_xml_str` methods handle stripping the XML BOM if it's appropriate.  Manually removing the BOM isn't needed and in the case of #1440 lead to issues with azurite, which does not provide the BOM.