### PR TITLE
WIP: flatten `allOf` models

### DIFF
--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -345,9 +345,14 @@ fn flatten_all_of(all_schemas: &IndexMap<RefKey, SchemaGen>, schema: &SchemaGen,
         all_properties.insert(property.name.clone(), property);
     }
 
-    for schema in flattened_schemas.clone() {
-        for property in schema.properties {
-            all_properties.insert(property.name.clone(), property);
+    for flattened_schema in flattened_schemas.clone() {
+        for property in flattened_schema.properties {
+            let _x = all_properties.insert(property.name.clone(), property);
+            // if let Some(x) = x {
+            //     println!("{:?}", schema.ref_key);
+            //     println!("inner all of: {:?}", flattened_schema.ref_key);
+            //     println!("property already in schema - so a duplicate: {}", x.name)
+            // }
         }
     }
 

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -218,13 +218,17 @@ impl SchemaGen {
     /// If the type should implement Default
     fn implement_default(&self) -> bool {
         if self.has_required() {
+            if self.required().len() == 1 && self.discriminator_parent().is_some() {
+                // if there is only one required field, we can implement default
+                return true;
+            }
             return false;
         }
-        for schema in self.all_of() {
-            if !schema.implement_default() {
-                return false;
-            }
-        }
+        // for schema in self.all_of() {
+        //     if !schema.implement_default() {
+        //         return false;
+        //     }
+        // }
         true
     }
 
@@ -1149,7 +1153,7 @@ fn create_struct(
 
     let properties = if schema.discriminator_value().is_some() {
         // we should expect that the schema has a parent
-        let (parent_ref_key, discriminator_parent_property) = schema
+        let (_parent_ref_key, discriminator_parent_property) = schema
             .discriminator_parent()
             .clone()
             .expect("discriminator parent not found - when it should exist");

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -223,12 +223,17 @@ impl SchemaGen {
     /// If the type should implement [Default]
     fn implement_default(&self) -> bool {
         if self.has_required() {
-            if self.required().len() == 1 && self.discriminator_parent().is_some() {
-                // if there is only one required field, we can implement default
-                return true;
-            } else {
-                return false;
+            if self.required().len() == 1 {
+                // if there is only one required field, we may be able to implement default dependent on discriminators
+                if self.discriminator_parent().is_some() {
+                    // if this is a child of a discriminator, we can implement default
+                    return self.required().contains(&self.discriminator_parent().as_ref().unwrap().1.as_str());
+                } else if self.discriminator().is_some() {
+                    // if this is a discriminator, we can implement default for the base class
+                    return self.required().contains(&self.discriminator().unwrap());
+                }
             }
+            return false;
         }
         true
     }

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -619,7 +619,7 @@ pub fn create_models(cg: &mut CodeGen) -> Result<ModelsCode> {
     }
 
     for (ref_key, schema) in all_schemas {
-        println!("ref_key: {:?}", ref_key.name);
+        // println!("ref_key: {:?}", ref_key.name);
         let doc_file = &ref_key.file_path;
         let schema_name = &ref_key.name;
         // println!("schema_name: {}", schema_name);
@@ -1546,7 +1546,7 @@ fn create_struct_field_code(
     lowercase_workaround: bool,
     needs_boxing: HashSet<String>,
 ) -> Result<NamedTypeCode> {
-    println!("property: {} {:#?}", property_name, property);
+    // println!("property: {} {:#?}", property_name, property);
     // let property = property.schema();
     match &property.schema().ref_key {
         Some(ref_key) => {

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -1029,28 +1029,28 @@ fn create_struct(
     // println!("struct: {} {:?}", struct_name_code, pageable);
     needs_boxing.insert(struct_name.to_camel_case_ident()?.to_string());
 
-    for base_schema in schema.all_of() {
-        // skip empty base types
-        if !base_schema.has_fields() {
-            continue;
-        }
-        let schema_name = base_schema.name()?;
-        let mut type_name = TypeNameCode::from(schema_name.to_camel_case_ident()?);
-        type_name.union(false);
-        let field_name = schema_name.to_snake_case_ident()?;
-        props.push(StructPropCode {
-            doc_comments: Vec::new(),
-            serde: SerdeCode::flatten(),
-            field_name: field_name.clone(),
-            field_type: type_name.clone(),
-        });
-        if base_schema.implement_default() {
-            new_fn_body.extend(quote! { #field_name: #type_name::default(), });
-        } else {
-            new_fn_params.push(quote! { #field_name: #type_name });
-            new_fn_body.extend(quote! { #field_name, });
-        }
-    }
+    // for base_schema in schema.all_of() {
+    //     // skip empty base types
+    //     if !base_schema.has_fields() {
+    //         continue;
+    //     }
+    //     let schema_name = base_schema.name()?;
+    //     let mut type_name = TypeNameCode::from(schema_name.to_camel_case_ident()?);
+    //     type_name.union(false);
+    //     let field_name = schema_name.to_snake_case_ident()?;
+    //     props.push(StructPropCode {
+    //         doc_comments: Vec::new(),
+    //         serde: SerdeCode::flatten(),
+    //         field_name: field_name.clone(),
+    //         field_type: type_name.clone(),
+    //     });
+    //     if base_schema.implement_default() {
+    //         new_fn_body.extend(quote! { #field_name: #type_name::default(), });
+    //     } else {
+    //         new_fn_params.push(quote! { #field_name: #type_name });
+    //         new_fn_body.extend(quote! { #field_name, });
+    //     }
+    // }
 
     let mut field_names = HashMap::new();
 

--- a/services/autorust/codegen/src/codegen_models.rs
+++ b/services/autorust/codegen/src/codegen_models.rs
@@ -1123,19 +1123,9 @@ fn create_struct(
 
     let mut field_names = HashMap::new();
 
-    let properties = if schema.discriminator_value().is_some() {
-        let (_parent_ref_key, discriminator_parent_property) = schema.discriminator_parent().clone().ok_or_else(|| {
-            // TODO: this currently fails 5 API specs
-            Error::message(
-                ErrorKind::CodeGen,
-                format!("discriminator parent not found for {} - when it should exist", struct_name),
-            )
-        })?;
-
-        // TODO: get the parent schema and get the discriminator property itself - exclude it from the properties of this schema
-        // or as I've done in a rather ugly way here as the second property of the option
+    let properties = if let Some((_ref_key, property_to_remove)) = schema.discriminator_parent() {
         let mut properties = schema.properties();
-        properties.retain(|property| property.name() != discriminator_parent_property);
+        properties.retain(|property| property.name() != property_to_remove);
         properties
     } else {
         schema.properties()

--- a/services/autorust/codegen/src/lib_rs.rs
+++ b/services/autorust/codegen/src/lib_rs.rs
@@ -60,7 +60,6 @@ impl ToTokens for BodyCode {
             #![allow(clippy::ptr_arg)]
             #![allow(clippy::large_enum_variant)]
             #![allow(clippy::derive_partial_eq_without_eq)]
-            #![allow(clippy::new_without_default)]
             #![allow(rustdoc::bare_urls)]
             #![allow(rustdoc::invalid_html_tags)]
             #![allow(rustdoc::broken_intra_doc_links)]

--- a/services/autorust/codegen/src/spec.rs
+++ b/services/autorust/codegen/src/spec.rs
@@ -320,6 +320,18 @@ pub struct RefKey {
     pub name: String,
 }
 
+impl Ord for RefKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl PartialOrd for RefKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.name.cmp(&other.name))
+    }
+}
+
 #[derive(Clone)]
 pub struct ResolvedSchema {
     pub ref_key: Option<RefKey>,


### PR DESCRIPTION
Primarily, this is an attempt to get further on #599.

What the solution has ended up looking like is [flattening/merging/composing] the `allOf` schema properties into the child models - there is no longer a use of `#[serde(flatten)]`.
For starters, I'd say this provides a neater API to the end user - more resemblant of what we see in Bicep and easier to reason about.

It also removes some ambiguities in the models, where a property could be defined multiple times in the created models. For an example of this, see https://github.com/Azure/azure-sdk-for-rust/pull/1524#issuecomment-1867881285 