### PR TITLE
Refactor RawResponse and Response<T> into a single Response<T> that can contain a ResponseBody

### DIFF
--- a/eng/test/mock_transport/src/mock_response.rs
+++ b/eng/test/mock_transport/src/mock_response.rs
@@ -33,18 +33,18 @@ impl MockResponse {
 
     pub(crate) async fn duplicate(response: Response<ResponseBody>) -> error::Result<(Response<ResponseBody>, Self)> {
         use error::ResultExt;
-        let (status, headers, body) = response.deconstruct();
+        let (status_code, header_map, body) = response.deconstruct();
         let response_bytes = body.collect().await.context(
             error::ErrorKind::Io,
             "an error occurred fetching the next part of the byte stream",
         )?;
 
         let response = Response::new(
-            status.clone(),
-            headers.clone(),
+            status_code,
+            header_map.clone(),
             ResponseBody::new(Box::pin(BytesStream::new(response_bytes.clone()))),
         );
-        let mock_response = MockResponse::new(status, headers, response_bytes);
+        let mock_response = MockResponse::new(status_code, header_map, response_bytes);
 
         Ok((response, mock_response))
     }

--- a/eng/test/mock_transport/src/mock_response.rs
+++ b/eng/test/mock_transport/src/mock_response.rs
@@ -1,4 +1,8 @@
-use azure_core::{base64, error, headers::{HeaderName, HeaderValue, Headers}, BytesStream, StatusCode, Response, ResponseBody};
+use azure_core::{
+    base64, error,
+    headers::{HeaderName, HeaderValue, Headers},
+    BytesStream, Response, ResponseBody, StatusCode,
+};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
@@ -31,7 +35,9 @@ impl MockResponse {
         }
     }
 
