### PR TITLE
Upgrade AzureauthCliCredential to latest TokenCredential trait and use TokenCache

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "bungcip.better-toml",
+    "tamasfe.even-better-toml",
     "editorconfig.editorconfig",
     "rust-lang.rust-analyzer"
   ]

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -39,6 +39,7 @@ env_logger = "0.10"
 serde_test = "1"
 azure_security_keyvault = { path = "../security_keyvault", default-features = false }
 serial_test = "3.0"
+clap = { version = "4.4.16", features = ["derive"] }
 
 [features]
 default = ["development", "enable_reqwest", "old_azure_cli"]
@@ -58,8 +59,19 @@ azureauth_cli = []
 old_azure_cli = ["time/local-offset", "tz-rs"]
 
 [package.metadata.docs.rs]
-features = ["enable_reqwest", "enable_reqwest_rustls", "development", "client_certificate", "azureauth_cli", "old_azure_cli"]
+features = [
+  "enable_reqwest",
+  "enable_reqwest_rustls",
+  "development",
+  "client_certificate",
+  "azureauth_cli",
+  "old_azure_cli",
+]
 
 [[example]]
-name="client_certificate_credentials"
+name = "client_certificate_credentials"
 required-features = ["client_certificate"]
+
+[[example]]
+name = "azureauth_cli_credential"
+required-features = ["azureauth_cli"]

--- a/sdk/identity/examples/azureauth_cli_credential.rs
+++ b/sdk/identity/examples/azureauth_cli_credential.rs
@@ -1,0 +1,31 @@
+use azure_core::auth::TokenCredential;
+use azure_identity::AzureauthCliCredential;
+use clap::Parser;
+use std::error::Error;
+use url::Url;
+
+#[derive(Debug, Parser)]
+struct Args {
+    tenant_id: String,
+    client_id: String,
+    scopes: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let Args {
+        tenant_id,
+        client_id,
+        scopes,
+    } = Args::parse();
+
+    let creds = AzureauthCliCredential::new(tenant_id, client_id);
+    let res = creds
+        // Get an access token for Azure Devops
+        .get_token(&["499b84ac-1321-427f-aa17-267ca6975798/.default"])
+        .await?;
+
+    println!("azureauth cli response == {res:?}");
+
+    Ok(())
+}

--- a/sdk/identity/examples/azureauth_cli_credential.rs
+++ b/sdk/identity/examples/azureauth_cli_credential.rs
@@ -8,7 +8,6 @@ use url::Url;
 struct Args {
     tenant_id: String,
     client_id: String,
-    scopes: Vec<String>,
 }
 
 #[tokio::main]
@@ -16,7 +15,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let Args {
         tenant_id,
         client_id,
-        scopes,
     } = Args::parse();
 
     let creds = AzureauthCliCredential::new(tenant_id, client_id);

--- a/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
@@ -107,8 +107,13 @@ impl AzureauthCliCredential {
     async fn get_access_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
         // try using azureauth.exe first, such that azureauth through WSL is
         // used first if possible.
-        let (cmd_name, use_windows_features) = if Command::new("azureauth.exe")
-            .arg("--version")
+        #[cfg(target_os = "windows")]
+        let which = "where";
+        #[cfg(not(target_os = "windows"))]
+        let which = "which";
+
+        let (cmd_name, use_windows_features) = if Command::new(which)
+            .arg("azureauth.exe")
             .output()
             .await
             .map(|x| x.status.success())
@@ -148,8 +153,6 @@ impl AzureauthCliCredential {
                 cmd.args(["--mode", mode]);
             }
         }
-
-        println!("Running azureauth with options: {:#?}", cmd);
 
         let result = cmd.output().await;
 

--- a/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
@@ -1,7 +1,9 @@
+use crate::token_credentials::cache::TokenCache;
 use async_process::Command;
 use azure_core::{
-    auth::{AccessToken, TokenCredential, TokenResponse},
+    auth::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
+    from_json,
 };
 use oauth2::ClientId;
 use serde::Deserialize;
