### PR TITLE
Fix docs.rs build for iot_hub, messaging_eventgrid, message_servicebus

### DIFF
--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -32,7 +32,12 @@ default = ["enable_reqwest", "hmac_rust"]
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
 enable_reqwest = ["azure_core/enable_reqwest"]
-enable_request_rustls = ["azure_core/enable_reqwest_rustls"]
+enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
 
 [package.metadata.docs.rs]
-features = ["enable_reqwest", "enable_reqwest_rustls", "hmac_rust", "hmac_openssl"]
+features = [
+  "enable_reqwest",
+  "enable_reqwest_rustls",
+  "hmac_rust",
+  "hmac_openssl",
+]

--- a/sdk/messaging_eventgrid/Cargo.toml
+++ b/sdk/messaging_eventgrid/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 [features]
 default = ["enable_reqwest"]
 enable_reqwest = ["azure_core/enable_reqwest"]
-enable_request_rustls = ["azure_core/enable_reqwest_rustls"]
+enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
 
 [package.metadata.docs.rs]
 features = ["enable_reqwest", "enable_reqwest_rustls"]

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -33,8 +33,13 @@ default = ["enable_reqwest", "hmac_rust"]
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
 enable_reqwest = ["azure_core/enable_reqwest"]
-enable_request_rustls = ["azure_core/enable_reqwest_rustls"]
+enable_reqwest_rustls = ["azure_core/enable_reqwest_rustls"]
 test_e2e = []
 
 [package.metadata.docs.rs]
-features = ["enable_reqwest", "enable_reqwest_rustls", "hmac_rust", "hmac_openssl"]
+features = [
+  "enable_reqwest",
+  "enable_reqwest_rustls",
+  "hmac_rust",
+  "hmac_openssl",
+]


### PR DESCRIPTION
See https://github.com/Azure/azure-sdk-for-rust/issues/1535#issuecomment-1879164384.

Not sure how this could be tested without spinning up a docs.rs local build container:
https://docs.rs/about/builds#testing-builds-locally