-    pub(crate) async fn duplicate(response: Response<ResponseBody>) -> error::Result<(Response<ResponseBody>, Self)> {
+    pub(crate) async fn duplicate(
+        response: Response<ResponseBody>,
+    ) -> error::Result<(Response<ResponseBody>, Self)> {
         use error::ResultExt;
         let (status_code, header_map, body) = response.deconstruct();
         let response_bytes = body.collect().await.context(

--- a/sdk/core/azure_core/src/error/http_error.rs
+++ b/sdk/core/azure_core/src/error/http_error.rs
@@ -1,4 +1,4 @@
-use crate::{headers, json::from_json, RawResponse, StatusCode};
+use crate::{headers, json::from_json, Response, ResponseBody, StatusCode};
 use bytes::Bytes;
 use serde::Deserialize;
 use std::{collections::HashMap, fmt};
@@ -16,7 +16,7 @@ impl HttpError {
     /// Create an error from an HTTP response.
     ///
     /// This does not check whether the response was successful and should only be used with unsuccessful responses.
-    pub async fn new(response: RawResponse) -> Self {
+    pub async fn new(response: Response<ResponseBody>) -> Self {
         let status = response.status();
         let headers: HashMap<String, String> = response
             .headers()

--- a/sdk/core/azure_core/src/http_client/mod.rs
+++ b/sdk/core/azure_core/src/http_client/mod.rs
@@ -31,5 +31,8 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
     ///
     /// It does not consume the request. Implementors are expected to clone the necessary parts
     /// of the request and pass them to the underlying transport.
-    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response<crate::ResponseBody>>;
+    async fn execute_request(
+        &self,
+        request: &crate::Request,
+    ) -> crate::Result<crate::Response<crate::ResponseBody>>;
 }

--- a/sdk/core/azure_core/src/http_client/mod.rs
+++ b/sdk/core/azure_core/src/http_client/mod.rs
@@ -31,5 +31,5 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
     ///
     /// It does not consume the request. Implementors are expected to clone the necessary parts
     /// of the request and pass them to the underlying transport.
-    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::RawResponse>;
+    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response<crate::ResponseBody>>;
 }

--- a/sdk/core/azure_core/src/http_client/noop.rs
+++ b/sdk/core/azure_core/src/http_client/noop.rs
@@ -14,7 +14,7 @@ pub(crate) fn new_noop_client() -> std::sync::Arc<dyn crate::HttpClient> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl crate::HttpClient for NoopClient {
     #[allow(clippy::diverging_sub_expression)]
-    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::RawResponse> {
+    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response<crate::ResponseBody>> {
         panic!(
             "A request was called on the default http client `NoopClient`.\
 	This client does nothing but panic. Make sure to enable an http\

--- a/sdk/core/azure_core/src/http_client/noop.rs
+++ b/sdk/core/azure_core/src/http_client/noop.rs
@@ -14,7 +14,10 @@ pub(crate) fn new_noop_client() -> std::sync::Arc<dyn crate::HttpClient> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl crate::HttpClient for NoopClient {
     #[allow(clippy::diverging_sub_expression)]
-    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response<crate::ResponseBody>> {
+    async fn execute_request(
+        &self,
+        request: &crate::Request,
+    ) -> crate::Result<crate::Response<crate::ResponseBody>> {
         panic!(
             "A request was called on the default http client `NoopClient`.\
 	This client does nothing but panic. Make sure to enable an http\

--- a/sdk/core/azure_core/src/http_client/reqwest.rs
+++ b/sdk/core/azure_core/src/http_client/reqwest.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{ErrorKind, ResultExt},
-    Body, HttpClient, PinnedStream, ResponseBody,
+    Body, HttpClient, ResponseBody,
 };
 use async_trait::async_trait;
 use futures::TryStreamExt;

--- a/sdk/core/azure_core/src/http_client/reqwest.rs
+++ b/sdk/core/azure_core/src/http_client/reqwest.rs
@@ -1,4 +1,7 @@
-use crate::{error::{ErrorKind, ResultExt}, Body, HttpClient, PinnedStream, ResponseBody};
+use crate::{
+    error::{ErrorKind, ResultExt},
+    Body, HttpClient, PinnedStream, ResponseBody,
+};
 use async_trait::async_trait;
 use futures::TryStreamExt;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
@@ -30,7 +33,10 @@ pub fn new_reqwest_client() -> Arc<dyn HttpClient> {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl HttpClient for ::reqwest::Client {
-    async fn execute_request(&self, request: &crate::Request) -> crate::Result<crate::Response<crate::ResponseBody>> {
+    async fn execute_request(
+        &self,
+        request: &crate::Request,
+    ) -> crate::Result<crate::Response<crate::ResponseBody>> {
         let url = request.url().clone();
         let method = request.method();
         let mut req = self.request(try_from_method(*method)?, url.clone());

--- a/sdk/core/azure_core/src/options/transport.rs
+++ b/sdk/core/azure_core/src/options/transport.rs
@@ -36,7 +36,7 @@ impl TransportOptions {
         &self,
         ctx: &crate::Context<'_>,
         request: &mut crate::Request,
-    ) -> crate::Result<crate::RawResponse> {
+    ) -> crate::Result<crate::Response<crate::ResponseBody>> {
         use TransportOptionsImpl as I;
         match &self.inner {
             I::Http { http_client } => http_client.execute_request(request).await,

--- a/sdk/core/azure_core/src/pipeline.rs
+++ b/sdk/core/azure_core/src/pipeline.rs
@@ -99,7 +99,6 @@ impl Pipeline {
         self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
             .await
-            .map(|resp| resp.into())
     }
 }
 

--- a/sdk/core/azure_core/src/pipeline.rs
+++ b/sdk/core/azure_core/src/pipeline.rs
@@ -110,8 +110,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        headers::Headers, BytesStream, Method, PolicyResult, StatusCode,
-        TransportOptions,
+        headers::Headers, BytesStream, Method, PolicyResult, StatusCode, TransportOptions,
     };
 
     #[tokio::test]

--- a/sdk/core/azure_core/src/policies/mod.rs
+++ b/sdk/core/azure_core/src/policies/mod.rs
@@ -8,12 +8,12 @@ pub use retry_policies::*;
 pub use telemetry_policy::*;
 pub use transport::*;
 
-use crate::{Context, RawResponse, Request};
+use crate::{Context, Request, Response, ResponseBody};
 use async_trait::async_trait;
 use std::sync::Arc;
 
 /// A specialized `Result` type for policies.
-pub type PolicyResult = crate::error::Result<RawResponse>;
+pub type PolicyResult = crate::error::Result<Response<ResponseBody>>;
 
 /// A pipeline policy.
 ///

--- a/sdk/core/azure_core/src/response.rs
+++ b/sdk/core/azure_core/src/response.rs
@@ -1,4 +1,9 @@
-use crate::{BytesStream, error::{ErrorKind, ResultExt}, headers::Headers, json::from_json, StatusCode};
+use crate::{
+    error::{ErrorKind, ResultExt},
+    headers::Headers,
+    json::from_json,
+    BytesStream, StatusCode,
+};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use serde::de::DeserializeOwned;
@@ -26,7 +31,7 @@ impl<T> Response<T> {
         Self {
             status,
             headers,
-            body
+            body,
         }
     }
 
@@ -41,7 +46,9 @@ impl<T> Response<T> {
     }
 
     /// Gets a reference to the body of the response.
-    pub fn body(&self) -> &T { &self.body }
+    pub fn body(&self) -> &T {
+        &self.body
+    }
 
     /// Consume the HTTP response and return the body.
     pub fn into_body(self) -> T {
@@ -181,10 +188,10 @@ impl fmt::Debug for ResponseBody {
 
 #[cfg(test)]
 mod tests {
+    use crate::headers::{HeaderName, HeaderValue, Headers};
+    use crate::Response;
     use http_types::StatusCode;
     use serde::Deserialize;
-    use crate::headers::{Headers, HeaderName, HeaderValue};
-    use crate::Response;
 
     #[derive(Deserialize)]
     pub struct TestObj {
@@ -230,10 +237,16 @@ mod tests {
         header_list.sort_by(|(nl, _), (nr, _)| nl.cmp(nr));
 
         assert_eq!(StatusCode::Accepted, json_resp.status());
-        assert_eq!(vec![
-            (&HeaderName::from("content-type"), &HeaderValue::from("application/json")),
-            (&HeaderName::from("foo"), &HeaderValue::from("bar")),
-        ], json_resp.headers().iter().collect::<Vec<_>>());
+        assert_eq!(
+            vec![
+                (
+                    &HeaderName::from("content-type"),
+                    &HeaderValue::from("application/json")
+                ),
+                (&HeaderName::from("foo"), &HeaderValue::from("bar")),
+            ],
+            json_resp.headers().iter().collect::<Vec<_>>()
+        );
         assert_eq!("foo", json_resp.body().string_prop);
         assert_eq!(42, json_resp.body().int_prop);
         assert_eq!(4.2, json_resp.body().float_prop);
@@ -244,7 +257,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(feature="xml")]
+    #[cfg(feature = "xml")]
     pub async fn deserialize_xml_response() {
         // It's not really that necessary to test all kinds of deserialization here.
         // We're using serde which should handle deserialization for us.
@@ -275,10 +288,16 @@ mod tests {
         header_list.sort_by(|(nl, _), (nr, _)| nl.cmp(nr));
 
         assert_eq!(StatusCode::Accepted, xml_resp.status());
-        assert_eq!(vec![
-            (&HeaderName::from("content-type"), &HeaderValue::from("application/json")),
-            (&HeaderName::from("foo"), &HeaderValue::from("bar")),
-        ], header_list);
+        assert_eq!(
+            vec![
+                (
+                    &HeaderName::from("content-type"),
+                    &HeaderValue::from("application/json")
+                ),
+                (&HeaderName::from("foo"), &HeaderValue::from("bar")),
+            ],
+            header_list
+        );
         assert_eq!("foo", xml_resp.body().string_prop);
         assert_eq!(42, xml_resp.body().int_prop);
         assert_eq!(4.2, xml_resp.body().float_prop);

--- a/sdk/core/azure_core/src/response.rs
+++ b/sdk/core/azure_core/src/response.rs
@@ -17,7 +17,7 @@ pub(crate) type PinnedStream = Pin<Box<dyn Stream<Item = crate::Result<Bytes>>>>
 /// The response to an HTTP request, including the status code, headers, and body.
 ///
 /// The HTTP pipeline produces responses that contain a body of type [`ResponseBody`], representing the raw bytes.
-/// This "raw" response can then be parsed using the [`Response<ResponseBody>::json`] or [`Response<ResponseBody>::xml`] methods to deserialize the body into a structured type.
+/// This "raw" response can then be parsed using a method such as [`Response<ResponseBody>::json`] to deserialize the body into a structured type.
 /// Parsing the body will transform the instance into a new [`Response`] instance containing the parsed body object, but retaining the original status code and headers.
 pub struct Response<T> {
     status: StatusCode,

--- a/sdk/core/azure_core/src/response.rs
+++ b/sdk/core/azure_core/src/response.rs
@@ -229,7 +229,7 @@ mod tests {
         headers.insert("content-type", "application/json");
         headers.insert("foo", "bar");
 
-        let resp = Response::from_bytes(StatusCode::Accepted, headers, body.into());
+        let resp = Response::from_bytes(StatusCode::Accepted, headers, body);
         let json_resp = resp.json::<TestObj>().await.unwrap();
 
         // Header order is inconsistent, so order the list
@@ -245,7 +245,7 @@ mod tests {
                 ),
                 (&HeaderName::from("foo"), &HeaderValue::from("bar")),
             ],
-            json_resp.headers().iter().collect::<Vec<_>>()
+            header_list
         );
         assert_eq!("foo", json_resp.body().string_prop);
         assert_eq!(42, json_resp.body().int_prop);
@@ -280,7 +280,7 @@ mod tests {
         headers.insert("content-type", "application/json");
         headers.insert("foo", "bar");
 
-        let resp = Response::from_bytes(StatusCode::Accepted, headers, body.into());
+        let resp = Response::from_bytes(StatusCode::Accepted, headers, body);
         let xml_resp = resp.xml::<TestObj>().await.unwrap();
 
         // Header order is inconsistent, so order the list

--- a/sdk/core/azure_core/src/response.rs
+++ b/sdk/core/azure_core/src/response.rs
@@ -16,9 +16,9 @@ pub(crate) type PinnedStream = Pin<Box<dyn Stream<Item = crate::Result<Bytes>>>>
 
 /// The response to an HTTP request, including the status code, headers, and body.
 ///
-/// The HTTP pipeline produces responses that contain a body of type [ResponseBody], representing the raw bytes.
-/// This "raw" response can then be parsed using the [Response<ResponseBody>::json] or [Response<ResponseBody>::xml] methods to deserialize the body into a structured type.
-/// Parsing the body will transform the instance into a new [Response] instance containing the parsed body object, but retaining the original status code and headers.
+/// The HTTP pipeline produces responses that contain a body of type [`ResponseBody`], representing the raw bytes.
+/// This "raw" response can then be parsed using the [`Response<ResponseBody>::json`] or [`Response<ResponseBody>::xml`] methods to deserialize the body into a structured type.
+/// Parsing the body will transform the instance into a new [`Response`] instance containing the parsed body object, but retaining the original status code and headers.
 pub struct Response<T> {
     status: StatusCode,
     headers: Headers,
@@ -62,21 +62,21 @@ impl<T> Response<T> {
 }
 
 impl Response<ResponseBody> {
-    /// Creates a [Response<ResponseBody>] from a raw collection of bytes.
+    /// Creates a [`Response<ResponseBody>`] from a raw collection of bytes.
     pub fn from_bytes(status: StatusCode, headers: Headers, body: impl Into<Bytes>) -> Self {
         let stream: BytesStream = body.into().into();
         let stream = Box::pin(stream);
         Self::new(status, headers, ResponseBody::new(stream))
     }
 
-    /// Consumes this instance, parses the body as JSON, and returns a new Response<T> containing the parsed value.
+    /// Consumes this instance, parses the body as JSON, and returns a new [`Response<T>`] containing the parsed value.
     pub async fn json<T: DeserializeOwned>(self) -> crate::Result<Response<T>> {
         let (status, headers, body) = self.deconstruct();
         let body = body.json().await?;
         Ok(Response::new(status, headers, body))
     }
 
-    /// Consumes this instance, parses the body as XML, and returns a new Response<T> containing the parsed value.
+    /// Consumes this instance, parses the body as XML, and returns a new [`Response<T>`] containing the parsed value.
     #[cfg(feature = "xml")]
     pub async fn xml<T: DeserializeOwned>(self) -> crate::Result<Response<T>> {
         let (status, headers, body) = self.deconstruct();

--- a/sdk/identity/azure_identity/examples/federated_credential.rs
+++ b/sdk/identity/azure_identity/examples/federated_credential.rs
@@ -27,7 +27,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         &AZURE_PUBLIC_CLOUD,
     )
     .await
-    .expect("federated_credentials_flow failed");
+    .expect("federated_credentials_flow failed")
+    .into_body();
+
     println!("Non interactive authorization == {token:?}");
 
     let url = Url::parse(&format!(

--- a/sdk/identity/azure_identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/device_code_flow/mod.rs
@@ -5,7 +5,13 @@
 //! You can learn more about this authorization flow [here](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code).
 mod device_code_responses;
 
-use azure_core::{content_type, error::{Error, ErrorKind}, headers, json::from_json, sleep, HttpClient, Method, Request, Url, Response, ResponseBody};
+use azure_core::{
+    content_type,
+    error::{Error, ErrorKind},
+    headers,
+    json::from_json,
+    sleep, HttpClient, Method, Request, Response, ResponseBody, Url,
+};
 pub use device_code_responses::*;
 use futures::stream::unfold;
 use serde::Deserialize;

--- a/sdk/identity/azure_identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/device_code_flow/mod.rs
@@ -5,13 +5,7 @@
 //! You can learn more about this authorization flow [here](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code).
 mod device_code_responses;
 
-use azure_core::{
-    content_type,
-    error::{Error, ErrorKind},
-    headers,
-    json::from_json,
-    sleep, HttpClient, Method, RawResponse, Request, Url,
-};
+use azure_core::{content_type, error::{Error, ErrorKind}, headers, json::from_json, sleep, HttpClient, Method, Request, Url, Response, ResponseBody};
 pub use device_code_responses::*;
 use futures::stream::unfold;
 use serde::Deserialize;
@@ -171,7 +165,7 @@ async fn post_form(
     http_client: Arc<dyn HttpClient>,
     url: &str,
     form_body: String,
-) -> azure_core::Result<RawResponse> {
+) -> azure_core::Result<Response<ResponseBody>> {
     let url = Url::parse(url)?;
     let mut req = Request::new(url, Method::Post);
     req.insert_header(

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
@@ -53,7 +53,7 @@ pub async fn perform(
     scopes: &[&str],
     tenant_id: &str,
     host: &Url,
-) -> azure_core::Result<LoginResponse> {
+) -> azure_core::Result<azure_core::Response<LoginResponse>> {
     let encoded: String = form_urlencoded::Serializer::new(String::new())
         .append_pair("client_id", client_id)
         .append_pair("scope", &scopes.join(" "))

--- a/sdk/identity/azure_identity/src/refresh_token.rs
+++ b/sdk/identity/azure_identity/src/refresh_token.rs
@@ -19,7 +19,7 @@ pub async fn exchange(
     client_id: &str,
     client_secret: Option<&str>,
     refresh_token: &Secret,
-) -> azure_core::Result<RefreshTokenResponse> {
+) -> azure_core::Result<azure_core::Response<RefreshTokenResponse>> {
     let encoded = {
         let mut encoded = &mut form_urlencoded::Serializer::new(String::new());
         encoded = encoded

--- a/sdk/identity/azure_identity/src/token_credentials/workload_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/workload_identity_credentials.rs
@@ -127,6 +127,7 @@ impl WorkloadIdentityCredential {
         )
         .await
         .map(|r| {
+            let r = r.into_body();
             AccessToken::new(
                 r.access_token().clone(),
                 OffsetDateTime::now_utc() + Duration::from_secs(r.expires_in),


### PR DESCRIPTION
In starting up on the Cosmos Rust SDK, I found that the `Response<T>` type requires that the caller know the serialization format used, in order to call `.json` or `.xml`. Since this is the type that client methods are [expected to return](https://azure.github.io/azure-sdk/rust_introduction.html#rust-client-methods-return) it seems like the layering isn't quite right there.

So, what I've got here is an idea for a little bit of a different approach. Currently there is `RawResponse`, which carries the actual data (status code, headers, body stream) and `Response<T>` which wraps the `RawResponse` and allows you to read it as a `T` (using either `.json` or `.xml` methods).

My proposal here is a little different. Instead, there is a single `Response<T>` type, which contains the actual `T` as a field (instead of using a phantom data field). The HTTP pipeline is then expected to return `Response<ResponseBody>` (using the existing `ResponseBody` type that wraps a "pinned stream"). This type has the `.json` and `.xml` properties on it (and any other future serialization formats we choose to add). Those methods, rather than just parsing the body, _transform_ a `Response<ResponseBody>` **into** a `Response<T>` (for a given `T: DeserializeOwned`) by deserializing the body.

This means that a client method is now implemented something like this:

```rust
pub async fn read_database(&self) -> azure_core::Result<azure_core::Response<DatabaseResponse>> {
    let req = Request::new("...", azure_core::Method::Get);
    let ctx = Context::new();
    let resp = self.pipeline.send(&ctx, &mut req).await?; // Returns a Response<ResponseBody>
    // ... early-return with an error if the response indicates failure ...
    let parsed_resp = resp.json().await?; // Returns a Response<DatabaseResponse> (inferred from the function return type)
    Ok(parsed_resp)
}
```

A few quirks here:

* I changed `Response<T>` to implement `Debug` only when `T: Debug`, to allow for `Debug` rendering of `Response<SomeClientSpecificObject>`. The `ResponseBody` type implements `Debug` using a placeholder value so the effect is mostly the same. I think it's unlikely someone will want to `Debug`-render and `Response<T>` where `T` is not `Debug`
* A few existing `azure_identity` APIs needed to be updated to return `Response<T>`. This also means that some of the places that _used_ those methods have to call `into_body` to unwrap the Response into the body type.

@heaths I'd appreciate your thoughts here. It should unblock me to be able to at least start an initial Cosmos DB SDK that can call _an_ API. We're still missing things like `Pager` in order to get into the core APIs, but this should allow us to put the initial package in place.