@@ -38,9 +40,12 @@ mod unix_date_string {
 
 #[derive(Debug, Clone, Deserialize)]
 struct CliTokenResponse {
-    pub token: AccessToken,
-    #[serde(with = "unix_date_string")]
-    pub expiration_date: OffsetDateTime,
+    pub user: String,
+    pub display_name: String,
+    #[serde(rename = "token")]
+    pub access_token: Secret,
+    #[serde(with = "unix_date_string", rename = "expiration_date")]
+    pub expires_on: OffsetDateTime,
 }
 
 /// Authentication Mode
@@ -55,10 +60,11 @@ pub enum AzureauthCliMode {
     Web,
 }
 
+#[derive(Debug)]
 /// Enables authentication to Azure Active Directory using Azure CLI to obtain an access token.
 pub struct AzureauthCliCredential {
     tenant_id: String,
-    client_id: ClientId,
+    client_id: String,
     modes: Vec<AzureauthCliMode>,
     prompt_hint: Option<String>,
     cache: TokenCache,
@@ -69,14 +75,14 @@ impl AzureauthCliCredential {
     pub fn new<T, C>(tenant_id: T, client_id: C) -> Self
     where
         T: Into<String>,
-        C: Into<ClientId>,
+        C: Into<String>,
     {
         Self {
             tenant_id: tenant_id.into(),
             client_id: client_id.into(),
             modes: Vec::new(),
             prompt_hint: None,
-            cache: TokenCache,
+            cache: TokenCache::new(),
         }
     }
 
@@ -98,12 +104,13 @@ impl AzureauthCliCredential {
         self
     }
 
-    async fn get_access_token(&self, resource: &str) -> azure_core::Result<CliTokenResponse> {
+    async fn get_access_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
         // try using azureauth.exe first, such that azureauth through WSL is
         // used first if possible.
         let (cmd_name, use_windows_features) = if Command::new("azureauth.exe")
             .arg("--version")
             .output()
+            .await
             .map(|x| x.status.success())
             .unwrap_or(false)
         {
@@ -112,21 +119,9 @@ impl AzureauthCliCredential {
             ("azureauth", false)
         };
 
-        let mut resource = resource.to_owned();
-        if !resource.ends_with("/.default") {
-            if resource.ends_with('/') {
-                resource.push_str(".default");
-            } else {
-                resource.push_str("/.default");
-            }
-        }
-
         let mut cmd = Command::new(cmd_name);
         cmd.args([
             "aad",
-            "--scope",
-            &resource,
-            resource,
             "--client",
             self.client_id.as_str(),
             "--tenant",
@@ -135,30 +130,26 @@ impl AzureauthCliCredential {
             "json",
         ]);
 
+        for scope in scopes {
+            cmd.args(["--scope", scope]);
+        }
+
         if let Some(prompt_hint) = &self.prompt_hint {
             cmd.args(["--prompt-hint", prompt_hint]);
         }
 
         for mode in &self.modes {
-            match mode {
-                AzureauthCliMode::All => {
-                    cmd.args(["--mode", "all"]);
-                }
-                AzureauthCliMode::IntegratedWindowsAuth => {
-                    if use_windows_features {
-                        cmd.args(["--mode", "iwa"]);
-                    }
-                }
-                AzureauthCliMode::Broker => {
-                    if use_windows_features {
-                        cmd.args(["--mode", "broker"]);
-                    }
-                }
-                AzureauthCliMode::Web => {
-                    cmd.args(["--mode", "web"]);
-                }
-            };
+            if let Some(mode) = match mode {
+                AzureauthCliMode::All => Some("all"),
+                AzureauthCliMode::IntegratedWindowsAuth => use_windows_features.then_some("iwa"),
+                AzureauthCliMode::Broker => use_windows_features.then_some("broker"),
+                AzureauthCliMode::Web => Some("web"),
+            } {
+                cmd.args(["--mode", mode]);
+            }
         }
+
+        println!("Running azureauth with options: {:#?}", cmd);
 
         let result = cmd.output().await;
 
@@ -179,111 +170,25 @@ impl AzureauthCliCredential {
         }
 
         let token_response: CliTokenResponse = from_json(output.stdout)?;
-
-        Ok(TokenResponse::new(
-            token_response.token,
-            token_response.expiration_date,
-        ))
-    }
-
-    /// Clear the azureauth cache as well as the internal cache
-    async fn clear_cache(&self) -> azure_core::Result<CliTokenResponse> {
-        let resources = { self.cache.read().await.keys().cloned().collect::<Vec<_>>() };
-
-        // try using azureauth.exe first, such that azureauth through WSL is
-        // used first if possible.
-        let (cmd_name) = if Command::new("azureauth.exe")
-            .arg("--version")
-            .output()
-            .map(|x| x.status.success())
-            .unwrap_or(false)
-        {
-            "azureauth.exe"
-        } else {
-            "azureauth"
-        };
-
-        for resource in resources {
-            let mut resource = resource.to_owned();
-            if !resource.ends_with("/.default") {
-                if resource.ends_with('/') {
-                    resource.push_str(".default");
-                } else {
-                    resource.push_str("/.default");
-                }
-            }
-
-            let mut cmd = Command::new(cmd_name);
-            cmd.args([
-                "aad",
-                "--scope",
-                &resource,
-                "--client",
-                self.client_id.as_str(),
-                "--tenant",
-                self.tenant_id.as_str(),
-                "--clear",
-            ]);
-
-            if let Some(prompt_hint) = &self.prompt_hint {
-                cmd.args(["--prompt-hint", prompt_hint]);
-            }
-
-            for mode in &self.modes {
-                match mode {
-                    AzureauthCliMode::All => {
-                        cmd.args(["--mode", "all"]);
-                    }
-                    AzureauthCliMode::IntegratedWindowsAuth => {
-                        if use_windows_features {
-                            cmd.args(["--mode", "iwa"]);
-                        }
-                    }
-                    AzureauthCliMode::Broker => {
-                        if use_windows_features {
-                            cmd.args(["--mode", "broker"]);
-                        }
-                    }
-                    AzureauthCliMode::Web => {
-                        cmd.args(["--mode", "web"]);
-                    }
-                };
-            }
-
-            let result = cmd.output().await;
-
-            let output = result.map_err(|e| match e.kind() {
-                std::io::ErrorKind::NotFound => {
-                    Error::message(ErrorKind::Other, "azureauth CLI not installed")
-                }
-                error_kind => Error::with_message(ErrorKind::Other, || {
-                    format!("Unknown error of kind: {error_kind:?}")
-                }),
-            })?;
-
-            if !output.status.success() {
-                let output = String::from_utf8_lossy(&output.stderr);
-                return Err(Error::with_message(ErrorKind::Credential, || {
-                    format!("'azureauth' command failed: {output}")
-                }));
-            }
-        }
-
-        self.cache.clear().await?;
-
-        Ok(())
+        Ok(AccessToken {
+            token: token_response.access_token,
+            expires_on: token_response.expires_on,
+        })
     }
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for AzureauthCliCredential {
-    async fn get_token(&self, resource: &str) -> azure_core::Result<TokenResponse> {
+    async fn get_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
         self.cache
-            .get_token(resource, self.get_access_token(resource))
+            .get_token(scopes, self.get_access_token(scopes))
             .await
     }
-    async fn clear_cache(&self) -> azure_core::Result<TokenResponse> {
+
+    async fn clear_cache(&self) -> azure_core::Result<()> {
+        // Clear internal cache only as there is no guarantee that the underlying MSAL caches will be cleared through azureauth.
+        // But clearing internally will force a new call to azureauth which handles refreshing the MSAL cache and always returns a valid token.
         self.cache.clear().await
     }
 }
@@ -302,9 +207,9 @@ mod tests {
         }"#;
 
         let response: CliTokenResponse = from_json(src)?;
-        assert_eq!(response.token.secret(), "security token here");
+        assert_eq!(response.access_token.secret(), "security token here");
         assert_eq!(
-            response.expiration_date,
+            response.expires_on,
             OffsetDateTime::from_unix_timestamp(1700166595).expect("known valid date")
         );
 

--- a/sdk/identity/src/token_credentials/mod.rs
+++ b/sdk/identity/src/token_credentials/mod.rs
@@ -7,7 +7,7 @@
 //! * Client secret
 #[cfg(not(target_arch = "wasm32"))]
 mod azure_cli_credentials;
-#[cfg(feature = "azureauth-cli")]
+#[cfg(feature = "azureauth_cli")]
 #[cfg(not(target_arch = "wasm32"))]
 mod azureauth_cli_credentials;
 mod cache;
@@ -21,7 +21,7 @@ mod workload_identity_credentials;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use azure_cli_credentials::*;
-#[cfg(feature = "azureauth-cli")]
+#[cfg(feature = "azureauth_cli")]
 #[cfg(not(target_arch = "wasm32"))]
 pub use azureauth_cli_credentials::*;
 #[cfg(feature = "client_certificate")]


### PR DESCRIPTION
This PR fixes up the `AzureauthCliCredential` with a few changes:
* The credential only builds behind feature flag `azureauth_cli`, but this was accidentally used in code with a dash (`-`) rather than a underscore (`_`). This is updated.
* The `TokenCache` was added as a more internal means of in-memory token caching, but the updates made to `AzureauthCliCredential` didn't build.
* The `TokenCredential` trait was updated, so we update the implementation for `AzureauthCliCredential`.
* Checking the version of AzureAuth before attempting to get an access token is slow, and doubles the time it takes to get your token which impacts developer command line tools quite a lot (anywhere from 600ms-2Kms). Switch from trying to use `azureauth --version` to using `which azureauth.exe` and fall back to `azureauth`.
* To ensure this all works I've added a corresponding example similar to the azure cli example. This example doesn't hardcode a client or tenant, only the AzureDevops Application ID (the default scope).

I've built and ran the example CLI confirming the azureauth usage works on the following platforms:
* Windows (x64)
* WSL (x64)
* Mac (arm64)
