### PR TITLE
move away from directory listings for finding generated crates

### DIFF
--- a/.github/workflows/check-all-services.yml
+++ b/.github/workflows/check-all-services.yml
@@ -4139,22 +4139,6 @@ jobs:
         cd services
         cargo check --all-features -p azure_svc_blobstorage
 
-  azure_svc_codesigning:
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-    - uses: Swatinem/rust-cache@v2
-    - name: check all features
-      run: |
-        cd services
-        cargo check --all-features -p azure_svc_codesigning
-
   azure_svc_confidentialledger:
     if: always()
     runs-on: ubuntu-latest

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -258,7 +258,6 @@ members = [
   "svc/attestation",
   "svc/batch",
   "svc/blobstorage",
-  "svc/codesigning",
   "svc/confidentialledger",
   "svc/containerregistry",
   "svc/datalakeanalytics",

--- a/services/autorust/codegen/Cargo.toml
+++ b/services/autorust/codegen/Cargo.toml
@@ -26,6 +26,7 @@ camino = "1.1"
 askama = "0.12"
 toml = "0.8"
 qstring = "0.7"
+cargo_toml = "0.17"
 
 [dev-dependencies]
 thiserror = "1.0"

--- a/services/autorust/codegen/src/crates.rs
+++ b/services/autorust/codegen/src/crates.rs
@@ -1,10 +1,12 @@
 use crate::{ErrorKind, Result, ResultExt};
 use camino::{Utf8Path, Utf8PathBuf};
+use cargo_toml::Manifest;
 use serde::Deserialize;
-use std::io::BufRead;
 use std::{
+    collections::BTreeSet,
     fs::{self, File},
-    io::BufReader,
+    io::{BufRead, BufReader},
+    path::Path,
     str::FromStr,
 };
 
@@ -22,23 +24,26 @@ fn list_dirs_in(dir: impl AsRef<Utf8Path>) -> Result<Vec<Utf8PathBuf>> {
     Ok(dirs)
 }
 
+pub fn list_crates(services_dir: &Path) -> Result<BTreeSet<String>> {
+    let mut package_names = BTreeSet::new();
+    let base_path = services_dir.join("Cargo.toml");
+    let manifest = Manifest::from_path(base_path)?;
+    if let Some(workspaces) = manifest.workspace {
+        for member in workspaces.members {
+            let member_path = services_dir.join(member).join("Cargo.toml");
+            let Ok(manifest) = Manifest::from_path(member_path) else { continue };
+            let Some(package) = manifest.package else {
+                continue;
+            };
+            package_names.insert(package.name);
+        }
+    }
+    Ok(package_names)
+}
+
 pub fn list_dirs() -> Result<Vec<Utf8PathBuf>> {
     let mut names: Vec<_> = list_dirs_in("../mgmt")?.into_iter().collect();
     names.extend(list_dirs_in("../svc")?);
-    names.sort();
-    Ok(names)
-}
-
-pub fn list_crate_names() -> Result<Vec<String>> {
-    let mut names: Vec<_> = list_dirs_in("../mgmt")?
-        .into_iter()
-        .filter_map(|d| d.file_name().map(|d| format!("azure_mgmt_{d}")))
-        .collect();
-    names.extend(
-        list_dirs_in("../svc")?
-            .into_iter()
-            .filter_map(|d| d.file_name().map(|d| format!("azure_svc_{d}"))),
-    );
     names.sort();
     Ok(names)
 }

--- a/services/autorust/codegen/src/error.rs
+++ b/services/autorust/codegen/src/error.rs
@@ -208,6 +208,12 @@ impl From<syn::Error> for Error {
     }
 }
 
+impl From<cargo_toml::Error> for Error {
+    fn from(error: cargo_toml::Error) -> Self {
+        Self::new(ErrorKind::Parse, error)
+    }
+}
+
 impl From<autorust_openapi::Error> for Error {
     fn from(error: autorust_openapi::Error) -> Self {
         Self::new(ErrorKind::Parse, error)


### PR DESCRIPTION
As identified in #1479, we do not currently handle deleted/renamed specifications well.

This update addresses this via the following:
* Moves to using parsing `cargo_toml` to parse services/Cargo.toml to know what crates already exist
* Replaces all uses of `list_crate_names` with using the results of `gen_crates`

As a byproduct, this identifies that the previously existing spec that would result in `azure_svc_codesigning` was removed.

ref: https://github.com/Azure/azure-rest-api-specs/pull/26635