### PR TITLE
fix the invalid scope by adding .default

### DIFF
--- a/sdk/data_cosmos/src/authorization_policy.rs
+++ b/sdk/data_cosmos/src/authorization_policy.rs
@@ -190,7 +190,7 @@ async fn generate_authorization(
 fn scope_from_url(url: &Url) -> String {
     let scheme = url.scheme();
     let hostname = url.host_str().unwrap();
-    format!("{scheme}://{hostname}")
+    format!("{scheme}://{hostname}/.default")
 }
 
 /// This function generates a valid authorization string, according to the documentation.
@@ -368,6 +368,6 @@ mon, 01 jan 1900 01:00:00 gmt
     fn scope_from_url_01() {
         let scope =
             scope_from_url(&Url::parse("https://.documents.azure.com/dbs/test_db/colls").unwrap());
-        assert_eq!(scope, "https://.documents.azure.com");
+        assert_eq!(scope, "https://.documents.azure.com/.default");
     }
 }

--- a/sdk/iot_hub/examples/updatetwin.rs
+++ b/sdk/iot_hub/examples/updatetwin.rs
@@ -18,9 +18,10 @@ async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     println!("Updating device twin for device: {device_id}");
 
     let service_client = ServiceClient::new_connection_string(iot_hub_connection_string, 3600)?;
+    let json: String = serde_json::from_str(&payload).expect("Invalid JSON");
     let updated_twin = service_client
         .update_device_twin(device_id)
-        .desired_properties(serde_json::from_str(&payload)?)
+        .desired_properties(json)
         .await?;
 
     println!("Received device twin: {updated_twin:?}");


### PR DESCRIPTION
fixes #1593 

The CosmosDB scope is currently incorrectly formatted as `"https://${YOUR_ACCOUNT_NAME}.documents.azure.com"`. This causes an error when using any auth flow other than primary key. This PR fixes the scope formatting changing the scope to `"https://${YOUR_ACCOUNT_NAME}.documents.azure.com/.default"`.

I have validated that this via sample apps:
```
2024-06-17T15:29:56.535446Z DEBUG azure_identity::federated_credentials_flow: rsp_status == Ok
2024-06-17T15:29:56.535522Z DEBUG azure_core::policies::transport: the following request will be passed to the transport policy:
```