### PR TITLE
(fix) Signing key for TopicClient not correctly encoded

### DIFF
--- a/sdk/messaging_servicebus/src/service_bus/topic_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/topic_client.rs
@@ -47,6 +47,9 @@ impl TopicClient {
         P: Into<String>,
         K: Into<Secret>,
     {
+        // NOTE: This is to account for the azure_core::auth::hmac_sha256 assumption
+        // that the key needs to be base64 decoded.
+        let signing_key = azure_core::base64::encode(signing_key.into().secret());
         Ok(Self {
             http_client,
             namespace: namespace.into(),


### PR DESCRIPTION
Fixes this issue https://github.com/Azure/azure-sdk-for-rust/issues/1637
It's a copy of the fix make for QueueClient in this commit https://github.com/Azure/azure-sdk-for-rust/commit/c999ef3df4c8c65edf458e7948235e31bd44dc61