### PR TITLE
Add missing serde attribute for deserialization.

### DIFF
--- a/sdk/iot_hub/src/service/resources/identity.rs
+++ b/sdk/iot_hub/src/service/resources/identity.rs
@@ -35,6 +35,7 @@ pub struct DeviceCapabilities {
 
 /// Representation of a symmetric key for authentication.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct SymmetricKey {
     /// The primary key.
     pub primary_key: Option<String>,


### PR DESCRIPTION
Add missing `serde` attribute to deserialize correctly the IoTHub Device Identity struct.