### PR TITLE
Removed mutex from storage credentials

### DIFF
--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.17", features = ["xml"] }
 time = "0.3.10"
-futures = "0.3"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -36,51 +36,46 @@ impl Policy for AuthorizationPolicy {
             "Authorization policies cannot be the last policy of a pipeline"
         );
 
-        // lock the credentials within a scope so that it is released as soon as possible
-        {
-            let creds = self.credentials.0.lock().await;
-
-            match creds.deref() {
-                StorageCredentialsInner::Key(account, key) => {
-                    if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
-                        let auth = generate_authorization(
-                            request.headers(),
-                            request.url(),
-                            *request.method(),
-                            account,
-                            key,
-                            *ctx.get()
-                                .expect("ServiceType must be in the Context at this point"),
-                        )?;
-                        request.insert_header(AUTHORIZATION, auth);
-                    }
+        match self.credentials.0.deref() {
+            StorageCredentialsInner::Key(account, key) => {
+                if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
+                    let auth = generate_authorization(
+                        request.headers(),
+                        request.url(),
+                        *request.method(),
+                        account,
+                        key,
+                        *ctx.get()
+                            .expect("ServiceType must be in the Context at this point"),
+                    )?;
+                    request.insert_header(AUTHORIZATION, auth);
                 }
-                StorageCredentialsInner::SASToken(query_pairs) => {
-                    // Ensure the signature param is not already present
-                    if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
-                        request
-                            .url_mut()
-                            .query_pairs_mut()
-                            .extend_pairs(query_pairs);
-                    }
-                }
-                StorageCredentialsInner::BearerToken(token) => {
-                    request.insert_header(AUTHORIZATION, format!("Bearer {token}"));
-                }
-                StorageCredentialsInner::TokenCredential(token_credential) => {
-                    let bearer_token = token_credential
-                        .get_token(STORAGE_TOKEN_SCOPE)
-                        .await
-                        .context(ErrorKind::Credential, "failed to get bearer token")?;
-
-                    request.insert_header(
-                        AUTHORIZATION,
-                        format!("Bearer {}", bearer_token.token.secret()),
-                    );
-                }
-                StorageCredentialsInner::Anonymous => {}
             }
-        };
+            StorageCredentialsInner::SASToken(query_pairs) => {
+                // Ensure the signature param is not already present
+                if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
+                    request
+                        .url_mut()
+                        .query_pairs_mut()
+                        .extend_pairs(query_pairs);
+                }
+            }
+            StorageCredentialsInner::BearerToken(token) => {
+                request.insert_header(AUTHORIZATION, format!("Bearer {token}"));
+            }
+            StorageCredentialsInner::TokenCredential(token_credential) => {
+                let bearer_token = token_credential
+                    .get_token(STORAGE_TOKEN_SCOPE)
+                    .await
+                    .context(ErrorKind::Credential, "failed to get bearer token")?;
+
+                request.insert_header(
+                    AUTHORIZATION,
+                    format!("Bearer {}", bearer_token.token.secret()),
+                );
+            }
+            StorageCredentialsInner::Anonymous => {}
+        }
 
         next[0].send(ctx, request, &next[1..]).await
     }

--- a/sdk/storage/src/clients.rs
+++ b/sdk/storage/src/clients.rs
@@ -54,8 +54,7 @@ pub async fn shared_access_signature(
     expiry: OffsetDateTime,
     permissions: AccountSasPermissions,
 ) -> Result<AccountSharedAccessSignature, Error> {
-    let creds = storage_credentials.0.lock().await;
-    let StorageCredentialsInner::Key(account, key) = creds.deref() else {
+    let StorageCredentialsInner::Key(account, key) = storage_credentials.0.deref() else {
         return Err(Error::message(
             ErrorKind::Credential,
             "Shared access signature generation - SAS can be generated with access_key clients",

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -13,7 +13,6 @@ use azure_storage::{
     },
     CloudLocation, StorageCredentials, StorageCredentialsInner,
 };
-use std::ops::Deref;
 use time::OffsetDateTime;
 
 #[derive(Debug, Clone)]
@@ -123,8 +122,8 @@ impl ContainerClient {
         permissions: BlobSasPermissions,
         expiry: OffsetDateTime,
     ) -> azure_core::Result<BlobSharedAccessSignature> {
-        let creds = self.service_client.credentials().0.lock().await;
-        let StorageCredentialsInner::Key(account, key) = creds.deref() else {
+        let creds = self.service_client.credentials().0.as_ref();
+        let StorageCredentialsInner::Key(account, key) = creds else {
             return Err(Error::message(
                 ErrorKind::Credential,
                 "Shared access signature generation - SAS can be generated with access_key clients",


### PR DESCRIPTION
Mutexes should be avoided whenever possible, as they can result in slower code and deadlocks. It also requires more code to use it, as well as a higher cognitive load on the developer side to reason about potential deadlocks and how to run stuff in parallel.

This PR removes the `Mutex` in StorageCredentials's inner argument.

A corollary is that many function signatures no longer need to be `async` (since most were async for the async lock operation). This PR does not make such a change, as it has a larger blast radius.

A second corollary is that the crate no longer needs to depend on `futures`. This PR removes this dependency.

# Backward incompatible changes:

* the inner attribute of `StorageCredentials` was modified from `Arc<Mutex<StorageCredentialsInner>>` to `Arc<StorageCredentialsInner>`. Its usage no longer requires locking.
* `StorageCredentials::replace`'s signature changed from `replace(&self, other: Self)` to `replace(&mut self, other: Self)`
