### PR TITLE
address unused_async lint

### DIFF
--- a/sdk/core/src/response.rs
+++ b/sdk/core/src/response.rs
@@ -130,7 +130,7 @@ impl CollectedResponse {
     }
 
     #[cfg(feature = "xml")]
-    pub async fn xml<T>(&self) -> crate::Result<T>
+    pub fn xml<T>(&self) -> crate::Result<T>
     where
         T: DeserializeOwned,
     {

--- a/sdk/data_cosmos/src/operations/delete_attachment.rs
+++ b/sdk/data_cosmos/src/operations/delete_attachment.rs
@@ -38,7 +38,7 @@ impl DeleteAttachmentBuilder {
                 )
                 .await?;
 
-            DeleteAttachmentResponse::try_from(response).await
+            DeleteAttachmentResponse::try_from(response)
         })
     }
 }
@@ -70,7 +70,7 @@ pub struct DeleteAttachmentResponse {
 }
 
 impl DeleteAttachmentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_collection.rs
+++ b/sdk/data_cosmos/src/operations/delete_collection.rs
@@ -28,7 +28,7 @@ impl DeleteCollectionBuilder {
                 )
                 .await?;
 
-            DeleteCollectionResponse::try_from(response).await
+            DeleteCollectionResponse::try_from(response)
         })
     }
 }
@@ -62,7 +62,7 @@ pub struct DeleteCollectionResponse {
 }
 
 impl DeleteCollectionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_database.rs
+++ b/sdk/data_cosmos/src/operations/delete_database.rs
@@ -23,7 +23,7 @@ impl DeleteDatabaseBuilder {
                 .cosmos_client()
                 .send(request, self.context.clone(), ResourceType::Databases)
                 .await?;
-            DeleteDatabaseResponse::try_from(response).await
+            DeleteDatabaseResponse::try_from(response)
         })
     }
 }
@@ -38,7 +38,7 @@ pub struct DeleteDatabaseResponse {
 }
 
 impl DeleteDatabaseResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         let charge = request_charge_from_headers(headers)?;

--- a/sdk/data_cosmos/src/operations/delete_document.rs
+++ b/sdk/data_cosmos/src/operations/delete_document.rs
@@ -45,7 +45,7 @@ impl DeleteDocumentBuilder {
                 )
                 .await?;
 
-            DeleteDocumentResponse::try_from(response).await
+            DeleteDocumentResponse::try_from(response)
         })
     }
 }
@@ -58,7 +58,7 @@ pub struct DeleteDocumentResponse {
 }
 
 impl DeleteDocumentResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         let charge = request_charge_from_headers(&headers)?;

--- a/sdk/data_cosmos/src/operations/delete_permission.rs
+++ b/sdk/data_cosmos/src/operations/delete_permission.rs
@@ -28,7 +28,7 @@ impl DeletePermissionBuilder {
                 )
                 .await?;
 
-            DeletePermissionResponse::try_from(response).await
+            DeletePermissionResponse::try_from(response)
         })
     }
 }
@@ -43,7 +43,7 @@ pub struct DeletePermissionResponse {
 }
 
 impl DeletePermissionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
+++ b/sdk/data_cosmos/src/operations/delete_stored_procedure.rs
@@ -31,7 +31,7 @@ impl DeleteStoredProcedureBuilder {
                 )
                 .await?;
 
-            DeleteStoredProcedureResponse::try_from(response).await
+            DeleteStoredProcedureResponse::try_from(response)
         })
     }
 }
@@ -47,7 +47,7 @@ pub struct DeleteStoredProcedureResponse {
 }
 
 impl DeleteStoredProcedureResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_trigger.rs
+++ b/sdk/data_cosmos/src/operations/delete_trigger.rs
@@ -30,7 +30,7 @@ impl DeleteTriggerBuilder {
                 )
                 .await?;
 
-            DeleteTriggerResponse::try_from(response).await
+            DeleteTriggerResponse::try_from(response)
         })
     }
 }
@@ -63,7 +63,7 @@ pub struct DeleteTriggerResponse {
     pub date: OffsetDateTime,
 }
 impl DeleteTriggerResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_user.rs
+++ b/sdk/data_cosmos/src/operations/delete_user.rs
@@ -25,7 +25,7 @@ impl DeleteUserBuilder {
                 )
                 .await?;
 
-            DeleteUserResponse::try_from(response).await
+            DeleteUserResponse::try_from(response)
         })
     }
 }
