### PR TITLE
fix: naive_redirect_server TCP Port should be a u16

### DIFF
--- a/sdk/identity/src/development.rs
+++ b/sdk/identity/src/development.rs
@@ -21,7 +21,7 @@ use tracing::debug;
 /// This implementation should only be used for testing.
 pub fn naive_redirect_server(
     auth_obj: &AuthorizationCodeFlow,
-    port: u32,
+    port: u16,
 ) -> azure_core::Result<AuthorizationCode> {
     let listener = TcpListener::bind(format!("127.0.0.1:{port}")).unwrap();
 


### PR DESCRIPTION
The Naive Redirect Server function accepts a u32 for what should be a 16-bit unsigned integer.

This change changes the function to accept a u16 to avoid out-of-bounds input.