### PR TITLE
fix partition key typo in cosmos readme

### DIFF
--- a/sdk/data_cosmos/README.md
+++ b/sdk/data_cosmos/README.md
@@ -15,7 +15,7 @@ use azure_core::Context;
 use serde::{Deserialize, Serialize};
 
 // This is the stuct we want to use in our sample.
-// Make sure to have a collection with partition key "a_number" for this example to
+// Make sure to have a collection with partition key "number" for this example to
 // work (you can create with this SDK too, check the examples folder for that task).
 #[derive(Serialize, Deserialize, Debug)]
 struct MySampleStruct {

--- a/sdk/data_cosmos/src/lib.rs
+++ b/sdk/data_cosmos/src/lib.rs
@@ -18,7 +18,7 @@ use azure_core::Context;
 use serde::{Deserialize, Serialize};
 
 // This is the stuct we want to use in our sample.
-// Make sure to have a collection with partition key "a_number" for this example to
+// Make sure to have a collection with partition key "number" for this example to
 // work (you can create with this SDK too, check the examples folder for that task).
 #[derive(Serialize, Deserialize, Debug)]
 struct MySampleStruct {


### PR DESCRIPTION
note: I'm unsure whether `a_number` was chosen to avoid confusion with reserved keywords in other languages but I decided to just make the comment consistent with the actual code.