### PR TITLE
move to RwLock rather than Mutex for storage credentials

### DIFF
--- a/sdk/core/src/auth.rs
+++ b/sdk/core/src/auth.rs
@@ -44,6 +44,12 @@ impl From<String> for Secret {
     }
 }
 
+impl From<&'static str> for Secret {
+    fn from(access_token: &'static str) -> Self {
+        Self::new(access_token)
+    }
+}
+
 impl Debug for Secret {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("Secret").field(&"<REDACTED>").finish()

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.17", features = ["xml"] }
 time = "0.3.10"
-futures = "0.3"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
@@ -25,6 +24,7 @@ url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 bytes = "1.0"
 RustyXML = "0.3"
+async-lock = "3.1"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -40,7 +40,7 @@ impl Policy for AuthorizationPolicy {
 
         // lock the credentials within a scope so that it is released as soon as possible
         {
-            let creds = self.credentials.0.lock().await;
+            let creds = self.credentials.0.read().await;
 
             match creds.deref() {
                 StorageCredentialsInner::Key(account, key) => {

--- a/sdk/storage/src/clients.rs
+++ b/sdk/storage/src/clients.rs
@@ -54,7 +54,7 @@ pub async fn shared_access_signature(
     expiry: OffsetDateTime,
     permissions: AccountSasPermissions,
 ) -> Result<AccountSharedAccessSignature, Error> {
-    let creds = storage_credentials.0.lock().await;
+    let creds = storage_credentials.0.read().await;
     let StorageCredentialsInner::Key(account, key) = creds.deref() else {
         return Err(Error::message(
             ErrorKind::Credential,

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -235,7 +235,7 @@ impl BlobClient {
         permissions: BlobSasPermissions,
         expiry: OffsetDateTime,
     ) -> azure_core::Result<BlobSharedAccessSignature> {
-        let creds = self.container_client.credentials().0.lock().await;
+        let creds = self.container_client.credentials().0.read().await;
         let StorageCredentialsInner::Key(account, key) = creds.deref() else {
             return Err(Error::message(
                 ErrorKind::Credential,
@@ -351,7 +351,7 @@ mod tests {
             .container_client
             .credentials()
             .0
-            .try_lock()
+            .try_read()
             .expect("creds should be unlocked at this point");
         assert!(matches!(
             creds.deref(),
@@ -364,7 +364,7 @@ mod tests {
             .container_client
             .credentials()
             .0
-            .try_lock()
+            .try_read()
             .expect("creds should be unlocked at this point");
         assert!(matches!(creds.deref(), StorageCredentialsInner::Anonymous));
 

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -276,7 +276,7 @@ mod tests {
 
         // check that the update occurred
         let credentials = blob_client.container_client().credentials();
-        let locked = credentials.0.lock().await;
+        let locked = credentials.0.read().await;
         assert!(matches!(
             locked.deref(),
             &StorageCredentialsInner::Anonymous

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -123,7 +123,7 @@ impl ContainerClient {
         permissions: BlobSasPermissions,
         expiry: OffsetDateTime,
     ) -> azure_core::Result<BlobSharedAccessSignature> {
-        let creds = self.service_client.credentials().0.lock().await;
+        let creds = self.service_client.credentials().0.read().await;
         let StorageCredentialsInner::Key(account, key) = creds.deref() else {
             return Err(Error::message(
                 ErrorKind::Credential,


### PR DESCRIPTION
Rather than using a Mutex, use a write-preferred RwLock implementation which should increase performance in many common situations.