### PR TITLE
switch to tokio::process

### DIFF
--- a/sdk/identity/Cargo.toml
+++ b/sdk/identity/Cargo.toml
@@ -27,7 +27,7 @@ uuid = { version = "1.0",  features = ["v4"] }
 pin-project = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-process = "2.0"
+tokio = { version = "1", features = ["process"] }
 
 [target.'cfg(unix)'.dependencies]
 tz-rs = { version = "0.6", optional = true }

--- a/sdk/identity/src/token_credentials/azure_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azure_cli_credentials.rs
@@ -1,5 +1,4 @@
 use crate::token_credentials::cache::TokenCache;
-use async_process::Command;
 use azure_core::{
     auth::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
@@ -8,6 +7,7 @@ use azure_core::{
 use serde::Deserialize;
 use std::str;
 use time::OffsetDateTime;
+use tokio::process::Command;
 use tracing::trace;
 
 #[cfg(feature = "old_azure_cli")]

--- a/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
@@ -1,5 +1,4 @@
 use crate::token_credentials::cache::TokenCache;
-use async_process::Command;
 use azure_core::{
     auth::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
@@ -9,6 +8,7 @@ use oauth2::ClientId;
 use serde::Deserialize;
 use std::str;
 use time::OffsetDateTime;
+use tokio::process::Command;
 
 mod unix_date_string {
     use azure_core::error::{Error, ErrorKind};


### PR DESCRIPTION
Resolves #1652.

As mentioned in the issue, reqwest already depends on tokio, so this removes a large section of the new dependency tree. tokio::process also uses non-blocking IO for windows, which async-process does not