### PR TITLE
Rename lock_expiry to timeout

### DIFF
--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -139,10 +139,10 @@ async fn peek_lock_message(
     queue_or_topic: &str,
     policy_name: &str,
     signing_key: &Secret,
-    lock_expiry: Option<Duration>,
+    timeout: Option<Duration>,
     subscription: Option<&str>,
 ) -> azure_core::Result<CollectedResponse> {
-    let url = craft_peek_lock_url(namespace, queue_or_topic, lock_expiry, subscription)?;
+    let url = craft_peek_lock_url(namespace, queue_or_topic, timeout, subscription)?;
 
     let req = finalize_request(url.as_ref(), Method::Post, None, policy_name, signing_key)?;
 
@@ -162,10 +162,10 @@ async fn peek_lock_message2(
     queue_or_topic: &str,
     policy_name: &str,
     signing_key: &Secret,
-    lock_expiry: Option<Duration>,
+    timeout: Option<Duration>,
     subscription: Option<&str>,
 ) -> azure_core::Result<PeekLockResponse> {
-    let url = craft_peek_lock_url(namespace, queue_or_topic, lock_expiry, subscription)?;
+    let url = craft_peek_lock_url(namespace, queue_or_topic, timeout, subscription)?;
 
     let req = finalize_request(url.as_ref(), Method::Post, None, policy_name, signing_key)?;
 

--- a/sdk/messaging_servicebus/src/service_bus/queue_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/queue_client.rs
@@ -79,13 +79,16 @@ impl QueueClient {
 
     /// Non-destructively read a message
     ///
+    /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
+    /// If no message is received within this time, an empty 204 HTTP response will be returned.
+    ///
     /// Note: This function does not return the delete location
     /// of the message, so, after reading, you will lose
     /// "track" of it until the lock expiry runs out and
     /// the message can be consumed by others. If you want to keep
     /// track of this message (i.e., have the possibility of deletion),
     /// use `peek_lock_message2`.
-    pub async fn peek_lock_message(&self, lock_expiry: Option<Duration>) -> Result<String, Error> {
+    pub async fn peek_lock_message(&self, timeout: Option<Duration>) -> Result<String, Error> {
         body_bytes_to_utf8(
             peek_lock_message(
                 &self.http_client,
@@ -93,7 +96,7 @@ impl QueueClient {
                 &self.queue,
                 &self.policy_name,
                 &self.signing_key,
-                lock_expiry,
+                timeout,
                 None,
             )
             .await?
@@ -102,6 +105,9 @@ impl QueueClient {
     }
 
     /// Non-destructively read a message but track it
+    ///
+    /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
+    /// If no message is received within this time, an empty 204 HTTP response will be returned.
     ///
     /// Note: This function returns a `PeekLockResponse`
     /// that contains a helper `delete_message` function.

--- a/sdk/messaging_servicebus/src/service_bus/topic_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/topic_client.rs
@@ -115,13 +115,16 @@ impl SubscriptionReceiver {
 
     /// Non-destructively read a message
     ///
+    /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
+    /// If no message is received within this time, an empty 204 HTTP response will be returned.
+    ///
     /// Note: This function does not return the delete location
     /// of the message, so, after reading, you will lose
     /// "track" of it until the lock expiry runs out and
     /// the message can be consumed by others. If you want to keep
     /// track of this message (i.e., have the possibility of deletion),
     /// use `peek_lock_message2`.
-    pub async fn peek_lock_message(&self, lock_expiry: Option<Duration>) -> Result<String, Error> {
+    pub async fn peek_lock_message(&self, timeout: Option<Duration>) -> Result<String, Error> {
         body_bytes_to_utf8(
             peek_lock_message(
                 &self.topic_client.http_client,
@@ -129,7 +132,7 @@ impl SubscriptionReceiver {
                 &self.topic_client.topic,
                 &self.topic_client.policy_name,
                 &self.topic_client.signing_key,
-                lock_expiry,
+                timeout,
                 Some(&self.subscription),
             )
             .await?
@@ -138,6 +141,9 @@ impl SubscriptionReceiver {
     }
 
     /// Non-destructively read a message but track it
+    ///
+    /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
+    /// If no message is received within this time, an empty 204 HTTP response will be returned.
     ///
     /// Note: This function returns a `PeekLockResponse`
     /// that contains a helper `delete_message` function.

--- a/sdk/messaging_servicebus/src/utils.rs
+++ b/sdk/messaging_servicebus/src/utils.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 pub fn craft_peek_lock_url(
     namespace: &str,
     queue_or_topic: &str,
-    lock_expiry: Option<Duration>,
+    timeout: Option<Duration>,
     subscription: Option<&str>,
 ) -> Result<Url, Error> {
     let url_path = get_head_url(namespace, queue_or_topic, subscription);
@@ -17,7 +17,7 @@ pub fn craft_peek_lock_url(
     )?;
 
     // add timeout, if given
-    if let Some(t) = lock_expiry {
+    if let Some(t) = timeout {
         url.query_pairs_mut()
             .append_pair("timeout", &t.as_secs().to_string());
     };


### PR DESCRIPTION
lock_expiry is not correctly named, and give incorrect indication about the behaviour.
I could not found documentation about this on azure but my experiences show that it represents the time after which the http connection send 204 empty response if no message is available

When using a timeout of 100s I get the following debug log from hyper (reqwest)

```
2024-04-26T15:17:20.027847Z DEBUG app::worker: Fetching message from queue
  at src/worker/mod.rs:46
  
2024-04-26T15:17:20.028454Z DEBUG hyper::client::connect::dns: resolving host="name.servicebus.windows.net"
  at /Users/baptiste/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.28/src/client/connect/dns.rs:122

2024-04-26T15:17:20.075441Z DEBUG hyper::client::connect::http: connecting to 23.102.0.186:443
  at /Users/baptiste/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.28/src/client/connect/http.rs:542

2024-04-26T15:17:20.108438Z DEBUG hyper::client::connect::http: connected to 23.102.0.186:443
  at /Users/baptiste/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.28/src/client/connect/http.rs:545

2024-04-26T15:17:20.181322Z DEBUG hyper::proto::h1::io: flushed 356 bytes
  at /Users/baptiste/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.28/src/proto/h1/io.rs:340

// Waiting 100s

2024-04-26T15:19:00.302686Z DEBUG hyper::proto::h1::io: parsed 5 headers
  at /Users/baptiste/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.28/src/proto/h1/io.rs:208

2024-04-26T15:19:00.302737Z DEBUG hyper::proto::h1::conn: incoming body is empty
  at /Users/baptiste/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.28/src/proto/h1/conn.rs:224

2024-04-26T15:19:00.302921Z DEBUG hyper::client::pool: pooling idle connection for ("https", name.servicebus.windows.net)
  at /Users/baptiste/.cargo/registry/src/index.crates.io-6f17d22bba15001f/hyper-0.14.28/src/client/pool.rs:380

2024-04-26T15:19:00.303130Z DEBUG app::worker: No Message in Queue
  at src/worker/mod.rs:50
  ```


On this [api doc](https://learn.microsoft.com/en-us/rest/api/servicebus/peek-lock-message-non-destructive-read?view=rest-servicebus-controlplane-2015-08-01) 204 response is described as `No messages available within the specified timeout period.`