### PR TITLE
include source stack in aggregated errors in DefaultAzureCredential

### DIFF
--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -209,14 +209,6 @@ fn format_aggregate_error(errors: &[Error]) -> String {
         })
         .collect::<Vec<String>>()
         .join("\n")
-
-    /*
-    errors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<String>>()
-        .join("\n")
-         */
 }
 
 #[cfg(test)]


### PR DESCRIPTION
As indicated in #1543, error details are swallowed when building an aggregate error message.

Currently, we format each of the errors using to_string, which results in the following:

```
Error {
    context: Full(
        Custom {
            kind: Credential,
            error: Error {
                context: Message {
                    kind: Credential,
                    message: "Multiple errors were encountered while attempting to authenticate:\nenvironment credential\nIMDS timeout\naz-cli",
                },
            },
        },
        "failed to get bearer token",
    ),
}
```

This doesn't help the user understand how to fix the issue.

With this update, we recurse through the error sources, building a more
detailed message.   This results in:

```
Error {
    context: Full(
        Custom {
            kind: Credential,
            error: Error {
                context: Message {
                    kind: Credential,
                    message: "Multiple errors were encountered while attempting to authenticate:\nenvironment credential - request token error - Server returned error response\nIMDS timeout - operation timed out\naz-cli - 'az account get-access-token' command failed: ERROR: AADSTS70011: The provided request must include a 'scope' input parameter. The provided value for the input parameter 'scope' is not valid. The scope https://storage.azure.com/ offline_access openid profile is not valid. The scope format is invalid. Scope must be in a valid URI form <https://example/scope> or a valid Guid <guid/scope>.  Trace ID: 346f391a-48f2-4e96-849f-9ecd6c589d02 Correlation ID: 7888c325-56ff-4100-8ce2-c8cf41561b40 Timestamp: 2024-01-05 01:31:04Z\nInteractive authentication is needed. Please run:\naz login --scope https://storage.azure.com/\n",
                },
            },
        },
        "failed to get bearer token",
    ),
}
```

When printed, this message looks like:
```
Multiple errors were encountered while attempting to authenticate:
environment credential - request token error - Server returned error response
IMDS timeout - operation timed out
az-cli - 'az account get-access-token' command failed: ERROR: AADSTS70011: The provided request must include a 'scope' input parameter. The provided value for the input parameter 'scope' is not valid. The scope https://storage.azure.com/ offline_access openid profile is not valid. The scope format is invalid. Scope must be in a valid URI form <https://example/scope> or a valid Guid <guid/scope>.  Trace ID: 02aecb08-69b4-4a5d-9ebb-784ea788c102 Correlation ID: dddc061a-ca11-4b21-b857-6d765a564597 Timestamp: 2024-01-05 01:43:45Z
Interactive authentication is needed. Please run:
az login --scope https://storage.azure.com/
```