### PR TITLE
add error context to autorust

### DIFF
--- a/services/autorust/azure-autorust/src/main.rs
+++ b/services/autorust/azure-autorust/src/main.rs
@@ -93,7 +93,7 @@ fn gen_crates(only_packages: &[&str]) -> Result<()> {
 
     if !errors.is_empty() {
         for error in &errors {
-            eprintln!("{error:?}");
+            eprintln!("{error:#?}");
         }
         return Err(Error::new(ErrorKind::CodeGen, "Failed to generate some crates"));
     }

--- a/services/autorust/azure-autorust/src/main.rs
+++ b/services/autorust/azure-autorust/src/main.rs
@@ -68,12 +68,12 @@ fn gen_crates(only_packages: &[&str]) -> Result<()> {
     let mgmt = get_mgmt_readmes()?.into_iter().map(|x| ("mgmt".to_string(), x));
     let crate_iters = svc.chain(mgmt).collect::<Vec<_>>();
 
-    let results: Vec<Result<Option<(String, Vec<String>)>>> = crate_iters
+    let results = crate_iters
         .par_iter()
         .map(|(crate_type, spec)| gen_crate(only_packages, crate_type, spec))
         .collect::<Vec<_>>()
         .into_iter()
-        .collect();
+        .collect::<Vec<_>>();
 
     let mut errors = vec![];
     let mut completed = vec![];


### PR DESCRIPTION
With the recent addition to generate the crates using rayon, understanding what is happening on failure is less easy.  This improves the situation by showing each of the errors with additional context.