### PR TITLE
Update azure-autorust to append path and parameters via URL lib

### DIFF
--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -142,6 +142,7 @@ fn generate_resource_link(request: &Request) -> String {
 /// - "primary": one of the two service-level tokens
 /// - "resource": e.g. a single database
 /// - "aad": Azure Active Directory token
+///
 /// In the "primary" case the signature must be constructed by signing the HTTP method,
 /// resource type, resource link (the relative URI) and the current time.
 ///

--- a/sdk/identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/src/token_credentials/default_credentials.rs
@@ -245,6 +245,7 @@ impl TokenCredential for DefaultAzureCredentialKind {
 /// - `EnvironmentCredential`
 /// - `ManagedIdentityCredential`
 /// - `AzureCliCredential`
+///
 /// Consult the documentation of these credential types for more information on how they attempt authentication.
 #[derive(Debug)]
 pub struct DefaultAzureCredential {

--- a/sdk/iot_hub/src/service/mod.rs
+++ b/sdk/iot_hub/src/service/mod.rs
@@ -68,6 +68,7 @@ impl std::fmt::Debug for IoTHubCredentials {
 /// There are several ways to construct the `IoTHub` Service object. Either by:
 /// - providing the `IoT` Hub name and the private key.
 /// - providing the connection string.
+///
 /// The `IoTHubService` then uses the provided information to create a SAS token that it will
 /// use to communicate with the `IoT` Hub.
 #[derive(Clone, Debug)]

--- a/sdk/messaging_servicebus/src/service_bus/queue_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/queue_client.rs
@@ -80,7 +80,7 @@ impl QueueClient {
     /// Non-destructively read a message
     ///
     /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
-    /// If no message is received within this time, an empty 204 HTTP response will be returned.
+    ///   If no message is received within this time, an empty 204 HTTP response will be returned.
     ///
     /// Note: This function does not return the delete location
     /// of the message, so, after reading, you will lose
@@ -107,7 +107,7 @@ impl QueueClient {
     /// Non-destructively read a message but track it
     ///
     /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
-    /// If no message is received within this time, an empty 204 HTTP response will be returned.
+    ///   If no message is received within this time, an empty 204 HTTP response will be returned.
     ///
     /// Note: This function returns a `PeekLockResponse`
     /// that contains a helper `delete_message` function.

--- a/sdk/messaging_servicebus/src/service_bus/topic_client.rs
+++ b/sdk/messaging_servicebus/src/service_bus/topic_client.rs
@@ -116,7 +116,7 @@ impl SubscriptionReceiver {
     /// Non-destructively read a message
     ///
     /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
-    /// If no message is received within this time, an empty 204 HTTP response will be returned.
+    ///   If no message is received within this time, an empty 204 HTTP response will be returned.
     ///
     /// Note: This function does not return the delete location
     /// of the message, so, after reading, you will lose
@@ -143,7 +143,7 @@ impl SubscriptionReceiver {
     /// Non-destructively read a message but track it
     ///
     /// * `timeout` : Sets the maximum duration for the HTTP connection when receiving a message.
-    /// If no message is received within this time, an empty 204 HTTP response will be returned.
+    ///   If no message is received within this time, an empty 204 HTTP response will be returned.
     ///
     /// Note: This function returns a `PeekLockResponse`
     /// that contains a helper `delete_message` function.


### PR DESCRIPTION
When returning a URL from Client::endpoint the URL contains a tailing slash in any case. This is handled by the URL lib which will append the tailing slash to the end upon calling Display::fmt. Therefore formatting the returned URL from Client::endpoint will result in a duplicated slash, which could cause some (not all) Azure endpoints to have some trouble.

For example:
Base URL: https://some-app-conf.azconfig.io/
AppConfigUrl: https://some-app-conf.azconfig.io//keys?api-version=2023-10-01 This resulted in a 404 response.

Removing the tailing slash from the base endpoint's URL manually does not solve the problem, due to the reason mentioned above.

This patch applies a fix to append (set) the formatted path via rust URL lib, which will handle the duplicated slash (or any other problem).

Although I tried to locally generate `mgmt` and `svc` crates, I encountered some problems, and `autorust` removed and added a bunch of new files and modules.
So I'd like to ask somebody to help me out with the generation.