### PR TITLE
Fix find blob by tag

### DIFF
--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.74.0"
 
 [dependencies]
 async-trait = "0.1"
-base64 = "0.21"
+base64 = "0.22"
 bytes = "1.0"
 dyn-clone = "1.0"
 futures = "0.3"

--- a/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
+++ b/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
@@ -8,21 +8,20 @@ operation! {
     FindBlobsByTags,
     client: BlobServiceClient,
     expression: String,
-    ?next_marker: NextMarker,
-    ?max_results: MaxResults,
     ?marker: NextMarker,
+    ?max_results: MaxResults,
 }
 
 impl FindBlobsByTagsBuilder {
     pub fn into_stream(self) -> FindBlobsByTags {
-        let make_request = move |next_marker: Option<NextMarker>| {
+        let make_request = move |continuation: Option<NextMarker>| {
             let this = self.clone();
             let mut ctx = self.context.clone();
             async move {
                 let mut url = this.client.url()?;
 
                 url.query_pairs_mut().append_pair("comp", "blobs");
-                if let Some(next_marker) = next_marker.or(this.marker) {
+                if let Some(next_marker) = continuation.or(this.marker) {
                     next_marker.append_to_url_query(&mut url);
                 }
                 url.query_pairs_mut().append_pair("where", &this.expression);

--- a/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
+++ b/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
@@ -57,7 +57,7 @@ pub type FindBlobsByTags = azure_core::Pageable<FindBlobsByTagsResponse, azure_c
 pub struct FindBlobsByTagsResponse {
     pub blobs: Vec<Blob>,
     pub delimiter: Option<String>,
-    next_marker: Option<NextMarker>,
+    pub next_marker: Option<NextMarker>,
     pub r#where: Option<String>,
     pub common: CommonStorageResponseHeaders,
 }

--- a/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
+++ b/sdk/storage_blobs/src/service/operations/find_blobs_by_tags.rs
@@ -9,7 +9,8 @@ operation! {
     client: BlobServiceClient,
     expression: String,
     ?next_marker: NextMarker,
-    ?max_results: MaxResults
+    ?max_results: MaxResults,
+    ?marker: NextMarker,
 }
 
 impl FindBlobsByTagsBuilder {
@@ -21,10 +22,11 @@ impl FindBlobsByTagsBuilder {
                 let mut url = this.client.url()?;
 
                 url.query_pairs_mut().append_pair("comp", "blobs");
-                if let Some(next_marker) = next_marker {
+                if let Some(next_marker) = next_marker.or(this.marker) {
                     next_marker.append_to_url_query(&mut url);
                 }
                 url.query_pairs_mut().append_pair("where", &this.expression);
+                this.max_results.append_to_url_query(&mut url);
 
                 make_url_compatible_with_api(&mut url);
 


### PR DESCRIPTION
There were 2 issues in here, one is that the API version got updated recently and that caused the response to be different than the one expected so querying blobs by tag wasn't working. I believe the version that the current `main` code has is the response for when we query with `x-ms-version: 2019-12-12`, however, we're now sending our requests with `x-ms-version: 2022-11-02` which caused this to completely break.

Another item was when we add multiple tags to the where expression, that was failing because of the way the URL was being encoded and that doesn't seem to be accepted by Azure REST API.

I've been using a workaround branch that was still using the old API for quite a while without any issues with this URL fix, related to this issue I raised a while ago https://github.com/Azure/azure-sdk-for-rust/issues/1284 

The error seems to have changed on the new API version as without the `make_url_compatible_with_api` if we query anything with more than 1 tag in the filter we get this error: 
```
<?xml version="1.0" encoding="utf-8"?>
<Error>
    <Code>AuthenticationFailed</Code>
    <Message>Server failed to authenticate the request. Make sure the value of Authorization header
        is formed correctly including the
        signature.RequestId:602fdf47-a01e-0010-5d99-732f4c000000Time:2024-03-11T09:50:11.4905786Z</Message>
    <AuthenticationErrorDetail>
        The MAC signature found in the HTTP request
        &apos;{{redacted}}&apos; is not the same as any computed
        signature. Server used following string to sign: &apos;GETx-ms-date:Mon, 11 Mar 2024
        09:50:06
        GMTx-ms-version:2022-11-02/{{redacted}}/comp:blobswhere:@container=&apos;unit-tests-with-index&apos;+AND+tagis=&apos;a&apos;&apos;.</AuthenticationErrorDetail>
</Error>
```

One question I have regarding the extra structs I had to add to have the response matching the new format of the XML for the tag content, do we need that at all? I was wondering if we could just drop the tag content as it doesn't seem like it's being used anywhere. Happy to keep it though in case there's any intention of using it in the future or if we want it for information purposes.