### PR TITLE
don't manually encode XML

### DIFF
--- a/sdk/storage_queues/src/lib.rs
+++ b/sdk/storage_queues/src/lib.rs
@@ -49,6 +49,7 @@ mod number_of_messages;
 pub mod operations;
 mod pop_receipt;
 pub mod prelude;
+mod queue_message;
 mod queue_service_properties;
 mod queue_stored_access_policy;
 mod visibility_timeout;

--- a/sdk/storage_queues/src/operations/put_message.rs
+++ b/sdk/storage_queues/src/operations/put_message.rs
@@ -1,6 +1,10 @@
-use crate::prelude::*;
+use crate::{prelude::*, queue_message::QueueMessageSubmit};
 use azure_core::{
-    date, headers::Headers, prelude::*, xml::read_xml, Method, Response as AzureResponse,
+    date,
+    headers::Headers,
+    prelude::*,
+    xml::{read_xml, to_xml},
+    Method, Response as AzureResponse,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
@@ -22,13 +26,9 @@ impl PutMessageBuilder {
             self.visibility_timeout.append_to_url_query(&mut url);
             self.ttl.append_to_url_query(&mut url);
 
-            // since the format is fixed we just decorate the message with the tags.
-            // This could be made optional in the future and/or more
-            // stringent.
-            let message = format!(
-                "<QueueMessage><MessageText>{}</MessageText></QueueMessage>",
-                self.body
-            );
+            let message = to_xml(&QueueMessageSubmit {
+                message_text: self.body,
+            })?;
 
             let mut request = QueueClient::finalize_request(
                 url,

--- a/sdk/storage_queues/src/operations/update_message.rs
+++ b/sdk/storage_queues/src/operations/update_message.rs
@@ -1,9 +1,10 @@
-use crate::{clients::PopReceiptClient, prelude::*};
+use crate::{clients::PopReceiptClient, prelude::*, queue_message::QueueMessageSubmit};
 use azure_core::{
     error::Error,
     headers::Headers,
     headers::{rfc1123_from_headers_mandatory, HeaderName},
     prelude::*,
+    xml::to_xml,
     Method, Response as AzureResponse,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
@@ -24,13 +25,9 @@ impl UpdateMessageBuilder {
 
             self.visibility_timeout.append_to_url_query(&mut url);
 
-            // since the format is fixed we just decorate the message with the tags.
-            // This could be made optional in the future and/or more
-            // stringent.
-            let message = format!(
-                "<QueueMessage><MessageText>{}</MessageText></QueueMessage>",
-                self.body
-            );
+            let message = to_xml(&QueueMessageSubmit {
+                message_text: self.body,
+            })?;
 
             let mut request = PopReceiptClient::finalize_request(
                 url,

--- a/sdk/storage_queues/src/queue_message.rs
+++ b/sdk/storage_queues/src/queue_message.rs
@@ -1,0 +1,24 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+#[serde(rename = "QueueMessage")]
+pub(crate) struct QueueMessageSubmit {
+    #[serde(rename = "MessageText")]
+    pub(crate) message_text: String,
+}
+
+#[cfg(test)]
+mod test {
+    use super::QueueMessageSubmit;
+    use azure_core::xml::to_xml;
+
+    #[test]
+    fn test_serialize() -> azure_core::Result<()> {
+        let serialized = to_xml(&QueueMessageSubmit {
+            message_text: "hello".to_string(),
+        })?;
+        let expected = "<QueueMessage><MessageText>hello</MessageText></QueueMessage>";
+        assert_eq!(expected, serialized);
+        Ok(())
+    }
+}

--- a/sdk/storage_queues/src/queue_message.rs
+++ b/sdk/storage_queues/src/queue_message.rs
@@ -15,9 +15,9 @@ mod test {
     #[test]
     fn test_serialize() -> azure_core::Result<()> {
         let serialized = to_xml(&QueueMessageSubmit {
-            message_text: "hello".to_string(),
+            message_text: "<hello> \" there &".to_string(),
         })?;
-        let expected = "<QueueMessage><MessageText>hello</MessageText></QueueMessage>";
+        let expected = "<QueueMessage><MessageText>&lt;hello&gt; &quot; there &amp;</MessageText></QueueMessage>";
         assert_eq!(expected, serialized);
         Ok(())
     }


### PR DESCRIPTION
put_message and update_message in azure_storage_queue hand-generated XML, which meant invalid XML could be created if the message contained XML-specific characters which should be escaped (such as ", <, >, and &).