### PR TITLE
enable AccessToken to be serialized & deserialized

### DIFF
--- a/sdk/core/src/auth.rs
+++ b/sdk/core/src/auth.rs
@@ -59,7 +59,7 @@ impl Debug for Secret {
 }
 
 /// Represents an Azure service bearer access token with expiry information.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AccessToken {
     /// Get the access token value.
     pub token: Secret,


### PR DESCRIPTION
This will enable developers to serialize tokens for reuse, akin to what is available via https://www.nuget.org/packages/Microsoft.Identity.Web.TokenCache/