### PR TITLE
Add lifetime annotation to ClientMethodOptionsBuilder trait

### DIFF
--- a/sdk/core/azure_core/src/options/builders.rs
+++ b/sdk/core/azure_core/src/options/builders.rs
@@ -57,9 +57,9 @@ pub trait ClientOptionsBuilder {
 }
 
 /// Methods to set general method options for client-specific [`ClientMethodOptions`].
-pub trait ClientMethodOptionsBuilder {
+pub trait ClientMethodOptionsBuilder<'a> {
     /// Set optional [`Context`] for each client method call.
-    fn with_context<P>(mut self, context: &Context<'_>) -> Self
+    fn with_context<P>(mut self, context: &'a Context) -> Self
     where
         Self: Sized,
     {

--- a/sdk/core/azure_core/src/options/builders.rs
+++ b/sdk/core/azure_core/src/options/builders.rs
@@ -59,7 +59,7 @@ pub trait ClientOptionsBuilder {
 /// Methods to set general method options for client-specific [`ClientMethodOptions`].
 pub trait ClientMethodOptionsBuilder<'a> {
     /// Set optional [`Context`] for each client method call.
-    fn with_context<P>(mut self, context: &'a Context) -> Self
+    fn with_context(mut self, context: &'a Context) -> Self
     where
         Self: Sized,
     {


### PR DESCRIPTION
This allows implementors of the trait to ensure that the lifetime of context lives at least as long as the trait's implementor.

This lets me write the following.
```rust
impl<'a> ClientMethodOptionsBuilder<'a> for ExtensibleStringGetKnownValueOptionsBuilder<'a> {
    fn with_context<P>(mut self, context: &'a Context) -> Self {
        self.options.method_options.set_context(context);
        self
    }
}
```
Without this change, the compiler complains that `context` might not live long enough.

I tried many permutations until I arrived at this solution. Please let me know if there's a better way and I can update as required.