### PR TITLE
use `cargo-docs-rs` to validate docs as part of the build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
   
   test-docs:
     name: SDK docs
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,15 +51,31 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - run: eng/scripts/sdk_tests.sh ${{ matrix.build }}
-  
-  test-docs:
+
+  test-docs-sdk:
     name: SDK docs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
-      - run: eng/scripts/verify-docs.sh
+      - run: eng/scripts/verify-docs.sh sdk
+  test-docs-svc:
+    name: SDK docs - svc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: eng/scripts/verify-docs.sh svc
+  test-docs-mgmt:
+    name: SDK docs - mgmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: eng/scripts/verify-docs.sh mgmt
 
   test-wasm:
     name: WASM Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
       - run: eng/scripts/sdk_tests.sh ${{ matrix.build }}
+  
+  test-docs:
+    name: SDK docs
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
 
   test-wasm:
     name: WASM Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/install@cargo-docs-rs
+      - run: eng/scripts/verify-docs.sh
 
   test-wasm:
     name: WASM Tests

--- a/eng/scripts/verify-docs.sh
+++ b/eng/scripts/verify-docs.sh
@@ -1,20 +1,65 @@
 #!/usr/bin/bash
 #
-# simple script to check docs using `cargo-docs-rs` 
+# simple script to check docs using `cargo-docs-rs`
 #
 
 set -eux -o pipefail
 
+BUILD=${1:-all}
+
 cd $(dirname ${BASH_SOURCE[0]})/../../
+
+case ${BUILD} in
+   all)
+	   echo building all docs
+	   ;;
+   sdk)
+	   echo building sdk docs
+	   ;;
+   svc)
+	   echo building svc docs
+	   ;;
+   mgmt)
+	   echo building mgmt docs
+	   ;;
+   *) echo ""
+
+esac
+
 
 SDK=$(cargo metadata --format-version=1 --no-deps | jq -r -c '.packages | .[] | select(.publish == null) | .name')
 SERVICES=$(cd services; cargo metadata --format-version=1 --no-deps | jq -r -c '.packages | .[] | select(.publish == null) | .name')
 
+
 for i in ${SDK}; do
-   cargo +nightly docs-rs -p ${i}
+    case ${BUILD} in
+       all | sdk)
+           cargo +nightly docs-rs -p ${i}
+	   ;;
+       svc | mgmt)
+           ;;
+       *)
+	   echo "unsupported build.  use all, sdk, svc, or mgmt"
+	   exit 1
+	   ;;
+    esac
 done
 
 for i in ${SERVICES}; do
-   cargo +nightly docs-rs -p ${i} --manifest-path services/Cargo.toml
+    case ${BUILD} in
+       all | svc )
+	   if [[ ${i} =~ "azure_svc_" ]]; then
+               cargo +nightly docs-rs -p ${i} --manifest-path services/Cargo.toml
+	   fi
+	   ;;
+       all | mgmt )
+	   if [[ ${i} == "azure_mgmt_" ]]; then
+               cargo +nightly docs-rs -p ${i} --manifest-path services/Cargo.toml
+	   fi
+           ;;
+       *)
+	   echo "unsupported build.  use all, sdk, svc, or mgmt"
+	   exit 1
+	   ;;
+    esac
 done
-

--- a/eng/scripts/verify-docs.sh
+++ b/eng/scripts/verify-docs.sh
@@ -35,7 +35,7 @@ for i in ${SERVICES}; do
            fi
            ;;
        all | mgmt )
-           if [[ ${i} == "azure_mgmt_" ]]; then
+           if [[ ${i} =~ "azure_mgmt_" ]]; then
                cargo +nightly docs-rs -p ${i} --manifest-path services/Cargo.toml
            fi
            ;;

--- a/eng/scripts/verify-docs.sh
+++ b/eng/scripts/verify-docs.sh
@@ -9,24 +9,6 @@ BUILD=${1:-all}
 
 cd $(dirname ${BASH_SOURCE[0]})/../../
 
-case ${BUILD} in
-   all)
-	   echo building all docs
-	   ;;
-   sdk)
-	   echo building sdk docs
-	   ;;
-   svc)
-	   echo building svc docs
-	   ;;
-   mgmt)
-	   echo building mgmt docs
-	   ;;
-   *) echo ""
-
-esac
-
-
 SDK=$(cargo metadata --format-version=1 --no-deps | jq -r -c '.packages | .[] | select(.publish == null) | .name')
 SERVICES=$(cd services; cargo metadata --format-version=1 --no-deps | jq -r -c '.packages | .[] | select(.publish == null) | .name')
 

--- a/eng/scripts/verify-docs.sh
+++ b/eng/scripts/verify-docs.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash
+#
+# simple script to check docs using `cargo-docs-rs` 
+#
+
+set -eux -o pipefail
+
+cd $(dirname ${BASH_SOURCE[0]})/../../
+
+SDK=$(cargo metadata --format-version=1 --no-deps | jq -r -c '.packages | .[] | select(.publish == null) | .name')
+SERVICES=$(cd services; cargo metadata --format-version=1 --no-deps | jq -r -c '.packages | .[] | select(.publish == null) | .name')
+
+for i in ${SDK}; do
+   cargo +nightly docs-rs -p ${i}
+done
+
+for i in ${SERVICES}; do
+   cargo +nightly docs-rs -p ${i} --manifest-path services/Cargo.toml
+done
+

--- a/eng/scripts/verify-docs.sh
+++ b/eng/scripts/verify-docs.sh
@@ -15,33 +15,35 @@ SERVICES=$(cd services; cargo metadata --format-version=1 --no-deps | jq -r -c '
 
 for i in ${SDK}; do
     case ${BUILD} in
-       all | sdk)
+       all | sdk )
            cargo +nightly docs-rs -p ${i}
-	   ;;
-       svc | mgmt)
+           ;;
+       svc | mgmt )
            ;;
        *)
-	   echo "unsupported build.  use all, sdk, svc, or mgmt"
-	   exit 1
-	   ;;
+           echo "unsupported build. (${BUILD}) use all, sdk, svc, or mgmt"
+           exit 1
+           ;;
     esac
 done
 
 for i in ${SERVICES}; do
     case ${BUILD} in
        all | svc )
-	   if [[ ${i} =~ "azure_svc_" ]]; then
+           if [[ ${i} =~ "azure_svc_" ]]; then
                cargo +nightly docs-rs -p ${i} --manifest-path services/Cargo.toml
-	   fi
-	   ;;
+           fi
+           ;;
        all | mgmt )
-	   if [[ ${i} == "azure_mgmt_" ]]; then
+           if [[ ${i} == "azure_mgmt_" ]]; then
                cargo +nightly docs-rs -p ${i} --manifest-path services/Cargo.toml
-	   fi
+           fi
+           ;;
+       sdk )
            ;;
        *)
-	   echo "unsupported build.  use all, sdk, svc, or mgmt"
-	   exit 1
-	   ;;
+           echo "unsupported build (${BUILD}) use all, sdk, svc, or mgmt"
+           exit 1
+           ;;
     esac
 done


### PR DESCRIPTION
This PR adds support to use [cargo-docs-rs](https://crates.io/crates/cargo-docs-rs) to build documentation to the CICD pipeline.

Running locally, this script would have found the issues identified in #1535 