### PR TITLE
move to using `tracing` instead of `log`

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -20,7 +20,7 @@ bytes = "1.0"
 dyn-clone = "1.0"
 futures = "0.3"
 http-types = { version = "2.12", default-features = false }
-log = "0.4"
+tracing = "0.1.40"
 rand = "0.8"
 reqwest = { version = "0.11.14", features = [
   "stream",
@@ -48,7 +48,7 @@ getrandom = { version = "0.2", features = ["js"] }
 rustc_version = "0.4"
 
 [dev-dependencies]
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 tokio = { version = "1.0", features = ["default", "macros", "rt", "time"] }
 thiserror = "1.0"
 

--- a/sdk/core/src/headers/utilities.rs
+++ b/sdk/core/src/headers/utilities.rs
@@ -80,7 +80,7 @@ pub fn delete_type_permanent_from_headers(headers: &Headers) -> crate::Result<bo
     if result.is_ok() {
         result
     } else {
-        log::warn!("Error receiving delete type permanent.  returning false");
+        tracing::warn!("Error receiving delete type permanent.  returning false");
         Ok(false)
     }
 }

--- a/sdk/core/src/http_client/reqwest.rs
+++ b/sdk/core/src/http_client/reqwest.rs
@@ -5,10 +5,11 @@ use crate::{
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
+use tracing::{debug, warn};
 
 /// Construct a new `HttpClient` with the `reqwest` backend.
 pub fn new_reqwest_client() -> Arc<dyn HttpClient> {
-    log::debug!("instantiating an http client using the reqwest backend");
+    debug!("instantiating an http client using the reqwest backend");
 
     // set `pool_max_idle_per_host` to `0` to avoid an issue in the underlying
     // `hyper` library that causes the `reqwest` client to hang in some cases.
@@ -53,7 +54,7 @@ impl HttpClient for ::reqwest::Client {
         }
         .context(ErrorKind::Other, "failed to build `reqwest` request")?;
 
-        log::debug!("performing request {method} '{url}' with `reqwest`");
+        debug!("performing request {method} '{url}' with `reqwest`");
         let rsp = self
             .execute(reqwest_request)
             .await
@@ -89,7 +90,7 @@ fn to_headers(map: &::reqwest::header::HeaderMap) -> crate::headers::Headers {
                     crate::headers::HeaderValue::from(value.to_owned()),
                 ))
             } else {
-                log::warn!("header value for `{key}` is not utf8");
+                warn!("header value for `{key}` is not utf8");
                 None
             }
         })

--- a/sdk/core/src/parsing.rs
+++ b/sdk/core/src/parsing.rs
@@ -49,7 +49,7 @@ pub fn from_azure_time(s: &str) -> crate::Result<time::OffsetDateTime> {
     if let Ok(dt) = date::parse_rfc1123(s) {
         Ok(dt)
     } else {
-        log::warn!("Received an invalid date: {}, returning now()", s);
+        tracing::warn!("Received an invalid date: {}, returning now()", s);
         Ok(time::OffsetDateTime::now_utc())
     }
 }

--- a/sdk/core/src/policies/custom_headers_policy.rs
+++ b/sdk/core/src/policies/custom_headers_policy.rs
@@ -1,7 +1,10 @@
-use crate::headers::Headers;
-use crate::policies::{Policy, PolicyResult};
-use crate::{Context, Request};
+use crate::{
+    headers::Headers,
+    policies::{Policy, PolicyResult},
+    Context, Request,
+};
 use std::sync::Arc;
+use tracing::trace;
 
 #[derive(Debug, Clone)]
 pub struct CustomHeaders(Headers);
