### PR TITLE
Support xml error respsonse

### DIFF
--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 pub struct HttpError {
     status: StatusCode,
     details: ErrorDetails,
-    headers: Headers,
+    headers: impl Into<std::collections::HashMap<String, String>>,
     body: Bytes,
 }
 

--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -11,7 +11,7 @@ use serde::Deserialize;
 pub struct HttpError {
     status: StatusCode,
     details: ErrorDetails,
-    headers: impl Into<std::collections::HashMap<String, String>>,
+    headers: Headers,
     body: Bytes,
 }
 

--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -114,14 +114,20 @@ fn get_error_code_from_header(headers: &Headers) -> Option<String> {
 
 #[derive(Deserialize)]
 struct NestedError {
+    #[serde(alias = "Message")]
     message: Option<String>,
+    #[serde(alias = "Code")]
     code: Option<String>,
 }
 
+/// Error from a response body, aliases are set because XML responses follow different case-ing
 #[derive(Deserialize)]
 struct ErrorBody {
+    #[serde(alias = "Error")]
     error: Option<NestedError>,
+    #[serde(alias = "Message")]
     message: Option<String>,
+    #[serde(alias = "Code")]
     code: Option<String>,
 }
 

--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -136,11 +136,10 @@ impl ErrorBody {
     ///
     /// The nested errors fields take precedence over those in the root of the structure
     fn into_code_message(self) -> (Option<String>, Option<String>) {
-        let (nested_code, nested_message) = if let Some(nested_error) = self.error {
-            (nested_error.code, nested_error.message)
-        } else {
-            (None, None)
-        };
+        let (nested_code, nested_message) = self
+            .error
+            .map(|nested_error| (nested_error.code, nested_error.message))
+            .unwrap_or((None, None));
         (nested_code.or(self.code), nested_message.or(self.message))
     }
 }
@@ -163,9 +162,7 @@ pub(crate) fn get_error_code_message_from_body(
             from_json(body).ok()
         };
 
-    if let Some(err_body) = err_body {
-        err_body.into_code_message()
-    } else {
-        (None, None)
-    }
+    err_body
+        .map(ErrorBody::into_code_message)
+        .unwrap_or((None, None))
 }

