### PR TITLE
use a temp directory for the emulator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ always() }}
 
   test-integration:
-    name: Integration Tests
+    name: Emulator Tests
     runs-on: ubuntu-20.04
     needs:
       - msrv

--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,5 @@ sample/
 *.swp
 *.swo
 *.vim
-__azurite*.json
-__blobstorage__
-__queuestorage__
 .idea/
-*.iml
-*.bat
-*.ps1
 .env

--- a/eng/scripts/emulator_tests.sh
+++ b/eng/scripts/emulator_tests.sh
@@ -19,9 +19,9 @@ function subprocesses {
 # stop all of the subprocesses for a given set of pids
 function stop_subprocesses {
     # sort pids numerically, and in reverse
-    PIDS=$(subprocesses $@ | sort -nr)
+    PIDS=$(subprocesses $$ | sort -nr)
     for P in ${PIDS}; do
-        if [ ${P} == ${1} ]; then
+        if [ ${P} == $$ ]; then
             continue
         fi
         kill -9 ${P} || echo "stopping ${P} failed"
@@ -32,7 +32,7 @@ function stop_subprocesses {
 # subprocesses (azurite)
 TMP=$(mktemp -d)
 function cleanup {
-    stop_subprocesses $$ || true
+    stop_subprocesses || true
     rm -rf ${TMP} || true
 }
 trap cleanup EXIT

--- a/eng/scripts/emulator_tests.sh
+++ b/eng/scripts/emulator_tests.sh
@@ -1,14 +1,50 @@
 #!/bin/bash
 
 set -eux -o pipefail
-cd $(dirname ${BASH_SOURCE[0]})/../../
-
-./eng/scripts/github-disk-cleanup.sh
-
 BUILD=${1:-stable}
 
-npm install azurite@3.26.0
+cd $(dirname ${BASH_SOURCE[0]})/../../
+./eng/scripts/github-disk-cleanup.sh
+
+# get the nested list of sub-processes for a given set of pids
+function subprocesses {
+    for P in $@; do
+        echo ${P}
+        for C in $(pgrep -P ${P}); do
+            subprocesses ${C}
+        done
+    done
+}
+
+# stop all of the subprocesses for a given set of pids
+function stop_subprocesses {
+    # sort pids numerically, and in reverse
+    PIDS=$(subprocesses $@ | sort -nr)
+    for P in ${PIDS}; do
+        if [ ${P} == ${1} ]; then
+            continue
+        fi
+        kill -9 ${P} || echo "stopping ${P} failed"
+    done
+}
+
+# at termination, we want to cleanup the temp directory and stop all
+# subprocesses (azurite)
+TMP=$(mktemp -d)
+function cleanup {
+    stop_subprocesses $$ || true
+    rm -rf ${TMP} || true
+}
+trap cleanup EXIT
+
+BASE_DIR=$(pwd)
+cd ${TMP}
+npm install azurite@3.28.0
 npx azurite &
 
+# wait for azurite to start
+sleep 5
+
+cd ${BASE_DIR}
 rustup update --no-self-update ${BUILD}
 cargo +${BUILD} test --features test_integration


### PR DESCRIPTION
Right now, the emulator script has two issues:

1. It can't be run repeatedly without manually stopping azurite
2. It litters the source tree with azurite related temp files

This update addresses these via three things:
1. Updates to the latest azurite
2. Terminates all sub-processes on script exit
3. Creates a tempdir and installs azurite in it, then cleans up the tempdir on exit.