### PR TITLE
Fix broken code behind client_certificate feature

### DIFF
--- a/eng/scripts/sdk_tests.sh
+++ b/eng/scripts/sdk_tests.sh
@@ -12,4 +12,6 @@ rustup update --no-self-update ${BUILD}
 export RUSTFLAGS="-Dwarnings"
 cargo +${BUILD} check -p azure_core --no-default-features
 cargo +${BUILD} check --all --features azurite_workaround
+cargo +${BUILD} check --all --all-targets --all-features
 cargo +${BUILD} test --all --features hmac_rust
+cargo +${BUILD} test --all --all-targets --all-features

--- a/eng/scripts/sdk_tests.sh
+++ b/eng/scripts/sdk_tests.sh
@@ -12,6 +12,4 @@ rustup update --no-self-update ${BUILD}
 export RUSTFLAGS="-Dwarnings"
 cargo +${BUILD} check -p azure_core --no-default-features
 cargo +${BUILD} check --all --features azurite_workaround
-cargo +${BUILD} check --all --all-targets --all-features
 cargo +${BUILD} test --all --features hmac_rust
-cargo +${BUILD} test --all --all-targets --all-features

--- a/sdk/core/src/error/macros.rs
+++ b/sdk/core/src/error/macros.rs
@@ -76,12 +76,6 @@ mod tests {
         }
     }
 
