### PR TITLE
Replaced `StorageCredentials` by `StorageCredentialsInner`

### DIFF
--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.17", features = ["xml"] }
 time = "0.3.10"
-futures = "0.3"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -36,51 +36,46 @@ impl Policy for AuthorizationPolicy {
             "Authorization policies cannot be the last policy of a pipeline"
         );
 
-        // lock the credentials within a scope so that it is released as soon as possible
-        {
-            let creds = self.credentials.0.lock().await;
-
-            match creds.deref() {
-                StorageCredentialsInner::Key(account, key) => {
-                    if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
-                        let auth = generate_authorization(
-                            request.headers(),
-                            request.url(),
-                            *request.method(),
-                            account,
-                            key,
-                            *ctx.get()
-                                .expect("ServiceType must be in the Context at this point"),
-                        )?;
-                        request.insert_header(AUTHORIZATION, auth);
-                    }
+        match self.credentials.0.deref() {
+            StorageCredentialsInner::Key(account, key) => {
+                if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
+                    let auth = generate_authorization(
+                        request.headers(),
+                        request.url(),
+                        *request.method(),
+                        account,
+                        key,
+                        *ctx.get()
+                            .expect("ServiceType must be in the Context at this point"),
+                    )?;
+                    request.insert_header(AUTHORIZATION, auth);
                 }
-                StorageCredentialsInner::SASToken(query_pairs) => {
-                    // Ensure the signature param is not already present
-                    if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
-                        request
-                            .url_mut()
-                            .query_pairs_mut()
-                            .extend_pairs(query_pairs);
-                    }
-                }
-                StorageCredentialsInner::BearerToken(token) => {
-                    request.insert_header(AUTHORIZATION, format!("Bearer {token}"));
-                }
-                StorageCredentialsInner::TokenCredential(token_credential) => {
-                    let bearer_token = token_credential
-                        .get_token(STORAGE_TOKEN_SCOPE)
-                        .await
-                        .context(ErrorKind::Credential, "failed to get bearer token")?;
-
-                    request.insert_header(
-                        AUTHORIZATION,
-                        format!("Bearer {}", bearer_token.token.secret()),
-                    );
-                }
-                StorageCredentialsInner::Anonymous => {}
             }
-        };
+            StorageCredentialsInner::SASToken(query_pairs) => {
+                // Ensure the signature param is not already present
+                if !request.url().query_pairs().any(|(k, _)| &*k == "sig") {
+                    request
+                        .url_mut()
+                        .query_pairs_mut()
+                        .extend_pairs(query_pairs);
+                }
+            }
+            StorageCredentialsInner::BearerToken(token) => {
+                request.insert_header(AUTHORIZATION, format!("Bearer {token}"));
+            }
+            StorageCredentialsInner::TokenCredential(token_credential) => {
+                let bearer_token = token_credential
+                    .get_token(STORAGE_TOKEN_SCOPE)
+                    .await
+                    .context(ErrorKind::Credential, "failed to get bearer token")?;
+
+                request.insert_header(
+                    AUTHORIZATION,
+                    format!("Bearer {}", bearer_token.token.secret()),
+                );
+            }
+            StorageCredentialsInner::Anonymous => {}
+        }
 
         next[0].send(ctx, request, &next[1..]).await
     }

