### PR TITLE
add range header in put_block_url function

### DIFF
--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -371,4 +371,4 @@ pub const BLOB_COMMITTED_BLOCK_COUNT: HeaderName =
     HeaderName::from_static("x-ms-blob-committed-block-count");
 pub const AZURE_ASYNCOPERATION: HeaderName = HeaderName::from_static("azure-asyncoperation");
 pub const OPERATION_LOCATION: HeaderName = HeaderName::from_static("operation-location");
-pub const COPY_SOURCE_RANGE: HeaderName = HeaderName::from_static("x-ms-source-range");
+pub const SOURCE_RANGE: HeaderName = HeaderName::from_static("x-ms-source-range");

--- a/sdk/core/src/headers/mod.rs
+++ b/sdk/core/src/headers/mod.rs
@@ -371,3 +371,4 @@ pub const BLOB_COMMITTED_BLOCK_COUNT: HeaderName =
     HeaderName::from_static("x-ms-blob-committed-block-count");
 pub const AZURE_ASYNCOPERATION: HeaderName = HeaderName::from_static("azure-asyncoperation");
 pub const OPERATION_LOCATION: HeaderName = HeaderName::from_static("operation-location");
+pub const COPY_SOURCE_RANGE: HeaderName = HeaderName::from_static("x-ms-source-range");

--- a/sdk/storage_blobs/src/blob/operations/put_block_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_url.rs
@@ -25,9 +25,7 @@ impl PutBlockUrlBuilder {
             headers.insert(COPY_SOURCE, self.url.to_string());
             headers.add(self.lease_id);
             if let Some(range) = self.range {
-                for (name, value) in range.as_headers() {
-                    headers.insert(name, value);
-                }
+                headers.insert(COPY_SOURCE_RANGE, format!("{range}"));
             }
 
             let mut request =

--- a/sdk/storage_blobs/src/blob/operations/put_block_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_url.rs
@@ -24,10 +24,8 @@ impl PutBlockUrlBuilder {
             let mut headers = Headers::new();
             headers.insert(COPY_SOURCE, self.url.to_string());
             headers.add(self.lease_id);
-            if let Some(mut range) = self.range {
-                // to accomodate with the standard HTTP range header format:
-                range.end += 1;
-                headers.insert(COPY_SOURCE_RANGE, format!("{range}"));
+            if let Some(range) = self.range {
+                headers.insert(SOURCE_RANGE, format!("{range}"));
             }
 
             let mut request =

--- a/sdk/storage_blobs/src/blob/operations/put_block_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_url.rs
@@ -24,7 +24,9 @@ impl PutBlockUrlBuilder {
             let mut headers = Headers::new();
             headers.insert(COPY_SOURCE, self.url.to_string());
             headers.add(self.lease_id);
-            if let Some(range) = self.range {
+            if let Some(mut range) = self.range {
+                // to accomodate with the standard HTTP range header format:
+                range.end += 1;
                 headers.insert(COPY_SOURCE_RANGE, format!("{range}"));
             }
 

--- a/sdk/storage_blobs/src/blob/operations/put_block_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/put_block_url.rs
@@ -9,6 +9,7 @@ operation! {
     block_id: BlockId,
     url: Url,
     ?hash: Hash,
+    ?range: Range,
     ?lease_id: LeaseId
 }
 
@@ -23,6 +24,11 @@ impl PutBlockUrlBuilder {
             let mut headers = Headers::new();
             headers.insert(COPY_SOURCE, self.url.to_string());
             headers.add(self.lease_id);
+            if let Some(range) = self.range {
+                for (name, value) in range.as_headers() {
+                    headers.insert(name, value);
+                }
+            }
 
             let mut request =
                 BlobClient::finalize_request(url, azure_core::Method::Put, headers, None)?;


### PR DESCRIPTION
As described in [document](https://learn.microsoft.com/en-us/rest/api/storageservices/put-block-from-url?tabs=azure-ad), the `put_block_url` function has a `x-ms-source-range` header request option. 