--- a/sdk/core/src/error/http_error.rs
+++ b/sdk/core/src/error/http_error.rs
@@ -107,7 +107,7 @@ impl ErrorDetails {
 /// Gets the error code if it's present in the headers
 ///
 /// For more info, see [here](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#handling-errors)
-fn get_error_code_from_header(headers: &Headers) -> Option<String> {
+pub(crate) fn get_error_code_from_header(headers: &Headers) -> Option<String> {
     headers.get_optional_string(&headers::ERROR_CODE)
 }
 

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -511,7 +511,7 @@ mod tests {
         ));
 
         let mut headers = Headers::new();
-        headers.insert(headers::ERROR_CODE, "teepot");
+        headers.insert(headers::ERROR_CODE, "teapot");
         let kind = ErrorKind::http_response_from_parts(StatusCode::ImATeapot, &headers, br#"{}"#);
 
         assert!(matches!(
@@ -520,7 +520,7 @@ mod tests {
                 status: StatusCode::ImATeapot,
                 error_code
             }
-            if error_code.as_deref() == Some("teepot")
+            if error_code.as_deref() == Some("teapot")
         ));
     }
 

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -44,8 +44,8 @@ impl ErrorKind {
         Self::HttpResponse { status, error_code }
     }
 
-    /// Constructs a [ErrorKind::HttpResponse] with given status code, the error code is taken from
-    /// the header [headers::ERROR_CODE] if present, otherwise the body is checked
+    /// Constructs an [`ErrorKind::HttpResponse`] with given status code. The error code is taken from
+    /// the header [`headers::ERROR_CODE`] if present; otherwise, it is taken from the body.
     pub fn http_response_from_parts(status: StatusCode, headers: &Headers, body: &[u8]) -> Self {
         if let Some(header_err_code) = get_error_code_from_header(headers) {
             Self::HttpResponse {

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -41,8 +41,12 @@ impl ErrorKind {
         Self::HttpResponse { status, error_code }
     }
 
-    pub fn http_response_from_body(status: StatusCode, body: &[u8]) -> Self {
-        let error_code = http_error::get_error_code_from_body(body);
+    pub fn http_response_from_body(
+        status: StatusCode,
+        body: &[u8],
+        content_type: Option<&str>,
+    ) -> Self {
+        let (error_code, _) = http_error::get_error_code_message_from_body(body, content_type);
         Self::HttpResponse { status, error_code }
     }
 }
@@ -469,7 +473,7 @@ mod tests {
 
     #[test]
     fn matching_against_http_error() {
-        let kind = ErrorKind::http_response_from_body(StatusCode::ImATeapot, b"{}");
+        let kind = ErrorKind::http_response_from_body(StatusCode::ImATeapot, b"{}", None);
 
         assert!(matches!(
             kind,
@@ -482,6 +486,7 @@ mod tests {
         let kind = ErrorKind::http_response_from_body(
             StatusCode::ImATeapot,
             br#"{"error": {"code":"teepot"}}"#,
+            None,
         );
 
         assert!(matches!(

--- a/sdk/core/src/error/mod.rs
+++ b/sdk/core/src/error/mod.rs
@@ -3,7 +3,10 @@ use std::borrow::Cow;
 use std::fmt::{Debug, Display};
 mod http_error;
 mod macros;
+use crate::headers::{self, Headers};
 pub use http_error::HttpError;
+
+use self::http_error::get_error_code_from_header;
 
 /// A convenience alias for `Result` where the error type is hard coded to `Error`
 pub type Result<T> = std::result::Result<T, Error>;
@@ -41,13 +44,21 @@ impl ErrorKind {
         Self::HttpResponse { status, error_code }
     }
 
-    pub fn http_response_from_body(
-        status: StatusCode,
-        body: &[u8],
-        content_type: Option<&str>,
-    ) -> Self {
-        let (error_code, _) = http_error::get_error_code_message_from_body(body, content_type);
-        Self::HttpResponse { status, error_code }
+    /// Constructs a [ErrorKind::HttpResponse] with given status code, the error code is taken from
+    /// the header [headers::ERROR_CODE] if present, otherwise the body is checked
+    pub fn http_response_from_parts(status: StatusCode, headers: &Headers, body: &[u8]) -> Self {
+        if let Some(header_err_code) = get_error_code_from_header(headers) {
+            Self::HttpResponse {
+                status,
+                error_code: Some(header_err_code),
+            }
+        } else {
+            let (error_code, _) = http_error::get_error_code_message_from_body(
+                body,
+                headers.get_optional_str(&headers::CONTENT_TYPE),
+            );
+            Self::HttpResponse { status, error_code }
+        }
     }
 }
 
@@ -473,7 +484,8 @@ mod tests {
 
     #[test]
     fn matching_against_http_error() {
-        let kind = ErrorKind::http_response_from_body(StatusCode::ImATeapot, b"{}", None);
+        let kind =
+            ErrorKind::http_response_from_parts(StatusCode::ImATeapot, &Headers::new(), b"{}");
 
         assert!(matches!(
             kind,
@@ -483,11 +495,24 @@ mod tests {
             }
         ));
 
-        let kind = ErrorKind::http_response_from_body(
+        let kind = ErrorKind::http_response_from_parts(
             StatusCode::ImATeapot,
+            &Headers::new(),
             br#"{"error": {"code":"teepot"}}"#,
-            None,
         );
+
+        assert!(matches!(
+            kind,
+            ErrorKind::HttpResponse {
+                status: StatusCode::ImATeapot,
+                error_code
+            }
+            if error_code.as_deref() == Some("teepot")
+        ));
+
+        let mut headers = Headers::new();
+        headers.insert(headers::ERROR_CODE, "teepot");
+        let kind = ErrorKind::http_response_from_parts(StatusCode::ImATeapot, &headers, br#"{}"#);
 
         assert!(matches!(
             kind,

--- a/sdk/core/src/http_client/mod.rs
+++ b/sdk/core/src/http_client/mod.rs
@@ -7,7 +7,7 @@ mod reqwest;
 use self::noop::new_noop_client;
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 use self::reqwest::new_reqwest_client;
-use crate::error::ErrorKind;
+use crate::{error::ErrorKind, headers};
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
@@ -49,7 +49,12 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
         if status.is_success() {
             Ok(crate::CollectedResponse::new(status, headers, body))
         } else {
-            Err(ErrorKind::http_response_from_body(status, &body).into_error())
+            Err(ErrorKind::http_response_from_body(
+                status,
+                &body,
+                headers.get_optional_str(&headers::CONTENT_TYPE),
+            )
+            .into_error())
         }
     }
 }

--- a/sdk/core/src/http_client/mod.rs
+++ b/sdk/core/src/http_client/mod.rs
@@ -7,7 +7,7 @@ mod reqwest;
 use self::noop::new_noop_client;
 #[cfg(any(feature = "enable_reqwest", feature = "enable_reqwest_rustls"))]
 use self::reqwest::new_reqwest_client;
-use crate::{error::ErrorKind, headers};
+use crate::error::ErrorKind;
 use async_trait::async_trait;
 use bytes::Bytes;
 use serde::{de::DeserializeOwned, Serialize};
@@ -49,12 +49,7 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
         if status.is_success() {
             Ok(crate::CollectedResponse::new(status, headers, body))
         } else {
-            Err(ErrorKind::http_response_from_body(
-                status,
-                &body,
-                headers.get_optional_str(&headers::CONTENT_TYPE),
-            )
-            .into_error())
+            Err(ErrorKind::http_response_from_parts(status, &headers, &body).into_error())
         }
     }
 }

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -79,12 +79,9 @@ pub async fn perform(
     let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
     let rsp_body = rsp_body.collect().await?;
     if !rsp_status.is_success() {
-        return Err(ErrorKind::http_response_from_body(
-            rsp_status,
-            &rsp_body,
-            rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
-        )
-        .into_error());
+        return Err(
+            ErrorKind::http_response_from_parts(rsp_status, &rsp_headers, &rsp_body).into_error(),
+        );
     }
     from_json(&rsp_body)
 }

--- a/sdk/identity/src/client_credentials_flow/mod.rs
+++ b/sdk/identity/src/client_credentials_flow/mod.rs
@@ -76,10 +76,15 @@ pub async fn perform(
     );
     req.set_body(encoded);
     let rsp = http_client.execute_request(&req).await?;
-    let rsp_status = rsp.status();
-    let rsp_body = rsp.into_body().collect().await?;
+    let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
+    let rsp_body = rsp_body.collect().await?;
     if !rsp_status.is_success() {
-        return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
+        return Err(ErrorKind::http_response_from_body(
+            rsp_status,
+            &rsp_body,
+            rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
+        )
+        .into_error());
     }
     from_json(&rsp_body)
 }

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -36,10 +36,15 @@ where
         .finish();
 
     let rsp = post_form(http_client.clone(), url, encoded).await?;
-    let rsp_status = rsp.status();
-    let rsp_body = rsp.into_body().collect().await?;
+    let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
+    let rsp_body = rsp_body.collect().await?;
     if !rsp_status.is_success() {
-        return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
+        return Err(ErrorKind::http_response_from_body(
+            rsp_status,
+            &rsp_body,
+            rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
+        )
+        .into_error());
     }
     let device_code_response: DeviceCodePhaseOneResponse = from_json(&rsp_body)?;
 

--- a/sdk/identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/src/device_code_flow/mod.rs
@@ -39,12 +39,9 @@ where
     let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
     let rsp_body = rsp_body.collect().await?;
     if !rsp_status.is_success() {
-        return Err(ErrorKind::http_response_from_body(
-            rsp_status,
-            &rsp_body,
-            rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
-        )
-        .into_error());
+        return Err(
+            ErrorKind::http_response_from_parts(rsp_status, &rsp_headers, &rsp_body).into_error(),
+        );
     }
     let device_code_response: DeviceCodePhaseOneResponse = from_json(&rsp_body)?;
 

--- a/sdk/identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/src/federated_credentials_flow/mod.rs
@@ -83,9 +83,15 @@ pub async fn perform(
     if rsp_status.is_success() {
         rsp.json().await
     } else {
-        let rsp_body = rsp.into_body().collect().await?;
+        let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
+        let rsp_body = rsp_body.collect().await?;
         let text = std::str::from_utf8(&rsp_body)?;
         error!("rsp_body == {:?}", text);
-        Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error())
+        Err(ErrorKind::http_response_from_body(
+            rsp_status,
+            &rsp_body,
+            rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
+        )
+        .into_error())
     }
 }

--- a/sdk/identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/src/federated_credentials_flow/mod.rs
@@ -87,11 +87,6 @@ pub async fn perform(
         let rsp_body = rsp_body.collect().await?;
         let text = std::str::from_utf8(&rsp_body)?;
         error!("rsp_body == {:?}", text);
-        Err(ErrorKind::http_response_from_body(
-            rsp_status,
-            &rsp_body,
-            rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
-        )
-        .into_error())
+        Err(ErrorKind::http_response_from_parts(rsp_status, &rsp_headers, &rsp_body).into_error())
     }
 }

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -53,11 +53,7 @@ pub async fn exchange(
         let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
         let rsp_body = rsp_body.collect().await?;
         let token_error: RefreshTokenError = from_json(&rsp_body).map_err(|_| {
-            ErrorKind::http_response_from_body(
-                rsp_status,
-                &rsp_body,
-                rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
-            )
+            ErrorKind::http_response_from_parts(rsp_status, &rsp_headers, &rsp_body)
         })?;
         Err(Error::new(ErrorKind::Credential, token_error))
     }

--- a/sdk/identity/src/refresh_token.rs
+++ b/sdk/identity/src/refresh_token.rs
@@ -50,9 +50,15 @@ pub async fn exchange(
     if rsp_status.is_success() {
         rsp.json().await.map_kind(ErrorKind::Credential)
     } else {
-        let rsp_body = rsp.into_body().collect().await?;
-        let token_error: RefreshTokenError = from_json(&rsp_body)
-            .map_err(|_| ErrorKind::http_response_from_body(rsp_status, &rsp_body))?;
+        let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
+        let rsp_body = rsp_body.collect().await?;
+        let token_error: RefreshTokenError = from_json(&rsp_body).map_err(|_| {
+            ErrorKind::http_response_from_body(
+                rsp_status,
+                &rsp_body,
+                rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
+            )
+        })?;
         Err(Error::new(ErrorKind::Credential, token_error))
     }
 }

--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -3,7 +3,7 @@ use azure_core::{
     auth::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind},
     from_json,
-    headers::{self, HeaderName},
+    headers::HeaderName,
     HttpClient, Method, Request, StatusCode, Url,
 };
 use serde::{
@@ -108,10 +108,10 @@ impl ImdsManagedIdentityCredential {
                     ))
                 }
                 rsp_status => {
-                    return Err(ErrorKind::http_response_from_body(
+                    return Err(ErrorKind::http_response_from_parts(
                         rsp_status,
+                        &rsp_headers,
                         &rsp_body,
-                        rsp_headers.get_optional_str(&headers::CONTENT_TYPE),
                     )
                     .into_error())
                 }


### PR DESCRIPTION
closes #1275 


As mentioned in the issue for those places that only need the error code it would've been easier to get it from the headers but I'm unsure whether there are any case where this information is only provided through the body.
So to keep the current behavior I decided to keep parsing it from the body (now based on `content-type` though)

If you think it would be alright to rely solely on the headers than I'd be happy to change that, it would remove a bit of code and prevent having to parse the body in some cases.


EDIT: Thanks to the all_tests script I discovered the issue of `quick-xml` being behind the `xml` feature flag.
I see two options but don't know which one is better:
- dont feature gate`quick-xml` / remove the `xml` feature
- create a non-xml version of the body parsing and gate the current one behind the `xml` feature (needs documentation)

To quick fix for CI I will remove `quick-xml` from the `xml` feature for now. I'm thankful for any further guidance here