### PR TITLE
use azure_core::Url reexport

### DIFF
--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -85,14 +85,14 @@ pub const EMPTY_BODY: bytes::Bytes = bytes::Bytes::new();
 
 /// Add a new query pair into the target URL's query string.
 pub trait AppendToUrlQuery {
-    fn append_to_url_query(&self, url: &mut url::Url);
+    fn append_to_url_query(&self, url: &mut crate::Url);
 }
 
 impl<T> AppendToUrlQuery for &T
 where
     T: AppendToUrlQuery,
 {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut crate::Url) {
         (*self).append_to_url_query(url);
     }
 }
@@ -101,7 +101,7 @@ impl<T> AppendToUrlQuery for Option<T>
 where
     T: AppendToUrlQuery,
 {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut crate::Url) {
         if let Some(i) = self {
             i.append_to_url_query(url);
         }

--- a/sdk/core/src/macros.rs
+++ b/sdk/core/src/macros.rs
@@ -343,7 +343,7 @@ macro_rules! request_query {
     ($(#[$outer:meta])* $name:ident, $option:expr) => {
         $crate::request_option!($(#[$outer])* $name);
         impl $crate::AppendToUrlQuery for $name {
-            fn append_to_url_query(&self, url: &mut url::Url) {
+            fn append_to_url_query(&self, url: &mut $crate::Url) {
                 url.query_pairs_mut().append_pair($option, &self.0);
             }
         }

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -1,10 +1,11 @@
-use crate::headers::{AsHeaders, Headers};
-use crate::Method;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::SeekableStream;
+use crate::{
+    headers::{AsHeaders, Headers},
+    Method, Url,
+};
 use bytes::Bytes;
 use std::fmt::Debug;
-use url::Url;
 
 /// An HTTP Body.
 #[derive(Debug, Clone)]

--- a/sdk/core/src/request_options/max_results.rs
+++ b/sdk/core/src/request_options/max_results.rs
@@ -1,4 +1,4 @@
-use crate::AppendToUrlQuery;
+use crate::{AppendToUrlQuery, Url};
 use std::convert::TryFrom;
 use std::num::NonZeroU32;
 
@@ -17,7 +17,7 @@ impl MaxResults {
 }
 
 impl AppendToUrlQuery for MaxResults {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("maxresults", &format!("{}", self.0));
     }

--- a/sdk/core/src/request_options/next_marker.rs
+++ b/sdk/core/src/request_options/next_marker.rs
@@ -1,5 +1,7 @@
-use crate::headers::{self, Headers};
-use crate::AppendToUrlQuery;
+use crate::{
+    headers::{self, Headers},
+    AppendToUrlQuery, Url,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,7 +24,7 @@ impl NextMarker {
         &self.0
     }
 
-    pub fn append_to_url_query_as_continuation(&self, url: &mut url::Url) {
+    pub fn append_to_url_query_as_continuation(&self, url: &mut Url) {
         url.query_pairs_mut().append_pair("continuation", &self.0);
     }
 
@@ -36,7 +38,7 @@ impl NextMarker {
 }
 
 impl AppendToUrlQuery for NextMarker {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut().append_pair("marker", &self.0);
     }
 }

--- a/sdk/core/src/request_options/timeout.rs
+++ b/sdk/core/src/request_options/timeout.rs
@@ -1,4 +1,4 @@
-use crate::AppendToUrlQuery;
+use crate::{AppendToUrlQuery, Url};
 use std::time::Duration;
 
 #[derive(Debug, Clone, Copy)]
@@ -11,7 +11,7 @@ impl Timeout {
 }
 
 impl AppendToUrlQuery for Timeout {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         if url.query_pairs().any(|(k, _)| k == "timeout") {
             return;
         }

--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -243,7 +243,7 @@ fn string_to_sign(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use azure_core::date;
+    use azure_core::{date, Url};
 
     #[test]
     fn string_to_sign_00() {
@@ -275,7 +275,7 @@ mon, 01 jan 1900 01:00:00 gmt
         )
         .unwrap();
 
-        let url = azure_core::Url::parse("https://.documents.azure.com/dbs/ToDoList").unwrap();
+        let url = Url::parse("https://.documents.azure.com/dbs/ToDoList").unwrap();
 
         let ret = generate_authorization(
             &auth_token,
@@ -303,7 +303,7 @@ mon, 01 jan 1900 01:00:00 gmt
         )
         .unwrap();
 
-        let url = azure_core::Url::parse("https://.documents.azure.com/dbs/ToDoList").unwrap();
+        let url = Url::parse("https://.documents.azure.com/dbs/ToDoList").unwrap();
 
         let ret = generate_authorization(
             &auth_token,
@@ -330,7 +330,7 @@ mon, 01 jan 1900 01:00:00 gmt
     #[test]
     fn generate_resource_link_00() {
         let request = Request::new(
-            reqwest::Url::parse("https://.documents.azure.com/dbs/second").unwrap(),
+            Url::parse("https://.documents.azure.com/dbs/second").unwrap(),
             azure_core::Method::Get,
         );
         assert_eq!(&generate_resource_link(&request), "dbs/second");
@@ -339,7 +339,7 @@ mon, 01 jan 1900 01:00:00 gmt
     #[test]
     fn generate_resource_link_01() {
         let request = Request::new(
-            reqwest::Url::parse("https://.documents.azure.com/dbs").unwrap(),
+            Url::parse("https://.documents.azure.com/dbs").unwrap(),
             azure_core::Method::Get,
         );
         assert_eq!(&generate_resource_link(&request), "");
@@ -348,7 +348,7 @@ mon, 01 jan 1900 01:00:00 gmt
     #[test]
     fn generate_resource_link_02() {
         let request = Request::new(
-            reqwest::Url::parse("https://.documents.azure.com/colls/second/third").unwrap(),
+            Url::parse("https://.documents.azure.com/colls/second/third").unwrap(),
             azure_core::Method::Get,
         );
         assert_eq!(&generate_resource_link(&request), "colls/second/third");
@@ -357,7 +357,7 @@ mon, 01 jan 1900 01:00:00 gmt
     #[test]
     fn generate_resource_link_03() {
         let request = Request::new(
-            reqwest::Url::parse("https://.documents.azure.com/dbs/test_db/colls").unwrap(),
+            Url::parse("https://.documents.azure.com/dbs/test_db/colls").unwrap(),
             azure_core::Method::Get,
         );
         assert_eq!(&generate_resource_link(&request), "dbs/test_db");
@@ -365,9 +365,8 @@ mon, 01 jan 1900 01:00:00 gmt
 
     #[test]
     fn scope_from_url_01() {
-        let scope = scope_from_url(
-            &azure_core::Url::parse("https://.documents.azure.com/dbs/test_db/colls").unwrap(),
-        );
+        let scope =
+            scope_from_url(&Url::parse("https://.documents.azure.com/dbs/test_db/colls").unwrap());
         assert_eq!(scope, "https://.documents.azure.com");
     }
 }

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -23,7 +23,6 @@ serde = { version = "1.0" }
 serde_derive = "1.0"
 serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
-url = "2.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -1,7 +1,6 @@
 use crate::{operations::*, prelude::*};
-use azure_core::{headers::Headers, Body, Context, Method, Request, Response};
+use azure_core::{headers::Headers, Body, Context, Method, Request, Response, Url};
 use serde::{de::DeserializeOwned, Serialize};
-use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct EntityClient {

--- a/sdk/data_tables/src/clients/partition_key_client.rs
+++ b/sdk/data_tables/src/clients/partition_key_client.rs
@@ -48,7 +48,7 @@ impl PartitionKeyClient {
         self.table_client.send(context, request).await
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    pub(crate) fn url(&self) -> azure_core::Result<Url> {
         self.table_client.url()
     }
 }

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -40,7 +40,7 @@ impl TableClient {
         Ok(InsertEntityBuilder::new(self.clone(), body))
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    pub(crate) fn url(&self) -> azure_core::Result<Url> {
         self.table_service_client.url()
     }
 

--- a/sdk/data_tables/src/clients/table_service_client.rs
+++ b/sdk/data_tables/src/clients/table_service_client.rs
@@ -1,9 +1,8 @@
 use crate::operations::ListTablesBuilder;
 use azure_core::{
-    headers::Headers, Body, ClientOptions, Context, Method, Pipeline, Request, Response,
+    headers::Headers, Body, ClientOptions, Context, Method, Pipeline, Request, Response, Url,
 };
 use azure_storage::{clients::ServiceType, prelude::StorageCredentials, CloudLocation};
-use url::Url;
 
 use super::TableClient;
 

--- a/sdk/data_tables/src/filter.rs
+++ b/sdk/data_tables/src/filter.rs
@@ -1,4 +1,4 @@
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,7 +11,7 @@ impl Filter {
 }
 
 impl AppendToUrlQuery for Filter {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("$filter", self.0.as_ref());
     }

--- a/sdk/data_tables/src/operations/mod.rs
+++ b/sdk/data_tables/src/operations/mod.rs
@@ -23,12 +23,11 @@ use crate::EntityWithMetadata;
 use azure_core::{
     error::{Error, ErrorKind},
     headers::{self, etag_from_headers, HeaderName},
-    CollectedResponse, Etag,
+    CollectedResponse, Etag, Url,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
 use serde::de::DeserializeOwned;
 use std::convert::{TryFrom, TryInto};
-use url::Url;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum InsertOperation {

--- a/sdk/data_tables/src/operations/transaction.rs
+++ b/sdk/data_tables/src/operations/transaction.rs
@@ -6,12 +6,11 @@ use azure_core::{
     error::{Error, ErrorKind},
     headers::*,
     prelude::*,
-    CollectedResponse, Etag, Method, Request, StatusCode,
+    CollectedResponse, Etag, Method, Request, StatusCode, Url,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
 use serde::Serialize;
 use std::convert::{TryFrom, TryInto};
-use url::Url;
 
 operation! {
     Transaction,

--- a/sdk/data_tables/src/select.rs
+++ b/sdk/data_tables/src/select.rs
@@ -1,4 +1,4 @@
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,7 +11,7 @@ impl Select {
 }
 
 impl AppendToUrlQuery for Select {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("$select", self.0.as_ref());
     }

--- a/sdk/data_tables/src/top.rs
+++ b/sdk/data_tables/src/top.rs
@@ -1,4 +1,4 @@
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Top(u32);
@@ -10,7 +10,7 @@ impl Top {
 }
 
 impl AppendToUrlQuery for Top {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("$top", &self.0.to_string());
     }

--- a/sdk/identity/README.md
+++ b/sdk/identity/README.md
@@ -6,9 +6,8 @@ This crate provides mechanisms for several ways to authenticate against Azure
 For example, to authenticate using the recommended `DefaultAzureCredential`, you can do the following:
 
 ```rust
-use azure_core::auth::TokenCredential;
+use azure_core::{auth::TokenCredential, Url};
 use azure_identity::{DefaultAzureCredential};
-use url::Url;
 
 use std::env;
 use std::error::Error;

--- a/sdk/identity/src/authorization_code_flow.rs
+++ b/sdk/identity/src/authorization_code_flow.rs
@@ -3,12 +3,13 @@
 //! You can learn more about the `OAuth2` authorization code flow [here](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow).
 
 use crate::oauth2_http_client::Oauth2HttpClient;
-use azure_core::error::{ErrorKind, ResultExt};
-use azure_core::HttpClient;
+use azure_core::{
+    error::{ErrorKind, ResultExt},
+    HttpClient, Url,
+};
 use oauth2::basic::BasicClient;
 use oauth2::{ClientId, ClientSecret};
 use std::sync::Arc;
-use url::Url;
 
 /// Start an authorization code flow.
 ///

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! ```no_run
 //! use azure_identity::client_credentials_flow;
-//! use url::Url;
+//! use azure_core::Url;
 //!
 //! use std::env;
 //! use std::error::Error;
@@ -41,11 +41,11 @@ use azure_core::Method;
 use azure_core::{
     content_type,
     error::{ErrorKind, ResultExt},
-    headers, HttpClient, Request,
+    headers, HttpClient, Request, Url,
 };
 use login_response::LoginResponse;
 use std::sync::Arc;
-use url::{form_urlencoded, Url};
+use url::form_urlencoded;
 
 /// Perform the client credentials flow
 pub async fn perform(

--- a/sdk/identity/src/development.rs
+++ b/sdk/identity/src/development.rs
@@ -2,12 +2,16 @@
 //!
 //! These utilities should not be used in production
 use crate::authorization_code_flow::AuthorizationCodeFlow;
-use azure_core::error::{Error, ErrorKind};
+use azure_core::{
+    error::{Error, ErrorKind},
+    Url,
+};
 use log::debug;
 use oauth2::{AuthorizationCode, CsrfToken};
-use std::io::{BufRead, BufReader, Write};
-use std::net::TcpListener;
-use url::Url;
+use std::{
+    io::{BufRead, BufReader, Write},
+    net::TcpListener,
+};
 
 /// A very naive implementation of a redirect server.
 ///

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -8,13 +8,13 @@ mod device_code_responses;
 use azure_core::{
     content_type,
     error::{Error, ErrorKind},
-    headers, sleep, HttpClient, Method, Request, Response,
+    headers, sleep, HttpClient, Method, Request, Response, Url,
 };
 pub use device_code_responses::*;
 use futures::stream::unfold;
 use serde::Deserialize;
 use std::{borrow::Cow, pin::Pin, sync::Arc, time::Duration};
-use url::{form_urlencoded, Url};
+use url::form_urlencoded;
 
 /// Start the device authorization grant flow.
 /// The user has only 15 minutes to sign in (the usual value for `expires_in`).

--- a/sdk/identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/src/federated_credentials_flow/mod.rs
@@ -1,9 +1,8 @@
 //! Authorize using the OAuth 2.0 client credentials flow with federated credentials.
 //!
 //! ```no_run
-//! use azure_core::authority_hosts::AZURE_PUBLIC_CLOUD;
+//! use azure_core::{authority_hosts::AZURE_PUBLIC_CLOUD, Url};
 //! use azure_identity::{federated_credentials_flow};
-//! use url::Url;
 //!
 //! use std::env;
 //! use std::error::Error;
@@ -40,12 +39,12 @@ use azure_core::Method;
 use azure_core::{
     content_type,
     error::{ErrorKind, ResultExt},
-    headers, HttpClient, Request,
+    headers, HttpClient, Request, Url,
 };
 use log::{debug, error};
 use login_response::LoginResponse;
 use std::sync::Arc;
-use url::{form_urlencoded, Url};
+use url::form_urlencoded;
 
 /// Perform the client credentials flow
 pub async fn perform(

--- a/sdk/identity/src/lib.rs
+++ b/sdk/identity/src/lib.rs
@@ -4,9 +4,8 @@
 //! For example, to authenticate using the recommended `DefaultAzureCredential`, you can do the following:
 //!
 //! ```no_run
-//! use azure_core::auth::TokenCredential;
+//! use azure_core::{auth::TokenCredential, Url};
 //! use azure_identity::{DefaultAzureCredential};
-//! use url::Url;
 //!
 //! use std::env;
 //! use std::error::Error;

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -5,12 +5,12 @@ use azure_core::{
     auth::Secret,
     content_type,
     error::{Error, ErrorKind, ResultExt},
-    headers, HttpClient, Request,
+    headers, HttpClient, Request, Url,
 };
 use serde::Deserialize;
 use std::fmt;
 use std::sync::Arc;
-use url::{form_urlencoded, Url};
+use url::form_urlencoded;
 
 /// Exchange a refresh token for a new access token and refresh token
 pub async fn exchange(

--- a/sdk/identity/src/token_credentials/client_secret_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_secret_credentials.rs
@@ -1,13 +1,13 @@
 use crate::oauth2_http_client::Oauth2HttpClient;
-use azure_core::auth::{AccessToken, Secret, TokenCredential};
-use azure_core::authority_hosts::AZURE_PUBLIC_CLOUD;
-use azure_core::error::{ErrorKind, ResultExt};
-use azure_core::HttpClient;
+use azure_core::{
+    auth::{AccessToken, Secret, TokenCredential},
+    authority_hosts::AZURE_PUBLIC_CLOUD,
+    error::{ErrorKind, ResultExt},
+    HttpClient, Url,
+};
 use oauth2::{basic::BasicClient, AuthType, AuthUrl, Scope, TokenUrl};
-use std::str;
-use std::sync::Arc;
+use std::{str, sync::Arc};
 use time::OffsetDateTime;
-use url::Url;
 
 /// Provides options to configure how the Identity library makes authentication
 /// requests to Azure Active Directory.

--- a/sdk/identity/src/token_credentials/environment_credentials.rs
+++ b/sdk/identity/src/token_credentials/environment_credentials.rs
@@ -1,9 +1,10 @@
 use super::{ClientSecretCredential, TokenCredentialOptions, WorkloadIdentityCredential};
-use azure_core::auth::{AccessToken, TokenCredential};
-use azure_core::error::{Error, ErrorKind, ResultExt};
-use azure_core::HttpClient;
+use azure_core::{
+    auth::{AccessToken, TokenCredential},
+    error::{Error, ErrorKind, ResultExt},
+    HttpClient, Url,
+};
 use std::sync::Arc;
-use url::Url;
 
 const AZURE_TENANT_ID_ENV_KEY: &str = "AZURE_TENANT_ID";
 const AZURE_CLIENT_ID_ENV_KEY: &str = "AZURE_CLIENT_ID";

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -1,7 +1,7 @@
 use azure_core::{
     auth::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
-    HttpClient, Method, Request, StatusCode,
+    HttpClient, Method, Request, StatusCode, Url,
 };
 use serde::{
     de::{self, Deserializer},
@@ -10,7 +10,6 @@ use serde::{
 use std::str;
 use std::sync::Arc;
 use time::OffsetDateTime;
-use url::Url;
 
 const MSI_ENDPOINT_ENV_KEY: &str = "IDENTITY_ENDPOINT";
 const MSI_SECRET_ENV_KEY: &str = "IDENTITY_HEADER";

--- a/sdk/iot_deviceupdate/Cargo.toml
+++ b/sdk/iot_deviceupdate/Cargo.toml
@@ -18,7 +18,6 @@ reqwest = { version = "0.11", features = ["json"], default-features = false }
 time = "0.3.10"
 const_format = "0.2"
 serde_json = "1.0"
-url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
 azure_core = { path = "../core", version = "0.17", default-features = false }

--- a/sdk/iot_deviceupdate/src/client.rs
+++ b/sdk/iot_deviceupdate/src/client.rs
@@ -1,12 +1,12 @@
 use azure_core::{
     auth::{AccessToken, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
+    Url,
 };
 use azure_identity::AutoRefreshingTokenCredential;
 use const_format::formatcp;
 use serde::de::DeserializeOwned;
 use std::sync::Arc;
-use url::Url;
 
 pub(crate) const API_VERSION: &str = "2021-06-01-preview";
 pub(crate) const API_VERSION_PARAM: &str = formatcp!("api-version={}", API_VERSION);

--- a/sdk/iot_deviceupdate/src/lib.rs
+++ b/sdk/iot_deviceupdate/src/lib.rs
@@ -8,15 +8,17 @@ use crate::device_update::UpdateOperation;
 
 #[cfg(test)]
 mod tests {
-    use azure_core::auth::{AccessToken, TokenCredential};
-    use azure_core::date;
+    use azure_core::{
+        auth::{AccessToken, TokenCredential},
+        date, Url,
+    };
     use azure_identity::AutoRefreshingTokenCredential;
     use std::sync::Arc;
     use time::OffsetDateTime;
 
     pub(crate) fn mock_client(server_url: String) -> crate::client::DeviceUpdateClient {
         crate::client::DeviceUpdateClient {
-            device_update_url: url::Url::parse(&server_url).unwrap(),
+            device_update_url: Url::parse(&server_url).unwrap(),
             endpoint: String::new(),
             token_credential: AutoRefreshingTokenCredential::new(Arc::new(MockCredential)),
         }

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -10,6 +10,7 @@ use azure_core::{
 use std::sync::Arc;
 use std::time::Duration;
 use time::OffsetDateTime;
+use url::form_urlencoded;
 
 /// Contains any operation that the `IoT` Hub service client can perform.
 pub mod operations;
@@ -120,7 +121,7 @@ impl ServiceClient {
 
         let sas_token = hmac_sha256(&data, private_key)?;
 
-        let encoded: String = url::form_urlencoded::Serializer::new(String::new())
+        let encoded: String = form_urlencoded::Serializer::new(String::new())
             .append_pair("sr", &format!("{iot_hub_name}.azure-devices.net"))
             .append_pair("sig", &sas_token)
             .append_pair("skn", key_name)

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -18,7 +18,6 @@ time = "0.3.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
-url = "2.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/messaging_eventgrid/src/event_grid_client.rs
+++ b/sdk/messaging_eventgrid/src/event_grid_client.rs
@@ -1,7 +1,6 @@
-use crate::event_grid_request_builder::EventGridRequestBuilder;
-use crate::Event;
+use crate::{event_grid_request_builder::EventGridRequestBuilder, Event};
+use azure_core::Url;
 use serde::ser::Serialize;
-use url::Url;
 
 #[derive(Clone)]
 pub struct EventGridClient {

--- a/sdk/messaging_servicebus/src/utils.rs
+++ b/sdk/messaging_servicebus/src/utils.rs
@@ -1,6 +1,8 @@
-use azure_core::error::{Error, ErrorKind, ResultExt};
+use azure_core::{
+    error::{Error, ErrorKind, ResultExt},
+    Url,
+};
 use std::time::Duration;
-use url::Url;
 
 pub fn craft_peek_lock_url(
     namespace: &str,

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -17,7 +17,6 @@ async-trait = "0.1"
 futures = "0.3"
 time = "0.3"
 serde_json = "1.0"
-url = "2.2"
 serde = { version = "1.0", features = ["derive"] }
 azure_core = { path = "../core", version = "0.17", default-features = false }
 

--- a/sdk/security_keyvault/src/account/operations/list_certificates.rs
+++ b/sdk/security_keyvault/src/account/operations/list_certificates.rs
@@ -1,8 +1,7 @@
 use crate::prelude::*;
 use azure_core::{
-    error::Error, headers::Headers, CollectedResponse, Continuable, Method, Pageable,
+    error::Error, headers::Headers, CollectedResponse, Continuable, Method, Pageable, Url,
 };
-use url::Url;
 
 operation! {
     #[stream]

--- a/sdk/security_keyvault/src/account/operations/list_secrets.rs
+++ b/sdk/security_keyvault/src/account/operations/list_secrets.rs
@@ -1,8 +1,7 @@
 use crate::prelude::*;
 use azure_core::{
-    error::Error, headers::Headers, CollectedResponse, Continuable, Method, Pageable,
+    error::Error, headers::Headers, CollectedResponse, Continuable, Method, Pageable, Url,
 };
-use url::Url;
 
 operation! {
     #[stream]

--- a/sdk/security_keyvault/src/certificates/operations/get_versions.rs
+++ b/sdk/security_keyvault/src/certificates/operations/get_versions.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-use azure_core::{error::Error, headers::Headers, CollectedResponse, Method, Pageable};
-use url::Url;
+use azure_core::{error::Error, headers::Headers, CollectedResponse, Method, Pageable, Url};
 
 operation! {
     #[stream]

--- a/sdk/security_keyvault/src/clients/keyvault_client.rs
+++ b/sdk/security_keyvault/src/clients/keyvault_client.rs
@@ -5,11 +5,10 @@ use azure_core::{
     error::{Error, ErrorKind},
     headers::*,
     prelude::*,
-    Body, Context, Method, Pipeline, Request, Response,
+    Body, Context, Method, Pipeline, Request, Response, Url,
 };
 use std::sync::Arc;
 use time::OffsetDateTime;
-use url::Url;
 
 pub const API_VERSION: &str = "7.0";
 const API_VERSION_PARAM: &str = "api-version";

--- a/sdk/security_keyvault/src/keys/operations/get_random_bytes.rs
+++ b/sdk/security_keyvault/src/keys/operations/get_random_bytes.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, CollectedResponse, Method, Url};
 use serde_json::{Map, Value};
 
 operation! {
@@ -14,7 +14,7 @@ impl GetRandomBytesBuilder {
         Box::pin(async move {
             // POST {HSMBaseUrl}//rng?api-version=7.4
             let vault_url = format!("https://{}.managedhsm.azure.net/", self.hsm_name);
-            let mut uri = url::Url::parse(&vault_url)?;
+            let mut uri = Url::parse(&vault_url)?;
             let path = "rng".to_string();
 
             uri.set_path(&path);

--- a/sdk/security_keyvault/src/secrets/operations/get_versions.rs
+++ b/sdk/security_keyvault/src/secrets/operations/get_versions.rs
@@ -1,6 +1,5 @@
 use crate::prelude::*;
-use azure_core::{error::Error, headers::Headers, CollectedResponse, Method, Pageable};
-use url::Url;
+use azure_core::{error::Error, headers::Headers, CollectedResponse, Method, Pageable, Url};
 
 operation! {
     #[stream]

--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -4,10 +4,9 @@ use azure_core::{
     error::{ErrorKind, ResultExt},
     headers::*,
     hmac::hmac_sha256,
-    Context, Method, Policy, PolicyResult, Request,
+    Context, Method, Policy, PolicyResult, Request, Url,
 };
 use std::{borrow::Cow, ops::Deref, sync::Arc};
-use url::Url;
 
 const STORAGE_TOKEN_SCOPE: &str = "https://storage.azure.com/";
 

--- a/sdk/storage/src/authorization/mod.rs
+++ b/sdk/storage/src/authorization/mod.rs
@@ -6,13 +6,13 @@ use async_lock::RwLock;
 use azure_core::{
     auth::{Secret, TokenCredential},
     error::{ErrorKind, ResultExt},
+    Url,
 };
 use std::{
     mem::replace,
     ops::{Deref, DerefMut},
     sync::Arc,
 };
-use url::Url;
 
 /// Credentials for accessing a storage account.
 ///
@@ -205,9 +205,9 @@ impl TryFrom<&Url> for StorageCredentials {
 fn get_sas_token_parms(sas_token: &str) -> azure_core::Result<Vec<(String, String)>> {
     // Any base url will do: we just need to parse the SAS token
     // to get its query pairs.
-    let base_url = url::Url::parse("https://blob.core.windows.net").unwrap();
+    let base_url = Url::parse("https://blob.core.windows.net").unwrap();
 
-    let url = url::Url::options().base_url(Some(&base_url));
+    let url = Url::options().base_url(Some(&base_url));
 
     // this code handles the leading ?
     // we support both with or without

--- a/sdk/storage/src/clients.rs
+++ b/sdk/storage/src/clients.rs
@@ -10,11 +10,10 @@ use azure_core::{
     date,
     error::{Error, ErrorKind},
     headers::*,
-    Body, ClientOptions, Method, Pipeline, Request,
+    Body, ClientOptions, Method, Pipeline, Request, Url,
 };
 use std::{ops::Deref, sync::Arc};
 use time::OffsetDateTime;
-use url::Url;
 
 /// The well-known account used by Azurite and the legacy Azure Storage Emulator.
 /// <https://docs.microsoft.com/azure/storage/common/storage-use-azurite#well-known-storage-account-and-key>

--- a/sdk/storage/src/cloud_location.rs
+++ b/sdk/storage/src/cloud_location.rs
@@ -1,6 +1,6 @@
 use crate::clients::ServiceType;
+use azure_core::Url;
 use std::convert::TryFrom;
-use url::Url;
 
 /// The cloud with which you want to interact.
 // TODO: Other govt clouds?
@@ -39,7 +39,7 @@ impl CloudLocation {
                 format!("http://{address}:{port}/{EMULATOR_ACCOUNT}")
             }
         };
-        Ok(url::Url::parse(&url)?)
+        Ok(Url::parse(&url)?)
     }
 }
 

--- a/sdk/storage_blobs/src/blob/block_list_type.rs
+++ b/sdk/storage_blobs/src/blob/block_list_type.rs
@@ -1,4 +1,4 @@
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockListType {
@@ -18,7 +18,7 @@ impl BlockListType {
 }
 
 impl AppendToUrlQuery for BlockListType {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("blocklisttype", self.to_str());
     }

--- a/sdk/storage_blobs/src/blob/operations/copy_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob.rs
@@ -2,11 +2,10 @@ use crate::{
     blob::{copy_status_from_headers, CopyStatus},
     prelude::*,
 };
-use azure_core::{headers::*, prelude::*, RequestId};
+use azure_core::{headers::*, prelude::*, RequestId, Url};
 use azure_storage::{copy_id_from_headers, CopyId};
 use std::convert::{TryFrom, TryInto};
 use time::OffsetDateTime;
-use url::Url;
 
 operation! {
     CopyBlob,

--- a/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
+++ b/sdk/storage_blobs/src/blob/operations/copy_blob_from_url.rs
@@ -2,13 +2,12 @@ use crate::{
     blob::{copy_status_from_headers, CopyStatus, SourceContentMD5},
     prelude::*,
 };
-use azure_core::{headers::*, prelude::*, RequestId};
+use azure_core::{headers::*, prelude::*, RequestId, Url};
 use azure_storage::{
     copy_id_from_headers, headers::content_md5_from_headers_optional, ConsistencyMD5, CopyId,
 };
 use std::convert::{TryFrom, TryInto};
 use time::OffsetDateTime;
-use url::Url;
 
 operation! {
     CopyBlobFromUrl,

--- a/sdk/storage_blobs/src/clients/blob_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_client.rs
@@ -7,7 +7,7 @@ use azure_core::{
     error::{Error, ErrorKind},
     headers::Headers,
     prelude::*,
-    Body, Method, Request, Response, StatusCode,
+    Body, Method, Request, Response, StatusCode, Url,
 };
 use azure_storage::{
     prelude::*,
@@ -20,7 +20,6 @@ use azure_storage::{
 use futures::StreamExt;
 use std::ops::Deref;
 use time::OffsetDateTime;
-use url::Url;
 
 /// A client for handling blobs
 ///
@@ -259,7 +258,7 @@ impl BlobClient {
     }
 
     /// Create a signed blob url
-    pub fn generate_signed_blob_url<T>(&self, signature: &T) -> azure_core::Result<url::Url>
+    pub fn generate_signed_blob_url<T>(&self, signature: &T) -> azure_core::Result<Url>
     where
         T: SasToken,
     {
@@ -303,7 +302,7 @@ impl BlobClient {
     }
 
     /// Full URL for the blob.
-    pub fn url(&self) -> azure_core::Result<url::Url> {
+    pub fn url(&self) -> azure_core::Result<Url> {
         let mut url = self.container_client().url()?;
         let parts = self.blob_name().trim_matches('/').split('/');
         url.path_segments_mut()
@@ -394,7 +393,7 @@ mod tests {
         }
     }
 
-    fn build_url(container_name: &str, blob_name: &str, sas: &FakeSas) -> url::Url {
+    fn build_url(container_name: &str, blob_name: &str, sas: &FakeSas) -> Url {
         let blob_client = ClientBuilder::emulator().blob_client(container_name, blob_name);
         blob_client
             .generate_signed_blob_url(sas)

--- a/sdk/storage_blobs/src/clients/blob_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_lease_client.rs
@@ -39,7 +39,7 @@ impl BlobLeaseClient {
         &self.blob_client
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    pub(crate) fn url(&self) -> azure_core::Result<Url> {
         self.blob_client.url()
     }
 

--- a/sdk/storage_blobs/src/clients/blob_service_client.rs
+++ b/sdk/storage_blobs/src/clients/blob_service_client.rs
@@ -192,7 +192,7 @@ impl BlobServiceClient {
         ListContainersBuilder::new(self.clone())
     }
 
-    pub fn url(&self) -> azure_core::Result<url::Url> {
+    pub fn url(&self) -> azure_core::Result<Url> {
         self.cloud_location.url(ServiceType::Blob)
     }
 

--- a/sdk/storage_blobs/src/clients/container_client.rs
+++ b/sdk/storage_blobs/src/clients/container_client.rs
@@ -141,7 +141,7 @@ impl ContainerClient {
         ))
     }
 
-    pub fn generate_signed_container_url<T>(&self, signature: &T) -> azure_core::Result<url::Url>
+    pub fn generate_signed_container_url<T>(&self, signature: &T) -> azure_core::Result<Url>
     where
         T: SasToken,
     {
@@ -151,7 +151,7 @@ impl ContainerClient {
     }
 
     /// Full URL for the container.
-    pub fn url(&self) -> azure_core::Result<url::Url> {
+    pub fn url(&self) -> azure_core::Result<Url> {
         let mut url = self.service_client.url()?;
         url.path_segments_mut()
             .map_err(|()| Error::message(ErrorKind::DataConversion, "Invalid url"))?

--- a/sdk/storage_blobs/src/clients/container_lease_client.rs
+++ b/sdk/storage_blobs/src/clients/container_lease_client.rs
@@ -31,7 +31,7 @@ impl ContainerLeaseClient {
         &self.container_client
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    pub(crate) fn url(&self) -> azure_core::Result<Url> {
         self.container_client.url()
     }
 

--- a/sdk/storage_blobs/src/options/blob_versioning.rs
+++ b/sdk/storage_blobs/src/options/blob_versioning.rs
@@ -1,6 +1,6 @@
 use super::VersionId;
 use crate::options::Snapshot;
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 
 #[derive(Debug, Clone)]
 pub enum BlobVersioning {
@@ -21,7 +21,7 @@ impl From<VersionId> for BlobVersioning {
 }
 
 impl AppendToUrlQuery for BlobVersioning {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         match self {
             BlobVersioning::Snapshot(snapshot) => snapshot.append_to_url_query(url),
             BlobVersioning::VersionId(version_id) => version_id.append_to_url_query(url),

--- a/sdk/storage_blobs/src/options/block_id.rs
+++ b/sdk/storage_blobs/src/options/block_id.rs
@@ -1,4 +1,4 @@
-use azure_core::{base64, AppendToUrlQuery};
+use azure_core::{base64, AppendToUrlQuery, Url};
 use bytes::Bytes;
 
 /// Struct wrapping the bytes of a block blob block-id,
@@ -24,7 +24,7 @@ impl BlockId {
 }
 
 impl AppendToUrlQuery for BlockId {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("blockid", &base64::encode(&self.0));
     }

--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate log;
 
-use azure_core::date;
+use azure_core::{date, Url};
 use azure_storage::prelude::*;
 use azure_storage_blobs::container::operations::ListBlobsResponse;
 use azure_storage_blobs::{blob::BlockListType, container::PublicAccess, prelude::*};
@@ -11,7 +11,6 @@ use futures::StreamExt;
 use std::ops::{Add, Deref};
 use std::time::Duration;
 use time::OffsetDateTime;
-use url::Url;
 use uuid::Uuid;
 
 #[tokio::test]

--- a/sdk/storage_datalake/src/clients/data_lake_client.rs
+++ b/sdk/storage_datalake/src/clients/data_lake_client.rs
@@ -1,9 +1,10 @@
-use crate::clients::FileSystemClient;
-use crate::operations::ListFileSystemsBuilder;
-use azure_core::{ClientOptions, Pipeline};
-use azure_storage::clients::{new_pipeline_from_options, ServiceType};
-use azure_storage::prelude::StorageCredentials;
-use azure_storage::CloudLocation;
+use crate::{clients::FileSystemClient, operations::ListFileSystemsBuilder};
+use azure_core::{ClientOptions, Pipeline, Url};
+use azure_storage::{
+    clients::{new_pipeline_from_options, ServiceType},
+    prelude::StorageCredentials,
+    CloudLocation,
+};
 
 /// A builder for the blob service client.
 #[derive(Debug, Clone)]
@@ -107,7 +108,7 @@ impl DataLakeClient {
         DataLakeClientBuilder::new(account, credentials)
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    pub(crate) fn url(&self) -> azure_core::Result<Url> {
         self.cloud_location.url(ServiceType::DataLake)
     }
 

--- a/sdk/storage_datalake/src/clients/directory_client.rs
+++ b/sdk/storage_datalake/src/clients/directory_client.rs
@@ -1,8 +1,7 @@
-use crate::operations::*;
-use crate::request_options::*;
-use crate::{clients::FileSystemClient, prelude::PathClient, Properties};
-use azure_core::prelude::IfMatchCondition;
-use url::Url;
+use crate::{
+    clients::FileSystemClient, operations::*, prelude::PathClient, request_options::*, Properties,
+};
+use azure_core::{prelude::IfMatchCondition, Url};
 
 #[derive(Debug, Clone)]
 pub struct DirectoryClient {

--- a/sdk/storage_datalake/src/clients/file_client.rs
+++ b/sdk/storage_datalake/src/clients/file_client.rs
@@ -1,8 +1,7 @@
 use super::{FileSystemClient, PathClient};
 use crate::{operations::*, request_options::*, Properties};
-use azure_core::prelude::IfMatchCondition;
+use azure_core::{prelude::IfMatchCondition, Url};
 use bytes::Bytes;
-use url::Url;
 
 #[derive(Debug, Clone)]
 pub struct FileClient {

--- a/sdk/storage_datalake/src/clients/file_system_client.rs
+++ b/sdk/storage_datalake/src/clients/file_system_client.rs
@@ -1,7 +1,6 @@
 use super::{DataLakeClient, DirectoryClient, FileClient};
-use crate::operations::*;
-use crate::Properties;
-use url::Url;
+use crate::{operations::*, Properties};
+use azure_core::Url;
 
 #[derive(Debug, Clone)]
 pub struct FileSystemClient {

--- a/sdk/storage_datalake/src/clients/mod.rs
+++ b/sdk/storage_datalake/src/clients/mod.rs
@@ -8,12 +8,12 @@ pub use directory_client::DirectoryClient;
 pub use file_client::FileClient;
 pub use file_system_client::FileSystemClient;
 
-use azure_core::{Context, Request, Response};
+use azure_core::{Context, Request, Response, Url};
 use std::fmt::Debug;
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait PathClient: Debug + Clone + Send + Sync {
-    fn url(&self) -> azure_core::Result<url::Url>;
+    fn url(&self) -> azure_core::Result<Url>;
     async fn send(&self, ctx: &mut Context, request: &mut Request) -> crate::Result<Response>;
 }

--- a/sdk/storage_datalake/src/request_options.rs
+++ b/sdk/storage_datalake/src/request_options.rs
@@ -1,7 +1,8 @@
 //! Request properties used in datalake rest api operations
-use azure_core::AppendToUrlQuery;
-use azure_core::Header;
+
+use azure_core::{AppendToUrlQuery, Header, Url};
 use azure_storage::headers;
+use url::form_urlencoded;
 
 #[derive(Debug, Clone)]
 pub enum ResourceType {
@@ -11,7 +12,7 @@ pub enum ResourceType {
 }
 
 impl AppendToUrlQuery for ResourceType {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let resource = match self {
             Self::File => "file",
             Self::Directory => "directory",
@@ -28,7 +29,7 @@ pub enum PathRenameMode {
 }
 
 impl AppendToUrlQuery for PathRenameMode {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let mode = match self {
             Self::Legacy => "legacy",
             Self::Posix => "posix",
@@ -45,7 +46,7 @@ pub enum PathGetPropertiesAction {
 }
 
 impl AppendToUrlQuery for PathGetPropertiesAction {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let action = match self {
             Self::CheckAccess => "checkAccess",
             Self::GetAccessControl => "getAccessControl",
@@ -59,7 +60,7 @@ impl AppendToUrlQuery for PathGetPropertiesAction {
 pub struct Recursive(bool);
 
 impl AppendToUrlQuery for Recursive {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let recursive = if self.0 { "true" } else { "false" };
         url.query_pairs_mut().append_pair("recursive", recursive);
     }
@@ -75,7 +76,7 @@ impl From<bool> for Recursive {
 pub struct Upn(bool);
 
 impl AppendToUrlQuery for Upn {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let upn = if self.0 { "true" } else { "false" };
         url.query_pairs_mut().append_pair("upn", upn);
     }
@@ -97,7 +98,7 @@ pub enum PathUpdateAction {
 }
 
 impl AppendToUrlQuery for PathUpdateAction {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let action = match self {
             Self::Append => "append",
             Self::Flush => "flush",
@@ -125,7 +126,7 @@ impl From<i64> for Position {
 }
 
 impl AppendToUrlQuery for Position {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("position", &self.0.to_string());
     }
@@ -147,7 +148,7 @@ impl From<bool> for Close {
 }
 
 impl AppendToUrlQuery for Close {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let close = if self.0 { "true" } else { "false" };
         url.query_pairs_mut().append_pair("close", close);
     }
@@ -169,7 +170,7 @@ impl From<bool> for RetainUncommittedData {
 }
 
 impl AppendToUrlQuery for RetainUncommittedData {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         let retain = if self.0 { "true" } else { "false" };
         url.query_pairs_mut()
             .append_pair("retainUncommittedData", retain);
@@ -194,7 +195,7 @@ impl Header for RenameSource {
     }
 
     fn value(&self) -> azure_core::headers::HeaderValue {
-        url::form_urlencoded::byte_serialize(self.0.as_bytes())
+        form_urlencoded::byte_serialize(self.0.as_bytes())
             .collect::<String>()
             .into()
     }

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -22,7 +22,6 @@ serde = { version = "1.0" }
 serde_derive = "1.0"
 serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
-url = "2.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/storage_queues/src/clients/pop_receipt_client.rs
+++ b/sdk/storage_queues/src/clients/pop_receipt_client.rs
@@ -1,5 +1,5 @@
 use crate::{operations::*, prelude::*};
-use azure_core::{Context, Request, Response};
+use azure_core::{Context, Request, Response, Url};
 
 #[derive(Debug, Clone)]
 pub struct PopReceiptClient {
@@ -44,7 +44,7 @@ impl PopReceiptClient {
     }
 
     pub(crate) fn finalize_request(
-        url: url::Url,
+        url: Url,
         method: azure_core::Method,
         headers: azure_core::headers::Headers,
         request_body: Option<azure_core::Body>,
@@ -52,7 +52,7 @@ impl PopReceiptClient {
         QueueClient::finalize_request(url, method, headers, request_body)
     }
 
-    pub(crate) fn url(&self) -> azure_core::Result<url::Url> {
+    pub(crate) fn url(&self) -> azure_core::Result<Url> {
         let mut url = self.client.messages_url()?;
 
         url.path_segments_mut()

--- a/sdk/storage_queues/src/clients/queue_client.rs
+++ b/sdk/storage_queues/src/clients/queue_client.rs
@@ -1,7 +1,7 @@
 use crate::{
     operations::*, PopReceipt, PopReceiptClient, QueueServiceClient, QueueStoredAccessPolicy,
 };
-use azure_core::{prelude::*, Context, Request, Response};
+use azure_core::{prelude::*, Context, Request, Response, Url};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone)]
@@ -94,7 +94,7 @@ impl QueueClient {
         &self.queue_name
     }
 
-    pub fn url(&self) -> azure_core::Result<url::Url> {
+    pub fn url(&self) -> azure_core::Result<Url> {
         let mut url = self.service_client.url()?;
         url.path_segments_mut()
             .expect("invalid base url")
@@ -102,7 +102,7 @@ impl QueueClient {
         Ok(url)
     }
 
-    pub(crate) fn messages_url(&self) -> azure_core::Result<url::Url> {
+    pub(crate) fn messages_url(&self) -> azure_core::Result<Url> {
         let mut url = self.url()?;
         url.path_segments_mut()
             .expect("invalid base url")
@@ -111,7 +111,7 @@ impl QueueClient {
     }
 
     pub(crate) fn finalize_request(
-        url: url::Url,
+        url: Url,
         method: azure_core::Method,
         headers: azure_core::headers::Headers,
         request_body: Option<azure_core::Body>,

--- a/sdk/storage_queues/src/clients/queue_service_client.rs
+++ b/sdk/storage_queues/src/clients/queue_service_client.rs
@@ -1,5 +1,5 @@
 use crate::{operations::*, QueueClient, QueueServiceProperties};
-use azure_core::{ClientOptions, Context, Pipeline, Request, Response};
+use azure_core::{ClientOptions, Context, Pipeline, Request, Response, Url};
 use azure_storage::{
     clients::{new_pipeline_from_options, ServiceType},
     prelude::StorageCredentials,
@@ -142,12 +142,12 @@ impl QueueServiceClient {
         QueueClient::new(self.clone(), queue_name.into())
     }
 
-    pub fn url(&self) -> azure_core::Result<url::Url> {
+    pub fn url(&self) -> azure_core::Result<Url> {
         self.cloud_location.url(ServiceType::Queue)
     }
 
     pub(crate) fn finalize_request(
-        url: url::Url,
+        url: Url,
         method: azure_core::Method,
         headers: azure_core::headers::Headers,
         request_body: Option<azure_core::Body>,

--- a/sdk/storage_queues/src/message_ttl.rs
+++ b/sdk/storage_queues/src/message_ttl.rs
@@ -1,4 +1,4 @@
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -11,7 +11,7 @@ impl MessageTTL {
 }
 
 impl AppendToUrlQuery for MessageTTL {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("messagettl", &self.0.as_secs().to_string());
     }

--- a/sdk/storage_queues/src/number_of_messages.rs
+++ b/sdk/storage_queues/src/number_of_messages.rs
@@ -1,4 +1,4 @@
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 
 #[derive(Debug, Clone)]
 pub struct NumberOfMessages(u8);
@@ -10,7 +10,7 @@ impl NumberOfMessages {
 }
 
 impl AppendToUrlQuery for NumberOfMessages {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("numofmessages", &self.0.to_string());
     }

--- a/sdk/storage_queues/src/visibility_timeout.rs
+++ b/sdk/storage_queues/src/visibility_timeout.rs
@@ -1,4 +1,4 @@
-use azure_core::AppendToUrlQuery;
+use azure_core::{AppendToUrlQuery, Url};
 use std::time::Duration;
 
 #[derive(Debug, Clone)]
@@ -11,7 +11,7 @@ impl VisibilityTimeout {
 }
 
 impl AppendToUrlQuery for VisibilityTimeout {
-    fn append_to_url_query(&self, url: &mut url::Url) {
+    fn append_to_url_query(&self, url: &mut Url) {
         url.query_pairs_mut()
             .append_pair("visibilitytimeout", &self.0.as_secs().to_string());
     }


### PR DESCRIPTION
A while back, we re-exported url::Url and started standardizing on that for URLs.  This completes the changeover.