@@ -28,7 +31,7 @@ impl Policy for CustomHeadersPolicy {
             custom_headers
                 .iter()
                 .for_each(|(header_name, header_value)| {
-                    log::trace!(
+                    trace!(
                         "injecting custom context header {:?} with value {:?}",
                         header_name,
                         header_value

--- a/sdk/core/src/policies/transport.rs
+++ b/sdk/core/src/policies/transport.rs
@@ -1,8 +1,10 @@
-use crate::policies::{Policy, PolicyResult};
-use crate::TransportOptions;
-use crate::{Context, Request};
+use crate::{
+    policies::{Policy, PolicyResult},
+    Context, Request, TransportOptions,
+};
 use async_trait::async_trait;
 use std::sync::Arc;
+use tracing::debug;
 
 #[derive(Debug, Clone)]
 pub struct TransportPolicy {
@@ -27,7 +29,7 @@ impl Policy for TransportPolicy {
         // there must be no more policies
         assert_eq!(0, next.len());
 
-        log::debug!("the following request will be passed to the transport policy: {request:#?}");
+        debug!("the following request will be passed to the transport policy: {request:#?}");
         let response = { self.transport_options.send(ctx, request) };
 
         response.await

--- a/sdk/core/src/tokio/fs.rs
+++ b/sdk/core/src/tokio/fs.rs
@@ -4,13 +4,13 @@ use crate::{
     setters,
 };
 use futures::{task::Poll, Future};
-use log::debug;
 use std::{cmp::min, io::SeekFrom, pin::Pin, sync::Arc, task::Context};
 use tokio::{
     fs::File,
     io::{AsyncReadExt, AsyncSeekExt, Take},
     sync::Mutex,
 };
+use tracing::debug;
 
 #[derive(Debug)]
 pub struct FileStreamBuilder {

--- a/sdk/data_cosmos/Cargo.toml
+++ b/sdk/data_cosmos/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = "0.1"
 azure_core = { path = "../core", version = "0.19" }
 time = "0.3.10"
 futures = "0.3"
-log = "0.4"
+tracing = "0.1.40"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 url = "2.2"
@@ -26,7 +26,7 @@ thiserror = "1.0"
 bytes = "1.0"
 
 [dev-dependencies]
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 clap = { version = "4.0.2", features = ["derive", "env"] }
 reqwest = "0.11.0"

--- a/sdk/data_cosmos/examples/cancellation.rs
+++ b/sdk/data_cosmos/examples/cancellation.rs
@@ -16,7 +16,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     // First we retrieve the account name and access key from environment variables, and
     // create an authorization token.
     let args = Args::parse();

--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -1,11 +1,13 @@
-use crate::resources::permission::AuthorizationToken;
-use crate::resources::ResourceType;
-use azure_core::headers::{HeaderValue, AUTHORIZATION, MS_DATE, VERSION};
-use azure_core::hmac::hmac_sha256;
-use azure_core::{date, Context, Policy, PolicyResult, Request, Url};
-use std::borrow::Cow;
-use std::sync::Arc;
+use crate::{resources::permission::AuthorizationToken, resources::ResourceType};
+use azure_core::{
+    date,
+    headers::{HeaderValue, AUTHORIZATION, MS_DATE, VERSION},
+    hmac::hmac_sha256,
+    Context, Policy, PolicyResult, Request, Url,
+};
+use std::{borrow::Cow, sync::Arc};
 use time::OffsetDateTime;
+use tracing::trace;
 use url::form_urlencoded;
 
 const AZURE_VERSION: &str = "2018-12-31";

--- a/sdk/data_cosmos/src/lib.rs
+++ b/sdk/data_cosmos/src/lib.rs
@@ -87,8 +87,6 @@ async fn main() -> azure_core::Result<()> {
 #![deny(missing_docs)]
 #![recursion_limit = "256"]
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde;
 #[macro_use]
 extern crate azure_core;

--- a/sdk/data_cosmos/src/operations/query_documents.rs
+++ b/sdk/data_cosmos/src/operations/query_documents.rs
@@ -16,6 +16,7 @@ use azure_core::{
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 use time::OffsetDateTime;
+use tracing::warn;
 
 operation! {
     #[stream]

--- a/sdk/data_cosmos/src/resource_quota.rs
+++ b/sdk/data_cosmos/src/resource_quota.rs
@@ -1,4 +1,5 @@
 use azure_core::error::{Error, ErrorKind};
+use tracing::{debug, trace};
 
 /// A resource quota for the given resource kind
 ///

--- a/sdk/data_cosmos/src/resources/permission/authorization_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/authorization_token.rs
@@ -1,7 +1,7 @@
 use super::PermissionToken;
 use azure_core::auth::{Secret, TokenCredential};
-use std::fmt;
-use std::sync::Arc;
+use std::{fmt, sync::Arc};
+use tracing::trace;
 
 /// Authorization tokens for accessing Cosmos.
 ///

--- a/sdk/data_cosmos/src/resources/permission/permission_token.rs
+++ b/sdk/data_cosmos/src/resources/permission/permission_token.rs
@@ -1,5 +1,6 @@
 use super::AuthorizationToken;
 use azure_core::{auth::Secret, base64};
+use tracing::trace;
 
 const PERMISSION_TYPE_PREFIX: &str = "type=";
 const VERSION_PREFIX: &str = "ver=";

--- a/sdk/data_cosmos/tests/collection_operations.rs
+++ b/sdk/data_cosmos/tests/collection_operations.rs
@@ -1,31 +1,32 @@
 use azure_data_cosmos::resources::collection::*;
 use futures::StreamExt;
+use tracing::{debug, info};
 
 mod setup_mock;
 
 #[tokio::test]
 async fn collection_operations() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     let client = setup_mock::initialize("collection_operations")?;
     let database_name = "test-collection-operations";
 
-    log::info!("Creating a database with name '{}'...", database_name);
+    info!("Creating a database with name '{}'...", database_name);
     client.create_database(database_name).await?;
-    log::info!("Successfully created a database");
+    info!("Successfully created a database");
 
     // create collection!
     let database = client.database_client(database_name);
 
     let collection_name = "sample_collection";
-    log::info!("Creating a collection with name '{}'...", collection_name);
+    info!("Creating a collection with name '{}'...", collection_name);
 
     let create_collection_response = database.create_collection(collection_name, "/id").await?;
 
     assert_eq!(create_collection_response.collection.id, collection_name);
 
-    log::info!("Successfully created a collection");
-    log::debug!(
+    info!("Successfully created a collection");
+    debug!(
         "The create_collection response: {:#?}",
         create_collection_response
     );
@@ -37,8 +38,8 @@ async fn collection_operations() -> azure_core::Result<()> {
 
     assert_eq!(get_collection.collection.id, collection_name);
 
-    log::info!("Successfully got a collection");
-    log::debug!("The get_collection response: {:#?}", get_collection);
+    info!("Successfully got a collection");
+    debug!("The get_collection response: {:#?}", get_collection);
 
     let collections = database
         .list_collections()
@@ -99,8 +100,8 @@ async fn collection_operations() -> azure_core::Result<()> {
         "/\"excludeme\"/?"
     );
 
-    log::info!("Successfully replaced collection");
-    log::debug!(
+    info!("Successfully replaced collection");
+    debug!(
         "The replace_collection response: {:#?}",
         replace_collection_response
     );
@@ -108,15 +109,15 @@ async fn collection_operations() -> azure_core::Result<()> {
     // delete collection!
     let delete_collection_response = collection.delete_collection().await?;
 
-    log::info!("Successfully deleted collection");
-    log::debug!(
+    info!("Successfully deleted collection");
+    debug!(
         "The delete_collection response: {:#?}",
         delete_collection_response
     );
 
     // delete database
     database.delete_database().await?;
-    log::info!("Successfully deleted database");
+    info!("Successfully deleted database");
 
     Ok(())
 }

--- a/sdk/data_cosmos/tests/user_defined_function_operations.rs
+++ b/sdk/data_cosmos/tests/user_defined_function_operations.rs
@@ -1,5 +1,6 @@
 use azure_data_cosmos::prelude::*;
 use futures::stream::StreamExt;
+use tracing::info;
 
 mod setup_mock;
 
@@ -17,35 +18,35 @@ function tax(income) {
 
 #[tokio::test]
 async fn user_defined_function_operations() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     const DATABASE_NAME: &str = "test-cosmos-db-udf";
     const COLLECTION_NAME: &str = "test-udf";
     const USER_DEFINED_FUNCTION_NAME: &str = "test";
 
     let client = setup_mock::initialize("user_defined_function_operations")?;
 
-    log::info!("creating database");
+    info!("creating database");
     // create a temp database
     let _ = client.create_database(DATABASE_NAME).await?;
-    log::info!("created database");
+    info!("created database");
 
     let database = client.database_client(DATABASE_NAME);
 
     // create a temp collection
-    log::info!("creating collection");
+    info!("creating collection");
     let _ = database.create_collection(COLLECTION_NAME, "/id").await?;
-    log::info!("created collection");
+    info!("created collection");
 
     let collection = database.collection_client(COLLECTION_NAME);
     let user_defined_function = collection.user_defined_function_client(USER_DEFINED_FUNCTION_NAME);
 
-    log::info!("creating user defined function");
+    info!("creating user defined function");
     let ret = user_defined_function
         .create_user_defined_function("body")
         .await?;
-    log::info!("created user defined function");
+    info!("created user defined function");
 
-    log::info!("listing user defined functions");
+    info!("listing user defined functions");
     let stream = collection
         .list_user_defined_functions()
         .max_item_count(3)
@@ -54,16 +55,16 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
     while let Some(ret) = stream.next().await {
         assert_eq!(ret?.item_count, 1);
     }
-    log::info!("listed user defined functions");
+    info!("listed user defined functions");
 
-    log::info!("replacing user defined functions");
+    info!("replacing user defined functions");
     let ret = user_defined_function
         .replace_user_defined_function(FN_BODY)
         .consistency_level(&ret)
         .await?;
-    log::info!("replaced user defined functions");
+    info!("replaced user defined functions");
 
-    log::info!("querying documents");
+    info!("querying documents");
     let query_stmt = format!("SELECT udf.{USER_DEFINED_FUNCTION_NAME}(100)");
     let ret = collection
         .query_documents(Query::new(query_stmt))
@@ -79,9 +80,9 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
     let fn_return = ret.documents().next().unwrap().as_object().unwrap();
     let value = fn_return.iter().take(1).next().unwrap().1.as_f64().unwrap();
     assert_eq!(value, 10.0);
-    log::info!("queried documents");
+    info!("queried documents");
 
-    log::info!("querying documents again");
+    info!("querying documents again");
     let query_stmt = format!("SELECT udf.{USER_DEFINED_FUNCTION_NAME}(10000)");
     let ret = collection
         .query_documents(Query::new(query_stmt))
@@ -104,9 +105,9 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
         .as_f64()
         .unwrap();
     assert_eq!(value, 4000.0);
-    log::info!("queried documents again");
+    info!("queried documents again");
 
-    log::info!("deleting test resources");
+    info!("deleting test resources");
     let _ret = user_defined_function
         .delete_user_defined_function()
         .consistency_level(&ret)
@@ -114,7 +115,7 @@ async fn user_defined_function_operations() -> azure_core::Result<()> {
 
     // delete the database
     database.delete_database().await?;
-    log::info!("deleted test resources");
+    info!("deleted test resources");
 
     Ok(())
 }

--- a/sdk/data_tables/Cargo.toml
+++ b/sdk/data_tables/Cargo.toml
@@ -18,13 +18,13 @@ azure_storage = { path = "../storage", version = "0.19", default-features = fals
 bytes = "1.0"
 time = "0.3.10"
 futures = "0.3"
-log = "0.4"
+tracing = "0.1.40"
 serde = { version = "1.0", features=["derive"] }
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 
 [features]
 default = ["enable_reqwest", "hmac_rust"]

--- a/sdk/data_tables/README.md
+++ b/sdk/data_tables/README.md
@@ -20,7 +20,7 @@ struct MyEntity {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/data_tables/examples/table.rs
+++ b/sdk/data_tables/examples/table.rs
@@ -15,7 +15,7 @@ struct MyEntity {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/data_tables/src/lib.rs
+++ b/sdk/data_tables/src/lib.rs
@@ -19,7 +19,7 @@ struct MyEntity {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =
@@ -63,8 +63,6 @@ async fn main() -> azure_core::Result<()> {
 
 */
 
-#[macro_use]
-extern crate log;
 #[macro_use]
 extern crate azure_core;
 

--- a/sdk/data_tables/src/operations/transaction.rs
+++ b/sdk/data_tables/src/operations/transaction.rs
@@ -11,6 +11,7 @@ use azure_core::{
 use azure_storage::headers::CommonStorageResponseHeaders;
 use serde::Serialize;
 use std::convert::{TryFrom, TryInto};
+use tracing::trace;
 
 operation! {
     Transaction,

--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -20,7 +20,7 @@ url = "2.2"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 time = { version = "0.3.10" }
-log = "0.4"
+tracing = "0.1.40"
 async-trait = "0.1"
 openssl = { version = "0.10.46",  optional=true }
 uuid = { version = "1.0",  features = ["v4"] }
@@ -35,7 +35,7 @@ tz-rs = { version = "0.6", optional = true }
 [dev-dependencies]
 reqwest = { version = "0.11", features = ["json"], default-features = false }
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 serde_test = "1"
 azure_security_keyvault = { path = "../security_keyvault", default-features = false }
 serial_test = "3.0"

--- a/sdk/identity/examples/client_certificate_credentials.rs
+++ b/sdk/identity/examples/client_certificate_credentials.rs
@@ -28,7 +28,7 @@ async fn get_certficate(vault_name: &str, certificate_name: &str) -> azure_core:
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     let client_id = var("CLIENT_ID").expect("Missing CLIENT_ID environment variable.");
     let tenant_id = var("TENANT_ID").expect("Missing TENANT_ID environment variable.");

--- a/sdk/identity/examples/default_credentials.rs
+++ b/sdk/identity/examples/default_credentials.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     let sub_id = var("AZURE_SUBSCRIPTION_ID")?;
     let creds = DefaultAzureCredentialBuilder::new()

--- a/sdk/identity/src/development.rs
+++ b/sdk/identity/src/development.rs
@@ -6,12 +6,12 @@ use azure_core::{
     error::{Error, ErrorKind},
     Url,
 };
-use log::debug;
 use oauth2::{AuthorizationCode, CsrfToken};
 use std::{
     io::{BufRead, BufReader, Write},
     net::TcpListener,
 };
+use tracing::debug;
 
 /// A very naive implementation of a redirect server.
 ///

--- a/sdk/identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/src/federated_credentials_flow/mod.rs
@@ -40,9 +40,9 @@ use azure_core::{
     error::{ErrorKind, ResultExt},
     headers, HttpClient, Method, Request, Url,
 };
-use log::{debug, error};
 use login_response::LoginResponse;
 use std::sync::Arc;
+use tracing::{debug, error};
 use url::form_urlencoded;
 
 /// Perform the client credentials flow

--- a/sdk/identity/src/oauth2_http_client.rs
+++ b/sdk/identity/src/oauth2_http_client.rs
@@ -6,6 +6,7 @@ use azure_core::{
     HttpClient, Request,
 };
 use std::{collections::HashMap, str::FromStr, sync::Arc};
+use tracing::warn;
 
 pub(crate) struct Oauth2HttpClient {
     http_client: Arc<dyn HttpClient>,
@@ -93,7 +94,7 @@ fn to_headers(map: &oauth2::http::header::HeaderMap) -> azure_core::headers::Hea
                     azure_core::headers::HeaderValue::from(value.to_owned()),
                 ))
             } else {
-                log::warn!("header value for `{key}` is not utf8");
+                warn!("header value for `{key}` is not utf8");
                 None
             }
         })

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -8,6 +8,7 @@ use azure_core::{
 use serde::Deserialize;
 use std::str;
 use time::OffsetDateTime;
+use tracing::trace;
 
 #[cfg(feature = "old_azure_cli")]
 mod az_cli_date_format {
@@ -188,7 +189,7 @@ impl AzureCliCredential {
             args.push(scopes);
         }
 
-        log::trace!(
+        trace!(
             "fetching credential via Azure CLI: {program} {}",
             args.join(" "),
         );

--- a/sdk/iot_deviceupdate/Cargo.toml
+++ b/sdk/iot_deviceupdate/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 getset = "0.1"
 azure_core = { path = "../core", version = "0.19", default-features = false }
-log = "0.4"
+tracing = "0.1.40"
 azure_identity = { path = "../identity", version = "0.19", default-features = false }
 
 [dev-dependencies]

--- a/sdk/iot_deviceupdate/src/device_update.rs
+++ b/sdk/iot_deviceupdate/src/device_update.rs
@@ -4,12 +4,11 @@ use azure_core::{
     sleep,
 };
 use getset::Getters;
-use log::debug;
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use std::fmt::Debug;
-use std::time::Duration;
+use std::{fmt::Debug, time::Duration};
 use time::OffsetDateTime;
+use tracing::debug;
 
 #[derive(Debug, Deserialize, Getters)]
 #[getset(get = "pub")]

--- a/sdk/iot_hub/Cargo.toml
+++ b/sdk/iot_hub/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = "1.0"
 futures = "0.3"
 
 [dev-dependencies]
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 hyper = "1.0"
 hyper-rustls = "0.26"
 reqwest = "0.11.0"

--- a/sdk/iot_hub/examples/query_iothub.rs
+++ b/sdk/iot_hub/examples/query_iothub.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     let iot_hub_connection_string = std::env::var("IOTHUB_CONNECTION_STRING")
         .expect("Set env variable IOTHUB_CONNECTION_STRING first!");

--- a/sdk/messaging_servicebus/Cargo.toml
+++ b/sdk/messaging_servicebus/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 [dependencies]
 azure_core = { path = "../core", version = "0.19" }
 time = { version = "0.3.10", features = ["serde-well-known"] }
-log = "0.4"
+tracing = "0.1.40"
 url = "2.2"
 bytes = "1.0"
 serde = "1.0"
@@ -25,7 +25,7 @@ serde = "1.0"
 [dev-dependencies]
 futures = "0.3"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 
 
 [features]

--- a/sdk/messaging_servicebus/tests/service_bus.rs
+++ b/sdk/messaging_servicebus/tests/service_bus.rs
@@ -1,5 +1,4 @@
 #![cfg(all(test, feature = "test_e2e"))] // to run this, do: `cargo test --features test_e2e`
-extern crate log;
 
 use azure_messaging_servicebus::service_bus::QueueClient;
 use std::time::Duration;

--- a/sdk/security_keyvault/Cargo.toml
+++ b/sdk/security_keyvault/Cargo.toml
@@ -24,7 +24,7 @@ azure_core = { path = "../core", version = "0.19", default-features = false }
 azure_identity = { path = "../identity", default-features = false }
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 
 [features]
 default = ["enable_reqwest"]

--- a/sdk/security_keyvault/examples/list_secrets.rs
+++ b/sdk/security_keyvault/examples/list_secrets.rs
@@ -5,7 +5,7 @@ use std::{env, sync::Arc};
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     let keyvault_url =
         env::var("KEYVAULT_URL").expect("Missing KEYVAULT_URL environment variable.");

--- a/sdk/storage/Cargo.toml
+++ b/sdk/storage/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2021"
 async-trait = "0.1"
 azure_core = { path = "../core", version = "0.19", features = ["xml"] }
 time = "0.3.10"
-log = "0.4"
+tracing = "0.1.40"
 serde = "1.0"
 serde_derive = "1.0"
 url = "2.2"
@@ -27,7 +27,7 @@ async-lock = "3.1"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 reqwest = "0.11"
 mock_transport = { path = "../../eng/test/mock_transport" }
 azure_identity = { path = "../identity", default-features = false }

--- a/sdk/storage/src/authorization/authorization_policy.rs
+++ b/sdk/storage/src/authorization/authorization_policy.rs
@@ -7,6 +7,7 @@ use azure_core::{
     Context, Method, Policy, PolicyResult, Request, Url,
 };
 use std::{borrow::Cow, ops::Deref, sync::Arc};
+use tracing::trace;
 
 const STORAGE_TOKEN_SCOPE: &str = "https://storage.azure.com/.default";
 

--- a/sdk/storage/src/connection_string.rs
+++ b/sdk/storage/src/connection_string.rs
@@ -3,6 +3,7 @@ use azure_core::{
     auth::Secret,
     error::{Error, ErrorKind},
 };
+use tracing::warn;
 
 // Key names.
 pub const ACCOUNT_KEY_KEY_NAME: &str = "AccountKey";
@@ -188,7 +189,7 @@ impl<'a> ConnectionString<'a> {
                 ..
             } => {
                 if self.account_key.is_some() {
-                    log::warn!("Both account key and SAS defined in connection string. Using only the provided SAS.");
+                    warn!("Both account key and SAS defined in connection string. Using only the provided SAS.");
                 }
                 StorageCredentials::sas_token(*sas_token)
             }

--- a/sdk/storage/src/lib.rs
+++ b/sdk/storage/src/lib.rs
@@ -19,8 +19,6 @@ Please use these crates for additional functionality:
 #![allow(clippy::new_without_default)]
 
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate azure_core;

--- a/sdk/storage/src/parsing_xml.rs
+++ b/sdk/storage/src/parsing_xml.rs
@@ -1,5 +1,8 @@
-use azure_core::error::{Error, ErrorKind};
-use azure_core::parsing::FromStringOptional;
+use azure_core::{
+    error::{Error, ErrorKind},
+    parsing::FromStringOptional,
+};
+use tracing::trace;
 use xml::Element;
 use xml::Xml::{CharacterNode, ElementNode};
 

--- a/sdk/storage_blobs/Cargo.toml
+++ b/sdk/storage_blobs/Cargo.toml
@@ -19,7 +19,7 @@ azure_svc_blobstorage = {path="../../services/svc/blobstorage", version = "0.19"
 bytes = "1.0"
 time = "0.3.10"
 futures = "0.3"
-log = "0.4"
+tracing = "0.1.40"
 md5 = {version="0.7", optional=true}
 RustyXML = "0.3"
 serde = { version = "1.0" }
@@ -30,7 +30,7 @@ url = "2.2"
 
 [dev-dependencies]
 tokio = {version = "1.0", features = ["macros", "rt-multi-thread", "io-util"]}
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 azure_identity = { path = "../identity", default-features = false }
 mock_transport = { path = "../../eng/test/mock_transport" }
 md5 = "0.7"

--- a/sdk/storage_blobs/examples/account.rs
+++ b/sdk/storage_blobs/examples/account.rs
@@ -3,7 +3,7 @@ use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     // First we retrieve the account name and access key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/blob_00.rs
+++ b/sdk/storage_blobs/examples/blob_00.rs
@@ -1,9 +1,8 @@
-#[macro_use]
-extern crate log;
 use azure_core::error::{ErrorKind, ResultExt};
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::StreamExt;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_blobs/examples/blob_01.rs
+++ b/sdk/storage_blobs/examples/blob_01.rs
@@ -4,7 +4,7 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/blob_02_bearer_token.rs
+++ b/sdk/storage_blobs/examples/blob_02_bearer_token.rs
@@ -1,8 +1,6 @@
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_blobs/examples/blob_04.rs
+++ b/sdk/storage_blobs/examples/blob_04.rs
@@ -5,7 +5,7 @@ use bytes::{BufMut, Bytes};
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/blob_05_default_credential.rs
+++ b/sdk/storage_blobs/examples/blob_05_default_credential.rs
@@ -5,12 +5,12 @@ use azure_core::{
 use azure_identity::DefaultAzureCredential;
 use azure_storage::StorageCredentials;
 use azure_storage_blobs::prelude::BlobServiceClient;
-use log::trace;
 use std::sync::Arc;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     // First we retrieve the account name, container and blob name from command line args
 
     let account = std::env::args()

--- a/sdk/storage_blobs/examples/blob_service_properties.rs
+++ b/sdk/storage_blobs/examples/blob_service_properties.rs
@@ -3,7 +3,7 @@ use azure_storage_blobs::prelude::*;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     // First we retrieve the account name and access key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/container_and_blob.rs
+++ b/sdk/storage_blobs/examples/container_and_blob.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     // First we retrieve the account name and access key from environment variables.
     let account =
         std::env::var("STORAGE_ACCOUNT").expect("Set env variable STORAGE_ACCOUNT first!");

--- a/sdk/storage_blobs/examples/emulator_00.rs
+++ b/sdk/storage_blobs/examples/emulator_00.rs
@@ -3,7 +3,7 @@ use futures::StreamExt;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     // this is how you use the emulator.
     let container_client = ClientBuilder::emulator().container_client("emulcont");

--- a/sdk/storage_blobs/examples/partial_range.rs
+++ b/sdk/storage_blobs/examples/partial_range.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/put_append_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_append_blob_00.rs
@@ -1,13 +1,11 @@
-#[macro_use]
-extern crate log;
-
 use azure_core::prelude::*;
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/put_block_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_block_blob_00.rs
@@ -1,14 +1,12 @@
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use bytes::Bytes;
 use std::time::Duration;
+use tracing::debug;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     debug!("log initialized");
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/put_multi_block_blob.rs
+++ b/sdk/storage_blobs/examples/put_multi_block_blob.rs
@@ -1,15 +1,12 @@
 /// This example shows how to upload a multi-block blob.
-
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::future::try_join_all;
+use tracing::debug;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     debug!("log initialized");
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/put_page_blob_00.rs
+++ b/sdk/storage_blobs/examples/put_page_blob_00.rs
@@ -1,13 +1,12 @@
-#[macro_use]
-extern crate log;
 use azure_core::prelude::*;
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use bytes::Bytes;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     trace!("example started");
 
     // First we retrieve the account name and access key from environment variables.

--- a/sdk/storage_blobs/examples/request_hdr_override.rs
+++ b/sdk/storage_blobs/examples/request_hdr_override.rs
@@ -4,16 +4,17 @@
 /// For more information see:
 /// - `Pipeline`: <https://docs.rs/azure_core/latest/azure_core/struct.Pipeline.html>
 /// - `Policy`: <https://docs.rs/azure_core/latest/azure_core/trait.Policy.html>
-
-#[macro_use]
-extern crate log;
 use async_trait::async_trait;
-use azure_core::error::{ErrorKind, ResultExt};
-use azure_core::{headers::HeaderValue, ClientOptions, Context, Policy, PolicyResult, Request};
+use azure_core::{
+    error::{ErrorKind, ResultExt},
+    headers::HeaderValue,
+    ClientOptions, Context, Policy, PolicyResult, Request,
+};
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::StreamExt;
 use std::sync::Arc;
+use tracing::trace;
 
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct VersionHeaderOverridePolicy {}

--- a/sdk/storage_blobs/examples/set_blob_properties_00.rs
+++ b/sdk/storage_blobs/examples/set_blob_properties_00.rs
@@ -1,7 +1,6 @@
-#[macro_use]
-extern crate log;
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_blobs/examples/shared_access_signature.rs
+++ b/sdk/storage_blobs/examples/shared_access_signature.rs
@@ -5,7 +5,7 @@ use time::OffsetDateTime;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/snapshot_blob.rs
+++ b/sdk/storage_blobs/examples/snapshot_blob.rs
@@ -1,13 +1,11 @@
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use bytes::Bytes;
+use tracing::debug;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     debug!("log initialized");
     // First we retrieve the account name and access key from environment variables.
     let account =

--- a/sdk/storage_blobs/examples/stream_blob_02.rs
+++ b/sdk/storage_blobs/examples/stream_blob_02.rs
@@ -7,6 +7,7 @@ use azure_storage_blobs::prelude::*;
 use clap::Parser;
 use std::path::PathBuf;
 use tokio::fs::File;
+use tracing::info;
 
 #[derive(Debug, Parser)]
 struct Args {
@@ -39,7 +40,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     let args = Args::parse();
 
     let storage_credentials =
@@ -69,10 +70,10 @@ async fn main() -> azure_core::Result<()> {
     if let Some(block_size) = args.block_size {
         let mut block_list = BlockList::default();
         for offset in (handle.offset..handle.stream_size).step_by(block_size as usize) {
-            log::info!("trying to upload at offset {offset} - {block_size}");
+            info!("trying to upload at offset {offset} - {block_size}");
             let block_id = format!("{:08X}", offset);
             blob_client.put_block(block_id.clone(), &handle).await?;
-            log::info!("uploaded block {block_id}");
+            info!("uploaded block {block_id}");
             block_list
                 .blocks
                 .push(BlobBlockType::new_uncommitted(block_id));

--- a/sdk/storage_blobs/examples/user_delegation_key.rs
+++ b/sdk/storage_blobs/examples/user_delegation_key.rs
@@ -22,7 +22,7 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
     let args = Args::parse();
 
     let default_creds: Arc<dyn TokenCredential> = Arc::new(DefaultAzureCredential::default());

--- a/sdk/storage_blobs/tests/append_blob.rs
+++ b/sdk/storage_blobs/tests/append_blob.rs
@@ -1,12 +1,11 @@
 #![cfg(all(test, feature = "test_e2e"))]
-#[macro_use]
-extern crate log;
 
 use azure_core::prelude::*;
 use azure_storage::prelude::*;
 use azure_storage_blobs::{container::PublicAccess, prelude::*};
 use bytes::Bytes;
 use futures::StreamExt;
+use tracing::trace;
 
 #[tokio::test]
 async fn put_append_blob() {

--- a/sdk/storage_blobs/tests/blob_operations.rs
+++ b/sdk/storage_blobs/tests/blob_operations.rs
@@ -1,7 +1,7 @@
 use azure_storage_blobs::container::PublicAccess;
 use bytes::Bytes;
 use futures::StreamExt;
-use log::trace;
+use tracing::trace;
 
 mod setup;
 

--- a/sdk/storage_blobs/tests/page_blob.rs
+++ b/sdk/storage_blobs/tests/page_blob.rs
@@ -1,10 +1,9 @@
 #![cfg(all(test, feature = "test_e2e"))]
-#[macro_use]
-extern crate log;
 use azure_core::prelude::*;
 use azure_storage::prelude::*;
 use azure_storage_blobs::prelude::*;
 use futures::StreamExt;
+use tracing::trace;
 
 #[tokio::test]
 async fn put_page_blob() {

--- a/sdk/storage_datalake/Cargo.toml
+++ b/sdk/storage_datalake/Cargo.toml
@@ -19,7 +19,7 @@ azure_storage = { path = "../storage", version = "0.19", default-features = fals
 bytes = "1.0"
 time = "0.3.10"
 futures = "0.3"
-log = "0.4"
+tracing = "0.1.40"
 serde = { version = "1.0" }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/sdk/storage_queues/Cargo.toml
+++ b/sdk/storage_queues/Cargo.toml
@@ -17,14 +17,14 @@ azure_core = { path = "../core", version = "0.19", default-features=false, featu
 azure_storage = { path = "../storage", version = "0.19", default-features=false }
 time = "0.3.10"
 futures = "0.3"
-log = "0.4"
+tracing = "0.1.40"
 serde = { version = "1.0", features=["derive"] }
 uuid = { version = "1.0", features = ["v4"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 uuid = { version = "1.0", features = ["v4"] }
-env_logger = "0.10"
+tracing-subscriber = "0.3"
 
 [features]
 default = ["enable_reqwest", "hmac_rust"]

--- a/sdk/storage_queues/examples/delete_message.rs
+++ b/sdk/storage_queues/examples/delete_message.rs
@@ -1,9 +1,7 @@
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_queues::prelude::*;
 use std::time::Duration;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_queues/examples/get_messages.rs
+++ b/sdk/storage_queues/examples/get_messages.rs
@@ -1,10 +1,8 @@
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_queues::prelude::*;
 use std::time::Duration;
 use time::OffsetDateTime;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_queues/examples/peek_messages.rs
+++ b/sdk/storage_queues/examples/peek_messages.rs
@@ -1,8 +1,6 @@
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_queues::prelude::*;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_queues/examples/put_message.rs
+++ b/sdk/storage_queues/examples/put_message.rs
@@ -1,9 +1,7 @@
-#[macro_use]
-extern crate log;
-
 use azure_storage::prelude::*;
 use azure_storage_queues::prelude::*;
 use time::OffsetDateTime;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_queues/examples/queue_create.rs
+++ b/sdk/storage_queues/examples/queue_create.rs
@@ -1,10 +1,8 @@
-#[macro_use]
-extern crate log;
 use azure_core::{date, prelude::*};
-
 use azure_storage::prelude::*;
 use azure_storage_queues::prelude::*;
 use time::OffsetDateTime;
+use tracing::trace;
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {

--- a/sdk/storage_queues/examples/queue_service_properties.rs
+++ b/sdk/storage_queues/examples/queue_service_properties.rs
@@ -3,7 +3,7 @@ use azure_storage_queues::{prelude::*, CorsRule};
 
 #[tokio::main]
 async fn main() -> azure_core::Result<()> {
-    env_logger::init();
+    tracing_subscriber::fmt().init();
 
     // First we retrieve the account name and access key from environment variables.
     let account =


### PR DESCRIPTION
In order to move towards supporting OpenTelemetry for distributed tracing, we need to move the underlying logging implementation to use `tracing`.

This does _not_ start exposing spans or tracing state yet.

ref: https://azure.github.io/azure-sdk/general_implementation.html