### PR TITLE
Standardize on json xml helpers

### DIFF
--- a/sdk/core/src/date/mod.rs
+++ b/sdk/core/src/date/mod.rs
@@ -137,8 +137,8 @@ pub fn diff(first: OffsetDateTime, second: OffsetDateTime) -> Duration {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::from_json;
     use serde::{Deserialize, Serialize};
-    use serde_json;
     use time::macros::datetime;
 
     #[derive(Serialize, Deserialize)]
@@ -207,7 +207,7 @@ mod tests {
             "created_time": "2021-07-01T10:45:02Z"
         }"#;
 
-        let state: ExampleState = serde_json::from_str(json_state).unwrap();
+        let state: ExampleState = from_json(json_state)?;
 
         assert_eq!(parse_rfc3339("2021-07-01T10:45:02Z")?, state.created_time);
         assert_eq!(state.deleted_time, None);
@@ -222,12 +222,12 @@ mod tests {
             "deleted_time": "2022-03-28T11:05:31Z"
         }"#;
 
-        let state: ExampleState = serde_json::from_str(json_state).unwrap();
+        let state: ExampleState = from_json(json_state)?;
 
         assert_eq!(parse_rfc3339("2021-07-01T10:45:02Z")?, state.created_time);
         assert_eq!(
             state.deleted_time,
-            Some(parse_rfc3339("2022-03-28T11:05:31Z").unwrap())
+            Some(parse_rfc3339("2022-03-28T11:05:31Z")?)
         );
 
         Ok(())

--- a/sdk/core/src/http_client/mod.rs
+++ b/sdk/core/src/http_client/mod.rs
@@ -10,7 +10,7 @@ use self::reqwest::new_reqwest_client;
 use crate::error::ErrorKind;
 use async_trait::async_trait;
 use bytes::Bytes;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 use std::sync::Arc;
 
 /// Construct a new `HttpClient`
@@ -60,4 +60,13 @@ where
     T: ?Sized + Serialize,
 {
     Ok(Bytes::from(serde_json::to_vec(value)?))
+}
+
+/// Reads the XML from bytes.
+pub fn from_json<S, T>(body: S) -> crate::Result<T>
+where
+    S: AsRef<[u8]>,
+    T: DeserializeOwned,
+{
+    serde_json::from_slice(body.as_ref()).map_err(|e| e.into())
 }

--- a/sdk/core/src/lib.rs
+++ b/sdk/core/src/lib.rs
@@ -55,7 +55,7 @@ pub use context::Context;
 pub use error::{Error, Result};
 #[doc(inline)]
 pub use headers::Header;
-pub use http_client::{new_http_client, to_json, HttpClient};
+pub use http_client::{from_json, new_http_client, to_json, HttpClient};
 pub use models::*;
 pub use options::*;
 pub use pageable::*;

--- a/sdk/core/src/request.rs
+++ b/sdk/core/src/request.rs
@@ -2,9 +2,10 @@
 use crate::SeekableStream;
 use crate::{
     headers::{AsHeaders, Headers},
-    Method, Url,
+    to_json, Method, Url,
 };
 use bytes::Bytes;
+use serde::Serialize;
 use std::fmt::Debug;
 
 /// An HTTP Body.
@@ -114,6 +115,14 @@ impl Request {
 
     pub fn body(&self) -> &Body {
         &self.body
+    }
+
+    pub fn set_json<T>(&mut self, data: &T) -> crate::Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.set_body(to_json(data)?);
+        Ok(())
     }
 
     pub fn set_body(&mut self, body: impl Into<Body>) {

--- a/sdk/core/src/util.rs
+++ b/sdk/core/src/util.rs
@@ -30,6 +30,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::from_json;
     use serde::Serialize;
 
     #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -54,7 +55,7 @@ mod tests {
     #[test]
     fn deserialize_empty() -> crate::Result<()> {
         let bytes = br#"{}"#;
-        let site_config: SiteConfig = serde_json::from_slice(bytes)?;
+        let site_config: SiteConfig = from_json(bytes)?;
         assert_eq!(Vec::<NameValuePair>::default(), site_config.app_settings);
         Ok(())
     }
@@ -62,7 +63,7 @@ mod tests {
     #[test]
     fn deserialize_null() -> crate::Result<()> {
         let bytes = br#"{ "appSettings": null }"#;
-        let site_config: SiteConfig = serde_json::from_slice(bytes)?;
+        let site_config: SiteConfig = from_json(bytes)?;
         assert_eq!(Vec::<NameValuePair>::default(), site_config.app_settings);
         Ok(())
     }

--- a/sdk/core/src/xml.rs
+++ b/sdk/core/src/xml.rs
@@ -76,7 +76,7 @@ mod test {
     }
 
     #[test]
-    fn reading_xml() {
+    fn reading_xml() -> crate::Result<()> {
         #[derive(Deserialize, PartialEq, Debug)]
         #[serde(rename = "Foo")]
         struct Test {
@@ -86,15 +86,16 @@ mod test {
             x: "Hello, world!".into(),
         };
         let xml = br#"<?xml version="1.0" encoding="utf-8"?><Foo><x>Hello, world!</x></Foo>"#;
-        assert_eq!(test, read_xml(xml).unwrap());
+        assert_eq!(test, read_xml(xml)?);
 
         let error = read_xml::<Test>(&xml[..xml.len() - 2]).unwrap_err();
         assert!(format!("{error}").contains("reading_xml::Test"));
 
         let xml = r#"<?xml version="1.0" encoding="utf-8"?><Foo><x>Hello, world!</x></Foo>"#;
-        assert_eq!(test, read_xml_str(xml).unwrap());
+        assert_eq!(test, read_xml_str(xml)?);
 
         let error = read_xml_str::<Test>(&xml[..xml.len() - 2]).unwrap_err();
         assert!(format!("{error}").contains("reading_xml::Test"));
+        Ok(())
     }
 }

--- a/sdk/data_cosmos/src/operations/create_collection.rs
+++ b/sdk/data_cosmos/src/operations/create_collection.rs
@@ -1,8 +1,12 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::collection::{IndexingPolicy, PartitionKey};
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Response as HttpResponse;
+use crate::{
+    headers::from_headers::*,
+    prelude::*,
+    resources::collection::{IndexingPolicy, PartitionKey},
+};
+use azure_core::{
+    headers::{etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -40,7 +44,7 @@ impl CreateCollectionBuilder {
                 partition_key: &self.partition_key,
             };
 
-            request.set_body(serde_json::to_vec(&collection)?);
+            request.set_json(&collection)?;
 
             let response = self
                 .client
@@ -73,10 +77,8 @@ pub struct CreateCollectionResponse {
 impl CreateCollectionResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
         Ok(Self {
-            collection: serde_json::from_slice(&body)?,
+            collection: body.json().await?,
             charge: request_charge_from_headers(&headers)?,
             activity_id: activity_id_from_headers(&headers)?,
             etag: etag_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/create_document.rs
+++ b/sdk/data_cosmos/src/operations/create_document.rs
@@ -34,7 +34,6 @@ impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {
     pub fn into_future(self) -> CreateDocument {
         Box::pin(async move {
             let document = self.document;
-            let serialized = serde_json::to_string(&document)?;
             let partition_key = match self.partition_key {
                 Some(s) => s,
                 None => serialize_partition_key(&document.partition_key())?,
@@ -64,7 +63,7 @@ impl<D: Serialize + CosmosEntity + Send + 'static> CreateDocumentBuilder<D> {
                     .unwrap_or(TentativeWritesAllowance::Deny),
             );
 
-            request.set_body(serialized);
+            request.set_json(&document)?;
             let response = self
                 .client
                 .pipeline()

--- a/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_attachment.rs
@@ -1,11 +1,8 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::Attachment;
-use crate::ResourceQuota;
-
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Response as HttpResponse;
-use azure_core::SessionToken;
+use crate::{headers::from_headers::*, prelude::*, resources::Attachment, ResourceQuota};
+use azure_core::{
+    headers::{etag_from_headers, session_token_from_headers},
+    Response as HttpResponse, SessionToken,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -42,13 +39,11 @@ impl CreateOrReplaceAttachmentBuilder {
                 pub media: &'r str,
             }
 
-            let body = azure_core::to_json(&Request {
+            req.set_json(&Request {
                 id: self.client.attachment_name(),
                 content_type: &self.content_type,
                 media: &self.media,
             })?;
-
-            req.set_body(body);
 
             let response = self
                 .client
@@ -94,12 +89,9 @@ pub struct CreateOrReplaceAttachmentResponse {
 impl CreateOrReplaceAttachmentResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let attachment: Attachment = serde_json::from_slice(&body)?;
 
         Ok(Self {
-            attachment,
+            attachment: body.json().await?,
             max_media_storage_usage_mb: max_media_storage_usage_mb_from_headers(&headers)?,
             media_storage_usage_mb: media_storage_usage_mb_from_headers(&headers)?,
             last_change: last_state_change_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_slug_attachment.rs
@@ -1,15 +1,12 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::Attachment;
-use crate::ResourceQuota;
-use azure_core::headers;
-use azure_core::headers::{
-    date_from_headers, etag_from_headers, session_token_from_headers, HeaderValue,
+use crate::{headers::from_headers::*, prelude::*, resources::Attachment, ResourceQuota};
+use azure_core::{
+    content_type,
+    headers::{
+        self, date_from_headers, etag_from_headers, session_token_from_headers, HeaderValue,
+    },
+    prelude::*,
+    Method, Response as HttpResponse, SessionToken,
 };
-use azure_core::Method;
-use azure_core::Response as HttpResponse;
-use azure_core::SessionToken;
-use azure_core::{content_type, prelude::*};
 use bytes::Bytes;
 use time::OffsetDateTime;
 
@@ -104,12 +101,9 @@ pub struct CreateOrReplaceSlugAttachmentResponse {
 impl CreateOrReplaceSlugAttachmentResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let attachment: Attachment = serde_json::from_slice(&body)?;
 
         Ok(Self {
-            attachment,
+            attachment: body.json().await?,
             max_media_storage_usage_mb: max_media_storage_usage_mb_from_headers(&headers)?,
             media_storage_usage_mb: media_storage_usage_mb_from_headers(&headers)?,
             last_change: last_state_change_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_trigger.rs
@@ -1,11 +1,10 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::trigger::*;
-use crate::resources::Trigger;
-use crate::ResourceQuota;
-
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Response as HttpResponse;
+use crate::{
+    headers::from_headers::*, prelude::*, resources::trigger::*, resources::Trigger, ResourceQuota,
+};
+use azure_core::{
+    headers::{etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -48,7 +47,7 @@ impl CreateOrReplaceTriggerBuilder {
                 body: &self.body,
             };
 
-            request.set_body(serde_json::to_vec(&request_body)?);
+            request.set_json(&request_body)?;
             let response = self
                 .client
                 .pipeline()
@@ -95,10 +94,9 @@ pub struct CreateOrReplaceTriggerResponse {
 impl CreateOrReplaceTriggerResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            trigger: serde_json::from_slice(&body)?,
+            trigger: body.json().await?,
             server: server_from_headers(&headers)?,
             last_state_change: last_state_change_from_headers(&headers)?,
             etag: etag_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/create_or_replace_user_defined_function.rs
@@ -1,10 +1,8 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::UserDefinedFunction;
-use crate::ResourceQuota;
-
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Response as HttpResponse;
+use crate::{headers::from_headers::*, prelude::*, resources::UserDefinedFunction, ResourceQuota};
+use azure_core::{
+    headers::{etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -37,7 +35,7 @@ impl CreateOrReplaceUserDefinedFunctionBuilder {
                 body: &self.body,
                 id: self.client.user_defined_function_name(),
             };
-            request.set_body(serde_json::to_vec(&request_body)?);
+            request.set_json(&request_body)?;
             let response = self
                 .client
                 .pipeline()
@@ -86,10 +84,9 @@ pub struct CreateOrReplaceUserDefinedFunctionResponse {
 impl CreateOrReplaceUserDefinedFunctionResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            user_defined_function: serde_json::from_slice(&body)?,
+            user_defined_function: body.json().await?,
             server: server_from_headers(&headers)?,
             last_state_change: last_state_change_from_headers(&headers)?,
             etag: etag_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/create_permission.rs
+++ b/sdk/data_cosmos/src/operations/create_permission.rs
@@ -1,6 +1,8 @@
-use crate::prelude::*;
-use crate::resources::permission::{
-    ExpirySeconds, PermissionMode, PermissionResponse as CreatePermissionResponse,
+use crate::{
+    prelude::*,
+    resources::permission::{
+        ExpirySeconds, PermissionMode, PermissionResponse as CreatePermissionResponse,
+    },
 };
 
 operation! {
@@ -42,7 +44,7 @@ impl CreatePermissionBuilder {
                 resource: self.permission_mode.resource(),
             };
 
-            request.set_body(serde_json::to_vec(&request_body)?);
+            request.set_json(&request_body)?;
             let response = self
                 .client
                 .pipeline()

--- a/sdk/data_cosmos/src/operations/create_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/create_stored_procedure.rs
@@ -1,9 +1,8 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::StoredProcedure;
-use crate::ResourceQuota;
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Response as HttpResponse;
+use crate::{headers::from_headers::*, prelude::*, resources::StoredProcedure, ResourceQuota};
+use azure_core::{
+    headers::{etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -34,7 +33,7 @@ impl CreateStoredProcedureBuilder {
                 id: self.client.stored_procedure_name(),
             };
 
-            req.set_body(serde_json::to_vec(&body)?);
+            req.set_json(&body)?;
 
             let response = self
                 .client
@@ -68,10 +67,9 @@ pub struct CreateStoredProcedureResponse {
 impl CreateStoredProcedureResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            stored_procedure: serde_json::from_slice(&body)?,
+            stored_procedure: body.json().await?,
             charge: request_charge_from_headers(&headers)?,
             activity_id: activity_id_from_headers(&headers)?,
             etag: etag_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/create_user.rs
+++ b/sdk/data_cosmos/src/operations/create_user.rs
@@ -23,7 +23,7 @@ impl CreateUserBuilder {
             let body = CreateUserBody {
                 id: self.client.user_name(),
             };
-            request.set_body(serde_json::to_vec(&body)?);
+            request.set_json(&body)?;
             let response = self
                 .client
                 .pipeline()

--- a/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/execute_stored_procedure.rs
@@ -1,14 +1,10 @@
-use std::marker::PhantomData;
-
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::stored_procedure::Parameters;
-
-use azure_core::headers::session_token_from_headers;
-use azure_core::prelude::*;
-use azure_core::{Response as HttpResponse, SessionToken};
+use crate::{headers::from_headers::*, prelude::*, resources::stored_procedure::Parameters};
+use azure_core::{
+    headers::session_token_from_headers, prelude::*, Response as HttpResponse, SessionToken,
+};
 use bytes::Bytes;
 use serde::de::DeserializeOwned;
+use std::marker::PhantomData;
 use time::OffsetDateTime;
 
 #[derive(Debug, Clone)]
@@ -134,10 +130,9 @@ where
 {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            payload: serde_json::from_slice(&body)?,
+            payload: body.json().await?,
             last_state_change: last_state_change_from_headers(&headers)?,
             schema_version: schema_version_from_headers(&headers)?,
             alt_content_path: alt_content_path_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/get_attachment.rs
+++ b/sdk/data_cosmos/src/operations/get_attachment.rs
@@ -1,13 +1,12 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::document::IndexingDirective;
-use crate::resources::Attachment;
-use crate::ResourceQuota;
-use azure_core::headers::{
-    content_type_from_headers, etag_from_headers, session_token_from_headers,
+use crate::{
+    headers::from_headers::*, prelude::*, resources::document::IndexingDirective,
+    resources::Attachment, ResourceQuota,
 };
-use azure_core::SessionToken;
-use azure_core::{prelude::*, Response as HttpResponse};
+use azure_core::{
+    headers::{content_type_from_headers, etag_from_headers, session_token_from_headers},
+    prelude::*,
+    Response as HttpResponse, SessionToken,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -76,10 +75,9 @@ pub struct GetAttachmentResponse {
 impl GetAttachmentResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            attachment: serde_json::from_slice(&body)?,
+            attachment: body.json().await?,
             content_type: content_type_from_headers(&headers)?,
             content_location: content_location_from_headers(&headers)?,
             last_change: last_state_change_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/get_collection.rs
+++ b/sdk/data_cosmos/src/operations/get_collection.rs
@@ -1,10 +1,8 @@
-use crate::prelude::*;
-
-use crate::headers::from_headers::*;
-use azure_core::headers::{
-    content_type_from_headers, etag_from_headers, session_token_from_headers,
+use crate::{headers::from_headers::*, prelude::*};
+use azure_core::{
+    headers::{content_type_from_headers, etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
 };
-use azure_core::Response as HttpResponse;
 use time::OffsetDateTime;
 
 operation! {
@@ -68,10 +66,9 @@ pub struct GetCollectionResponse {
 impl GetCollectionResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            collection: serde_json::from_slice(&body)?,
+            collection: body.json().await?,
             last_state_change: last_state_change_from_headers(&headers)?,
             etag: etag_from_headers(&headers)?,
             collection_partition_index: collection_partition_index_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/get_database.rs
+++ b/sdk/data_cosmos/src/operations/get_database.rs
@@ -1,9 +1,8 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::ResourceQuota;
-
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Response as HttpResponse;
+use crate::{headers::from_headers::*, prelude::*, ResourceQuota};
+use azure_core::{
+    headers::{etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -48,10 +47,8 @@ pub struct GetDatabaseResponse {
 impl GetDatabaseResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
         Ok(Self {
-            database: serde_json::from_slice(&body)?,
+            database: body.json().await?,
             charge: request_charge_from_headers(&headers)?,
             activity_id: activity_id_from_headers(&headers)?,
             session_token: session_token_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 use crate::resources::Document;
 use crate::ResourceQuota;
 use azure_core::headers::{etag_from_headers, session_token_from_headers, Headers};
-use azure_core::{prelude::*, StatusCode};
+use azure_core::{from_json, prelude::*, StatusCode};
 use azure_core::{Response as HttpResponse, SessionToken};
 use serde::de::DeserializeOwned;
 use time::OffsetDateTime;
@@ -153,8 +153,7 @@ where
 {
     async fn try_from(headers: &Headers, body: bytes::Bytes) -> azure_core::Result<Self> {
         Ok(Self {
-            document: serde_json::from_slice(&body)?,
-
+            document: from_json(&body)?,
             content_location: content_location_from_headers(headers)?,
             last_state_change: last_state_change_from_headers(headers)?,
             etag: etag_from_headers(headers)?,

--- a/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
+++ b/sdk/data_cosmos/src/operations/get_partition_key_ranges.rs
@@ -1,8 +1,9 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::ResourceType;
-use azure_core::headers::{item_count_from_headers, session_token_from_headers};
-use azure_core::{prelude::*, Response as HttpResponse};
+use crate::{headers::from_headers::*, prelude::*, resources::ResourceType};
+use azure_core::{
+    headers::{item_count_from_headers, session_token_from_headers},
+    prelude::*,
+    Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -74,7 +75,6 @@ pub struct GetPartitionKeyRangesResponse {
 impl GetPartitionKeyRangesResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         #[derive(Debug, Deserialize)]
         struct Response {
@@ -84,7 +84,7 @@ impl GetPartitionKeyRangesResponse {
             pub partition_key_ranges: Vec<PartitionKeyRange>,
         }
 
-        let r: Response = serde_json::from_slice(&body)?;
+        let r: Response = body.json().await?;
 
         Ok(Self {
             rid: r.rid,

--- a/sdk/data_cosmos/src/operations/list_attachments.rs
+++ b/sdk/data_cosmos/src/operations/list_attachments.rs
@@ -1,14 +1,15 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::Attachment;
-use crate::resources::ResourceType;
-use crate::ResourceQuota;
-
-use azure_core::headers::{
-    continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
+use crate::{
+    headers::from_headers::*, prelude::*, resources::Attachment, resources::ResourceType,
+    ResourceQuota,
 };
-use azure_core::prelude::*;
-use azure_core::{Pageable, Response as HttpResponse, SessionToken};
+use azure_core::{
+    headers::{
+        continuation_token_from_headers_optional, item_count_from_headers,
+        session_token_from_headers,
+    },
+    prelude::*,
+    Pageable, Response as HttpResponse, SessionToken,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -107,9 +108,7 @@ pub struct ListAttachmentsResponse {
 impl ListAttachmentsResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let json: JsonListAttachmentResponse = serde_json::from_slice(&body)?;
+        let json: JsonListAttachmentResponse = body.json().await?;
 
         Ok(Self {
             rid: json.rid,

--- a/sdk/data_cosmos/src/operations/list_collections.rs
+++ b/sdk/data_cosmos/src/operations/list_collections.rs
@@ -1,11 +1,9 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::Collection;
-use crate::ResourceQuota;
-use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
-use azure_core::prelude::*;
-use azure_core::Pageable;
-use azure_core::Response as HttpResponse;
+use crate::{headers::from_headers::*, prelude::*, resources::Collection, ResourceQuota};
+use azure_core::{
+    headers::{continuation_token_from_headers_optional, session_token_from_headers},
+    prelude::*,
+    Pageable, Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -67,7 +65,6 @@ pub struct ListCollectionsResponse {
 impl ListCollectionsResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         #[derive(Deserialize, Debug)]
         pub struct Response {
@@ -78,7 +75,7 @@ impl ListCollectionsResponse {
             pub count: u32,
         }
 
-        let response: Response = serde_json::from_slice(&body)?;
+        let response: Response = body.json().await?;
 
         Ok(Self {
             rid: response._rid,

--- a/sdk/data_cosmos/src/operations/list_databases.rs
+++ b/sdk/data_cosmos/src/operations/list_databases.rs
@@ -1,10 +1,9 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::Database;
-use crate::ResourceQuota;
-
-use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
-use azure_core::{prelude::*, Pageable, Response};
+use crate::{headers::from_headers::*, prelude::*, resources::Database, ResourceQuota};
+use azure_core::{
+    headers::{continuation_token_from_headers_optional, session_token_from_headers},
+    prelude::*,
+    Pageable, Response,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -64,7 +63,6 @@ pub struct ListDatabasesResponse {
 impl ListDatabasesResponse {
     pub(crate) async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         #[derive(Deserialize, Debug)]
         pub struct Response {
@@ -76,7 +74,7 @@ impl ListDatabasesResponse {
             pub count: u32,
         }
 
-        let response: Response = serde_json::from_slice(&body)?;
+        let response: Response = body.json().await?;
 
         Ok(Self {
             rid: response.rid,

--- a/sdk/data_cosmos/src/operations/list_documents.rs
+++ b/sdk/data_cosmos/src/operations/list_documents.rs
@@ -6,7 +6,7 @@ use crate::ResourceQuota;
 use azure_core::headers::{
     continuation_token_from_headers_optional, item_count_from_headers, session_token_from_headers,
 };
-use azure_core::{prelude::*, Pageable};
+use azure_core::{from_json, prelude::*, Pageable};
 use azure_core::{Response, SessionToken};
 use serde::de::DeserializeOwned;
 use time::OffsetDateTime;
@@ -126,8 +126,8 @@ where
         // 2- Deserialize the result a type T. The extra fields will be ignored.
         // 3- Zip 1 and 2 in the resulting structure.
         // There is a lot of data movement here, let's hope the compiler is smarter than me :)
-        let document_attributes: ListDocumentsResponseAttributes = serde_json::from_slice(&body)?;
-        let entries: ListDocumentsResponseEntities<T> = serde_json::from_slice(&body)?;
+        let document_attributes: ListDocumentsResponseAttributes = from_json(&body)?;
+        let entries: ListDocumentsResponseEntities<T> = from_json(&body)?;
 
         let documents = document_attributes
             .documents
@@ -218,11 +218,10 @@ mod tests {
     }
 
     #[test]
-    fn test_list_document() {
-        let _document_attributes =
-            serde_json::from_slice::<ListDocumentsResponseAttributes>(BODY.as_bytes()).unwrap();
-        let _entries =
-            serde_json::from_slice::<ListDocumentsResponseEntities<MyStruct>>(BODY.as_bytes())
-                .unwrap();
+    fn test_list_document() -> azure_core::Result<()> {
+        let _document_attributes: ListDocumentsResponseAttributes = from_json(BODY)?;
+        let _entries: ListDocumentsResponseEntities<MyStruct> = from_json(BODY)?;
+
+        Ok(())
     }
 }

--- a/sdk/data_cosmos/src/operations/list_permissions.rs
+++ b/sdk/data_cosmos/src/operations/list_permissions.rs
@@ -1,11 +1,9 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::Permission;
-use crate::resources::ResourceType;
-
-use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
-use azure_core::prelude::*;
-use azure_core::{Pageable, Response as HttpResponse};
+use crate::{headers::from_headers::*, prelude::*, resources::Permission, resources::ResourceType};
+use azure_core::{
+    headers::{continuation_token_from_headers_optional, session_token_from_headers},
+    prelude::*,
+    Pageable, Response as HttpResponse,
+};
 
 operation! {
     #[stream]
@@ -66,7 +64,6 @@ pub struct ListPermissionsResponse {
 impl ListPermissionsResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         #[derive(Debug, Deserialize)]
         struct Response {
@@ -76,7 +73,7 @@ impl ListPermissionsResponse {
             _count: u32,
         }
 
-        let response: Response = serde_json::from_slice(&body)?;
+        let response: Response = body.json().await?;
         let permissions = response.permissions;
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/list_stored_procedures.rs
+++ b/sdk/data_cosmos/src/operations/list_stored_procedures.rs
@@ -1,12 +1,12 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::ResourceType;
-use crate::resources::StoredProcedure;
-use crate::ResourceQuota;
-
-use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
-use azure_core::prelude::*;
-use azure_core::{Pageable, Response as HttpResponse};
+use crate::{
+    headers::from_headers::*, prelude::*, resources::ResourceType, resources::StoredProcedure,
+    ResourceQuota,
+};
+use azure_core::{
+    headers::{continuation_token_from_headers_optional, session_token_from_headers},
+    prelude::*,
+    Pageable, Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -73,8 +73,6 @@ pub struct ListStoredProceduresResponse {
 impl ListStoredProceduresResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
         #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
         struct Response {
             pub _rid: String,
@@ -83,8 +81,9 @@ impl ListStoredProceduresResponse {
             pub _count: u64,
         }
 
+        let response: Response = body.json().await?;
         Ok(Self {
-            stored_procedures: serde_json::from_slice::<Response>(&body)?.stored_procedures,
+            stored_procedures: response.stored_procedures,
             charge: request_charge_from_headers(&headers)?,
             activity_id: activity_id_from_headers(&headers)?,
             session_token: session_token_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/list_triggers.rs
+++ b/sdk/data_cosmos/src/operations/list_triggers.rs
@@ -1,12 +1,10 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::ResourceType;
-use crate::ResourceQuota;
-
-use azure_core::headers::item_count_from_headers;
-use azure_core::headers::{continuation_token_from_headers_optional, session_token_from_headers};
-use azure_core::prelude::*;
-use azure_core::{Pageable, Response as HttpResponse};
+use crate::{headers::from_headers::*, prelude::*, resources::ResourceType, ResourceQuota};
+use azure_core::{
+    headers::item_count_from_headers,
+    headers::{continuation_token_from_headers_optional, session_token_from_headers},
+    prelude::*,
+    Pageable, Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -88,19 +86,18 @@ pub struct ListTriggersResponse {
 impl ListTriggersResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         #[derive(Debug, Deserialize)]
-        struct Response<'a> {
+        struct Response {
             #[serde(rename = "_rid")]
-            rid: &'a str,
+            rid: String,
             #[serde(rename = "Triggers")]
             triggers: Vec<Trigger>,
             #[serde(rename = "_count")]
             #[allow(unused)]
             count: u32,
         }
-        let response: Response = serde_json::from_slice(&body)?;
+        let response: Response = body.json().await?;
 
         Ok(Self {
             rid: response.rid.to_owned(),

--- a/sdk/data_cosmos/src/operations/list_users.rs
+++ b/sdk/data_cosmos/src/operations/list_users.rs
@@ -1,13 +1,14 @@
-use crate::headers::from_headers::{activity_id_from_headers, request_charge_from_headers};
-use crate::prelude::*;
-use crate::resources::User;
-use azure_core::prelude::Continuation;
+use crate::{
+    headers::from_headers::{activity_id_from_headers, request_charge_from_headers},
+    prelude::*,
+    resources::User,
+};
 use azure_core::{
     headers::{continuation_token_from_headers_optional, session_token_from_headers},
+    prelude::Continuation,
     prelude::MaxItemCount,
-    Response as HttpResponse, SessionToken,
+    Continuable, Pageable, Response as HttpResponse, SessionToken,
 };
-use azure_core::{Continuable, Pageable};
 
 operation! {
     #[stream]
@@ -66,7 +67,6 @@ pub struct ListUsersResponse {
 impl ListUsersResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         #[derive(Deserialize, Debug)]
         pub struct Response {
@@ -78,7 +78,7 @@ impl ListUsersResponse {
             pub count: u32,
         }
 
-        let response: Response = serde_json::from_slice(&body)?;
+        let response: Response = body.json().await?;
 
         Ok(Self {
             users: response.users,

--- a/sdk/data_cosmos/src/operations/patch_document.rs
+++ b/sdk/data_cosmos/src/operations/patch_document.rs
@@ -1,11 +1,7 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::document::DocumentAttributes;
-use crate::ResourceQuota;
-
-use azure_core::headers::session_token_from_headers;
-use azure_core::Response as HttpResponse;
-use azure_core::SessionToken;
+use crate::{
+    headers::from_headers::*, prelude::*, resources::document::DocumentAttributes, ResourceQuota,
+};
+use azure_core::{headers::session_token_from_headers, Response as HttpResponse, SessionToken};
 use serde::Serialize;
 use serde_json::Value;
 use time::OffsetDateTime;
@@ -32,8 +28,7 @@ impl PatchDocumentBuilder {
                 operations: self.operations,
             };
 
-            let serialized = azure_core::to_json(&patch_request)?;
-            request.set_body(serialized);
+            request.set_json(&patch_request)?;
 
             let response = self
                 .client
@@ -153,10 +148,8 @@ pub struct PatchDocumentResponse {
 impl PatchDocumentResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-        let document_attributes = serde_json::from_slice(&body)?;
-
         Ok(Self {
+            document_attributes: body.json().await?,
             content_location: content_location_from_headers(&headers)?,
             last_state_change: last_state_change_from_headers(&headers)?,
             resource_quota: resource_quota_from_headers(&headers)?,
@@ -180,7 +173,6 @@ impl PatchDocumentResponse {
             activity_id: activity_id_from_headers(&headers)?,
             gateway_version: gateway_version_from_headers(&headers)?,
             date: date_from_headers(&headers)?,
-            document_attributes,
         })
     }
 }

--- a/sdk/data_cosmos/src/operations/replace_collection.rs
+++ b/sdk/data_cosmos/src/operations/replace_collection.rs
@@ -1,10 +1,12 @@
-use crate::headers::from_headers::*;
-use crate::prelude::*;
-use crate::resources::collection::{IndexingPolicy, PartitionKey};
-use azure_core::headers::{
-    content_type_from_headers, etag_from_headers, session_token_from_headers,
+use crate::{
+    headers::from_headers::*,
+    prelude::*,
+    resources::collection::{IndexingPolicy, PartitionKey},
 };
-use azure_core::Response as HttpResponse;
+use azure_core::{
+    headers::{content_type_from_headers, etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
+};
 use time::OffsetDateTime;
 
 operation! {
@@ -30,7 +32,7 @@ impl ReplaceCollectionBuilder {
                 partition_key: &self.partition_key,
             };
 
-            request.set_body(serde_json::to_vec(&collection)?);
+            request.set_json(&collection)?;
 
             let response = self
                 .client
@@ -88,9 +90,8 @@ pub struct ReplaceCollectionResponse {
 impl ReplaceCollectionResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
         Ok(Self {
-            collection: serde_json::from_slice(&body)?,
+            collection: body.json().await?,
             last_state_change: last_state_change_from_headers(&headers)?,
             etag: etag_from_headers(&headers)?,
             collection_partition_index: collection_partition_index_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/operations/replace_permission.rs
+++ b/sdk/data_cosmos/src/operations/replace_permission.rs
@@ -1,6 +1,8 @@
-use crate::prelude::*;
-use crate::resources::permission::{
-    ExpirySeconds, PermissionMode, PermissionResponse as ReplacePermissionResponse,
+use crate::{
+    prelude::*,
+    resources::permission::{
+        ExpirySeconds, PermissionMode, PermissionResponse as ReplacePermissionResponse,
+    },
 };
 
 operation! {
@@ -35,7 +37,7 @@ impl ReplacePermissionBuilder {
                 resource: self.permission_mode.resource(),
             };
 
-            request.set_body(serde_json::to_vec(&request_body)?);
+            request.set_json(&request_body)?;
             let response = self
                 .client
                 .pipeline()

--- a/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/replace_stored_procedure.rs
@@ -29,7 +29,7 @@ impl ReplaceStoredProcedureBuilder {
                 id: self.client.stored_procedure_name(),
             };
 
-            req.set_body(serde_json::to_vec(&body)?);
+            req.set_json(&body)?;
 
             let response = self
                 .client

--- a/sdk/data_cosmos/src/operations/replace_user.rs
+++ b/sdk/data_cosmos/src/operations/replace_user.rs
@@ -18,7 +18,7 @@ impl ReplaceUserBuilder {
             let body = ReplaceUserBody {
                 id: &self.user_name,
             };
-            request.set_body(serde_json::to_vec(&body)?);
+            request.set_json(&body)?;
             let response = self
                 .client
                 .pipeline()

--- a/sdk/data_cosmos/src/resources/document/document_attributes.rs
+++ b/sdk/data_cosmos/src/resources/document/document_attributes.rs
@@ -1,4 +1,4 @@
-use azure_core::{prelude::IfMatchCondition, CollectedResponse};
+use azure_core::{from_json, prelude::IfMatchCondition, CollectedResponse};
 
 /// A document's attributes
 #[derive(Default, Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -55,14 +55,7 @@ impl std::convert::TryFrom<&bytes::Bytes> for DocumentAttributes {
     type Error = azure_core::error::Error;
 
     fn try_from(body: &bytes::Bytes) -> Result<Self, Self::Error> {
-        let str = std::str::from_utf8(body).unwrap_or("<NON-UTF8>");
-        serde_json::from_slice(body).map_err(|e| {
-            azure_core::error::Error::full(
-                azure_core::error::ErrorKind::DataConversion,
-                e,
-                format!("failed to convert json '{str}' into DocumentAttributes"),
-            )
-        })
+        from_json(body)
     }
 }
 

--- a/sdk/data_cosmos/src/resources/document/mod.rs
+++ b/sdk/data_cosmos/src/resources/document/mod.rs
@@ -12,7 +12,7 @@ use super::Resource;
 use crate::headers;
 
 use azure_core::headers::{AsHeaders, HeaderName, HeaderValue, Headers};
-use azure_core::Header;
+use azure_core::{from_json, Header};
 use serde::de::DeserializeOwned;
 
 /// User-defined content in JSON format.
@@ -45,16 +45,7 @@ where
 {
     type Error = azure_core::error::Error;
     fn try_from((_, body): (&Headers, &[u8])) -> Result<Self, Self::Error> {
-        use azure_core::error::ResultExt;
-        serde_json::from_slice::<Self>(body).with_context(
-            azure_core::error::ErrorKind::DataConversion,
-            || {
-                format!(
-                    "could not convert json '{}' into Permission",
-                    std::str::from_utf8(body).unwrap_or("<NON-UTF8>")
-                )
-            },
-        )
+        from_json(body)
     }
 }
 

--- a/sdk/data_cosmos/src/resources/document/query.rs
+++ b/sdk/data_cosmos/src/resources/document/query.rs
@@ -73,7 +73,7 @@ mod tests {
     use serde_json;
 
     #[test]
-    fn tst_query() {
+    fn tst_query() -> azure_core::Result<()> {
         let v3 = Value::from(vec![1, 2, 3]);
         let query = Query::with_params(
             "SELECT * FROM t".into(),
@@ -90,5 +90,6 @@ mod tests {
             ser,
             r#"{"query":"SELECT * FROM t","parameters":[{"name":"p1","value":"string"},{"name":"p2","value":100},{"name":"p3","value":[1,2,3]}]}"#
         );
+        Ok(())
     }
 }

--- a/sdk/data_cosmos/src/resources/permission/permission.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission.rs
@@ -1,6 +1,7 @@
 use super::PermissionToken;
 use crate::resources::Resource;
 
+use azure_core::from_json;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
@@ -90,16 +91,7 @@ impl std::convert::TryFrom<&[u8]> for Permission {
     type Error = azure_core::error::Error;
 
     fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
-        use azure_core::error::ResultExt;
-        serde_json::from_slice::<Self>(slice).with_context(
-            azure_core::error::ErrorKind::DataConversion,
-            || {
-                format!(
-                    "could not convert json '{}' into Permission",
-                    std::str::from_utf8(slice).unwrap_or("<NON-UTF8>")
-                )
-            },
-        )
+        from_json(slice)
     }
 }
 
@@ -120,8 +112,8 @@ mod tests {
 } "#;
 
     #[test]
-    fn parse_permission() {
-        let permission: Permission = serde_json::from_str(PERMISSION_JSON).unwrap();
+    fn parse_permission() -> azure_core::Result<()> {
+        let permission: Permission = from_json(PERMISSION_JSON)?;
 
         assert_eq!(
             permission.permission_token,
@@ -131,5 +123,6 @@ mod tests {
             permission.permission_mode,
             PermissionMode::Read(r#"dbs/volcanodb/colls/volcano1"#.into())
         );
+        Ok(())
     }
 }

--- a/sdk/data_cosmos/src/resources/permission/permission_response.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission_response.rs
@@ -1,9 +1,9 @@
-use crate::headers::from_headers::*;
-
-use azure_core::headers::{etag_from_headers, session_token_from_headers};
-use azure_core::Response as HttpResponse;
-
 use super::Permission;
+use crate::headers::from_headers::*;
+use azure_core::{
+    headers::{etag_from_headers, session_token_from_headers},
+    Response as HttpResponse,
+};
 
 #[derive(Debug, Clone)]
 pub struct PermissionResponse {
@@ -19,10 +19,9 @@ pub struct PermissionResponse {
 impl PermissionResponse {
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<PermissionResponse> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            permission: serde_json::from_slice(&body)?,
+            permission: body.json().await?,
             charge: request_charge_from_headers(&headers)?,
             activity_id: activity_id_from_headers(&headers)?,
             session_token: session_token_from_headers(&headers)?,

--- a/sdk/data_cosmos/src/resources/user.rs
+++ b/sdk/data_cosmos/src/resources/user.rs
@@ -3,6 +3,7 @@
 use super::Resource;
 use crate::headers::from_headers::*;
 use azure_core::{
+    from_json,
     headers::{etag_from_headers, session_token_from_headers},
     Response as HttpResponse,
 };
@@ -36,9 +37,9 @@ pub struct User {
 }
 
 impl std::convert::TryFrom<&[u8]> for User {
-    type Error = serde_json::Error;
+    type Error = azure_core::Error;
     fn try_from(body: &[u8]) -> Result<Self, Self::Error> {
-        serde_json::from_slice(body)
+        from_json(body)
     }
 }
 
@@ -67,10 +68,9 @@ impl UserResponse {
     /// Creates a `UserResponse` from an `HttpResponse`
     pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
         Ok(Self {
-            user: serde_json::from_slice(&body)?,
+            user: body.json().await?,
             charge: request_charge_from_headers(&headers)?,
             activity_id: activity_id_from_headers(&headers)?,
             session_token: session_token_from_headers(&headers)?,

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -19,9 +19,7 @@ bytes = "1.0"
 time = "0.3.10"
 futures = "0.3"
 log = "0.4"
-serde = { version = "1.0" }
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = { version = "1.0", features=["derive"] }
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/sdk/data_tables/src/clients/entity_client.rs
+++ b/sdk/data_tables/src/clients/entity_client.rs
@@ -1,5 +1,5 @@
 use crate::{operations::*, prelude::*};
-use azure_core::{headers::Headers, Body, Context, Method, Request, Response, Url};
+use azure_core::{headers::Headers, to_json, Body, Context, Method, Request, Response, Url};
 use serde::{de::DeserializeOwned, Serialize};
 
 #[derive(Debug, Clone)]
@@ -34,7 +34,7 @@ impl EntityClient {
         entity: E,
         if_match_condition: IfMatchCondition,
     ) -> azure_core::Result<UpdateOrMergeEntityBuilder> {
-        let body = serde_json::to_string(&entity)?.into();
+        let body = to_json(&entity)?.into();
         Ok(UpdateOrMergeEntityBuilder::new(
             self.clone(),
             body,
@@ -48,7 +48,7 @@ impl EntityClient {
         entity: E,
         if_match_condition: IfMatchCondition,
     ) -> azure_core::Result<UpdateOrMergeEntityBuilder> {
-        let body = serde_json::to_string(&entity)?.into();
+        let body = to_json(&entity)?.into();
         Ok(UpdateOrMergeEntityBuilder::new(
             self.clone(),
             body,
@@ -61,7 +61,7 @@ impl EntityClient {
         &self,
         entity: E,
     ) -> azure_core::Result<InsertOrReplaceOrMergeEntityBuilder> {
-        let body = serde_json::to_string(&entity)?.into();
+        let body = to_json(&entity)?.into();
         Ok(InsertOrReplaceOrMergeEntityBuilder::new(
             self.clone(),
             body,
@@ -73,7 +73,7 @@ impl EntityClient {
         &self,
         entity: E,
     ) -> azure_core::Result<InsertOrReplaceOrMergeEntityBuilder> {
-        let body = serde_json::to_string(&entity)?.into();
+        let body = to_json(&entity)?.into();
         Ok(InsertOrReplaceOrMergeEntityBuilder::new(
             self.clone(),
             body,

--- a/sdk/data_tables/src/clients/table_client.rs
+++ b/sdk/data_tables/src/clients/table_client.rs
@@ -1,5 +1,5 @@
 use crate::{clients::*, operations::*};
-use azure_core::{headers::Headers, Body, Context, Method, Request, Response, Url};
+use azure_core::{headers::Headers, to_json, Body, Context, Method, Request, Response, Url};
 use serde::{de::DeserializeOwned, Serialize};
 
 #[derive(Debug, Clone)]
@@ -36,7 +36,7 @@ impl TableClient {
         &self,
         entity: E,
     ) -> azure_core::Result<InsertEntityBuilder<R>> {
-        let body = serde_json::to_string(&entity)?.into();
+        let body = to_json(&entity)?.into();
         Ok(InsertEntityBuilder::new(self.clone(), body))
     }
 

--- a/sdk/data_tables/src/entity_with_metadata.rs
+++ b/sdk/data_tables/src/entity_with_metadata.rs
@@ -13,12 +13,12 @@ impl<S> TryFrom<CollectedResponse> for EntityWithMetadata<S>
 where
     S: DeserializeOwned,
 {
-    type Error = serde_json::Error;
+    type Error = azure_core::Error;
 
     fn try_from(response: CollectedResponse) -> Result<Self, Self::Error> {
         Ok(EntityWithMetadata {
-            metadata: serde_json::from_slice(response.body())?,
-            entity: serde_json::from_slice(response.body())?,
+            metadata: response.json()?,
+            entity: response.json()?,
         })
     }
 }

--- a/sdk/data_tables/src/lib.rs
+++ b/sdk/data_tables/src/lib.rs
@@ -66,8 +66,6 @@ async fn main() -> azure_core::Result<()> {
 #[macro_use]
 extern crate log;
 #[macro_use]
-extern crate serde_derive;
-#[macro_use]
 extern crate azure_core;
 
 pub mod clients;

--- a/sdk/data_tables/src/operations/create_table.rs
+++ b/sdk/data_tables/src/operations/create_table.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use azure_core::{headers::*, prelude::*, Method, Response};
+use azure_core::{headers::*, prelude::*, to_json, Method, Response};
 use azure_storage::headers::CommonStorageResponseHeaders;
+use serde::Serialize;
 use std::convert::TryInto;
 
 operation! {
@@ -19,7 +20,7 @@ impl CreateTableBuilder {
                 table_name: &'a str,
             }
 
-            let body = serde_json::to_string(&RequestBody {
+            let body = to_json(&RequestBody {
                 table_name: self.client.table_name(),
             })?
             .into();
@@ -48,11 +49,9 @@ pub struct CreateTableResponse {
 impl CreateTableResponse {
     async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
         Ok(CreateTableResponse {
             common_storage_response_headers: (&headers).try_into()?,
-            table: serde_json::from_slice(&body)?,
+            table: body.json().await?,
         })
     }
 }

--- a/sdk/data_tables/src/operations/get_entity.rs
+++ b/sdk/data_tables/src/operations/get_entity.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 use azure_core::{headers::*, AppendToUrlQuery, Context, Etag, Method, Response};
 use azure_storage::headers::CommonStorageResponseHeaders;
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{convert::TryInto, marker::PhantomData};
 
 #[derive(Debug, Clone)]
@@ -83,10 +83,8 @@ where
 {
     async fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
 
-        let get_entity_response_internal: GetEntityResponseInternal<T> =
-            serde_json::from_slice(&body)?;
+        let get_entity_response_internal: GetEntityResponseInternal<T> = body.json().await?;
 
         Ok(GetEntityResponse {
             common_storage_response_headers: (&headers).try_into()?,

--- a/sdk/data_tables/src/operations/list_tables.rs
+++ b/sdk/data_tables/src/operations/list_tables.rs
@@ -3,6 +3,7 @@ use azure_core::{
     error::Error, headers::*, prelude::*, AppendToUrlQuery, CollectedResponse, Method, Pageable,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
+use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
 operation! {
@@ -75,8 +76,7 @@ impl TryFrom<CollectedResponse> for ListTablesResponse {
     type Error = Error;
 
     fn try_from(response: CollectedResponse) -> azure_core::Result<Self> {
-        let list_tables_response_internal: ListTablesResponseInternal =
-            serde_json::from_slice(response.body())?;
+        let list_tables_response_internal: ListTablesResponseInternal = response.json()?;
 
         let continuation_next_table_name = response
             .headers()

--- a/sdk/data_tables/src/operations/query_entity.rs
+++ b/sdk/data_tables/src/operations/query_entity.rs
@@ -6,7 +6,7 @@ use azure_core::{
     AppendToUrlQuery, CollectedResponse, Method, Pageable,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
-use serde::de::DeserializeOwned;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
 
 operation! {
@@ -107,8 +107,7 @@ impl<E: DeserializeOwned + Send + Sync> TryFrom<CollectedResponse> for QueryEnti
     type Error = Error;
 
     fn try_from(response: CollectedResponse) -> azure_core::Result<Self> {
-        let query_entity_response_internal: QueryEntityResponseInternal<E> =
-            serde_json::from_slice(response.body())?;
+        let query_entity_response_internal: QueryEntityResponseInternal<E> = response.json()?;
 
         let headers = response.headers();
 

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -20,7 +20,6 @@ url = "2.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 time = { version = "0.3.10", features = ["local-offset"] }
-serde_json = "1.0"
 log = "0.4"
 async-trait = "0.1"
 openssl = { version = "0.10.46",  optional=true }

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -37,12 +37,12 @@
 
 mod login_response;
 
-use azure_core::Method;
 use azure_core::{
     content_type,
     error::{ErrorKind, ResultExt},
     headers, HttpClient, Request, Url,
 };
+use azure_core::{from_json, Method};
 use login_response::LoginResponse;
 use std::sync::Arc;
 use url::form_urlencoded;
@@ -81,5 +81,5 @@ pub async fn perform(
     if !rsp_status.is_success() {
         return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
     }
-    serde_json::from_slice(&rsp_body).map_kind(ErrorKind::DataConversion)
+    from_json(&rsp_body)
 }

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -8,7 +8,7 @@ mod device_code_responses;
 use azure_core::{
     content_type,
     error::{Error, ErrorKind},
-    headers, sleep, HttpClient, Method, Request, Response, Url,
+    from_json, headers, sleep, HttpClient, Method, Request, Response, Url,
 };
 pub use device_code_responses::*;
 use futures::stream::unfold;
@@ -41,7 +41,7 @@ where
     if !rsp_status.is_success() {
         return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
     }
-    let device_code_response: DeviceCodePhaseOneResponse = serde_json::from_slice(&rsp_body)?;
+    let device_code_response: DeviceCodePhaseOneResponse = from_json(&rsp_body)?;
 
     // we need to capture some variables that will be useful in
     // the second phase (the client, the tenant_id and the client_id)
@@ -131,20 +131,14 @@ impl<'a> DeviceCodePhaseOneResponse<'a> {
                                     Err(e) => return Some((Err(e), NextState::Finish)),
                                 };
                                 if rsp_status.is_success() {
-                                    match serde_json::from_slice::<DeviceCodeAuthorization>(
-                                        &rsp_body,
-                                    ) {
+                                    match from_json::<_, DeviceCodeAuthorization>(&rsp_body) {
                                         Ok(authorization) => {
                                             Some((Ok(authorization), NextState::Finish))
                                         }
-                                        Err(error) => {
-                                            Some((Err(Error::from(error)), NextState::Finish))
-                                        }
+                                        Err(error) => Some((Err(error), NextState::Finish)),
                                     }
                                 } else {
-                                    match serde_json::from_slice::<DeviceCodeErrorResponse>(
-                                        &rsp_body,
-                                    ) {
+                                    match from_json::<_, DeviceCodeErrorResponse>(&rsp_body) {
                                         Ok(error_rsp) => {
                                             let next_state =
                                                 if error_rsp.error == "authorization_pending" {
@@ -157,9 +151,7 @@ impl<'a> DeviceCodePhaseOneResponse<'a> {
                                                 next_state,
                                             ))
                                         }
-                                        Err(error) => {
-                                            Some((Err(Error::from(error)), NextState::Finish))
-                                        }
+                                        Err(error) => Some((Err(error), NextState::Finish)),
                                     }
                                 }
                             }

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -1,9 +1,11 @@
 use crate::token_credentials::cache::TokenCache;
-use azure_core::auth::{AccessToken, Secret, TokenCredential};
-use azure_core::error::{Error, ErrorKind, ResultExt};
+use azure_core::{
+    auth::{AccessToken, Secret, TokenCredential},
+    error::{Error, ErrorKind},
+    from_json,
+};
 use serde::Deserialize;
-use std::process::Command;
-use std::str;
+use std::{process::Command, str};
 use time::OffsetDateTime;
 
 mod az_cli_date_format {
@@ -159,8 +161,7 @@ impl AzureCliCredential {
             Ok(az_output) if az_output.status.success() => {
                 let output = str::from_utf8(&az_output.stdout)?;
 
-                let access_token = serde_json::from_str::<CliTokenResponse>(output)
-                    .map_kind(ErrorKind::DataConversion)?;
+                let access_token = from_json(output)?;
                 Ok(access_token)
             }
             Ok(az_output) => {

--- a/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
@@ -178,10 +178,8 @@ impl AzureauthCliCredential {
             }));
         }
 
-        let output = String::from_utf8(output.stdout)?;
+        let token_response: CliTokenResponse = from_json(output.stdout)?;
 
-        let token_response = serde_json::from_str::<CliTokenResponse>(&output)
-            .map_kind(ErrorKind::DataConversion)?;
         Ok(TokenResponse::new(
             token_response.token,
             token_response.expiration_date,
@@ -303,7 +301,7 @@ mod tests {
             "expiration_date": "1700166595"
         }"#;
 
-        let response: CliTokenResponse = serde_json::from_str(src)?;
+        let response: CliTokenResponse = from_json(src)?;
         assert_eq!(response.token.secret(), "security token here");
         assert_eq!(
             response.expiration_date,

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -238,13 +238,13 @@ impl ClientCertificateCredential {
 
         let rsp = self.http_client.execute_request(&req).await?;
         let rsp_status = rsp.status();
-        let rsp_body = rsp.into_body().collect().await?;
 
         if !rsp_status.is_success() {
+            let rsp_body = rsp.into_body().collect().await?;
             return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
         }
 
-        let response: AadTokenResponse = serde_json::from_slice(&rsp_body)?;
+        let response: AadTokenResponse = rsp.json().await?;
         Ok(AccessToken::new(
             response.access_token,
             OffsetDateTime::now_utc() + Duration::from_secs(response.expires_in),

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -2,7 +2,7 @@ use crate::token_credentials::cache::TokenCache;
 use azure_core::{
     auth::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
-    HttpClient, Method, Request, StatusCode, Url,
+    from_json, HttpClient, Method, Request, StatusCode, Url,
 };
 use serde::{
     de::{self, Deserializer},
@@ -149,7 +149,7 @@ impl ImdsManagedIdentityCredential {
             }
         }
 
-        let token_response: MsiTokenResponse = serde_json::from_slice(&rsp_body)?;
+        let token_response: MsiTokenResponse = from_json(&rsp_body)?;
         Ok(AccessToken::new(
             token_response.access_token,
             token_response.expires_on,
@@ -215,6 +215,7 @@ struct MsiTokenResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use azure_core::from_json;
     use time::macros::datetime;
 
     #[derive(Debug, Deserialize)]
@@ -224,11 +225,11 @@ mod tests {
     }
 
     #[test]
-    fn check_expires_on_string() {
+    fn check_expires_on_string() -> azure_core::Result<()> {
         let as_string = r#"{"date": "1586984735"}"#;
         let expected = datetime!(2020-4-15 21:5:35 UTC);
-        let parsed: TestExpires =
-            serde_json::from_str(as_string).expect("deserialize should succeed");
+        let parsed: TestExpires = from_json(as_string)?;
         assert_eq!(expected, parsed.date);
+        Ok(())
     }
 }

--- a/sdk/iot_deviceupdate/src/client.rs
+++ b/sdk/iot_deviceupdate/src/client.rs
@@ -1,7 +1,7 @@
 use azure_core::{
     auth::{AccessToken, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
-    Url,
+    from_json, Url,
 };
 use const_format::formatcp;
 use serde::de::DeserializeOwned;
@@ -80,10 +80,7 @@ impl DeviceUpdateClient {
         let body = resp.bytes().await.with_context(ErrorKind::Io, || {
             format!("failed to read response body text. uri: {uri}")
         })?;
-        serde_json::from_slice(&body).context(
-            ErrorKind::DataConversion,
-            "failed to deserialize json response body",
-        )
+        from_json(&body)
     }
 
     pub(crate) async fn post(

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -16,7 +16,6 @@ bytes = "1.0"
 time = "0.3.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_derive = "1.0"
 url = "2.2"
 thiserror = "1.0"
 futures = "0.3"

--- a/sdk/iot_hub/src/service/operations/apply_on_edge_device.rs
+++ b/sdk/iot_hub/src/service/operations/apply_on_edge_device.rs
@@ -1,7 +1,7 @@
 use crate::service::{ServiceClient, API_VERSION};
-
 use azure_core::{operation, Method};
 use serde::Serialize;
+
 operation! {
     /// The ApplyOnEdgeDeviceBuilder is used to construct a new device identity
     /// or the update an existing one.
@@ -29,8 +29,7 @@ impl ApplyOnEdgeDeviceBuilder {
                 modules_content: self.modules_content.unwrap_or_default(),
             };
 
-            let body = azure_core::to_json(&body)?;
-            request.set_body(body);
+            request.set_json(&body)?;
 
             self.client.send(&self.context, &mut request).await?;
 

--- a/sdk/iot_hub/src/service/operations/create_or_update_configuration.rs
+++ b/sdk/iot_hub/src/service/operations/create_or_update_configuration.rs
@@ -103,12 +103,13 @@ impl CreateOrUpdateConfigurationBuilder {
                 target_condition: &self.target_condition,
             };
 
-            let body = azure_core::to_json(&body)?;
-            request.set_body(body);
+            request.set_json(&body)?;
 
-            let response = self.client.send(&self.context, &mut request).await?;
-
-            CreateOrUpdateConfigurationResponse::try_from(response).await
+            self.client
+                .send(&self.context, &mut request)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/create_or_update_device_identity.rs
+++ b/sdk/iot_hub/src/service/operations/create_or_update_device_identity.rs
@@ -64,12 +64,13 @@ impl CreateOrUpdateDeviceIdentityBuilder {
                 etag: self.etag,
             };
 
-            let body = azure_core::to_json(&body)?;
-            request.set_body(body);
+            request.set_json(&body)?;
 
-            let response = self.client.send(&self.context, &mut request).await?;
-
-            CreateOrUpdateDeviceIdentityResponse::try_from(response).await
+            self.client
+                .send(&self.context, &mut request)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/create_or_update_module_identity.rs
+++ b/sdk/iot_hub/src/service/operations/create_or_update_module_identity.rs
@@ -47,12 +47,13 @@ impl CreateOrUpdateModuleIdentityBuilder {
                 etag: self.etag,
             };
 
-            let body = azure_core::to_json(&body)?;
-            request.set_body(body);
+            request.set_json(&body)?;
 
-            let response = self.client.send(&self.context, &mut request).await?;
-
-            CreateOrUpdateModuleIdentityResponse::try_from(response).await
+            self.client
+                .send(&self.context, &mut request)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/get_configuration.rs
+++ b/sdk/iot_hub/src/service/operations/get_configuration.rs
@@ -29,9 +29,11 @@ impl GetConfigurationBuilder {
             let mut request = self.client.finalize_request(&uri, Method::Get)?;
             request.set_body(azure_core::EMPTY_BODY);
 
-            let response = self.client.send(&self.context, &mut request).await?;
-
-            GetConfigurationResponse::try_from(response).await
+            self.client
+                .send(&self.context, &mut request)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/invoke_method.rs
+++ b/sdk/iot_hub/src/service/operations/invoke_method.rs
@@ -39,13 +39,13 @@ impl InvokeMethodBuilder {
                 response_timeout_in_seconds: self.response_time_out.unwrap_or(15),
             };
 
-            let body = azure_core::to_json(&method)?;
+            request.set_json(&method)?;
 
-            request.set_body(body);
-
-            let response = self.client.send(&self.context, &mut request).await?;
-
-            InvokeMethodResponse::try_from(response).await
+            self.client
+                .send(&self.context, &mut request)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/iot_hub/src/service/operations/query.rs
+++ b/sdk/iot_hub/src/service/operations/query.rs
@@ -30,12 +30,11 @@ impl QueryBuilder {
             );
 
             let query_body = QueryBody { query: self.query };
-            let body = azure_core::to_json(&query_body)?;
 
             let mut request = self.client.finalize_request(&uri, Method::Post)?;
             request.add_optional_header(&self.continuation);
             request.add_mandatory_header(&self.max_item_count.unwrap_or_default());
-            request.set_body(body);
+            request.set_json(&query_body)?;
 
             let response = self.client.send(&self.context, &mut request).await?;
 

--- a/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
+++ b/sdk/iot_hub/src/service/operations/update_or_replace_twin.rs
@@ -82,9 +82,8 @@ impl UpdateOrReplaceTwinBuilder {
             if let Some(if_match) = self.if_match {
                 request.insert_header(headers::IF_MATCH, format!("\"{if_match}\""));
             }
-            let body = azure_core::to_json(&body)?;
 
-            request.set_body(body);
+            request.set_json(&body)?;
 
             let response = self.client.send(&self.context, &mut request).await?;
 

--- a/sdk/iot_hub/src/service/responses/configuration_response.rs
+++ b/sdk/iot_hub/src/service/responses/configuration_response.rs
@@ -1,5 +1,5 @@
 use crate::service::resources::Configuration;
-use azure_core::{error::Error, CollectedResponse};
+use azure_core::error::Error;
 use serde::{Deserialize, Serialize};
 
 /// The configuration response
@@ -9,22 +9,9 @@ pub type ConfigurationResponse = Configuration;
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct MultipleConfigurationResponse(Vec<ConfigurationResponse>);
 
-impl ConfigurationResponse {
-    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
-        let collected = CollectedResponse::from_response(response).await?;
-        let body = collected.body();
-        Ok(serde_json::from_slice(body)?)
-    }
-}
-
 impl std::convert::TryFrom<crate::service::CollectedResponse> for MultipleConfigurationResponse {
     type Error = Error;
-
     fn try_from(response: crate::service::CollectedResponse) -> azure_core::Result<Self> {
-        let body = response.body();
-
-        let configuration_response: MultipleConfigurationResponse = serde_json::from_slice(body)?;
-
-        Ok(configuration_response)
+        response.json()
     }
 }

--- a/sdk/iot_hub/src/service/responses/device_identity_response.rs
+++ b/sdk/iot_hub/src/service/responses/device_identity_response.rs
@@ -1,7 +1,6 @@
 use crate::service::resources::{
     AuthenticationMechanism, ConnectionState, DeviceCapabilities, Status,
 };
-use azure_core::error::Error;
 use serde::{Deserialize, Serialize};
 
 /// The representation of a device identity.
@@ -37,25 +36,5 @@ pub struct DeviceIdentityResponse {
     pub status_updated_time: String,
 }
 
-impl std::convert::TryFrom<crate::service::CollectedResponse> for DeviceIdentityResponse {
-    type Error = Error;
-
-    fn try_from(response: crate::service::CollectedResponse) -> azure_core::Result<Self> {
-        let body = response.body();
-
-        let device_identity_response: DeviceIdentityResponse = serde_json::from_slice(body)?;
-
-        Ok(device_identity_response)
-    }
-}
-
 /// Response of `CreateOrUpdateDeviceIdentity`
 pub type CreateOrUpdateDeviceIdentityResponse = DeviceIdentityResponse;
-
-impl CreateOrUpdateDeviceIdentityResponse {
-    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
-        let collected = azure_core::CollectedResponse::from_response(response).await?;
-        let body = collected.body();
-        Ok(serde_json::from_slice(body)?)
-    }
-}

--- a/sdk/iot_hub/src/service/responses/device_twin_response.rs
+++ b/sdk/iot_hub/src/service/responses/device_twin_response.rs
@@ -49,10 +49,6 @@ impl std::convert::TryFrom<crate::service::CollectedResponse> for DeviceTwinResp
     type Error = Error;
 
     fn try_from(response: crate::service::CollectedResponse) -> azure_core::Result<Self> {
-        let body = response.body();
-
-        let device_twin_response: DeviceTwinResponse = serde_json::from_slice(body)?;
-
-        Ok(device_twin_response)
+        response.json()
     }
 }

--- a/sdk/iot_hub/src/service/responses/invoke_method_response.rs
+++ b/sdk/iot_hub/src/service/responses/invoke_method_response.rs
@@ -9,11 +9,3 @@ pub struct InvokeMethodResponse {
     /// The response payload of the direct method invocation.
     pub payload: Option<serde_json::Value>,
 }
-
-impl InvokeMethodResponse {
-    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
-        let collected = azure_core::CollectedResponse::from_response(response).await?;
-        let body = collected.body();
-        Ok(serde_json::from_slice(body)?)
-    }
-}

--- a/sdk/iot_hub/src/service/responses/module_identity_response.rs
+++ b/sdk/iot_hub/src/service/responses/module_identity_response.rs
@@ -33,21 +33,9 @@ impl std::convert::TryFrom<crate::service::CollectedResponse> for ModuleIdentity
     type Error = Error;
 
     fn try_from(response: crate::service::CollectedResponse) -> azure_core::Result<Self> {
-        let body = response.body();
-
-        let module_identity_response: ModuleIdentityResponse = serde_json::from_slice(body)?;
-
-        Ok(module_identity_response)
+        response.json()
     }
 }
 
 /// Response for `CreateOrUpdateModuleIdentity`
 pub type CreateOrUpdateModuleIdentityResponse = ModuleIdentityResponse;
-
-impl CreateOrUpdateModuleIdentityResponse {
-    pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
-        let collected = azure_core::CollectedResponse::from_response(response).await?;
-        let body = collected.body();
-        Ok(serde_json::from_slice(body)?)
-    }
-}

--- a/sdk/iot_hub/src/service/responses/module_twin_response.rs
+++ b/sdk/iot_hub/src/service/responses/module_twin_response.rs
@@ -1,7 +1,7 @@
 use crate::service::resources::{
     AuthenticationType, ConnectionState, Status, TwinProperties, X509ThumbPrint,
 };
-use azure_core::error::Error;
+use azure_core::{from_json, CollectedResponse};
 use serde::Deserialize;
 
 /// The representation of a response for a module twin request.
@@ -36,14 +36,10 @@ pub struct ModuleTwinResponse {
     pub x509_thumbprint: X509ThumbPrint,
 }
 
-impl std::convert::TryFrom<crate::service::CollectedResponse> for ModuleTwinResponse {
-    type Error = Error;
+impl std::convert::TryFrom<CollectedResponse> for ModuleTwinResponse {
+    type Error = azure_core::Error;
 
-    fn try_from(response: crate::service::CollectedResponse) -> azure_core::Result<Self> {
-        let body = response.body();
-
-        let module_twin_response: ModuleTwinResponse = serde_json::from_slice(body)?;
-
-        Ok(module_twin_response)
+    fn try_from(response: CollectedResponse) -> azure_core::Result<Self> {
+        from_json(response)
     }
 }

--- a/sdk/iot_hub/src/service/responses/query_response.rs
+++ b/sdk/iot_hub/src/service/responses/query_response.rs
@@ -1,5 +1,7 @@
-use azure_core::headers::{self, continuation_token_from_headers_optional};
-use azure_core::prelude::Continuation;
+use azure_core::{
+    headers::{self, continuation_token_from_headers_optional},
+    prelude::Continuation,
+};
 use serde_json::Value;
 
 /// The response for a query invocation
@@ -15,10 +17,10 @@ pub struct QueryResponse {
 impl QueryResponse {
     pub(crate) async fn try_from(response: azure_core::Response) -> azure_core::Result<Self> {
         let collected = azure_core::CollectedResponse::from_response(response).await?;
-        let body = collected.body();
+        let result = collected.json()?;
 
         Ok(QueryResponse {
-            result: serde_json::from_slice(body)?,
+            result,
             continuation_token: continuation_token_from_headers_optional(collected.headers())?,
             item_type: collected.headers().get_as(&headers::ITEM_TYPE)?,
         })

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -16,7 +16,6 @@ edition = "2021"
 azure_core = { path = "../core", version = "0.17", default-features = false }
 time = "0.3.10"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/sdk/messaging_eventgrid/src/event.rs
+++ b/sdk/messaging_eventgrid/src/event.rs
@@ -63,6 +63,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use azure_core::to_json;
     use serde::{self, Serialize};
     use time::macros::datetime;
 
@@ -72,7 +73,7 @@ mod tests {
     }
 
     #[test]
-    fn create_and_serialize() {
+    fn create_and_serialize() -> azure_core::Result<()> {
         let mut event = Event::<Data>::new(
             Some(String::from("an id")),
             "ACME.Data.DataPointCreated",
@@ -83,8 +84,9 @@ mod tests {
         event.event_time = datetime!(2020-12-21 14:53:41 UTC);
 
         assert_eq!(
-            serde_json::to_string(&event).unwrap(),
+            to_json(&event)?,
             "{\"topic\":null,\"id\":\"an id\",\"eventType\":\"ACME.Data.DataPointCreated\",\"subject\":\"/acme/data\",\"eventTime\":\"2020-12-21T14:53:41Z\",\"data\":{\"number\":42},\"dataVersion\":\"1.0\",\"metadataVersion\":null}"
         );
+        Ok(())
     }
 }

--- a/sdk/messaging_eventgrid/src/event_grid_client.rs
+++ b/sdk/messaging_eventgrid/src/event_grid_client.rs
@@ -27,11 +27,11 @@ impl EventGridClient {
 
     /// Publishes events to a topic.
     /// REST API Spec: https://docs.microsoft.com/rest/api/eventgrid/dataplane/publishevents/publishevents
-    pub async fn publish_events<T>(&self, events: &[Event<T>]) -> Result<(), azure_core::Error>
+    pub async fn publish_events<T>(&self, events: &[Event<T>]) -> azure_core::Result<()>
     where
         T: Serialize,
     {
-        let body = serde_json::to_string(&events).unwrap();
+        let body = from_json(&events)?;
         EventGridRequestBuilder::new(Method::Post, &self.events_url()?)
             .sas_key(&self.topic_key)
             .body(Some(&body), Some("application/json"))?

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -21,7 +21,6 @@ log = "0.4"
 url = "2.2"
 bytes = "1.0"
 serde = "1.0"
-serde_json = "1.0"
 
 [dev-dependencies]
 futures = "0.3"

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -1,22 +1,23 @@
-use azure_core::auth::Secret;
-use azure_core::hmac::hmac_sha256;
-use azure_core::{
-    error::Error, headers, CollectedResponse, HttpClient, Method, Request, StatusCode, Url,
-};
-use serde::Deserialize;
-use std::str::FromStr;
-use std::time::Duration;
-use std::{ops::Add, sync::Arc};
-use time::OffsetDateTime;
-use url::form_urlencoded::{self, Serializer};
-
 mod queue_client;
 mod topic_client;
 
+pub use self::{
+    queue_client::QueueClient,
+    topic_client::{SubscriptionReceiver, TopicClient, TopicSender},
+};
 use crate::utils::{craft_peek_lock_url, get_head_url};
-
-pub use self::queue_client::QueueClient;
-pub use self::topic_client::{SubscriptionReceiver, TopicClient, TopicSender};
+use azure_core::{
+    auth::Secret, error::Error, from_json, headers, hmac::hmac_sha256, CollectedResponse,
+    HttpClient, Method, Request, StatusCode, Url,
+};
+use serde::Deserialize;
+use std::{
+    str::FromStr,
+    time::Duration,
+    {ops::Add, sync::Arc},
+};
+use time::OffsetDateTime;
+use url::form_urlencoded::{self, Serializer};
 
 /// Default duration for the SAS token in days — We might want to make this configurable at some point
 const DEFAULT_SAS_DURATION: u64 = 3_600; // seconds = 1 hour
@@ -304,9 +305,9 @@ impl BrokerProperties {
 }
 
 impl FromStr for BrokerProperties {
-    type Err = serde_json::Error;
+    type Err = azure_core::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s)
+        from_json(s)
     }
 }

--- a/sdk/security_keyvault/src/account/operations/list_certificates.rs
+++ b/sdk/security_keyvault/src/account/operations/list_certificates.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
-use azure_core::{
-    error::Error, headers::Headers, CollectedResponse, Continuable, Method, Pageable, Url,
-};
+use azure_core::{error::Error, headers::Headers, Continuable, Method, Pageable, Url};
 
 operation! {
     #[stream]
@@ -26,13 +24,12 @@ impl ListCertificatesBuilder {
                 let headers = Headers::new();
                 let mut request = KeyvaultClient::finalize_request(url, Method::Get, headers, None);
 
-                let response = this.client.keyvault_client.send(&ctx, &mut request).await?;
-
-                let response = CollectedResponse::from_response(response).await?;
-                let body = response.body();
-
-                let response = serde_json::from_slice::<KeyVaultGetCertificatesResponse>(body)?;
-                Ok(response)
+                this.client
+                    .keyvault_client
+                    .send(&ctx, &mut request)
+                    .await?
+                    .json()
+                    .await
             }
         };
         Pageable::new(make_request)

--- a/sdk/security_keyvault/src/account/operations/list_secrets.rs
+++ b/sdk/security_keyvault/src/account/operations/list_secrets.rs
@@ -1,7 +1,5 @@
 use crate::prelude::*;
-use azure_core::{
-    error::Error, headers::Headers, CollectedResponse, Continuable, Method, Pageable, Url,
-};
+use azure_core::{error::Error, headers::Headers, Continuable, Method, Pageable, Url};
 
 operation! {
     #[stream]
@@ -26,13 +24,12 @@ impl ListSecretsBuilder {
                 let headers = Headers::new();
                 let mut request = KeyvaultClient::finalize_request(url, Method::Get, headers, None);
 
-                let response = this.client.keyvault_client.send(&ctx, &mut request).await?;
-
-                let response = CollectedResponse::from_response(response).await?;
-                let body = response.body();
-
-                let response = serde_json::from_slice::<KeyVaultGetSecretsResponse>(body)?;
-                Ok(response)
+                this.client
+                    .keyvault_client
+                    .send(&ctx, &mut request)
+                    .await?
+                    .json()
+                    .await
             }
         };
         Pageable::new(make_request)

--- a/sdk/security_keyvault/src/certificates/operations/backup.rs
+++ b/sdk/security_keyvault/src/certificates/operations/backup.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 
 operation! {
     CertificateBackup,
@@ -16,17 +16,12 @@ impl CertificateBackupBuilder {
             let headers = Headers::new();
             let mut request = KeyvaultClient::finalize_request(uri, Method::Post, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let backup_blob = serde_json::from_slice(body)?;
-            Ok(backup_blob)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/create.rs
+++ b/sdk/security_keyvault/src/certificates/operations/create.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, to_json, Method};
 use serde::Serialize;
 use std::collections::HashMap;
 use time::OffsetDateTime;
@@ -127,22 +127,18 @@ impl CreateCertificateBuilder {
                 tags: self.tags,
             };
 
-            let body = serde_json::to_string(&request)?;
+            let body = to_json(&request)?;
 
             let headers = Headers::new();
             let mut request =
                 KeyvaultClient::finalize_request(uri, Method::Post, headers, Some(body.into()));
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-            let response = serde_json::from_slice::<CertificateOperationResponse>(body)?;
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/delete.rs
+++ b/sdk/security_keyvault/src/certificates/operations/delete.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 
 operation! {
     DeleteCertificate,
@@ -16,16 +16,12 @@ impl DeleteCertificateBuilder {
             let headers = Headers::new();
             let mut request = KeyvaultClient::finalize_request(uri, Method::Delete, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-            let response = serde_json::from_slice::<KeyVaultGetCertificateResponse>(body)?;
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/delete_operation.rs
+++ b/sdk/security_keyvault/src/certificates/operations/delete_operation.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 
 operation! {
     DeleteCertificateOperation,
@@ -16,16 +16,12 @@ impl DeleteCertificateOperationBuilder {
             let headers = Headers::new();
             let mut request = KeyvaultClient::finalize_request(uri, Method::Delete, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-            let response = serde_json::from_slice::<CertificateOperationResponse>(body)?;
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/get_certificate.rs
+++ b/sdk/security_keyvault/src/certificates/operations/get_certificate.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 
 operation! {
     GetCertificate,
@@ -18,18 +18,12 @@ impl GetCertificateBuilder {
             let headers = Headers::new();
             let mut request = KeyvaultClient::finalize_request(uri, Method::Get, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let response: KeyVaultGetCertificateResponse = serde_json::from_slice(body)?;
-
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/get_operation.rs
+++ b/sdk/security_keyvault/src/certificates/operations/get_operation.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 
 operation! {
     GetCertificateOperation,
@@ -16,18 +16,12 @@ impl GetCertificateOperationBuilder {
             let headers = Headers::new();
             let mut request = KeyvaultClient::finalize_request(uri, Method::Get, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let response: CertificateOperationResponse = serde_json::from_slice(body)?;
-
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/get_versions.rs
+++ b/sdk/security_keyvault/src/certificates/operations/get_versions.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{error::Error, headers::Headers, CollectedResponse, Method, Pageable, Url};
+use azure_core::{error::Error, headers::Headers, Method, Pageable, Url};
 
 operation! {
     #[stream]
@@ -24,13 +24,12 @@ impl GetCertificateVersionsBuilder {
                 let headers = Headers::new();
                 let mut request = KeyvaultClient::finalize_request(uri, Method::Get, headers, None);
 
-                let response = this.client.keyvault_client.send(&ctx, &mut request).await?;
-
-                let response = CollectedResponse::from_response(response).await?;
-                let body = response.body();
-
-                let response = serde_json::from_slice::<KeyVaultGetCertificatesResponse>(body)?;
-                Ok(response)
+                this.client
+                    .keyvault_client
+                    .send(&ctx, &mut request)
+                    .await?
+                    .json()
+                    .await
             }
         };
         Pageable::new(make_request)

--- a/sdk/security_keyvault/src/certificates/operations/import.rs
+++ b/sdk/security_keyvault/src/certificates/operations/import.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, to_json, Method};
 use serde::Serialize;
 use std::collections::HashMap;
 use time::OffsetDateTime;
@@ -52,22 +52,18 @@ impl ImportCertificateBuilder {
                 tags: self.tags,
             };
 
-            let body = serde_json::to_string(&request)?;
+            let body = to_json(&request)?;
 
             let headers = Headers::new();
             let mut request =
                 KeyvaultClient::finalize_request(uri, Method::Post, headers, Some(body.into()));
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-            let response = serde_json::from_slice::<KeyVaultGetCertificateResponse>(body)?;
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/merge.rs
+++ b/sdk/security_keyvault/src/certificates/operations/merge.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, to_json, Method};
 use serde::Serialize;
 use std::collections::HashMap;
 use time::OffsetDateTime;
@@ -49,22 +49,18 @@ impl MergeCertificateBuilder {
                 tags: self.tags,
             };
 
-            let body = serde_json::to_string(&request)?;
+            let body = to_json(&request)?;
 
             let headers = Headers::new();
             let mut request =
                 KeyvaultClient::finalize_request(uri, Method::Post, headers, Some(body.into()));
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-            let response = serde_json::from_slice::<KeyVaultGetCertificateResponse>(body)?;
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/certificates/operations/update_properties.rs
+++ b/sdk/security_keyvault/src/certificates/operations/update_properties.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, Method};
+use azure_core::{headers::Headers, to_json, Method};
 use serde::Serialize;
 use time::OffsetDateTime;
 
@@ -44,7 +44,7 @@ impl UpdateCertificatePropertiesBuilder {
                 },
             };
 
-            let body = serde_json::to_string(&request)?;
+            let body = to_json(&request)?;
 
             let headers = Headers::new();
             let mut request =

--- a/sdk/security_keyvault/src/keys/operations/decrypt.rs
+++ b/sdk/security_keyvault/src/keys/operations/decrypt.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{base64, headers::Headers, CollectedResponse, Method};
+use azure_core::{base64, headers::Headers, Method};
 use serde_json::{Map, Value};
 
 operation! {
@@ -64,16 +64,14 @@ impl DecryptBuilder {
                 Some(Value::Object(request_body).to_string().into()),
             );
 
-            let response = self
+            let mut result: DecryptResponse = self
                 .client
                 .keyvault_client
                 .send(&self.context, &mut request)
+                .await?
+                .json()
                 .await?;
 
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let mut result = serde_json::from_slice::<DecryptResult>(body)?;
             result.algorithm = algorithm;
             Ok(result)
         })

--- a/sdk/security_keyvault/src/keys/operations/encrypt.rs
+++ b/sdk/security_keyvault/src/keys/operations/encrypt.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{base64, headers::Headers, CollectedResponse, Method};
+use azure_core::{base64, headers::Headers, Method};
 use serde_json::{Map, Value};
 
 operation! {
@@ -64,16 +64,13 @@ impl EncryptBuilder {
                 Some(Value::Object(request_body).to_string().into()),
             );
 
-            let response = self
+            let mut result: EncryptResult = self
                 .client
                 .keyvault_client
                 .send(&self.context, &mut request)
+                .await?
+                .json()
                 .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let mut result = serde_json::from_slice::<EncryptResult>(body)?;
             result.algorithm = algorithm;
             Ok(result)
         })

--- a/sdk/security_keyvault/src/keys/operations/get_key.rs
+++ b/sdk/security_keyvault/src/keys/operations/get_key.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 
 operation! {
     GetKey,
@@ -19,17 +19,12 @@ impl GetKeyBuilder {
             let headers = Headers::new();
             let mut request = KeyvaultClient::finalize_request(uri, Method::Get, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-            let response = serde_json::from_slice::<KeyVaultKey>(body)?;
-
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/keys/operations/get_random_bytes.rs
+++ b/sdk/security_keyvault/src/keys/operations/get_random_bytes.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method, Url};
+use azure_core::{headers::Headers, Method, Url};
 use serde_json::{Map, Value};
 
 operation! {
@@ -30,17 +30,12 @@ impl GetRandomBytesBuilder {
                 Some(Value::Object(request_body).to_string().into()),
             );
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let result = serde_json::from_slice::<GetRandomBytesResult>(body)?;
-            Ok(result)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/keys/operations/sign.rs
+++ b/sdk/security_keyvault/src/keys/operations/sign.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 use serde_json::{Map, Value};
 
 operation! {
@@ -31,16 +31,13 @@ impl SignBuilder {
                 Some(Value::Object(request_body).to_string().into()),
             );
 
-            let response = self
+            let mut result: SignResult = self
                 .client
                 .keyvault_client
                 .send(&self.context, &mut request)
+                .await?
+                .json()
                 .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let mut result = serde_json::from_slice::<SignResult>(body)?;
             result.algorithm = self.algorithm;
             Ok(result)
         })

--- a/sdk/security_keyvault/src/keys/operations/unwrap_key.rs
+++ b/sdk/security_keyvault/src/keys/operations/unwrap_key.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 use serde_json::{Map, Value};
 
 operation! {
@@ -64,16 +64,13 @@ impl UnwrapKeyBuilder {
                 Some(Value::Object(request_body).to_string().into()),
             );
 
-            let response = self
+            let mut result: UnwrapKeyResult = self
                 .client
                 .keyvault_client
                 .send(&self.context, &mut request)
+                .await?
+                .json()
                 .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let mut result = serde_json::from_slice::<UnwrapKeyResult>(body)?;
             result.algorithm = algorithm;
             Ok(result)
         })

--- a/sdk/security_keyvault/src/secrets/operations/backup_secret.rs
+++ b/sdk/security_keyvault/src/secrets/operations/backup_secret.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 use serde::Deserialize;
 
 operation! {
@@ -17,17 +17,12 @@ impl BackupSecretBuilder {
             let headers = Headers::new();
             let mut request = KeyvaultClient::finalize_request(uri, Method::Post, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-
-            let response = serde_json::from_slice::<BackupSecretResponse>(body)?;
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/secrets/operations/get_secret.rs
+++ b/sdk/security_keyvault/src/secrets/operations/get_secret.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, CollectedResponse, Method};
+use azure_core::{headers::Headers, Method};
 
 operation! {
     GetSecret,
@@ -18,16 +18,12 @@ impl GetSecretBuilder {
 
             let mut request = KeyvaultClient::finalize_request(uri, Method::Get, headers, None);
 
-            let response = self
-                .client
+            self.client
                 .keyvault_client
                 .send(&self.context, &mut request)
-                .await?;
-
-            let response = CollectedResponse::from_response(response).await?;
-            let body = response.body();
-            let response = serde_json::from_slice::<KeyVaultGetSecretResponse>(body)?;
-            Ok(response)
+                .await?
+                .json()
+                .await
         })
     }
 }

--- a/sdk/security_keyvault/src/secrets/operations/get_versions.rs
+++ b/sdk/security_keyvault/src/secrets/operations/get_versions.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{error::Error, headers::Headers, CollectedResponse, Method, Pageable, Url};
+use azure_core::{error::Error, headers::Headers, Method, Pageable, Url};
 
 operation! {
     #[stream]
@@ -24,13 +24,12 @@ impl GetSecretVersionsBuilder {
                 let headers = Headers::new();
                 let mut request = KeyvaultClient::finalize_request(uri, Method::Get, headers, None);
 
-                let response = this.client.keyvault_client.send(&ctx, &mut request).await?;
-
-                let response = CollectedResponse::from_response(response).await?;
-                let body = response.body();
-
-                let response = serde_json::from_slice::<KeyVaultGetSecretsResponse>(body)?;
-                Ok(response)
+                this.client
+                    .keyvault_client
+                    .send(&ctx, &mut request)
+                    .await?
+                    .json()
+                    .await
             }
         };
         Pageable::new(make_request)

--- a/sdk/security_keyvault/src/secrets/operations/update_secret.rs
+++ b/sdk/security_keyvault/src/secrets/operations/update_secret.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, Method};
+use azure_core::{headers::Headers, to_json, Method};
 use serde::Serialize;
 use std::collections::HashMap;
 use time::OffsetDateTime;
@@ -55,7 +55,7 @@ impl UpdateSecretBuilder {
                 tags: self.tags,
             };
 
-            let body = serde_json::to_string(&request)?;
+            let body = to_json(&request)?;
 
             let headers = Headers::new();
             let mut request =

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -19,7 +19,6 @@ time = "0.3.10"
 log = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
-serde_json = "1.0"
 url = "2.2"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 bytes = "1.0"

--- a/sdk/storage_blobs/src/container/operations/list_blobs.rs
+++ b/sdk/storage_blobs/src/container/operations/list_blobs.rs
@@ -1,11 +1,9 @@
 use crate::{blob::Blob, prelude::*};
-use azure_core::Method;
 use azure_core::{
     error::Error,
     headers::{date_from_headers, request_id_from_headers, Headers},
     prelude::*,
-    xml::read_xml,
-    Pageable, RequestId, Response as AzureResponse,
+    Method, Pageable, RequestId, Response as AzureResponse,
 };
 use time::OffsetDateTime;
 
@@ -149,9 +147,7 @@ pub struct BlobPrefix {
 impl ListBlobsResponse {
     pub async fn try_from(response: AzureResponse) -> azure_core::Result<Self> {
         let (_, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let list_blobs_response_internal: ListBlobsResponseInternal = read_xml(&body)?;
+        let list_blobs_response_internal: ListBlobsResponseInternal = body.xml().await?;
 
         let next_marker = match list_blobs_response_internal.next_marker {
             Some(ref nm) if nm.is_empty() => None,
@@ -180,6 +176,7 @@ impl Continuable for ListBlobsResponse {
 
 #[cfg(test)]
 mod tests {
+    use azure_core::xml::read_xml;
     use bytes::Bytes;
 
     use super::*;

--- a/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
+++ b/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
@@ -1,7 +1,6 @@
-use azure_core::{prelude::*, xml::read_xml, Response as HttpResponse};
-use azure_storage::headers::CommonStorageResponseHeaders;
-
 use crate::prelude::BlobServiceClient;
+use azure_core::{prelude::*, Response as HttpResponse};
+use azure_storage::headers::CommonStorageResponseHeaders;
 
 operation! {
     #[stream]
@@ -62,8 +61,7 @@ impl Continuable for FindBlobsByTagsResponse {
 impl FindBlobsByTagsResponse {
     async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-        let body: ListBlobsByTagsBody = read_xml(&body)?;
+        let body: ListBlobsByTagsBody = body.xml().await?;
 
         Ok(Self {
             blobs: body.blobs.blobs,
@@ -101,9 +99,10 @@ pub struct Blob {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use azure_core::xml::read_xml;
 
     #[test]
-    fn parse_body() {
+    fn parse_body() -> azure_core::Result<()> {
         const BODY: &[u8] = b"<?xml version=\"1.0\" encoding=\"utf-8\"?>
         <EnumerationResults ServiceEndpoint=\"https://hsdgeventstoredev.blob.core.windows.net/\">
           <Where>tag1='value1'</Where>
@@ -117,8 +116,9 @@ mod tests {
           <NextMarker/>
         </EnumerationResults>";
 
-        let body: ListBlobsByTagsBody = read_xml(BODY).unwrap();
+        let body: ListBlobsByTagsBody = read_xml(BODY)?;
         assert_eq!(body.blobs.blobs.len(), 1);
         assert_eq!(body.blobs.blobs[0].name, "test1");
+        Ok(())
     }
 }

--- a/sdk/storage_blobs/src/service/operations/get_blob_service_properties.rs
+++ b/sdk/storage_blobs/src/service/operations/get_blob_service_properties.rs
@@ -38,9 +38,7 @@ impl GetBlobServicePropertiesResponse {
         response: Response,
     ) -> azure_core::Result<GetBlobServicePropertiesResponse> {
         let common = CommonStorageResponseHeaders::try_from(response.headers())?;
-        let body = response.into_body().collect().await?;
-        println!("body {body:?}");
-        let properties = azure_core::xml::read_xml(&body)?;
+        let properties = response.xml().await?;
 
         Ok(GetBlobServicePropertiesResponse { common, properties })
     }

--- a/sdk/storage_datalake/src/clients/directory_client.rs
+++ b/sdk/storage_datalake/src/clients/directory_client.rs
@@ -1,7 +1,7 @@
 use crate::{
     clients::FileSystemClient, operations::*, prelude::PathClient, request_options::*, Properties,
 };
-use azure_core::{prelude::IfMatchCondition, Url};
+use azure_core::{prelude::IfMatchCondition, Response, Url};
 
 #[derive(Debug, Clone)]
 pub struct DirectoryClient {
@@ -22,7 +22,7 @@ impl PathClient for DirectoryClient {
         &self,
         ctx: &mut azure_core::Context,
         request: &mut azure_core::Request,
-    ) -> crate::Result<azure_core::Response> {
+    ) -> azure_core::Result<Response> {
         self.file_system_client.send(ctx, request).await
     }
 }

--- a/sdk/storage_datalake/src/clients/file_client.rs
+++ b/sdk/storage_datalake/src/clients/file_client.rs
@@ -22,7 +22,7 @@ impl PathClient for FileClient {
         &self,
         ctx: &mut azure_core::Context,
         request: &mut azure_core::Request,
-    ) -> crate::Result<azure_core::Response> {
+    ) -> azure_core::Result<azure_core::Response> {
         self.file_system_client.send(ctx, request).await
     }
 }

--- a/sdk/storage_datalake/src/clients/mod.rs
+++ b/sdk/storage_datalake/src/clients/mod.rs
@@ -15,5 +15,5 @@ use std::fmt::Debug;
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 pub trait PathClient: Debug + Clone + Send + Sync {
     fn url(&self) -> azure_core::Result<Url>;
-    async fn send(&self, ctx: &mut Context, request: &mut Request) -> crate::Result<Response>;
+    async fn send(&self, ctx: &mut Context, request: &mut Request) -> azure_core::Result<Response>;
 }

--- a/sdk/storage_datalake/src/file_system.rs
+++ b/sdk/storage_datalake/src/file_system.rs
@@ -1,4 +1,4 @@
-use azure_core::Etag;
+use azure_core::{from_json, Etag};
 use bytes::Bytes;
 use serde::{self, Deserialize, Deserializer};
 use std::convert::TryFrom;
@@ -20,10 +20,10 @@ pub(crate) struct FileSystemList {
 }
 
 impl TryFrom<Bytes> for FileSystemList {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(response: Bytes) -> Result<Self, Self::Error> {
-        Ok(serde_json::from_slice::<FileSystemList>(response.as_ref())?)
+        from_json(response)
     }
 }
 
@@ -52,7 +52,7 @@ impl TryFrom<Bytes> for PathList {
     type Error = azure_core::error::Error;
 
     fn try_from(response: Bytes) -> Result<Self, Self::Error> {
-        Ok(serde_json::from_slice(response.as_ref())?)
+        from_json(response)
     }
 }
 
@@ -95,7 +95,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn test_path_serialization() {
+    fn test_path_serialization() -> azure_core::Result<()> {
         let payload = json!({
             "contentLength": 100_i64,
             "etag": "etag",
@@ -107,7 +107,7 @@ mod tests {
             "owner": "owner"
         });
 
-        let path: Path = serde_json::from_slice(payload.to_string().as_ref()).unwrap();
+        let path: Path = from_json(payload.to_string())?;
         assert_eq!(path.content_length, 100);
         assert!(path.is_directory);
 
@@ -122,8 +122,10 @@ mod tests {
             "owner": "owner"
         });
 
-        let path: Path = serde_json::from_slice(payload_str.to_string().as_ref()).unwrap();
+        let path: Path = from_json(payload_str.to_string())?;
         assert_eq!(path.content_length, 100);
         assert!(path.is_directory);
+
+        Ok(())
     }
 }

--- a/sdk/storage_datalake/src/lib.rs
+++ b/sdk/storage_datalake/src/lib.rs
@@ -18,6 +18,5 @@ mod properties;
 pub mod request_options;
 mod util;
 
-pub use azure_core::error::{Error, Result};
 pub use file_system::FileSystem;
 pub use properties::Properties;

--- a/sdk/storage_datalake/src/properties.rs
+++ b/sdk/storage_datalake/src/properties.rs
@@ -59,7 +59,7 @@ impl Header for Properties {
 }
 
 impl TryFrom<&Headers> for Properties {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(headers: &Headers) -> Result<Self, Self::Error> {
         let header_value = headers.get_str(&PROPERTIES)?;
@@ -68,7 +68,7 @@ impl TryFrom<&Headers> for Properties {
 }
 
 impl TryFrom<&str> for Properties {
-    type Error = crate::Error;
+    type Error = azure_core::Error;
 
     fn try_from(header_value: &str) -> Result<Self, Self::Error> {
         let mut properties = Self::new();
@@ -103,14 +103,14 @@ impl TryFrom<&str> for Properties {
                 // we do not check if there are more entries. We just ignore them.
                 Ok((key, value))
             })
-            .collect::<crate::Result<Vec<(&str, &str)>>>()? // if we have an error, return error
+            .collect::<azure_core::Result<Vec<(&str, &str)>>>()? // if we have an error, return error
             .into_iter()
             .map(|(key, value)| {
                 // the value is base64 encoded se we decode it
                 let value = String::from_utf8(base64::decode(value)?)?;
                 Ok((key, value))
             })
-            .collect::<crate::Result<Vec<(&str, String)>>>()? // if we have an error, return error
+            .collect::<azure_core::Result<Vec<(&str, String)>>>()? // if we have an error, return error
             .into_iter()
             .for_each(|(key, value)| {
                 properties.insert(key.to_owned(), value); // finally store the key and value into the properties

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -18,9 +18,7 @@ azure_storage = { path = "../storage", version = "0.17", default-features=false 
 time = "0.3.10"
 futures = "0.3"
 log = "0.4"
-serde = { version = "1.0" }
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = { version = "1.0", features=["derive"] }
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]

--- a/sdk/storage_queues/src/lib.rs
+++ b/sdk/storage_queues/src/lib.rs
@@ -39,8 +39,6 @@ async fn main() -> azure_core::Result<()> {
 */
 
 #[macro_use]
-extern crate serde_derive;
-#[macro_use]
 extern crate azure_core;
 
 mod clients;

--- a/sdk/storage_queues/src/operations/get_queue_service_properties.rs
+++ b/sdk/storage_queues/src/operations/get_queue_service_properties.rs
@@ -1,5 +1,5 @@
 use crate::{QueueServiceClient, QueueServiceProperties};
-use azure_core::{headers::Headers, xml::read_xml, Method, Response as AzureResponse};
+use azure_core::{headers::Headers, Method, Response as AzureResponse};
 use azure_storage::headers::CommonStorageResponseHeaders;
 use std::convert::TryInto;
 
@@ -35,9 +35,7 @@ pub struct GetQueueServicePropertiesResponse {
 impl GetQueueServicePropertiesResponse {
     async fn try_from(response: AzureResponse) -> azure_core::Result<Self> {
         let (_, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let queue_service_properties = read_xml(&body)?;
+        let queue_service_properties = body.xml().await?;
 
         Ok(GetQueueServicePropertiesResponse {
             common_storage_response_headers: (&headers).try_into()?,

--- a/sdk/storage_queues/src/operations/get_queue_service_stats.rs
+++ b/sdk/storage_queues/src/operations/get_queue_service_stats.rs
@@ -3,10 +3,10 @@ use azure_core::{
     date,
     error::{ErrorKind, ResultExt},
     headers::Headers,
-    xml::read_xml,
     Method, Response as AzureResponse,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
+use serde::Deserialize;
 use std::convert::TryInto;
 use time::OffsetDateTime;
 
@@ -64,9 +64,7 @@ struct GeoReplication {
 impl GetQueueServiceStatsResponse {
     async fn try_from(response: AzureResponse) -> azure_core::Result<Self> {
         let (_, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let response: GetQueueServiceStatsResponseInternal = read_xml(&body)?;
+        let response: GetQueueServiceStatsResponseInternal = body.xml().await?;
 
         Ok(GetQueueServiceStatsResponse {
             common_storage_response_headers: (&headers).try_into()?,

--- a/sdk/storage_queues/src/operations/peek_messages.rs
+++ b/sdk/storage_queues/src/operations/peek_messages.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
-use azure_core::{headers::Headers, prelude::*, xml::read_xml, Method, Response as AzureResponse};
+use azure_core::{headers::Headers, prelude::*, Method, Response as AzureResponse};
 use azure_storage::headers::CommonStorageResponseHeaders;
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use time::OffsetDateTime;
 
@@ -55,9 +56,8 @@ pub struct PeekMessage {
 impl PeekMessagesResponse {
     async fn try_from(response: AzureResponse) -> azure_core::Result<Self> {
         let (_, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let messages = read_xml::<PeekMessagesBody>(&body)?.messages;
+        let body: PeekMessagesBody = body.xml().await?;
+        let messages = body.messages;
 
         Ok(PeekMessagesResponse {
             common_storage_response_headers: (&headers).try_into()?,

--- a/sdk/storage_queues/src/operations/put_message.rs
+++ b/sdk/storage_queues/src/operations/put_message.rs
@@ -1,12 +1,9 @@
 use crate::{prelude::*, queue_message::QueueMessageSubmit};
 use azure_core::{
-    date,
-    headers::Headers,
-    prelude::*,
-    xml::{read_xml, to_xml},
-    Method, Response as AzureResponse,
+    date, headers::Headers, prelude::*, xml::to_xml, Method, Response as AzureResponse,
 };
 use azure_storage::headers::CommonStorageResponseHeaders;
+use serde::{Deserialize, Serialize};
 use std::convert::TryInto;
 use time::OffsetDateTime;
 
@@ -82,9 +79,7 @@ struct QueueMessageInternal {
 impl PutMessageResponse {
     async fn try_from(response: AzureResponse) -> azure_core::Result<Self> {
         let (_, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-
-        let response: PutMessageResponseInternal = read_xml(&body)?;
+        let response: PutMessageResponseInternal = body.xml().await?;
         let queue_message = response.queue_message;
 
         let queue_message = QueueMessage {

--- a/sdk/storage_queues/src/queue_service_properties.rs
+++ b/sdk/storage_queues/src/queue_service_properties.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct QueueServiceProperties {


### PR DESCRIPTION
In past PRs, we added centralized json & xml helpers.

This builds upon that idea by exposing helpers for Request & Response (including CollectedResponse and ResponseBody, as those are sometimes needed as well).

This significantly reduces the complexity for _most_ of the callers and models what `reqwest` does for handling serialization and deserialization of requests.

This PR is broken up into two commits:
1. updates to azure_core.  This includes adding helpers to the Request & Response types, and making use of the helpers throughout the azure_core crate
2. updates to the rest of the crates to use the helpers