### PR TITLE
fix: sequence_number should be i64

### DIFF
--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -289,7 +289,7 @@ pub struct BrokerProperties {
     pub message_id: String,
     pub sequence_number: i64,
     pub state: String,
-    pub time_to_live: i64,
+    pub time_to_live: f64,
 }
 
 impl BrokerProperties {

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -287,7 +287,7 @@ pub struct BrokerProperties {
     #[serde(with = "time::serde::rfc2822")]
     pub locked_until_utc: OffsetDateTime,
     pub message_id: String,
-    pub sequence_number: i32,
+    pub sequence_number: i64,
     pub state: String,
     pub time_to_live: i64,
 }


### PR DESCRIPTION
I tought I'd give it a try to check if would break in multiple place to fix this issue :
https://github.com/Azure/azure-sdk-for-rust/issues/1447

It's a breaking change for the api, but it's still better than having the runtime issue I met

Let me know, if you more information 

Thanks for the good work on all the crates