### PR TITLE
fix handling application/xml in generated crates

### DIFF
--- a/sdk/core/src/xml.rs
+++ b/sdk/core/src/xml.rs
@@ -1,4 +1,5 @@
 use crate::error::{ErrorKind, ResultExt};
+use bytes::Bytes;
 pub use quick_xml::serde_helpers::text_content;
 use quick_xml::{
     de::{from_reader, from_str},
@@ -32,24 +33,27 @@ where
     })
 }
 
-pub fn to_xml<T>(value: &T) -> crate::Result<String>
+pub fn to_xml<T>(value: &T) -> crate::Result<Bytes>
 where
     T: serde::Serialize,
 {
-    to_string(value).with_context(ErrorKind::DataConversion, || {
+    let value = to_string(value).with_context(ErrorKind::DataConversion, || {
         let t = core::any::type_name::<T>();
         format!("failed to serialize {t} into xml")
-    })
+    })?;
+    Ok(Bytes::from(value))
 }
 
-pub fn to_xml_with_root<T>(root_tag: &str, value: &T) -> crate::Result<String>
+pub fn to_xml_with_root<T>(root_tag: &str, value: &T) -> crate::Result<Bytes>
 where
     T: serde::Serialize,
 {
-    to_string_with_root(root_tag, value).with_context(ErrorKind::DataConversion, || {
-        let t = core::any::type_name::<T>();
-        format!("failed to serialize {t} into xml")
-    })
+    let value =
+        to_string_with_root(root_tag, value).with_context(ErrorKind::DataConversion, || {
+            let t = core::any::type_name::<T>();
+            format!("failed to serialize {t} into xml")
+        })?;
+    Ok(Bytes::from(value))
 }
 
 /// Returns bytes without the UTF-8 BOM.

--- a/sdk/storage_blobs/src/options/tags.rs
+++ b/sdk/storage_blobs/src/options/tags.rs
@@ -3,6 +3,7 @@ use azure_core::{
     headers::{Header, HeaderName, HeaderValue, TAGS},
     xml::to_xml,
 };
+use bytes::{Bytes, BytesMut};
 use std::{
     collections::HashMap,
     iter::{Extend, IntoIterator},
@@ -62,11 +63,10 @@ impl Tags {
         });
     }
 