@@ -38,7 +38,7 @@ pub struct DeleteUserResponse {
 }
 
 impl DeleteUserResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
+++ b/sdk/data_cosmos/src/operations/delete_user_defined_function.rs
@@ -32,7 +32,7 @@ impl DeleteUserDefinedFunctionBuilder {
                 )
                 .await?;
 
-            DeleteUserDefinedFunctionResponse::try_from(response).await
+            DeleteUserDefinedFunctionResponse::try_from(response)
         })
     }
 }
@@ -66,7 +66,7 @@ pub struct DeleteUserDefinedFunctionResponse {
 }
 
 impl DeleteUserDefinedFunctionResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/data_cosmos/src/operations/get_document.rs
+++ b/sdk/data_cosmos/src/operations/get_document.rs
@@ -109,12 +109,12 @@ where
             status_code == StatusCode::Ok || status_code == StatusCode::NotModified;
 
         if has_been_found {
-            Ok(GetDocumentResponse::Found(
-                FoundDocumentResponse::try_from(&headers, body).await?,
-            ))
+            Ok(GetDocumentResponse::Found(FoundDocumentResponse::try_from(
+                &headers, body,
+            )?))
         } else {
             Ok(GetDocumentResponse::NotFound(
-                NotFoundDocumentResponse::try_from(&headers).await?,
+                NotFoundDocumentResponse::try_from(&headers)?,
             ))
         }
     }
