### PR TITLE
Add throttling support using retry-after headers

### DIFF
--- a/sdk/core/src/lro.rs
+++ b/sdk/core/src/lro.rs
@@ -1,5 +1,6 @@
-use crate::headers::{Headers, RETRY_AFTER, RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS};
+use crate::headers::Headers;
 use std::time::Duration;
+use time::OffsetDateTime;
 
 /// Default retry time for long running operations if no retry-after header is present
 ///
@@ -36,25 +37,8 @@ impl From<&str> for LroStatus {
     }
 }
 
-/// Get the duration to delay between polling attempts
-///
-/// This function will check for the following headers in order:
-/// * `Retry-After`
-/// * `retry-after-ms`
-/// * `x-ms-retry-after-ms`
-///
-/// If no header is provided, the default retry time will be returned.
 pub fn get_retry_after(headers: &Headers) -> Duration {
-    [RETRY_AFTER, RETRY_AFTER_MS, X_MS_RETRY_AFTER_MS]
-        .iter()
-        .find_map(|header| {
-            headers
-                .get_str(header)
-                .ok()
-                .and_then(|v| v.parse::<u64>().ok())
-                .map(Duration::from_secs)
-        })
-        .unwrap_or(DEFAULT_RETRY_TIME)
+    crate::get_retry_after(headers, OffsetDateTime::now_utc).unwrap_or(DEFAULT_RETRY_TIME)
 }
 
 pub mod location {

--- a/sdk/core/src/policies/retry_policies/mod.rs
+++ b/sdk/core/src/policies/retry_policies/mod.rs
@@ -6,4 +6,5 @@ mod retry_policy;
 pub use exponential_retry::*;
 pub use fixed_retry::*;
 pub use no_retry::*;
+pub(crate) use retry_policy::get_retry_after;
 pub use retry_policy::RetryPolicy;


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-rust/issues/1516

Updated `azure_core` retry policy to implement throttling by looking for and using the values returned by a server via `retry-after`, `retry-after-ms` or `x-ms-retry-after-ms` headers when the server returns 429 (`TooManyRequests`) or 503 (`ServerUnavailable`).

Details:
- There was already some parsing of the `retry-after` headers in `lro.rs` (long-running operations).
  - I moved this into the `retry_policies` module, as I felt this was probably a more appropriate home for it.
  - The existing code had a bug where it was treating the "ms" variant values as seconds rather than milliseconds.  I've fixed this.
  - The existing code also looked for the headers in a different order to the Javascript SDK.  I've switched this around to match - now looking for the `<xxx>-ms` headers before the `retry-after` header.
- I modified the `RetryPolicy` trait `wait(...)` method to have an additional `retry_after` parameter, to enable passing in of retry-after duration extracted from the headers (if any):
    ```rust
    async fn wait(&self, _error: &Error, retry_count: u32, retry_after: Option<Duration>)
    ```
- I updated the common retry policy code to extract any `retry-after` header value when the server response is 429 or 503.  Then when calculating the sleep time for any retry policy in the `wait(...)` method it takes the maximum of the retry-after value (if any) and the calculated policy value.
- I added some unit tests for the new code.