-    #[derive(thiserror::Error, Debug)]
-    enum IntermediateError {
-        #[error("second error")]
-        Io(#[from] std::io::Error),
-    }
-
     #[test]
     fn ensure_works() {
         fn test_ensure(predicate: bool) -> crate::Result<()> {

--- a/sdk/identity/examples/azureauth_cli_credential.rs
+++ b/sdk/identity/examples/azureauth_cli_credential.rs
@@ -2,7 +2,6 @@ use azure_core::auth::TokenCredential;
 use azure_identity::AzureauthCliCredential;
 use clap::Parser;
 use std::error::Error;
-use url::Url;
 
 #[derive(Debug, Parser)]
 struct Args {

--- a/sdk/identity/examples/client_certificate_credentials.rs
+++ b/sdk/identity/examples/client_certificate_credentials.rs
@@ -4,9 +4,7 @@
 /// please make sure to set the `send_certificate_chain` option to true otherwise
 /// the authentication will fail.
 use azure_core::auth::{Secret, TokenCredential};
-use azure_identity::{
-    ClientCertificateCredential, ClientCertificateCredentialOptions,
-};
+use azure_identity::{ClientCertificateCredential, ClientCertificateCredentialOptions};
 use azure_security_keyvault::KeyvaultClient;
 use std::env::var;
 use url::Url;

--- a/sdk/identity/examples/client_certificate_credentials.rs
+++ b/sdk/identity/examples/client_certificate_credentials.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let creds =
         ClientCertificateCredential::new(tenant_id, client_id, cert, String::new(), options);
 
-    let res = creds
+    let res = creds?
         .get_token(&["https://management.azure.com/.default"])
         .await?;
     // Let's enumerate the Azure SQL Databases instances

--- a/sdk/identity/examples/client_certificate_credentials.rs
+++ b/sdk/identity/examples/client_certificate_credentials.rs
@@ -5,7 +5,7 @@
 /// the authentication will fail.
 use azure_core::auth::{Secret, TokenCredential};
 use azure_identity::{
-    ClientCertificateCredential, ClientCertificateCredentialOptions, DefaultAzureCredential,
+    ClientCertificateCredential, ClientCertificateCredentialOptions,
 };
 use azure_security_keyvault::KeyvaultClient;
 use std::env::var;

--- a/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
+++ b/sdk/identity/src/token_credentials/azureauth_cli_credentials.rs
@@ -2,10 +2,9 @@ use crate::token_credentials::cache::TokenCache;
 use async_process::Command;
 use azure_core::{
     auth::{AccessToken, Secret, TokenCredential},
-    error::{Error, ErrorKind, ResultExt},
+    error::{Error, ErrorKind},
     from_json,
 };
-use oauth2::ClientId;
 use serde::Deserialize;
 use std::str;
 use time::OffsetDateTime;
@@ -40,7 +39,9 @@ mod unix_date_string {
 
 #[derive(Debug, Clone, Deserialize)]
 struct CliTokenResponse {
+    #[allow(dead_code)]
     pub user: String,
+    #[allow(dead_code)]
     pub display_name: String,
     #[serde(rename = "token")]
     pub access_token: Secret,
@@ -211,6 +212,8 @@ mod tests {
 
         let response: CliTokenResponse = from_json(src)?;
         assert_eq!(response.access_token.secret(), "security token here");
+        assert_eq!(response.user, "example@contoso.com");
+        assert_eq!(response.display_name, "Example User");
         assert_eq!(
             response.expires_on,
             OffsetDateTime::from_unix_timestamp(1700166595).expect("known valid date")

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -258,8 +258,9 @@ impl ClientCertificateCredential {
         let rsp_status = rsp.status();
 
         if !rsp_status.is_success() {
-            let rsp_body = rsp.into_body().collect().await?;
-            return Err(ErrorKind::http_response_from_body(rsp_status, &rsp_body).into_error());
+            let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
+            let rsp_body = rsp_body.collect().await?;
+            return Err(ErrorKind::http_response_from_parts(rsp_status, &rsp_headers, &rsp_body).into_error());
         }
 
         let response: AadTokenResponse = rsp.json().await?;

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -260,7 +260,10 @@ impl ClientCertificateCredential {
         if !rsp_status.is_success() {
             let (rsp_status, rsp_headers, rsp_body) = rsp.deconstruct();
             let rsp_body = rsp_body.collect().await?;
-            return Err(ErrorKind::http_response_from_parts(rsp_status, &rsp_headers, &rsp_body).into_error());
+            return Err(
+                ErrorKind::http_response_from_parts(rsp_status, &rsp_headers, &rsp_body)
+                    .into_error(),
+            );
         }
 
         let response: AadTokenResponse = rsp.json().await?;

--- a/sdk/identity/src/token_credentials/client_certificate_credentials.rs
+++ b/sdk/identity/src/token_credentials/client_certificate_credentials.rs
@@ -116,22 +116,22 @@ impl ClientCertificateCredential {
         client_certificate: C,
         client_certificate_pass: P,
         options: impl Into<ClientCertificateCredentialOptions>,
-    ) -> ClientCertificateCredential
+    ) -> azure_core::Result<ClientCertificateCredential>
     where
         C: Into<Secret>,
         P: Into<Secret>,
     {
         let options = options.into();
-        ClientCertificateCredential {
+        Ok(ClientCertificateCredential {
             tenant_id,
             client_id,
             client_certificate: client_certificate.into(),
             client_certificate_pass: client_certificate_pass.into(),
             http_client: options.options().http_client().clone(),
-            authority_host: options.options().authority_host().clone(),
+            authority_host: options.options().authority_host()?.clone(),
             send_certificate_chain: options.send_certificate_chain(),
             cache: TokenCache::new(),
-        }
+        })
     }
 
     fn sign(jwt: &str, pkey: &PKey<Private>) -> Result<Vec<u8>, ErrorStack> {
@@ -316,13 +316,13 @@ impl ClientCertificateCredential {
                 )
             })?;
 
-        Ok(ClientCertificateCredential::new(
+        ClientCertificateCredential::new(
             tenant_id,
             client_id,
             client_certificate,
             client_certificate_password,
             options,
-        ))
+        )
     }
 }
 

--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -1,7 +1,4 @@
 #![cfg(all(test, feature = "test_e2e", feature = "md5"))]
-#[macro_use]
-extern crate log;
-
 use azure_core::{date, Url};
 use azure_storage::prelude::*;
 use azure_storage_blobs::container::operations::ListBlobsResponse;
@@ -12,6 +9,7 @@ use std::ops::{Add, Deref};
 use std::time::Duration;
 use time::OffsetDateTime;
 use uuid::Uuid;
+use tracing::trace;
 
 #[tokio::test]
 async fn content_headers() -> azure_core::Result<()> {

--- a/sdk/storage_blobs/tests/blob.rs
+++ b/sdk/storage_blobs/tests/blob.rs
@@ -8,8 +8,8 @@ use futures::StreamExt;
 use std::ops::{Add, Deref};
 use std::time::Duration;
 use time::OffsetDateTime;
-use uuid::Uuid;
 use tracing::trace;
+use uuid::Uuid;
 
 #[tokio::test]
 async fn content_headers() -> azure_core::Result<()> {


### PR DESCRIPTION
See https://github.com/Azure/azure-sdk-for-rust/pull/1650 for details. This PR replaces that since the fork's `main` branch is locked despite the PR allowing maintainer edits.