@@ -151,7 +151,7 @@ impl<T> FoundDocumentResponse<T>
 where
     T: DeserializeOwned,
 {
-    async fn try_from(headers: &Headers, body: bytes::Bytes) -> azure_core::Result<Self> {
+    fn try_from(headers: &Headers, body: bytes::Bytes) -> azure_core::Result<Self> {
         Ok(Self {
             document: from_json(&body)?,
             content_location: content_location_from_headers(headers)?,
@@ -203,7 +203,7 @@ pub struct NotFoundDocumentResponse {
 }
 
 impl NotFoundDocumentResponse {
-    async fn try_from(headers: &Headers) -> azure_core::Result<Self> {
+    fn try_from(headers: &Headers) -> azure_core::Result<Self> {
         Ok(Self {
             content_location: content_location_from_headers(headers)?,
             last_state_change: last_state_change_from_headers(headers)?,

--- a/sdk/storage_blobs/src/blob/operations/get_blob.rs
+++ b/sdk/storage_blobs/src/blob/operations/get_blob.rs
@@ -55,7 +55,7 @@ impl GetBlobBuilder {
 
                 let response = this.client.send(&mut ctx, &mut request).await?;
 
-                GetBlobResponse::try_from(this, response).await
+                GetBlobResponse::try_from(this, response)
             }
         };
         Pageable::new(make_request)
@@ -73,10 +73,7 @@ pub struct GetBlobResponse {
 }
 
 impl GetBlobResponse {
-    async fn try_from(
-        request: GetBlobBuilder,
-        response: AzureResponse,
-    ) -> azure_core::Result<Self> {
+    fn try_from(request: GetBlobBuilder, response: AzureResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         let request_id = request_id_from_headers(headers)?;

--- a/sdk/storage_datalake/src/operations/file_system_create.rs
+++ b/sdk/storage_datalake/src/operations/file_system_create.rs
@@ -30,7 +30,7 @@ impl CreateFileSystemBuilder {
                 .send(&mut self.context.clone(), &mut request)
                 .await?;
 
-            CreateFileSystemResponse::try_from(response).await
+            CreateFileSystemResponse::try_from(response)
         })
     }
 }
@@ -44,7 +44,7 @@ pub struct CreateFileSystemResponse {
 }
 
 impl CreateFileSystemResponse {
-    pub async fn try_from(response: Response) -> azure_core::Result<Self> {
+    pub fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/file_system_delete.rs
+++ b/sdk/storage_datalake/src/operations/file_system_delete.rs
@@ -25,7 +25,7 @@ impl DeleteFileSystemBuilder {
                 .send(&mut self.context.clone(), &mut request)
                 .await?;
 
-            DeleteFileSystemResponse::try_from(response).await
+            DeleteFileSystemResponse::try_from(response)
         })
     }
 }
@@ -36,7 +36,7 @@ pub struct DeleteFileSystemResponse {
 }
 
 impl DeleteFileSystemResponse {
-    pub async fn try_from(response: Response) -> azure_core::Result<Self> {
+    pub fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/file_system_get_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_get_properties.rs
@@ -28,7 +28,7 @@ impl GetFileSystemPropertiesBuilder {
                 .send(&mut self.context.clone(), &mut request)
                 .await?;
 
-            GetFileSystemPropertiesResponse::try_from(response).await
+            GetFileSystemPropertiesResponse::try_from(response)
         })
     }
 }
@@ -43,7 +43,7 @@ pub struct GetFileSystemPropertiesResponse {
 }
 
 impl GetFileSystemPropertiesResponse {
-    pub async fn try_from(response: Response) -> azure_core::Result<Self> {
+    pub fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(GetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/file_system_set_properties.rs
+++ b/sdk/storage_datalake/src/operations/file_system_set_properties.rs
@@ -32,7 +32,7 @@ impl SetFileSystemPropertiesBuilder {
                 .send(&mut self.context.clone(), &mut request)
                 .await?;
 
-            SetFileSystemPropertiesResponse::try_from(response).await
+            SetFileSystemPropertiesResponse::try_from(response)
         })
     }
 }
@@ -45,7 +45,7 @@ pub struct SetFileSystemPropertiesResponse {
 }
 
 impl SetFileSystemPropertiesResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(SetFileSystemPropertiesResponse {

--- a/sdk/storage_datalake/src/operations/path_delete.rs
+++ b/sdk/storage_datalake/src/operations/path_delete.rs
@@ -34,7 +34,7 @@ impl<C: PathClient + 'static> DeletePathBuilder<C> {
                 request.insert_headers(&this.if_match_condition);
                 request.insert_headers(&this.if_modified_since);
                 let response = this.client.send(&mut ctx, &mut request).await?;
-                DeletePathResponse::try_from(response).await
+                DeletePathResponse::try_from(response)
             }
         };
         Pageable::new(make_request)
@@ -48,7 +48,7 @@ pub struct DeletePathResponse {
 }
 
 impl DeletePathResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/path_head.rs
+++ b/sdk/storage_datalake/src/operations/path_head.rs
@@ -35,7 +35,7 @@ impl<C: PathClient + 'static> HeadPathBuilder<C> {
                 .send(&mut self.context.clone(), &mut request)
                 .await?;
 
-            HeadPathResponse::try_from(response).await
+            HeadPathResponse::try_from(response)
         })
     }
 }
@@ -52,7 +52,7 @@ pub struct HeadPathResponse {
 }
 
 impl HeadPathResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let headers = response.headers();
 
         Ok(Self {

--- a/sdk/storage_datalake/src/operations/path_patch.rs
+++ b/sdk/storage_datalake/src/operations/path_patch.rs
@@ -58,7 +58,7 @@ impl<C: PathClient + 'static> PatchPathBuilder<C> {
                 .send(&mut self.context.clone(), &mut request)
                 .await?;
 
-            PatchPathResponse::try_from(response).await
+            PatchPathResponse::try_from(response)
         })
     }
 }
@@ -72,7 +72,7 @@ pub struct PatchPathResponse {
 }
 
 impl PatchPathResponse {
-    pub async fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
+    pub fn try_from(response: HttpResponse) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         let etag = match etag_from_headers(&headers) {

--- a/sdk/storage_datalake/src/operations/path_put.rs
+++ b/sdk/storage_datalake/src/operations/path_put.rs
@@ -42,7 +42,7 @@ impl<C: PathClient + 'static> PutPathBuilder<C> {
                 .send(&mut self.context.clone(), &mut request)
                 .await?;
 
-            PutPathResponse::try_from(response).await
+            PutPathResponse::try_from(response)
         })
     }
 }
@@ -56,7 +56,7 @@ pub struct PutPathResponse {
 }
 
 impl PutPathResponse {
-    pub async fn try_from(response: Response) -> azure_core::Result<Self> {
+    pub fn try_from(response: Response) -> azure_core::Result<Self> {
         let (_status_code, headers, _pinned_stream) = response.deconstruct();
 
         Ok(Self {


### PR DESCRIPTION
> Async functions with no async code create overhead, both mentally and computationally. Callers of async methods either need to be calling from an async function themselves or run it on an executor, both of which causes runtime overhead and hassle for the caller.

https://rust-lang.github.io/rust-clippy/master/index.html#/unused_async