### PR TITLE
Fix service bus queue SAS token generation 

### DIFF
--- a/sdk/core/src/hmac.rs
+++ b/sdk/core/src/hmac.rs
@@ -5,7 +5,15 @@ use crate::{
     error::{ErrorKind, ResultExt},
 };
 
-// if both hmac_rust and hmac_openssl are enabled, use hmac_openssl
+/// Tries to create an HMAC SHA256 signature from the given `data` and `key`.
+/// The `key` is expected to be a base64 encoded string and will be decoded
+/// before using it for signing. The returned signature is also base64 encoded.
+///
+/// If both `hmac_rust` and `hmac_openssl` are enabled, use `hmac_openssl`.
+///
+/// # Errors
+/// - If the `key` is not a valid base64 encoded string.
+/// - If it fails to create the HMAC from the `key`.
 #[cfg(all(feature = "hmac_rust", not(feature = "hmac_openssl")))]
 pub fn hmac_sha256(data: &str, key: &Secret) -> crate::Result<String> {
     use hmac::{Hmac, Mac};

--- a/sdk/messaging_servicebus/src/service_bus/queue_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/queue_client.rs
@@ -37,7 +37,7 @@ impl QueueClient {
         K: Into<Secret>,
     {
         // NOTE: This is to account for the azure_core::auth::hmac_sha256 assumption
-        // that the key is base64 encoded.
+        // that the key needs to be base64 decoded.
         let signing_key = azure_core::base64::encode(signing_key.into().secret());
         Ok(QueueClient {
             http_client,

--- a/sdk/messaging_servicebus/src/service_bus/queue_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/queue_client.rs
@@ -36,6 +36,9 @@ impl QueueClient {
         P: Into<String>,
         K: Into<Secret>,
     {
+        // NOTE: This is to account for the azure_core::auth::hmac_sha256 assumption
+        // that the key is base64 encoded.
+        let signing_key = azure_core::base64::encode(signing_key.into().secret());
         Ok(QueueClient {
             http_client,
             namespace: namespace.into(),


### PR DESCRIPTION
The PR to standardize HMAC implementation (#1473) introduced an issue in generating service bus queue SAS tokens.

The standard implementation in `azure_core::auth::hmac` assumes the signing key is the `base64::decoded` of the _key_ passed as an argument:

https://github.com/Azure/azure-sdk-for-rust/blob/a32e4115d42b426a054ba29e5c1563b5a0526d6c/sdk/core/src/hmac.rs#L12

On the `service_bus/queue_client` side it is used like the following, which means it'll be decoded inside the hmac function.
https://github.com/Azure/azure-sdk-for-rust/blob/a32e4115d42b426a054ba29e5c1563b5a0526d6c/sdk/messaging_servicebus/src/service_bus/mod.rs#L67

However, from the version before the merge, I gathered the key needs to be used verbatim as bytes:
https://github.com/Azure/azure-sdk-for-rust/blob/346330b6b8448d1d14228ec225e038282a39e0ce/sdk/messaging_servicebus/src/service_bus/mod.rs#L67

Tested this using [this example](https://github.com/Azure/azure-sdk-for-rust/blob/main/sdk/messaging_servicebus/examples/service_bus00.rs) and confirmed that the fix works. If this is not the direction / style of fix you want, I'd be happy to rework it to make it more suitable.

I also wanted to add a few unit tests for the SAS token generation but this would need a time-mocking library so I wanted to check before changing the code further.