-    pub fn to_xml(&self) -> azure_core::Result<String> {
-        Ok(format!(
-            "<?xml version=\"1.0\" encoding=\"utf-8\"?>{}",
-            to_xml(&self)?
-        ))
+    pub fn to_xml(&self) -> azure_core::Result<Bytes> {
+        let mut value = BytesMut::from("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
+        value.extend(to_xml(&self)?);
+        Ok(value.freeze())
     }
 }
 

--- a/services/svc/blobstorage/src/package_2020_12/mod.rs
+++ b/services/svc/blobstorage/src/package_2020_12/mod.rs
@@ -453,7 +453,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2020-12-06");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -864,7 +864,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2020-12-06");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.key_info)?;
+                        let req_body = azure_core::xml::to_xml(&this.key_info)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2541,7 +2541,7 @@ pub mod container {
                         req.insert_header(azure_core::headers::VERSION, "2020-12-06");
                         let req_body = if let Some(container_acl) = &this.container_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(container_acl)?
+                            azure_core::xml::to_xml(container_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -9613,7 +9613,7 @@ pub mod blob {
                         req.insert_header(azure_core::headers::VERSION, "2020-12-06");
                         let req_body = if let Some(query_request) = &this.query_request {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(query_request)?
+                            azure_core::xml::to_xml(query_request)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -10014,7 +10014,7 @@ pub mod blob {
                         }
                         let req_body = if let Some(tags) = &this.tags {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(tags)?
+                            azure_core::xml::to_xml(tags)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -16168,7 +16168,7 @@ pub mod block_blob {
                             req.insert_header("x-ms-if-tags", x_ms_if_tags);
                         }
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.blocks)?;
+                        let req_body = azure_core::xml::to_xml(&this.blocks)?;
                         if let Some(x_ms_client_request_id) = &this.x_ms_client_request_id {
                             req.insert_header("x-ms-client-request-id", x_ms_client_request_id);
                         }

--- a/services/svc/blobstorage/src/package_2021_02/mod.rs
+++ b/services/svc/blobstorage/src/package_2021_02/mod.rs
@@ -453,7 +453,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-02-12");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -864,7 +864,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-02-12");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.key_info)?;
+                        let req_body = azure_core::xml::to_xml(&this.key_info)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2541,7 +2541,7 @@ pub mod container {
                         req.insert_header(azure_core::headers::VERSION, "2021-02-12");
                         let req_body = if let Some(container_acl) = &this.container_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(container_acl)?
+                            azure_core::xml::to_xml(container_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -9613,7 +9613,7 @@ pub mod blob {
                         req.insert_header(azure_core::headers::VERSION, "2021-02-12");
                         let req_body = if let Some(query_request) = &this.query_request {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(query_request)?
+                            azure_core::xml::to_xml(query_request)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -10014,7 +10014,7 @@ pub mod blob {
                         }
                         let req_body = if let Some(tags) = &this.tags {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(tags)?
+                            azure_core::xml::to_xml(tags)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -16168,7 +16168,7 @@ pub mod block_blob {
                             req.insert_header("x-ms-if-tags", x_ms_if_tags);
                         }
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.blocks)?;
+                        let req_body = azure_core::xml::to_xml(&this.blocks)?;
                         if let Some(x_ms_client_request_id) = &this.x_ms_client_request_id {
                             req.insert_header("x-ms-client-request-id", x_ms_client_request_id);
                         }

--- a/services/svc/blobstorage/src/package_2021_04/mod.rs
+++ b/services/svc/blobstorage/src/package_2021_04/mod.rs
@@ -453,7 +453,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-04-10");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -864,7 +864,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-04-10");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.key_info)?;
+                        let req_body = azure_core::xml::to_xml(&this.key_info)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2556,7 +2556,7 @@ pub mod container {
                         req.insert_header(azure_core::headers::VERSION, "2021-04-10");
                         let req_body = if let Some(container_acl) = &this.container_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(container_acl)?
+                            azure_core::xml::to_xml(container_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -9802,7 +9802,7 @@ pub mod blob {
                         req.insert_header(azure_core::headers::VERSION, "2021-04-10");
                         let req_body = if let Some(query_request) = &this.query_request {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(query_request)?
+                            azure_core::xml::to_xml(query_request)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -10203,7 +10203,7 @@ pub mod blob {
                         }
                         let req_body = if let Some(tags) = &this.tags {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(tags)?
+                            azure_core::xml::to_xml(tags)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -16367,7 +16367,7 @@ pub mod block_blob {
                             req.insert_header("x-ms-if-tags", x_ms_if_tags);
                         }
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.blocks)?;
+                        let req_body = azure_core::xml::to_xml(&this.blocks)?;
                         if let Some(x_ms_client_request_id) = &this.x_ms_client_request_id {
                             req.insert_header("x-ms-client-request-id", x_ms_client_request_id);
                         }

--- a/services/svc/blobstorage/src/package_2021_08/mod.rs
+++ b/services/svc/blobstorage/src/package_2021_08/mod.rs
@@ -454,7 +454,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-08-06");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -865,7 +865,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-08-06");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.key_info)?;
+                        let req_body = azure_core::xml::to_xml(&this.key_info)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2564,7 +2564,7 @@ pub mod container {
                         req.insert_header(azure_core::headers::VERSION, "2021-08-06");
                         let req_body = if let Some(container_acl) = &this.container_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(container_acl)?
+                            azure_core::xml::to_xml(container_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -9816,7 +9816,7 @@ pub mod blob {
                         req.insert_header(azure_core::headers::VERSION, "2021-08-06");
                         let req_body = if let Some(query_request) = &this.query_request {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(query_request)?
+                            azure_core::xml::to_xml(query_request)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -10217,7 +10217,7 @@ pub mod blob {
                         }
                         let req_body = if let Some(tags) = &this.tags {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(tags)?
+                            azure_core::xml::to_xml(tags)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -16391,7 +16391,7 @@ pub mod block_blob {
                             req.insert_header("x-ms-if-tags", x_ms_if_tags);
                         }
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.blocks)?;
+                        let req_body = azure_core::xml::to_xml(&this.blocks)?;
                         if let Some(x_ms_client_request_id) = &this.x_ms_client_request_id {
                             req.insert_header("x-ms-client-request-id", x_ms_client_request_id);
                         }

--- a/services/svc/blobstorage/src/package_2021_12/mod.rs
+++ b/services/svc/blobstorage/src/package_2021_12/mod.rs
@@ -454,7 +454,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-12-02");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -865,7 +865,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-12-02");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.key_info)?;
+                        let req_body = azure_core::xml::to_xml(&this.key_info)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2564,7 +2564,7 @@ pub mod container {
                         req.insert_header(azure_core::headers::VERSION, "2021-12-02");
                         let req_body = if let Some(container_acl) = &this.container_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(container_acl)?
+                            azure_core::xml::to_xml(container_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -9823,7 +9823,7 @@ pub mod blob {
                         req.insert_header(azure_core::headers::VERSION, "2021-12-02");
                         let req_body = if let Some(query_request) = &this.query_request {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(query_request)?
+                            azure_core::xml::to_xml(query_request)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -10224,7 +10224,7 @@ pub mod blob {
                         }
                         let req_body = if let Some(tags) = &this.tags {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(tags)?
+                            azure_core::xml::to_xml(tags)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -16398,7 +16398,7 @@ pub mod block_blob {
                             req.insert_header("x-ms-if-tags", x_ms_if_tags);
                         }
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.blocks)?;
+                        let req_body = azure_core::xml::to_xml(&this.blocks)?;
                         if let Some(x_ms_client_request_id) = &this.x_ms_client_request_id {
                             req.insert_header("x-ms-client-request-id", x_ms_client_request_id);
                         }

--- a/services/svc/filestorage/src/package_2021_12/mod.rs
+++ b/services/svc/filestorage/src/package_2021_12/mod.rs
@@ -363,7 +363,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2021-12-02");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2942,7 +2942,7 @@ pub mod share {
                         req.insert_header(azure_core::headers::VERSION, "2021-12-02");
                         let req_body = if let Some(share_acl) = &this.share_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(share_acl)?
+                            azure_core::xml::to_xml(share_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };

--- a/services/svc/filestorage/src/package_2022_11/mod.rs
+++ b/services/svc/filestorage/src/package_2022_11/mod.rs
@@ -363,7 +363,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2022-11-02");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2962,7 +2962,7 @@ pub mod share {
                         req.insert_header(azure_core::headers::VERSION, "2022-11-02");
                         let req_body = if let Some(share_acl) = &this.share_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(share_acl)?
+                            azure_core::xml::to_xml(share_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };

--- a/services/svc/filestorage/src/package_2023_01/mod.rs
+++ b/services/svc/filestorage/src/package_2023_01/mod.rs
@@ -363,7 +363,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2023-01-03");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2962,7 +2962,7 @@ pub mod share {
                         req.insert_header(azure_core::headers::VERSION, "2023-01-03");
                         let req_body = if let Some(share_acl) = &this.share_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(share_acl)?
+                            azure_core::xml::to_xml(share_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };

--- a/services/svc/filestorage/src/package_2023_08/mod.rs
+++ b/services/svc/filestorage/src/package_2023_08/mod.rs
@@ -363,7 +363,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2023-08-03");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2962,7 +2962,7 @@ pub mod share {
                         req.insert_header(azure_core::headers::VERSION, "2023-08-03");
                         let req_body = if let Some(share_acl) = &this.share_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(share_acl)?
+                            azure_core::xml::to_xml(share_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };

--- a/services/svc/filestorage/src/package_2024_02/mod.rs
+++ b/services/svc/filestorage/src/package_2024_02/mod.rs
@@ -363,7 +363,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2024-02-04");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -2962,7 +2962,7 @@ pub mod share {
                         req.insert_header(azure_core::headers::VERSION, "2024-02-04");
                         let req_body = if let Some(share_acl) = &this.share_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(share_acl)?
+                            azure_core::xml::to_xml(share_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };

--- a/services/svc/queuestorage/src/package_2018_03/mod.rs
+++ b/services/svc/queuestorage/src/package_2018_03/mod.rs
@@ -389,7 +389,7 @@ pub mod service {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2018-03-28");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.storage_service_properties)?;
+                        let req_body = azure_core::xml::to_xml(&this.storage_service_properties)?;
                         if let Some(timeout) = &this.timeout {
                             req.url_mut().query_pairs_mut().append_pair("timeout", &timeout.to_string());
                         }
@@ -1474,7 +1474,7 @@ pub mod queue {
                         req.insert_header(azure_core::headers::VERSION, "2018-03-28");
                         let req_body = if let Some(queue_acl) = &this.queue_acl {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(queue_acl)?
+                            azure_core::xml::to_xml(queue_acl)?
                         } else {
                             azure_core::EMPTY_BODY
                         };
@@ -1822,7 +1822,7 @@ pub mod messages {
                         req.insert_header(azure_core::headers::AUTHORIZATION, format!("Bearer {}", bearer_token.secret()));
                         req.insert_header(azure_core::headers::VERSION, "2018-03-28");
                         req.insert_header("content-type", "application/xml");
-                        let req_body = azure_core::to_json(&this.queue_message)?;
+                        let req_body = azure_core::xml::to_xml(&this.queue_message)?;
                         if let Some(visibilitytimeout) = &this.visibilitytimeout {
                             req.url_mut()
                                 .query_pairs_mut()
@@ -2281,7 +2281,7 @@ pub mod message_id {
                         req.insert_header(azure_core::headers::VERSION, "2018-03-28");
                         let req_body = if let Some(queue_message) = &this.queue_message {
                             req.insert_header("content-type", "application/xml");
-                            azure_core::to_json(queue_message)?
+                            azure_core::xml::to_xml(queue_message)?
                         } else {
                             azure_core::EMPTY_BODY
                         };


### PR DESCRIPTION
This includes two changes:
1. Align `to_xml` to `to_json` by returning Bytes instead of String
2. Updates generator to use `to_xml` when the content-type is set to `application/xml`