### PR TITLE
use expire_on from Azure CLI 2.54.0 if it exists

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -19,7 +19,7 @@ oauth2 = { version = "4.0.0", default-features = false }
 url = "2.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-time = { version = "0.3.10", features = ["local-offset"] }
+time = { version = "0.3.10" }
 log = "0.4"
 async-trait = "0.1"
 openssl = { version = "0.10.46",  optional=true }
@@ -27,7 +27,7 @@ uuid = { version = "1.0",  features = ["v4"] }
 pin-project = "1.0"
 
 [target.'cfg(unix)'.dependencies]
-tz-rs = "0.6"
+tz-rs = { version = "0.6", optional = true }
 
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json"], default-features = false }
@@ -38,7 +38,7 @@ azure_security_keyvault = { path = "../security_keyvault", default-features = fa
 serial_test = "2.0"
 
 [features]
-default = ["development", "enable_reqwest"]
+default = ["development", "enable_reqwest", "old_azure_cli"]
 enable_reqwest = ["azure_core/enable_reqwest"]
 enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
 development = []
@@ -47,8 +47,15 @@ client_certificate = ["openssl"]
 vendored_openssl = ["openssl/vendored"]
 azureauth_cli = []
 
+# If you are using and Azure CLI version older than 2.54.0 from November 2023,
+# upgrade your Azure CLI version or enable this feature.
+# Azure CLI 2.54.0 and above has an "expires_on" timestamp that we can use.
+# https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.54.0
+# https://github.com/Azure/azure-cli/issues/19700
+old_azure_cli = ["time/local-offset", "tz-rs"]
+
 [package.metadata.docs.rs]
-features = ["enable_reqwest", "enable_reqwest_rustls", "development", "client_certificate", "azureauth_cli"]
+features = ["enable_reqwest", "enable_reqwest_rustls", "development", "client_certificate", "azureauth_cli", "old_azure_cli"]
 
 [[example]]
 name="client_certificate_credentials"

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -108,7 +108,7 @@ struct CliTokenResponse {
     pub local_expires_on: OffsetDateTime,
     #[serde(rename = "expires_on")]
     /// The token's expiry time in seconds since the epoch, a unix timestamp.
-    /// Available in Azure CLI 2.54.0 or newer
+    /// Available in Azure CLI 2.54.0 or newer.
     pub expires_on: Option<i64>,
     pub subscription: String,
     pub tenant: String,
@@ -333,7 +333,7 @@ mod tests {
             token_response.tenant,
             "065e9f5e-870d-4ed1-af2b-1b58092353f3"
         );
-        assert_eq!(token_response.expires_on_timestamp, Some(1704158596));
+        assert_eq!(token_response.expires_on, Some(1704158596));
         assert_eq!(token_response.expires_on()?.unix_timestamp(), 1704158596);
         Ok(())
     }

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -95,7 +95,7 @@ mod az_cli_date_format {
     }
 }
 
-/// The respnose from `az account get-access-token --output json`.
+/// The response from `az account get-access-token --output json`.
 #[derive(Debug, Clone, Deserialize)]
 struct CliTokenResponse {
     #[serde(rename = "accessToken")]


### PR DESCRIPTION
Related to #1533. Now that https://github.com/Azure/azure-cli/issues/19700 was released with Azure CLI 2.54.0 in November, the `expires_on` timestamp can be used instead of `expiresOn` that is a local date. It will be used if present. It will continue to fallback to `expiresOn` if the `old_azure_cli` feature is enabled. I added it to default features. May be in 2025, we can remove it from default features.