### PR TITLE
make ImdsManagedIdentityCredential public again

### DIFF
--- a/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -14,7 +14,7 @@ use std::{str, sync::Arc};
 use time::OffsetDateTime;
 
 #[derive(Debug)]
-pub(crate) enum ImdsId {
+pub enum ImdsId {
     SystemAssigned,
     #[allow(dead_code)]
     ClientId(String),
@@ -30,7 +30,7 @@ pub(crate) enum ImdsId {
 ///
 /// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
 #[derive(Debug)]
-pub(crate) struct ImdsManagedIdentityCredential {
+pub struct ImdsManagedIdentityCredential {
     http_client: Arc<dyn HttpClient>,
     endpoint: Url,
     api_version: String,


### PR DESCRIPTION
Fixes #1659. As it points out, I think it was a bit too early to make `ImdsManagedIdentityCredential` private in #1532. I think it is the right direction after the credentials that use it like `VirtualMachineManagedIdentityCredential` and `AppServiceManagedIdentityCredential` add support for configurating user managed identities.