--- a/sdk/storage/src/clients.rs
+++ b/sdk/storage/src/clients.rs
@@ -1,5 +1,5 @@
 use crate::{
-    authorization::{AuthorizationPolicy, StorageCredentialsInner},
+    authorization::AuthorizationPolicy,
     shared_access_signature::account_sas::{
         AccountSasPermissions, AccountSasResource, AccountSasResourceType,
         AccountSharedAccessSignature,
@@ -12,7 +12,7 @@ use azure_core::{
     headers::*,
     Body, ClientOptions, Method, Pipeline, Request,
 };
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 use time::OffsetDateTime;
 use url::Url;
 
@@ -54,7 +54,7 @@ pub async fn shared_access_signature(
     expiry: OffsetDateTime,
     permissions: AccountSasPermissions,
 ) -> Result<AccountSharedAccessSignature, Error> {
-    let StorageCredentialsInner::Key(account, key) = storage_credentials.0.deref() else {
+    let StorageCredentials::Key(account, key) = &storage_credentials else {
         return Err(Error::message(
             ErrorKind::Credential,
             "Shared access signature generation - SAS can be generated with access_key clients",

--- a/sdk/storage/src/clients.rs
+++ b/sdk/storage/src/clients.rs
@@ -54,8 +54,7 @@ pub async fn shared_access_signature(
     expiry: OffsetDateTime,
     permissions: AccountSasPermissions,
 ) -> Result<AccountSharedAccessSignature, Error> {
-    let creds = storage_credentials.0.lock().await;
-    let StorageCredentialsInner::Key(account, key) = creds.deref() else {
+    let StorageCredentialsInner::Key(account, key) = storage_credentials.0.deref() else {
         return Err(Error::message(
             ErrorKind::Credential,
             "Shared access signature generation - SAS can be generated with access_key clients",

--- a/sdk/storage/src/lib.rs
+++ b/sdk/storage/src/lib.rs
@@ -39,7 +39,7 @@ pub mod shared_access_signature;
 
 pub use self::connection_string::{ConnectionString, EndpointProtocol};
 pub use self::connection_string_builder::ConnectionStringBuilder;
-pub use authorization::{StorageCredentials, StorageCredentialsInner};
+pub use authorization::StorageCredentials;
 pub use cloud_location::*;
 pub mod headers;
 pub use copy_id::{copy_id_from_headers, CopyId};

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -15,7 +15,6 @@ use azure_storage::{
         service_sas::{BlobSharedAccessSignature, BlobSignedResource},
         SasToken,
     },
-    StorageCredentialsInner,
 };
 use futures::StreamExt;
 use time::OffsetDateTime;
@@ -234,8 +233,8 @@ impl BlobClient {
         permissions: BlobSasPermissions,
         expiry: OffsetDateTime,
     ) -> azure_core::Result<BlobSharedAccessSignature> {
-        let creds = &self.container_client.credentials().0;
-        let StorageCredentialsInner::Key(account, key) = creds.as_ref() else {
+        let creds = self.container_client.credentials();
+        let StorageCredentials::Key(account, key) = creds else {
             return Err(Error::message(
                 ErrorKind::Credential,
                 "Shared access signature generation - SAS can be generated with access_key clients",
@@ -346,13 +345,13 @@ mod tests {
         assert_eq!(blob_client.blob_name(), path);
         assert_eq!(blob_client.container_client().container_name(), container);
 
-        let creds = blob_client.container_client.credentials().0.as_ref();
-        assert!(matches!(creds, StorageCredentialsInner::SASToken(_)));
+        let creds = blob_client.container_client.credentials();
+        assert!(matches!(creds, StorageCredentials::SASToken(_)));
 
         let url = Url::parse("https://accountname.blob.core.windows.net/mycontainer/myblob")?;
         let blob_client = BlobClient::from_sas_url(&url)?;
-        let creds = blob_client.container_client.credentials().0.as_ref();
-        assert!(matches!(creds, StorageCredentialsInner::Anonymous));
+        let creds = blob_client.container_client.credentials();
+        assert!(matches!(creds, StorageCredentials::Anonymous));
 
         let url = Url::parse("https://accountname.blob.core.windows.net/mycontainer?token=1")?;
         assert!(BlobClient::from_sas_url(&url).is_err(), "missing path");

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -13,7 +13,6 @@ use azure_storage::{
     },
     CloudLocation, StorageCredentials, StorageCredentialsInner,
 };
-use std::ops::Deref;
 use time::OffsetDateTime;
 
 #[derive(Debug, Clone)]
@@ -123,8 +122,8 @@ impl ContainerClient {
         permissions: BlobSasPermissions,
         expiry: OffsetDateTime,
     ) -> azure_core::Result<BlobSharedAccessSignature> {
-        let creds = self.service_client.credentials().0.lock().await;
-        let StorageCredentialsInner::Key(account, key) = creds.deref() else {
+        let creds = self.service_client.credentials().0.as_ref();
+        let StorageCredentialsInner::Key(account, key) = creds else {
             return Err(Error::message(
                 ErrorKind::Credential,
                 "Shared access signature generation - SAS can be generated with access_key clients",

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -11,7 +11,7 @@ use azure_storage::{
         service_sas::{BlobSharedAccessSignature, BlobSignedResource},
         SasToken,
     },
-    CloudLocation, StorageCredentials, StorageCredentialsInner,
+    CloudLocation, StorageCredentials,
 };
 use time::OffsetDateTime;
 
@@ -122,8 +122,8 @@ impl ContainerClient {
         permissions: BlobSasPermissions,
         expiry: OffsetDateTime,
     ) -> azure_core::Result<BlobSharedAccessSignature> {
-        let creds = self.service_client.credentials().0.as_ref();
-        let StorageCredentialsInner::Key(account, key) = creds else {
+        let creds = self.service_client.credentials();
+        let StorageCredentials::Key(account, key) = creds else {
             return Err(Error::message(
                 ErrorKind::Credential,
                 "Shared access signature generation - SAS can be generated with access_key clients",


### PR DESCRIPTION
This PR:

* Removes `StorageCredentials` struct
* Renames `StorageCredentialsInner` to `StorageCredentials`

Thereby removing one level of indirection in the storage credentials.

# Background

The struct `StorageCredentials` was a wrapper to `pub Arc<Mutex<StorageCredentialsInner>>`. However, this is not really needed:

* #1470 removed the `Mutex`, thereby making `StorageCredentials(pub Arc<StorageCredentialsInner>)`
* The `Arc` in this context is not required, as `StorageCredentialsInner` is not a large enum (and if any of the members is large, we should optimize them instead, e.g. using `Arc<[String]>` instead of `Vec<String>`).

# This PR

As such, we can make life easier for our users by providing an easier API: remove the indirection provided by `StorageCredentials` by replacing it altogether with the current `StorageCredentialsInner`. This PR does this.