### PR TITLE
check wasm with default features

### DIFF
--- a/eng/scripts/check_wasm.sh
+++ b/eng/scripts/check_wasm.sh
@@ -11,4 +11,4 @@ rustup update --no-self-update ${BUILD}
 rustup target add --toolchain ${BUILD} wasm32-unknown-unknown
 
 export RUSTFLAGS="-Dwarnings"
-cargo +${BUILD} check --target=wasm32-unknown-unknown --no-default-features
+cargo +${BUILD} check --target=wasm32-unknown-unknown


### PR DESCRIPTION
As indicated in #1554, we're not catching changes that impact real-world WASM use in CICD.

Originally, our WASM implementation was a best-effort path as reqwest (our first-class supported HTTP backend) did not support WASM.  Now that reqwest supports WASM, we should update our CICD to validate WASM with the default features.