### PR TITLE
standardize hmac_sha256 implementation

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -34,6 +34,9 @@ pin-project = "1.0"
 paste = "1.0"
 time = { version = "0.3.10", features = ["serde-well-known", "macros"] }
 tokio = {version="1.0", optional=true}
+hmac = {version="0.12", optional=true}
+sha2 = {version="0.10", optional=true}
+openssl = {version="0.10", optional=true}
 
 # When target is `wasm32`, include `getrandom` and enable `wasm-bindgen` feature in `time`.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -53,6 +56,8 @@ default = []
 enable_reqwest = ["reqwest/default-tls"]
 enable_reqwest_gzip = ["reqwest/gzip"]
 enable_reqwest_rustls = ["reqwest/rustls-tls"]
+hmac_rust = ["dep:sha2", "dep:hmac"]
+hmac_openssl = ["dep:openssl"]
 test_e2e = []
 azurite_workaround = []
 xml = ["quick-xml"]

--- a/sdk/core/src/hmac.rs
+++ b/sdk/core/src/hmac.rs
@@ -36,6 +36,11 @@ pub fn hmac_sha256(data: &str, key: &str) -> crate::Result<String> {
     Ok(base64::encode(signature))
 }
 
+#[cfg(not(any(feature = "hmac_rust", feature = "hmac_openssl")))]
+pub fn hmac_sha256(_data: &str, _key: &str) -> crate::Result<String> {
+    unimplemented!("An HMAC signing request was called without an hmac implementation.  Make sure to enable either the `hmac_rust` or `hmac_openssl` feature");
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/sdk/core/src/hmac.rs
+++ b/sdk/core/src/hmac.rs
@@ -4,7 +4,8 @@ use crate::{
     error::{ErrorKind, ResultExt},
 };
 
-#[cfg(feature = "hmac_rust")]
+// if both hmac_rust and hmac_openssl are enabled, use hmac_openssl
+#[cfg(all(feature = "hmac_rust", not(feature = "hmac_openssl")))]
 pub fn hmac_sha256(data: &str, key: &str) -> crate::Result<String> {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;

--- a/sdk/core/src/hmac.rs
+++ b/sdk/core/src/hmac.rs
@@ -1,24 +1,27 @@
-use azure_core::{
+#[cfg(any(feature = "hmac_rust", feature = "hmac_openssl"))]
+use crate::{
     base64,
     error::{ErrorKind, ResultExt},
 };
 
-#[cfg(not(feature = "enable_openssl_sign"))]
-pub fn sign(data: &str, key: &str) -> azure_core::Result<String> {
+#[cfg(feature = "hmac_rust")]
+pub fn hmac_sha256(data: &str, key: &str) -> crate::Result<String> {
     use hmac::{Hmac, Mac};
     use sha2::Sha256;
-    let mut hmac = Hmac::<Sha256>::new_from_slice(&base64::decode(key)?)
+    let key = base64::decode(key)?;
+    let mut hmac = Hmac::<Sha256>::new_from_slice(&key)
         .with_context(ErrorKind::DataConversion, || {
-            format!("failed to create hmac from key: {key}")
+            "failed to create hmac from key"
         })?;
     hmac.update(data.as_bytes());
     let signature = hmac.finalize().into_bytes();
     Ok(base64::encode(signature))
 }
 
-#[cfg(feature = "enable_openssl_sign")]
-pub fn sign(data: &str, key: &str) -> azure_core::Result<String> {
+#[cfg(feature = "hmac_openssl")]
+pub fn hmac_sha256(data: &str, key: &str) -> crate::Result<String> {
     use openssl::{error::ErrorStack, hash::MessageDigest, pkey::PKey, sign::Signer};
+
     let dkey = base64::decode(key)?;
     let signature = || -> Result<Vec<u8>, ErrorStack> {
         let pkey = PKey::hmac(&dkey)?;
@@ -27,7 +30,7 @@ pub fn sign(data: &str, key: &str) -> azure_core::Result<String> {
         Ok(signer.sign_to_vec()?)
     }()
     .with_context(ErrorKind::DataConversion, || {
-        format!("failed to create hmac from key: {key}")
+        "failed to create hmac from key"
     })?;
     Ok(base64::encode(signature))
 }
@@ -40,7 +43,7 @@ mod tests {
         let data = "create hmac signature for data";
         let key = "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
-        let sig = super::sign(data, key).unwrap();
+        let sig = super::hmac_sha256(data, key).unwrap();
 
         let expected_sig = "D/y9XyIEdUzEbdV570h8dou/mfkbMA1lKCOPqPDPAd0=";
         assert_eq!(sig, expected_sig);

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -20,6 +20,7 @@ mod constants;
 mod context;
 pub mod date;
 pub mod error;
+pub mod hmac;
 mod http_client;
 mod models;
 mod options;

--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -24,8 +24,6 @@ url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 thiserror = "1.0"
 bytes = "1.0"
-hmac = "0.12"
-sha2 = "0.10"
 
 [dev-dependencies]
 env_logger = "0.10"
@@ -36,8 +34,10 @@ stop-token = { version = "0.7.0", features = ["tokio"] }
 mock_transport = { path = "../../eng/test/mock_transport" }
 
 [features]
-default = ["enable_reqwest"]
+default = ["enable_reqwest", "hmac_rust"]
 enable_reqwest = ["azure_core/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
 test_e2e = []
 into_future = []
+hmac_rust = ["azure_core/hmac_rust"]
+hmac_openssl = ["azure_core/hmac_openssl"]

--- a/sdk/data_cosmos/README.md
+++ b/sdk/data_cosmos/README.md
@@ -48,7 +48,7 @@ async fn main() -> azure_core::Result<()> {
 
     // First, create an authorization token. There are two types of tokens: primary and resource constrained.
     // Please check the Azure documentation or the examples folder on how to create and use token-based permissions.
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(&primary_key)?;
 
     // Next we will create a Cosmos client.
     let client = CosmosClient::new(account, authorization_token);

--- a/sdk/data_cosmos/examples/attachments.rs
+++ b/sdk/data_cosmos/examples/attachments.rs
@@ -40,7 +40,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -20,7 +20,7 @@ async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables, and
     // create an authorization token.
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     // Create a new Cosmos client.
     let client = CosmosClient::new(args.account, authorization_token);

--- a/sdk/data_cosmos/examples/client_builder.rs
+++ b/sdk/data_cosmos/examples/client_builder.rs
@@ -18,7 +18,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let _database = CosmosClient::builder(args.account, authorization_token)
         .retry(RetryOptions::default())

--- a/sdk/data_cosmos/examples/collection.rs
+++ b/sdk/data_cosmos/examples/collection.rs
@@ -19,7 +19,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
 
     // This is how you construct an authorization token.
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     // Once we have an authorization token you can create a client instance. You can change the
     // authorization token at later time if you need, for example, to escalate the privileges for a

--- a/sdk/data_cosmos/examples/create_delete_database.rs
+++ b/sdk/data_cosmos/examples/create_delete_database.rs
@@ -28,8 +28,7 @@ async fn main() -> azure_core::Result<()> {
     // errors, plus Azure specific ones. For example if a REST call returns the
     // unexpected result (ie NotFound instead of Ok) we return an Err telling
     // you that.
-    let authorization_token =
-        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = permission::AuthorizationToken::primary_key(args.primary_key)?;
 
     // Once we have an authorization token you can create a client instance. You can change the
     // authorization token at later time if you need, for example, to escalate the privileges for a

--- a/sdk/data_cosmos/examples/database.rs
+++ b/sdk/data_cosmos/examples/database.rs
@@ -19,8 +19,7 @@ async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
 
     // First, we create an authorization token.
-    let authorization_token =
-        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = permission::AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token);
 

--- a/sdk/data_cosmos/examples/document.rs
+++ b/sdk/data_cosmos/examples/document.rs
@@ -51,7 +51,7 @@ async fn main() -> azure_core::Result<()> {
     // First, we create an authorization token. There are two types of tokens, master and resource
     // constrained. Please check the Azure documentation for details. You can change tokens
     // at will and it's a good practice to raise your privileges only when needed.
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     // Next we will create a Cosmos client. You need an authorization_token but you can later
     // change it if needed.

--- a/sdk/data_cosmos/examples/document_entries.rs
+++ b/sdk/data_cosmos/examples/document_entries.rs
@@ -42,8 +42,7 @@ impl azure_data_cosmos::CosmosEntity for MySampleStruct {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token =
-        permission::AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = permission::AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/get_database.rs
+++ b/sdk/data_cosmos/examples/get_database.rs
@@ -22,7 +22,7 @@ async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name.clone());

--- a/sdk/data_cosmos/examples/key_ranges.rs
+++ b/sdk/data_cosmos/examples/key_ranges.rs
@@ -18,7 +18,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/permission.rs
+++ b/sdk/data_cosmos/examples/permission.rs
@@ -25,7 +25,7 @@ async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token);
 

--- a/sdk/data_cosmos/examples/query_document.rs
+++ b/sdk/data_cosmos/examples/query_document.rs
@@ -53,7 +53,7 @@ struct Person {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token)
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/readme.rs
+++ b/sdk/data_cosmos/examples/readme.rs
@@ -55,7 +55,7 @@ async fn main() -> azure_core::Result<()> {
     // There are two types of tokens: primary and resource constrained. The SDK supports both, but
     // we'll use a primary token. Please check the Azure documentation for details or the examples folder
     // on how to create and use token-based permissions.
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     // Next we will create a Cosmos client.
     let client = CosmosClient::new(args.account, authorization_token);

--- a/sdk/data_cosmos/examples/remove_all_documents.rs
+++ b/sdk/data_cosmos/examples/remove_all_documents.rs
@@ -24,7 +24,7 @@ struct Args {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     // Next we will create a Cosmos client.
     let client = CosmosClient::new(args.account, authorization_token);

--- a/sdk/data_cosmos/examples/stored_proc.rs
+++ b/sdk/data_cosmos/examples/stored_proc.rs
@@ -31,7 +31,7 @@ const FUNCTION_BODY: &str = r#"
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let collection = CosmosClient::new(args.account.clone(), authorization_token)
         .database_client(args.database_name)

--- a/sdk/data_cosmos/examples/trigger.rs
+++ b/sdk/data_cosmos/examples/trigger.rs
@@ -52,7 +52,7 @@ function updateMetadata() {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name);

--- a/sdk/data_cosmos/examples/user.rs
+++ b/sdk/data_cosmos/examples/user.rs
@@ -21,7 +21,7 @@ async fn main() -> azure_core::Result<()> {
     // First we retrieve the account name and access key from environment variables.
     // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name);

--- a/sdk/data_cosmos/examples/user_defined_function.rs
+++ b/sdk/data_cosmos/examples/user_defined_function.rs
@@ -31,7 +31,7 @@ function tax(income) {
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
     let args = Args::parse();
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name);

--- a/sdk/data_cosmos/examples/user_permission_token.rs
+++ b/sdk/data_cosmos/examples/user_permission_token.rs
@@ -24,7 +24,7 @@ async fn main() -> azure_core::Result<()> {
     // We expect access keys (ie, not resource constrained)
     let args = Args::parse();
 
-    let authorization_token = AuthorizationToken::primary_from_base64(&args.primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(args.primary_key)?;
 
     let client = CosmosClient::new(args.account, authorization_token);
     let database = client.database_client(args.database_name.clone());

--- a/sdk/data_cosmos/src/clients/cosmos.rs
+++ b/sdk/data_cosmos/src/clients/cosmos.rs
@@ -235,7 +235,7 @@ impl CloudLocation {
             | CloudLocation::China { auth_token, .. }
             | CloudLocation::Custom { auth_token, .. } => auth_token.clone(),
             CloudLocation::Emulator { .. } => {
-                AuthorizationToken::primary_from_base64(EMULATOR_ACCOUNT_KEY).unwrap()
+                AuthorizationToken::primary_key(EMULATOR_ACCOUNT_KEY).unwrap()
             }
         }
     }

--- a/sdk/data_cosmos/src/clients/mod.rs
+++ b/sdk/data_cosmos/src/clients/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! let account: String = todo!("Get Cosmos account name from the Azure Portal");
 //! let primary_key: String = todo!("Get Cosmos primary key from the Azure Portal");
-//! let authorization_token = AuthorizationToken::primary_from_base64(&primary_key).unwrap();
+//! let authorization_token = AuthorizationToken::primary_key(&primary_key).unwrap();
 //! let database_name: String = todo!("Think of some database name");
 //!
 //! // Create an http client, then a `CosmosClient`, and then a `DatabaseClient`

--- a/sdk/data_cosmos/src/lib.rs
+++ b/sdk/data_cosmos/src/lib.rs
@@ -51,7 +51,7 @@ async fn main() -> azure_core::Result<()> {
 
     // First, create an authorization token. There are two types of tokens: primary and resource constrained.
     // Please check the Azure documentation or the examples folder on how to create and use token-based permissions.
-    let authorization_token = AuthorizationToken::primary_from_base64(&primary_key)?;
+    let authorization_token = AuthorizationToken::primary_key(&primary_key)?;
 
     // Next we will create a Cosmos client.
     let client = CosmosClient::new(account, authorization_token);

--- a/sdk/data_cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/authorization_token.rs
@@ -1,9 +1,5 @@
 use super::PermissionToken;
 use azure_core::auth::TokenCredential;
-use azure_core::{
-    base64,
-    error::{Error, ErrorKind},
-};
 use std::fmt;
 use std::sync::Arc;
 
@@ -13,7 +9,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub enum AuthorizationToken {
     /// Used for administrative resources: database accounts, databases, users, and permissions
-    Primary(Vec<u8>),
+    PrimaryKey(String),
     /// Used for application resources: containers, documents, attachments, stored procedures, triggers, and UDFs
     Resource(String),
     /// AAD token credential
@@ -24,12 +20,11 @@ impl AuthorizationToken {
     /// Create a primary `AuthorizationToken` from base64 encoded data
     ///
     /// The token is *not* verified to be valid.
-    pub fn primary_from_base64(base64_encoded: &str) -> azure_core::Result<AuthorizationToken> {
-        let key = base64::decode(base64_encoded).map_err(|e|
-            Error::full(ErrorKind::Credential, e, "failed to base64 decode the primary credential - ensure that the credential is properly base64 encoded")
-        )?;
-
-        Ok(AuthorizationToken::Primary(key))
+    pub fn primary_key<S>(key: S) -> azure_core::Result<AuthorizationToken>
+    where
+        S: Into<String>,
+    {
+        Ok(AuthorizationToken::PrimaryKey(key.into()))
     }
 
     /// Create a resource `AuthorizationToken` for the given resource.
@@ -50,7 +45,7 @@ impl fmt::Debug for AuthorizationToken {
             f,
             "AuthorizationToken::{}(***hidden***)",
             match self {
-                AuthorizationToken::Primary(_) => "Master",
+                AuthorizationToken::PrimaryKey(_) => "Master",
                 AuthorizationToken::Resource(_) => "Resource",
                 AuthorizationToken::TokenCredential(_) => "TokenCredential",
             }

--- a/sdk/data_cosmos/src/resources/permission/permission_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission_token.rs
@@ -17,9 +17,9 @@ pub struct PermissionToken {
 
 impl PartialEq for PermissionToken {
     fn eq(&self, other: &Self) -> bool {
-        use AuthorizationToken::{Primary, Resource};
+        use AuthorizationToken::{PrimaryKey, Resource};
         match (&self.token, &other.token) {
-            (Primary(a), Primary(b)) => a == b,
+            (PrimaryKey(a), PrimaryKey(b)) => a == b,
             (Resource(a), Resource(b)) => a == b,
             _ => false,
         }
@@ -42,7 +42,7 @@ impl std::fmt::Display for PermissionToken {
         use std::borrow::Cow;
         let (permission_type, signature) = match &self.token {
             AuthorizationToken::Resource(s) => ("resource", Cow::Borrowed(s)),
-            AuthorizationToken::Primary(s) => ("master", Cow::Owned(base64::encode(s))),
+            AuthorizationToken::PrimaryKey(s) => ("master", Cow::Owned(base64::encode(s))),
             AuthorizationToken::TokenCredential(_) => {
                 panic!("TokenCredential not supported for PermissionToken")
             }
@@ -86,10 +86,7 @@ impl std::convert::TryFrom<&str> for PermissionToken {
         let permission_type = try_get_item(s, &parts, PERMISSION_TYPE_PREFIX)?;
         let signature = try_get_item(s, &parts, SIGNATURE_PREFIX)?.to_owned();
         let token = match permission_type {
-            "master" => AuthorizationToken::Primary(
-                base64::decode(signature)
-                    .map_err(PermissionTokenParseError::InvalidBase64Encoding)?,
-            ),
+            "master" => AuthorizationToken::PrimaryKey(signature),
             "resource" => AuthorizationToken::Resource(signature),
             _ => {
                 return Err(PermissionTokenParseError::UnrecognizedPermissionType {

--- a/sdk/data_cosmos/tests/setup.rs
+++ b/sdk/data_cosmos/tests/setup.rs
@@ -17,5 +17,5 @@ fn get_authorization_token() -> azure_core::Result<AuthorizationToken> {
     let key =
         std::env::var("COSMOS_PRIMARY_KEY").expect("Set env variable COSMOS_PRIMARY_KEY first!");
 
-    AuthorizationToken::primary_from_base64(&key)
+    AuthorizationToken::primary_key(key)
 }

--- a/sdk/data_cosmos/tests/setup_mock.rs
+++ b/sdk/data_cosmos/tests/setup_mock.rs
@@ -30,7 +30,7 @@ fn get_authorization_token() -> AuthorizationToken {
         let key = std::env::var("COSMOS_PRIMARY_KEY")
             .expect("Set env variable COSMOS_PRIMARY_KEY first!");
 
-        AuthorizationToken::primary_from_base64(&key).ok()
+        AuthorizationToken::primary_key(key).ok()
     })
     .flatten()
     .unwrap_or_else(|| AuthorizationToken::new_resource(String::from("MOCK_RESOURCE")))

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -14,11 +14,9 @@ async-trait = "0.1"
 azure_core = { path = "../core", version = "0.17", default-features = false }
 bytes = "1.0"
 time = "0.3.10"
-hmac = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_derive = "1.0"
-sha2 = "0.10"
 url = "2.2"
 thiserror = "1.0"
 futures = "0.3"
@@ -31,4 +29,6 @@ reqwest = "0.11.0"
 tokio = { version = "1.0", features = ["macros"] }
 
 [features]
-default = ["azure_core/enable_reqwest"]
+default = ["azure_core/enable_reqwest", "hmac_rust"]
+hmac_rust = ["azure_core/hmac_rust"]
+hmac_openssl = ["azure_core/hmac_openssl"]

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -19,7 +19,6 @@ azure_core = { path = "../core", version = "0.17" }
 time = { version = "0.3.10", features = ["serde-well-known"] }
 log = "0.4"
 url = "2.2"
-ring = "0.17"
 bytes = "1.0"
 serde = "1.0"
 serde_json = "1.0"
@@ -30,5 +29,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 env_logger = "0.10"
 
 [features]
-default = ["azure_core/enable_reqwest"]
+default = ["azure_core/enable_reqwest", "hmac_rust"]
 test_e2e = []
+hmac_rust = ["azure_core/hmac_rust"]
+hmac_openssl = ["azure_core/hmac_openssl"]

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -19,12 +19,11 @@ azure_core = { path = "../core", version = "0.17" }
 time = { version = "0.3.10", features = ["serde-well-known"] }
 log = "0.4"
 url = "2.2"
-hmac = "0.12"
-sha2 = "0.10"
 ring = "0.17"
 bytes = "1.0"
 serde = "1.0"
 serde_json = "1.0"
+
 [dev-dependencies]
 futures = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -1,7 +1,7 @@
+use azure_core::hmac::hmac_sha256;
 use azure_core::{
-    base64, error::Error, headers, CollectedResponse, HttpClient, Method, Request, StatusCode, Url,
+    error::Error, headers, CollectedResponse, HttpClient, Method, Request, StatusCode, Url,
 };
-use ring::hmac;
 use serde::Deserialize;
 use std::str::FromStr;
 use std::time::Duration;
@@ -26,7 +26,7 @@ fn finalize_request(
     method: azure_core::Method,
     body: Option<String>,
     policy_name: &str,
-    signing_key: &hmac::Key,
+    signing_key: &str,
 ) -> azure_core::Result<Request> {
     // generate sas auth
     let sas = generate_signature(
@@ -34,7 +34,7 @@ fn finalize_request(
         signing_key,
         url,
         Duration::from_secs(DEFAULT_SAS_DURATION),
-    );
+    )?;
 
     // create request builder
     let mut request = Request::new(Url::parse(url)?, method);
@@ -56,26 +56,27 @@ fn finalize_request(
 /// Generates a SAS signature
 fn generate_signature(
     policy_name: &str,
-    signing_key: &hmac::Key,
+    signing_key: &str,
     url: &str,
     ttl: Duration,
-) -> String {
+) -> azure_core::Result<String> {
     let sr: String = form_urlencoded::byte_serialize(url.as_bytes()).collect(); // <namespace>.servicebus.windows.net
     let se = OffsetDateTime::now_utc().add(ttl).unix_timestamp(); // token expiry instant
 
     let str_to_sign = format!("{sr}\n{se}");
-    let sig = hmac::sign(signing_key, str_to_sign.as_bytes()); // shared access key
+    let sig = hmac_sha256(&str_to_sign, signing_key)?;
 
     // shadow sig
     let sig = {
-        let sig = base64::encode(sig.as_ref());
         let mut ser = Serializer::new(String::new());
         ser.append_pair("sig", &sig);
         ser.finish()
     };
 
     // format sas
-    format!("SharedAccessSignature sr={sr}&{sig}&se={se}&skn={policy_name}")
+    Ok(format!(
+        "SharedAccessSignature sr={sr}&{sig}&se={se}&skn={policy_name}"
+    ))
 }
 
 /// Sends a message to the queue or topic
@@ -84,7 +85,7 @@ async fn send_message(
     namespace: &str,
     queue_or_topic: &str,
     policy_name: &str,
-    signing_key: &hmac::Key,
+    signing_key: &str,
     msg: &str,
 ) -> azure_core::Result<()> {
     let url = format!("https://{namespace}.servicebus.windows.net/{queue_or_topic}/messages");
@@ -110,7 +111,7 @@ async fn receive_and_delete_message(
     namespace: &str,
     queue_or_topic: &str,
     policy_name: &str,
-    signing_key: &hmac::Key,
+    signing_key: &str,
     subscription: Option<&str>,
 ) -> azure_core::Result<CollectedResponse> {
     let url = get_head_url(namespace, queue_or_topic, subscription);
@@ -135,7 +136,7 @@ async fn peek_lock_message(
     namespace: &str,
     queue_or_topic: &str,
     policy_name: &str,
-    signing_key: &hmac::Key,
+    signing_key: &str,
     lock_expiry: Option<Duration>,
     subscription: Option<&str>,
 ) -> azure_core::Result<CollectedResponse> {
@@ -158,7 +159,7 @@ async fn peek_lock_message2(
     namespace: &str,
     queue_or_topic: &str,
     policy_name: &str,
-    signing_key: &hmac::Key,
+    signing_key: &str,
     lock_expiry: Option<Duration>,
     subscription: Option<&str>,
 ) -> azure_core::Result<PeekLockResponse> {
@@ -199,7 +200,7 @@ pub struct PeekLockResponse {
     status: StatusCode,
     http_client: Arc<dyn HttpClient>,
     policy_name: String,
-    signing_key: hmac::Key,
+    signing_key: String,
 }
 
 impl PeekLockResponse {

--- a/sdk/messaging_servicebus/src/service_bus/queue_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/queue_client.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     utils::body_bytes_to_utf8,
 };
-use ring::hmac::Key;
 use std::time::Duration;
 
 use azure_core::{error::Error, HttpClient};
@@ -19,7 +18,7 @@ pub struct QueueClient {
     namespace: String,
     queue: String,
     policy_name: String,
-    signing_key: Key,
+    signing_key: String,
 }
 
 impl QueueClient {
@@ -29,22 +28,20 @@ impl QueueClient {
         namespace: N,
         queue: Q,
         policy_name: P,
-        policy_key: K,
+        signing_key: K,
     ) -> Result<QueueClient, Error>
     where
         N: Into<String>,
         Q: Into<String>,
         P: Into<String>,
-        K: AsRef<str>,
+        K: Into<String>,
     {
-        let signing_key = Key::new(ring::hmac::HMAC_SHA256, policy_key.as_ref().as_bytes());
-
         Ok(QueueClient {
             http_client,
             namespace: namespace.into(),
             queue: queue.into(),
             policy_name: policy_name.into(),
-            signing_key,
+            signing_key: signing_key.into(),
         })
     }
 

--- a/sdk/messaging_servicebus/src/service_bus/topic_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/topic_client.rs
@@ -7,7 +7,6 @@ use crate::{
     },
     utils::body_bytes_to_utf8,
 };
-use ring::hmac::Key;
 use std::time::Duration;
 
 use azure_core::{error::Error, HttpClient};
@@ -19,7 +18,7 @@ pub struct TopicClient {
     namespace: String,
     topic: String,
     policy_name: String,
-    signing_key: Key,
+    signing_key: String,
 }
 
 #[derive(Debug, Clone)]
@@ -40,22 +39,20 @@ impl TopicClient {
         namespace: N,
         topic: T,
         policy_name: P,
-        policy_key: K,
+        signing_key: K,
     ) -> Result<TopicClient, Error>
     where
         N: Into<String>,
         T: Into<String>,
         P: Into<String>,
-        K: AsRef<str>,
+        K: Into<String>,
     {
-        let signing_key = Key::new(ring::hmac::HMAC_SHA256, policy_key.as_ref().as_bytes());
-
         Ok(Self {
             http_client,
             namespace: namespace.into(),
             topic: topic.into(),
             policy_name: policy_name.into(),
-            signing_key,
+            signing_key: signing_key.into(),
         })
     }
 

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -25,9 +25,6 @@ url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 bytes = "1.0"
 RustyXML = "0.3"
-hmac = "0.12"
-sha2 = "0.10"
-openssl = { version = "0.10", optional=true }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
@@ -38,9 +35,10 @@ azure_identity = { path = "../identity", default-features = false }
 
 
 [features]
-default = ["enable_reqwest"]
+default = ["enable_reqwest", "hmac_rust"]
 test_e2e = []
 test_integration = []
-enable_openssl_sign = ["dep:openssl"]
 enable_reqwest = ["azure_core/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
+hmac_rust = ["azure_core/hmac_rust"]
+hmac_openssl = ["azure_core/hmac_openssl"]

--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -2,6 +2,7 @@ use crate::{clients::ServiceType, StorageCredentials, StorageCredentialsInner};
 use azure_core::{
     error::{ErrorKind, ResultExt},
     headers::*,
+    hmac::hmac_sha256,
     Context, Method, Policy, PolicyResult, Request,
 };
 use std::{borrow::Cow, ops::Deref, sync::Arc};
@@ -95,7 +96,7 @@ fn generate_authorization(
     service_type: ServiceType,
 ) -> azure_core::Result<String> {
     let str_to_sign = string_to_sign(h, u, method, account, service_type);
-    let auth = crate::hmac::sign(&str_to_sign, key).context(
+    let auth = hmac_sha256(&str_to_sign, key).context(
         azure_core::error::ErrorKind::Credential,
         "failed to sign the hmac",
     )?;

--- a/sdk/storage/src/lib.rs
+++ b/sdk/storage/src/lib.rs
@@ -32,7 +32,6 @@ mod connection_string;
 mod connection_string_builder;
 mod copy_id;
 mod copy_progress;
-pub mod hmac;
 mod macros;
 pub mod prelude;
 pub mod shared_access_signature;

--- a/sdk/storage/src/shared_access_signature/account_sas.rs
+++ b/sdk/storage/src/shared_access_signature/account_sas.rs
@@ -1,7 +1,5 @@
-use crate::{
-    hmac::sign,
-    shared_access_signature::{format_date, SasProtocol, SasToken},
-};
+use crate::shared_access_signature::{format_date, SasProtocol, SasToken};
+use azure_core::hmac::hmac_sha256;
 use std::fmt;
 use time::OffsetDateTime;
 use url::form_urlencoded;
@@ -192,7 +190,7 @@ impl AccountSharedAccessSignature {
                     self.version,
                 );
 
-                sign(&string_to_sign, &self.key).unwrap()
+                hmac_sha256(&string_to_sign, &self.key).unwrap()
             }
             _ => {
                 // TODO: support other version tags?

--- a/sdk/storage/src/shared_access_signature/service_sas.rs
+++ b/sdk/storage/src/shared_access_signature/service_sas.rs
@@ -1,7 +1,5 @@
-use crate::{
-    hmac,
-    shared_access_signature::{format_date, SasProtocol, SasToken},
-};
+use crate::shared_access_signature::{format_date, SasProtocol, SasToken};
+use azure_core::hmac::hmac_sha256;
 use std::fmt;
 use time::OffsetDateTime;
 use url::form_urlencoded;
@@ -157,7 +155,7 @@ impl BlobSharedAccessSignature {
             String::new(), // rsct
         ];
 
-        hmac::sign(&content.join("\n"), &self.key).expect("HMAC signing failed")
+        hmac_sha256(&content.join("\n"), &self.key).expect("HMAC signing failed")
     }
 }
 

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -43,11 +43,7 @@ default = ["enable_reqwest"]
 test_e2e = []
 test_integration = []
 azurite_workaround = ["azure_core/azurite_workaround"]
-enable_openssl_sign = ["azure_storage/enable_openssl_sign"]
 enable_reqwest = ["azure_core/enable_reqwest", "azure_storage/enable_reqwest"]
-enable_reqwest_rustls = [
-  "azure_core/enable_reqwest_rustls",
-  "azure_storage/enable_reqwest_rustls",
-]
+enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls", "azure_storage/enable_reqwest_rustls"]
 into_future = []
 md5 = ["dep:md5"]


### PR DESCRIPTION
With #1467 , we now include an openssl based hmac 256 implementation.

This unifies the implementation across the crates that need it.  Future work would be to provide an implementation that makes use of schannel as well.