### PR TITLE
Adds Cold as AccessTier option

### DIFF
--- a/sdk/storage_blobs/src/options/access_tier.rs
+++ b/sdk/storage_blobs/src/options/access_tier.rs
@@ -3,6 +3,7 @@ use azure_core::headers::{self, Header};
 create_enum!(
     AccessTier,
     (Hot, "Hot"),
+    (Cold, "Cold"),
     (Cool, "Cool"),
     (Archive, "Archive")
 );


### PR DESCRIPTION
Azure Storage has 4 AccessTier option. 
* Hot
* Cold
* Cool
* Archive
here in AccessTier enum , Cold does not exist which causes Unsupported type error