### PR TITLE
Take 2: Refactoring Response<T> to collapse json/xml methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 resolver = "2"
 members = [
-  "sdk/typespec",
-  "sdk/typespec/typespec_client_core",
-  "sdk/core/azure_core",
-  "sdk/core/azure_core_amqp",
-  "sdk/identity/azure_identity",
-  "sdk/eventhubs/azure_messaging_eventhubs",
-  "eng/test/mock_transport",
-  "sdk/storage",
-  "sdk/storage/azure_storage_blob",
+    "sdk/typespec",
+    "sdk/typespec/typespec_client_core",
+    "sdk/core/azure_core",
+    "sdk/core/azure_core_amqp",
+    "sdk/identity/azure_identity",
+    "sdk/eventhubs/azure_messaging_eventhubs",
+    "eng/test/mock_transport",
+    "sdk/storage",
+    "sdk/storage/azure_storage_blob",
 ]
 
 [workspace.package]
@@ -67,8 +67,8 @@ pin-project = "1.0"
 quick-xml = { version = "0.31", features = ["serialize", "serde-types"] }
 rand = "0.8"
 reqwest = { version = "0.12", features = [
-  "json",
-  "stream",
+    "json",
+    "stream",
 ], default-features = false }
 rustc_version = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -80,15 +80,14 @@ serial_test = "3.0"
 sha2 = { version = "0.10" }
 thiserror = "1.0"
 time = { version = "0.3.10", features = [
-  "serde-well-known",
-  "macros",
-  "wasm-bindgen",
+    "serde-well-known",
+    "macros",
+    "wasm-bindgen",
 ] }
 tokio = { version = "1.0", default-features = false, features = [
-  "macros",
-  "time",
+    "macros",
+    "time",
 ] }
-tokio-test = "0.4.4"
 tracing = "0.1.40"
 tracing-subscriber = "0.3"
 tz-rs = { version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 resolver = "2"
 members = [
-    "sdk/typespec",
-    "sdk/typespec/typespec_client_core",
-    "sdk/core/azure_core",
-    "sdk/core/azure_core_amqp",
-    "sdk/identity/azure_identity",
-    "sdk/eventhubs/azure_messaging_eventhubs",
-    "eng/test/mock_transport",
-    "sdk/storage",
-    "sdk/storage/azure_storage_blob",
+  "sdk/typespec",
+  "sdk/typespec/typespec_client_core",
+  "sdk/core/azure_core",
+  "sdk/core/azure_core_amqp",
+  "sdk/identity/azure_identity",
+  "sdk/eventhubs/azure_messaging_eventhubs",
+  "eng/test/mock_transport",
+  "sdk/storage",
+  "sdk/storage/azure_storage_blob",
 ]
 
 [workspace.package]
@@ -67,8 +67,8 @@ pin-project = "1.0"
 quick-xml = { version = "0.31", features = ["serialize", "serde-types"] }
 rand = "0.8"
 reqwest = { version = "0.12", features = [
-    "json",
-    "stream",
+  "json",
+  "stream",
 ], default-features = false }
 rustc_version = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -80,13 +80,13 @@ serial_test = "3.0"
 sha2 = { version = "0.10" }
 thiserror = "1.0"
 time = { version = "0.3.10", features = [
-    "serde-well-known",
-    "macros",
-    "wasm-bindgen",
+  "serde-well-known",
+  "macros",
+  "wasm-bindgen",
 ] }
 tokio = { version = "1.0", default-features = false, features = [
-    "macros",
-    "time",
+  "macros",
+  "time",
 ] }
 tokio-test = "0.4.4"
 tracing = "0.1.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 resolver = "2"
 members = [
-  "sdk/typespec",
-  "sdk/typespec/typespec_client_core",
-  "sdk/core/azure_core",
-  "sdk/core/azure_core_amqp",
-  "sdk/identity/azure_identity",
-  "sdk/eventhubs/azure_messaging_eventhubs",
-  "eng/test/mock_transport",
-  "sdk/storage",
-  "sdk/storage/azure_storage_blob",
+    "sdk/typespec",
+    "sdk/typespec/typespec_client_core",
+    "sdk/core/azure_core",
+    "sdk/core/azure_core_amqp",
+    "sdk/identity/azure_identity",
+    "sdk/eventhubs/azure_messaging_eventhubs",
+    "eng/test/mock_transport",
+    "sdk/storage",
+    "sdk/storage/azure_storage_blob",
 ]
 
 [workspace.package]
@@ -67,8 +67,8 @@ pin-project = "1.0"
 quick-xml = { version = "0.31", features = ["serialize", "serde-types"] }
 rand = "0.8"
 reqwest = { version = "0.12", features = [
-  "json",
-  "stream",
+    "json",
+    "stream",
 ], default-features = false }
 rustc_version = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -80,14 +80,15 @@ serial_test = "3.0"
 sha2 = { version = "0.10" }
 thiserror = "1.0"
 time = { version = "0.3.10", features = [
-  "serde-well-known",
-  "macros",
-  "wasm-bindgen",
+    "serde-well-known",
+    "macros",
+    "wasm-bindgen",
 ] }
 tokio = { version = "1.0", default-features = false, features = [
-  "macros",
-  "time",
+    "macros",
+    "time",
 ] }
+tokio-test = "0.4.4"
 tracing = "0.1.40"
 tracing-subscriber = "0.3"
 tz-rs = { version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 resolver = "2"
 members = [
-    "sdk/typespec",
-    "sdk/typespec/typespec_client_core",
-    "sdk/core/azure_core",
-    "sdk/core/azure_core_amqp",
-    "sdk/identity/azure_identity",
-    "sdk/eventhubs/azure_messaging_eventhubs",
-    "eng/test/mock_transport",
-    "sdk/storage",
-    "sdk/storage/azure_storage_blob",
+  "sdk/typespec",
+  "sdk/typespec/typespec_client_core",
+  "sdk/core/azure_core",
+  "sdk/core/azure_core_amqp",
+  "sdk/identity/azure_identity",
+  "sdk/eventhubs/azure_messaging_eventhubs",
+  "eng/test/mock_transport",
+  "sdk/storage",
+  "sdk/storage/azure_storage_blob",
 ]
 
 [workspace.package]
@@ -67,8 +67,8 @@ pin-project = "1.0"
 quick-xml = { version = "0.31", features = ["serialize", "serde-types"] }
 rand = "0.8"
 reqwest = { version = "0.12", features = [
-    "json",
-    "stream",
+  "json",
+  "stream",
 ], default-features = false }
 rustc_version = "0.4"
 serde = { version = "1.0", features = ["derive"] }
@@ -80,13 +80,13 @@ serial_test = "3.0"
 sha2 = { version = "0.10" }
 thiserror = "1.0"
 time = { version = "0.3.10", features = [
-    "serde-well-known",
-    "macros",
-    "wasm-bindgen",
+  "serde-well-known",
+  "macros",
+  "wasm-bindgen",
 ] }
 tokio = { version = "1.0", default-features = false, features = [
-    "macros",
-    "time",
+  "macros",
+  "time",
 ] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3"

--- a/eng/test/mock_transport/src/mock_response.rs
+++ b/eng/test/mock_transport/src/mock_response.rs
@@ -1,7 +1,7 @@
 use azure_core::{
     base64, error,
     headers::{HeaderName, HeaderValue, Headers},
-    BytesStream, RawResponse, StatusCode,
+    BytesStream, Response, StatusCode,
 };
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,7 @@ pub(crate) struct MockResponse {
     body: Bytes,
 }
 
-impl From<MockResponse> for RawResponse {
+impl From<MockResponse> for Response {
     fn from(mock_response: MockResponse) -> Self {
         let bytes_stream: azure_core::BytesStream = mock_response.body.into();
 
@@ -35,7 +35,7 @@ impl MockResponse {
         }
     }
 
-    pub(crate) async fn duplicate(response: RawResponse) -> error::Result<(RawResponse, Self)> {
+    pub(crate) async fn duplicate(response: Response) -> error::Result<(Response, Self)> {
         use error::ResultExt;
         let (status_code, header_map, body) = response.deconstruct();
         let response_bytes = body.collect().await.context(
@@ -43,7 +43,7 @@ impl MockResponse {
             "an error occurred fetching the next part of the byte stream",
         )?;
 
-        let response = RawResponse::new(
+        let response = Response::new(
             status_code,
             header_map.clone(),
             Box::pin(BytesStream::new(response_bytes.clone())),

--- a/sdk/core/azure_core/src/lib.rs
+++ b/sdk/core/azure_core/src/lib.rs
@@ -42,10 +42,10 @@ pub use models::*;
 pub use options::*;
 pub use pipeline::*;
 pub use policies::*;
-pub use typespec_client_core::http::{FromResponseBody, PinnedStream, Response, ResponseBody};
-pub use typespec_client_core::json_serializable;
+pub use typespec_client_core::http::{Model, PinnedStream, Response, ResponseBody};
+pub use typespec_client_core::json_model;
 #[cfg(feature = "xml")]
-pub use typespec_client_core::xml_serializable;
+pub use typespec_client_core::xml_model;
 
 // Re-export typespec types that are not specific to Azure.
 pub use typespec::{Error, Result};

--- a/sdk/core/azure_core/src/lib.rs
+++ b/sdk/core/azure_core/src/lib.rs
@@ -42,9 +42,10 @@ pub use models::*;
 pub use options::*;
 pub use pipeline::*;
 pub use policies::*;
-pub use typespec_client_core::http::{
-    CollectedResponse, PinnedStream, RawResponse, Response, ResponseBody,
-};
+pub use typespec_client_core::http::{FromResponseBody, PinnedStream, Response, ResponseBody};
+pub use typespec_client_core::json_serializable;
+#[cfg(feature = "xml")]
+pub use typespec_client_core::xml_serializable;
 
 // Re-export typespec types that are not specific to Azure.
 pub use typespec::{Error, Result};

--- a/sdk/identity/azure_identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/device_code_flow/mod.rs
@@ -5,14 +5,7 @@
 //! You can learn more about this authorization flow [here](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code).
 mod device_code_responses;
 
-use azure_core::{
-    content_type,
-    error::{http_response_from_body, Error, ErrorKind},
-    headers,
-    json::from_json,
-    sleep::sleep,
-    HttpClient, Method, RawResponse, Request, Url,
-};
+use azure_core::{content_type, error::{http_response_from_body, Error, ErrorKind}, headers, json::from_json, sleep::sleep, HttpClient, Method, Request, Response, Url};
 pub use device_code_responses::*;
 use futures::stream::unfold;
 use serde::Deserialize;
@@ -172,7 +165,7 @@ async fn post_form(
     http_client: Arc<dyn HttpClient>,
     url: &str,
     form_body: String,
-) -> azure_core::Result<RawResponse> {
+) -> azure_core::Result<Response> {
     let url = Url::parse(url)?;
     let mut req = Request::new(url, Method::Post);
     req.insert_header(

--- a/sdk/identity/azure_identity/src/device_code_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/device_code_flow/mod.rs
@@ -5,7 +5,14 @@
 //! You can learn more about this authorization flow [here](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code).
 mod device_code_responses;
 
-use azure_core::{content_type, error::{http_response_from_body, Error, ErrorKind}, headers, json::from_json, sleep::sleep, HttpClient, Method, Request, Response, Url};
+use azure_core::{
+    content_type,
+    error::{http_response_from_body, Error, ErrorKind},
+    headers,
+    json::from_json,
+    sleep::sleep,
+    HttpClient, Method, Request, Response, Url,
+};
 pub use device_code_responses::*;
 use futures::stream::unfold;
 use serde::Deserialize;

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/login_response.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/login_response.rs
@@ -33,6 +33,7 @@ impl<'de> Deserialize<'de> for LoginResponse {
         Ok(LoginResponse::from_base_response(resp))
     }
 }
+
 azure_core::json_serializable!(LoginResponse);
 
 impl LoginResponse {

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/login_response.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/login_response.rs
@@ -33,6 +33,7 @@ impl<'de> Deserialize<'de> for LoginResponse {
         Ok(LoginResponse::from_base_response(resp))
     }
 }
+azure_core::json_serializable!(LoginResponse);
 
 impl LoginResponse {
     pub fn access_token(&self) -> &Secret {

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/login_response.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/login_response.rs
@@ -34,7 +34,7 @@ impl<'de> Deserialize<'de> for LoginResponse {
     }
 }
 
-azure_core::json_serializable!(LoginResponse);
+azure_core::json_model!(LoginResponse);
 
 impl LoginResponse {
     pub fn access_token(&self) -> &Secret {

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
@@ -77,7 +77,7 @@ pub async fn perform(
         content_type::APPLICATION_X_WWW_FORM_URLENCODED,
     );
     req.set_body(encoded);
-    let rsp: Response<LoginResponse> = http_client.execute_request(&req).await?.map();
+    let rsp: Response<LoginResponse> = http_client.execute_request(&req).await?.map_body();
     let rsp_status = rsp.status();
     debug!("rsp_status == {:?}", rsp_status);
     if rsp_status.is_success() {

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
@@ -77,11 +77,11 @@ pub async fn perform(
         content_type::APPLICATION_X_WWW_FORM_URLENCODED,
     );
     req.set_body(encoded);
-    let rsp: Response<LoginResponse> = http_client.execute_request(&req).await?.map_body();
+    let rsp: Response = http_client.execute_request(&req).await?;
     let rsp_status = rsp.status();
     debug!("rsp_status == {:?}", rsp_status);
     if rsp_status.is_success() {
-        rsp.deserialize_body().await
+        rsp.deserialize_body_into().await
     } else {
         let rsp_body = rsp.into_body().collect().await?;
         let text = std::str::from_utf8(&rsp_body)?;

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
@@ -38,7 +38,7 @@ mod login_response;
 use azure_core::{
     content_type,
     error::{http_response_from_body, ErrorKind, ResultExt},
-    headers, HttpClient, Method, Request, Url,
+    headers, HttpClient, Method, Request, Response, Url,
 };
 use login_response::LoginResponse;
 use std::sync::Arc;
@@ -81,7 +81,7 @@ pub async fn perform(
     let rsp_status = rsp.status();
     debug!("rsp_status == {:?}", rsp_status);
     if rsp_status.is_success() {
-        rsp.read_body().await
+        rsp.deserialize_body().await
     } else {
         let rsp_body = rsp.into_body().collect().await?;
         let text = std::str::from_utf8(&rsp_body)?;

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
@@ -77,11 +77,11 @@ pub async fn perform(
         content_type::APPLICATION_X_WWW_FORM_URLENCODED,
     );
     req.set_body(encoded);
-    let rsp = http_client.execute_request(&req).await?;
+    let rsp: Response<LoginResponse> = http_client.execute_request(&req).await?.map();
     let rsp_status = rsp.status();
     debug!("rsp_status == {:?}", rsp_status);
     if rsp_status.is_success() {
-        rsp.json().await
+        rsp.read_body().await
     } else {
         let rsp_body = rsp.into_body().collect().await?;
         let text = std::str::from_utf8(&rsp_body)?;

--- a/sdk/identity/azure_identity/src/refresh_token.rs
+++ b/sdk/identity/azure_identity/src/refresh_token.rs
@@ -49,7 +49,7 @@ pub async fn exchange(
     let rsp_status = rsp.status();
 
     if rsp_status.is_success() {
-        rsp.read_body().await.map_kind(ErrorKind::Credential)
+        rsp.deserialize_body().await.map_kind(ErrorKind::Credential)
     } else {
         let rsp_body = rsp.into_body().collect().await?;
         let token_error: RefreshTokenError =

--- a/sdk/identity/azure_identity/src/refresh_token.rs
+++ b/sdk/identity/azure_identity/src/refresh_token.rs
@@ -45,11 +45,11 @@ pub async fn exchange(
     );
     req.set_body(encoded);
 
-    let rsp = http_client.execute_request(&req).await?;
+    let rsp = http_client.execute_request(&req).await?.map();
     let rsp_status = rsp.status();
 
     if rsp_status.is_success() {
-        rsp.json().await.map_kind(ErrorKind::Credential)
+        rsp.read_body().await.map_kind(ErrorKind::Credential)
     } else {
         let rsp_body = rsp.into_body().collect().await?;
         let token_error: RefreshTokenError =
@@ -69,6 +69,7 @@ pub struct RefreshTokenResponse {
     access_token: Secret,
     refresh_token: Secret,
 }
+azure_core::json_serializable!(RefreshTokenResponse);
 
 impl RefreshTokenResponse {
     /// Returns the `token_type`. Always `Bearer` for Azure AD.

--- a/sdk/identity/azure_identity/src/refresh_token.rs
+++ b/sdk/identity/azure_identity/src/refresh_token.rs
@@ -45,11 +45,13 @@ pub async fn exchange(
     );
     req.set_body(encoded);
 
-    let rsp = http_client.execute_request(&req).await?.map_body();
+    let rsp = http_client.execute_request(&req).await?;
     let rsp_status = rsp.status();
 
     if rsp_status.is_success() {
-        rsp.deserialize_body().await.map_kind(ErrorKind::Credential)
+        rsp.deserialize_body_into()
+            .await
+            .map_kind(ErrorKind::Credential)
     } else {
         let rsp_body = rsp.into_body().collect().await?;
         let token_error: RefreshTokenError =
@@ -69,7 +71,7 @@ pub struct RefreshTokenResponse {
     access_token: Secret,
     refresh_token: Secret,
 }
-azure_core::json_serializable!(RefreshTokenResponse);
+azure_core::json_model!(RefreshTokenResponse);
 
 impl RefreshTokenResponse {
     /// Returns the `token_type`. Always `Bearer` for Azure AD.

--- a/sdk/identity/azure_identity/src/refresh_token.rs
+++ b/sdk/identity/azure_identity/src/refresh_token.rs
@@ -45,7 +45,7 @@ pub async fn exchange(
     );
     req.set_body(encoded);
 
-    let rsp = http_client.execute_request(&req).await?.map();
+    let rsp = http_client.execute_request(&req).await?.map_body();
     let rsp_status = rsp.status();
 
     if rsp_status.is_success() {

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -42,12 +42,12 @@ tokio.workspace = true
 
 [features]
 default = [
-    "http",
-    "json",
-    "reqwest",
-    "reqwest_gzip",
-    "reqwest_rustls",
-    "tokio_sleep",
+  "http",
+  "json",
+  "reqwest",
+  "reqwest_gzip",
+  "reqwest_rustls",
+  "tokio_sleep",
 ]
 http = ["dep:http-types", "typespec/http"]
 json = ["typespec/json"]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -43,12 +43,12 @@ tokio-test.workspace = true
 
 [features]
 default = [
-    "http",
-    "json",
-    "reqwest",
-    "reqwest_gzip",
-    "reqwest_rustls",
-    "tokio_sleep",
+  "http",
+  "json",
+  "reqwest",
+  "reqwest_gzip",
+  "reqwest_rustls",
+  "tokio_sleep",
 ]
 http = ["dep:http-types", "typespec/http"]
 json = ["typespec/json"]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -38,15 +38,17 @@ tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [dev-dependencies]
 once_cell = { workspace = true }
+tokio.workspace = true
+tokio-test.workspace = true
 
 [features]
 default = [
-  "http",
-  "json",
-  "reqwest",
-  "reqwest_gzip",
-  "reqwest_rustls",
-  "tokio_sleep",
+    "http",
+    "json",
+    "reqwest",
+    "reqwest_gzip",
+    "reqwest_rustls",
+    "tokio_sleep",
 ]
 http = ["dep:http-types", "typespec/http"]
 json = ["typespec/json"]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -39,16 +39,15 @@ tokio = { workspace = true, features = ["macros", "rt", "time"] }
 [dev-dependencies]
 once_cell = { workspace = true }
 tokio.workspace = true
-tokio-test.workspace = true
 
 [features]
 default = [
-  "http",
-  "json",
-  "reqwest",
-  "reqwest_gzip",
-  "reqwest_rustls",
-  "tokio_sleep",
+    "http",
+    "json",
+    "reqwest",
+    "reqwest_gzip",
+    "reqwest_rustls",
+    "tokio_sleep",
 ]
 http = ["dep:http-types", "typespec/http"]
 json = ["typespec/json"]

--- a/sdk/typespec/typespec_client_core/src/error/http_error.rs
+++ b/sdk/typespec/typespec_client_core/src/error/http_error.rs
@@ -5,7 +5,7 @@
 use crate::json::from_json;
 use crate::{
     error::ErrorKind,
-    http::{headers, RawResponse, StatusCode},
+    http::{headers, Response, StatusCode},
     Error,
 };
 use bytes::Bytes;
@@ -25,7 +25,7 @@ impl HttpError {
     /// Create an error from an HTTP response.
     ///
     /// This does not check whether the response was successful and should only be used with unsuccessful responses.
-    pub async fn new(response: Response) -> Self {
+    pub async fn new(response: Response<()>) -> Self {
         let status = response.status();
         let headers: HashMap<String, String> = response
             .headers()

--- a/sdk/typespec/typespec_client_core/src/error/http_error.rs
+++ b/sdk/typespec/typespec_client_core/src/error/http_error.rs
@@ -25,7 +25,7 @@ impl HttpError {
     /// Create an error from an HTTP response.
     ///
     /// This does not check whether the response was successful and should only be used with unsuccessful responses.
-    pub async fn new(response: RawResponse) -> Self {
+    pub async fn new(response: Response) -> Self {
         let status = response.status();
         let headers: HashMap<String, String> = response
             .headers()

--- a/sdk/typespec/typespec_client_core/src/http/clients/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/mod.rs
@@ -13,7 +13,7 @@ use self::noop::new_noop_client;
 #[cfg(any(feature = "reqwest", feature = "reqwest_rustls"))]
 use self::reqwest::new_reqwest_client;
 
-use crate::http::{RawResponse, Request};
+use crate::http::{Request, Response};
 use async_trait::async_trait;
 use std::sync::Arc;
 use typespec::error::Result;
@@ -38,5 +38,5 @@ pub trait HttpClient: Send + Sync + std::fmt::Debug {
     ///
     /// It does not consume the request. Implementors are expected to clone the necessary parts
     /// of the request and pass them to the underlying transport.
-    async fn execute_request(&self, request: &Request) -> Result<RawResponse>;
+    async fn execute_request(&self, request: &Request) -> Result<Response>;
 }

--- a/sdk/typespec/typespec_client_core/src/http/clients/noop.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/noop.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     error::Result,
-    http::{RawResponse, Request},
+    http::{Request, Response},
 };
 use async_trait::async_trait;
 

--- a/sdk/typespec/typespec_client_core/src/http/clients/noop.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/noop.rs
@@ -19,7 +19,7 @@ pub(crate) fn new_noop_client() -> std::sync::Arc<dyn super::HttpClient> {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl super::HttpClient for NoopClient {
     #[allow(clippy::diverging_sub_expression)]
-    async fn execute_request(&self, request: &Request) -> Result<RawResponse> {
+    async fn execute_request(&self, request: &Request) -> Result<Response> {
         panic!(
             "A request was called on the default http client `NoopClient`.\
 	This client does nothing but panic. Make sure to enable an http\

--- a/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
@@ -3,7 +3,7 @@
 
 use crate::http::{
     headers::{HeaderName, HeaderValue, Headers},
-    Body, HttpClient, Method, PinnedStream, RawResponse, Request, Response, StatusCode,
+    Body, HttpClient, Method, PinnedStream, Request, Response, StatusCode,
 };
 use async_trait::async_trait;
 use futures::TryStreamExt;

--- a/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
@@ -3,7 +3,7 @@
 
 use crate::http::{
     headers::{HeaderName, HeaderValue, Headers},
-    Body, HttpClient, Method, PinnedStream, RawResponse, Request, StatusCode,
+    Body, HttpClient, Method, PinnedStream, RawResponse, Request, Response, StatusCode,
 };
 use async_trait::async_trait;
 use futures::TryStreamExt;
@@ -37,7 +37,7 @@ pub fn new_reqwest_client() -> Arc<dyn HttpClient> {
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl HttpClient for ::reqwest::Client {
-    async fn execute_request(&self, request: &Request) -> Result<RawResponse> {
+    async fn execute_request(&self, request: &Request) -> Result<Response> {
         let url = request.url().clone();
         let method = request.method();
         let mut req = self.request(try_from_method(*method)?, url.clone());
@@ -75,7 +75,7 @@ impl HttpClient for ::reqwest::Client {
             )
         }));
 
-        Ok(RawResponse::new(try_from_status(status)?, headers, body))
+        Ok(Response::new(try_from_status(status)?, headers, body))
     }
 }
 

--- a/sdk/typespec/typespec_client_core/src/http/options/transport.rs
+++ b/sdk/typespec/typespec_client_core/src/http/options/transport.rs
@@ -36,7 +36,7 @@ impl TransportOptions {
     }
 
     /// Use these options to send a request.
-    pub async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<RawResponse> {
+    pub async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<Response> {
         use TransportOptionsImpl as I;
         match &self.inner {
             I::Http { http_client } => http_client.execute_request(request).await,

--- a/sdk/typespec/typespec_client_core/src/http/options/transport.rs
+++ b/sdk/typespec/typespec_client_core/src/http/options/transport.rs
@@ -40,7 +40,7 @@ impl TransportOptions {
         use TransportOptionsImpl as I;
         match &self.inner {
             I::Http { http_client } => http_client.execute_request(request).await,
-            I::Custom(s) => s.send(ctx, request, &[]).await,
+            I::Custom(s) => s.send(ctx, request, &[]).await.map(|r| r.map_body()),
         }
     }
 }

--- a/sdk/typespec/typespec_client_core/src/http/options/transport.rs
+++ b/sdk/typespec/typespec_client_core/src/http/options/transport.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::http::{clients, Context, HttpClient, Policy, RawResponse, Request};
+use crate::http::{clients, Context, HttpClient, Policy, Request, Response};
 use std::sync::Arc;
 use typespec::error::Result;
 
@@ -36,12 +36,14 @@ impl TransportOptions {
     }
 
     /// Use these options to send a request.
-    pub async fn send(&self, ctx: &Context<'_>, request: &mut Request) -> Result<Response> {
+    pub async fn send<T>(&self, ctx: &Context<'_>, request: &mut Request) -> Result<Response<T>> {
         use TransportOptionsImpl as I;
-        match &self.inner {
+        let raw_response = match &self.inner {
             I::Http { http_client } => http_client.execute_request(request).await,
-            I::Custom(s) => s.send(ctx, request, &[]).await.map(|r| r.map_body()),
-        }
+            I::Custom(s) => s.send(ctx, request, &[]).await,
+        };
+
+        raw_response.map(|r| r.map_body())
     }
 }
 

--- a/sdk/typespec/typespec_client_core/src/http/options/transport.rs
+++ b/sdk/typespec/typespec_client_core/src/http/options/transport.rs
@@ -43,7 +43,7 @@ impl TransportOptions {
             I::Custom(s) => s.send(ctx, request, &[]).await,
         };
 
-        raw_response.map(|r| r.set_default_deserialize_type())
+        raw_response.map(|r| r.with_default_deserialize_type())
     }
 }
 

--- a/sdk/typespec/typespec_client_core/src/http/options/transport.rs
+++ b/sdk/typespec/typespec_client_core/src/http/options/transport.rs
@@ -43,7 +43,7 @@ impl TransportOptions {
             I::Custom(s) => s.send(ctx, request, &[]).await,
         };
 
-        raw_response.map(|r| r.map_body())
+        raw_response.map(|r| r.set_default_deserialize_type())
     }
 }
 

--- a/sdk/typespec/typespec_client_core/src/http/pipeline.rs
+++ b/sdk/typespec/typespec_client_core/src/http/pipeline.rs
@@ -86,7 +86,7 @@ impl Pipeline {
         self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
             .await
-            .map(|resp| resp.map_body())
+            .map(|resp| resp.set_default_deserialize_type())
     }
 }
 

--- a/sdk/typespec/typespec_client_core/src/http/pipeline.rs
+++ b/sdk/typespec/typespec_client_core/src/http/pipeline.rs
@@ -86,7 +86,7 @@ impl Pipeline {
         self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
             .await
-            .map(|resp| resp.into())
+            .map(|resp| resp.map_body())
     }
 }
 
@@ -94,7 +94,8 @@ impl Pipeline {
 mod tests {
     use super::*;
     use crate::{
-        http::{headers::Headers, Method, PolicyResult, RawResponse, StatusCode, TransportOptions},
+        http::{headers::Headers, Method, PolicyResult, StatusCode, TransportOptions},
+        json_serializable,
         stream::BytesStream,
     };
     use bytes::Bytes;
@@ -116,7 +117,7 @@ mod tests {
             ) -> PolicyResult {
                 let buffer = Bytes::from_static(br#"{"foo":1,"bar":"baz"}"#);
                 let stream: BytesStream = buffer.into();
-                let response = RawResponse::new(StatusCode::Ok, Headers::new(), Box::pin(stream));
+                let response = Response::new(StatusCode::Ok, Headers::new(), Box::pin(stream));
                 Ok(std::future::ready(response).await)
             }
         }
@@ -126,6 +127,7 @@ mod tests {
             foo: i32,
             bar: String,
         }
+        json_serializable!(Model);
 
         let options =
             ClientOptions::new(TransportOptions::new_custom_policy(Arc::new(Responder {})));
@@ -136,7 +138,7 @@ mod tests {
             .send(&Context::default(), &mut request)
             .await
             .unwrap()
-            .json()
+            .deserialize_body()
             .await
             .unwrap();
 

--- a/sdk/typespec/typespec_client_core/src/http/pipeline.rs
+++ b/sdk/typespec/typespec_client_core/src/http/pipeline.rs
@@ -86,7 +86,7 @@ impl Pipeline {
         self.pipeline[0]
             .send(ctx, request, &self.pipeline[1..])
             .await
-            .map(|resp| resp.set_default_deserialize_type())
+            .map(|resp| resp.with_default_deserialize_type())
     }
 }
 

--- a/sdk/typespec/typespec_client_core/src/http/pipeline.rs
+++ b/sdk/typespec/typespec_client_core/src/http/pipeline.rs
@@ -95,7 +95,7 @@ mod tests {
     use super::*;
     use crate::{
         http::{headers::Headers, Method, PolicyResult, StatusCode, TransportOptions},
-        json_serializable,
+        json_model,
         stream::BytesStream,
     };
     use bytes::Bytes;
@@ -127,7 +127,7 @@ mod tests {
             foo: i32,
             bar: String,
         }
-        json_serializable!(Model);
+        json_model!(Model);
 
         let options =
             ClientOptions::new(TransportOptions::new_custom_policy(Arc::new(Responder {})));

--- a/sdk/typespec/typespec_client_core/src/http/policies/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/mod.rs
@@ -3,7 +3,7 @@
 
 //! HTTP pipeline policies.
 
-use crate::http::{Context, RawResponse, Request};
+use crate::http::{Context, Request, Response};
 use async_trait::async_trait;
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ pub use retry::*;
 pub use transport::*;
 
 /// A specialized `Result` type for policies.
-pub type PolicyResult = typespec::error::Result<RawResponse>;
+pub type PolicyResult = typespec::error::Result<Response>;
 
 /// A pipeline policy.
 ///

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -139,7 +139,7 @@ impl Response<()> {
     /// Changes the type of the response body.
     ///
     /// Used to set the "type" of an untyped `Response<()>`, transforming it into a `Response<T>`.
-    pub fn map_body<T>(self) -> Response<T> {
+    pub(crate) fn set_default_deserialize_type<T>(self) -> Response<T> {
         Response {
             status: self.status,
             headers: self.headers,
@@ -176,14 +176,15 @@ impl<T: Model> Response<T> {
     /// #   SecretClient { }
     /// # }
     ///
-    /// # tokio_test::block_on(async {
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// let secret_client = create_secret_client();
     /// let response = secret_client.get_secret().await;
     /// assert_eq!(response.status(), http_types::StatusCode::Ok);
     /// let model = response.deserialize_body().await.unwrap();
     /// assert_eq!(model.name, "database_password");
     /// assert_eq!(model.value, "hunter2");
-    /// # });
+    /// # }
     /// ```
     pub async fn deserialize_body(self) -> crate::Result<T> {
         T::from_response_body(self.body).await

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -115,6 +115,7 @@ impl<T> Response<T> {
     /// struct MySecretResponse {
     ///    value: String,
     /// }
+    /// azure_core::json_serializable!(MySecretResponse); // Mark the type as deserializable from JSON.
     ///
     /// async fn parse_response(response: Response<GetSecretResponse>) {
     ///   // Calling `map` will parse the body into `MySecretResponse` instead of `GetSecretResponse`.

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -139,7 +139,7 @@ impl Response<()> {
     /// Changes the type of the response body.
     ///
     /// Used to set the "type" of an untyped `Response<()>`, transforming it into a `Response<T>`.
-    pub(crate) fn set_default_deserialize_type<T>(self) -> Response<T> {
+    pub(crate) fn with_default_deserialize_type<T>(self) -> Response<T> {
         Response {
             status: self.status,
             headers: self.headers,

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -5,6 +5,7 @@ use crate::http::{headers::Headers, StatusCode};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use serde::de::DeserializeOwned;
+use std::future::Future;
 use std::{fmt, marker::PhantomData, pin::Pin};
 use typespec::error::{ErrorKind, ResultExt};
 
@@ -13,20 +14,66 @@ pub type PinnedStream = Pin<Box<dyn Stream<Item = crate::Result<Bytes>> + Send +
 #[cfg(target_arch = "wasm32")]
 pub type PinnedStream = Pin<Box<dyn Stream<Item = crate::Result<Bytes>>>>;
 
-/// An HTTP response containing a stream of bytes.
-pub struct RawResponse {
+/// Trait that represents types that can be deserialized from an HTTP response body.
+pub trait FromResponseBody: Sized {
+    /// Deserialize the response body into type `Self`.
+    ///
+    /// A [`ResponseBody`] represents a stream of bytes coming from the server.
+    /// The server may still be sending data, so it's up to implementors whether they want to wait for the entire body to be received or not.
+    /// For example, a type representing a simple REST API response will want to wait for the entire body to be received and then parse the body.
+    /// However, a type representing the download of a large file, may not want to do that and instead prepare to stream the body to a file or other destination.
+    fn from_response_body(body: ResponseBody) -> impl Future<Output = crate::Result<Self>>;
+}
+
+#[macro_export]
+macro_rules! json_serializable {
+    ($type:ty) => {
+        impl $crate::FromResponseBody for $type {
+            async fn from_response_body(body: $crate::ResponseBody) -> $crate::Result<Self> {
+                body.json().await
+            }
+        }
+    };
+}
+
+#[macro_export]
+#[cfg(feature = "xml")]
+macro_rules! xml_serializable {
+    ($type:ty) => {
+        impl $crate::FromResponseBody for $type {
+            async fn from_response_body(body: $crate::ResponseBody) -> $crate::Result<Self> {
+                body.xml().await
+            }
+        }
+    };
+}
+
+/// Represents an HTTP response, which may be deserialized into a type `T`.
+pub struct Response<T = ()> {
     status: StatusCode,
     headers: Headers,
     body: ResponseBody,
+    phantom: PhantomData<T>,
 }
 
-impl RawResponse {
-    /// Create an HTTP response.
+impl<T> Response<T> {
+    /// Create an HTTP response from an asynchronous stream of bytes.
     pub fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self {
         Self {
             status,
             headers,
             body: ResponseBody::new(stream),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Create an HTTP response from raw bytes.
+    pub fn from_bytes(status: StatusCode, headers: Headers, bytes: impl Into<Bytes>) -> Self {
+        Self {
+            status,
+            headers,
+            body: ResponseBody::from_bytes(bytes),
+            phantom: PhantomData,
         }
     }
 
@@ -45,179 +92,60 @@ impl RawResponse {
         (self.status, self.headers, self.body)
     }
 
-    /// Consume the HTTP response and return the HTTP body bytes.
+    /// Fetches the entire body and returns it as raw bytes.
+    ///
+    /// This method will force the entire body to be downloaded from the server and consume the response.
+    /// If you want to parse the body into a type, use [`read_body`](Response::read_body) instead.
     pub fn into_body(self) -> ResponseBody {
         self.body
     }
 
-    /// Get the response body as the specified type from JSON.
-    pub async fn json<T>(self) -> crate::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self.into_body().json().await
-    }
-
-    /// Get the response body as the specified type from XML.
-    #[cfg(feature = "xml")]
-    pub async fn xml<T>(self) -> crate::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self.into_body().xml().await
-    }
-}
-
-impl fmt::Debug for RawResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Response")
-            .field("status", &self.status)
-            .field("headers", &self.headers)
-            .field("body", &"(body)")
-            .finish()
-    }
-}
-
-impl<T> From<RawResponse> for Response<T> {
-    fn from(response: RawResponse) -> Self {
-        Self {
-            response,
+    /// Produces a new [`Response`] that will parse the body into type `U`.
+    ///
+    /// This method is intended for use in rare cases where the body of a service response should be parsed into a user-provided type.
+    ///
+    /// # Example
+    /// ```rust
+    /// # pub struct GetSecretResponse { }
+    /// use typespec_client_core::http::Response;
+    /// use serde::Deserialize;
+    /// use bytes::Bytes;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct MySecretResponse {
+    ///    value: String,
+    /// }
+    ///
+    /// async fn parse_response(response: Response<GetSecretResponse>) {
+    ///   // Calling `map` will parse the body into `MySecretResponse` instead of `GetSecretResponse`.
+    ///   let my_struct: MySecretResponse = response.map().read_body().await.unwrap();
+    ///   println!("value: {}", my_struct.value);
+    /// }
+    pub fn map<U>(self) -> Response<U> {
+        Response {
+            status: self.status,
+            headers: self.headers,
+            body: self.body,
             phantom: PhantomData,
         }
     }
 }
 
-/// An HTTP response to deserialize a stream of bytes into a model of type `T`.
-pub struct Response<T> {
-    response: RawResponse,
-    phantom: PhantomData<T>,
-}
-
-impl<T> Response<T> {
-    /// Create an HTTP response.
-    pub fn new(status: StatusCode, headers: Headers, stream: PinnedStream) -> Self {
-        Self {
-            response: RawResponse::new(status, headers, stream),
-            phantom: PhantomData,
-        }
-    }
-
-    /// Get the status code from the response.
-    pub fn status(&self) -> StatusCode {
-        self.response.status
-    }
-
-    /// Get the headers from the response.
-    pub fn headers(&self) -> &Headers {
-        &self.response.headers
-    }
-
-    /// Deconstruct the HTTP response into its components.
-    pub fn deconstruct(self) -> (StatusCode, Headers, ResponseBody) {
-        (
-            self.response.status,
-            self.response.headers,
-            self.response.body,
-        )
-    }
-
-    /// Consume the HTTP response and return the HTTP body bytes.
-    pub fn into_body(self) -> ResponseBody {
-        self.response.body
-    }
-
-    /// Get the response body as the specified type from JSON.
-    pub async fn json(self) -> crate::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self.into_body().json().await
-    }
-
-    /// Get the response body as the specified type from XML.
-    #[cfg(feature = "xml")]
-    pub async fn xml(self) -> crate::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        self.into_body().xml().await
+// TODO: We don't want Bytes here, but I'm having ownership issues with &'a [u8] so we stick with this for now.
+impl<T: FromResponseBody> Response<T> {
+    /// Fetches the entire body and tries to convert it into type `T`.
+    pub async fn read_body(self) -> crate::Result<T> {
+        T::from_response_body(self.body).await
     }
 }
 
 impl<T> fmt::Debug for Response<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Response")
-            .field("status", &self.response.status)
-            .field("headers", &self.response.headers)
+            .field("status", &self.status)
+            .field("headers", &self.headers)
             .field("body", &"(body)")
             .finish()
-    }
-}
-
-/// An HTTP response with the body collected as bytes.
-#[derive(Debug, Clone)]
-pub struct CollectedResponse<T> {
-    status: StatusCode,
-    headers: Headers,
-    body: Bytes,
-    phantom: PhantomData<T>,
-}
-
-impl<T> CollectedResponse<T> {
-    /// Create a collected HTTP response.
-    pub fn new(status: StatusCode, headers: Headers, body: Bytes) -> Self {
-        Self {
-            status,
-            headers,
-            body,
-            phantom: PhantomData,
-        }
-    }
-
-    /// Get the status code from the response.
-    pub fn status(&self) -> &StatusCode {
-        &self.status
-    }
-
-    /// Get the headers from the response.
-    pub fn headers(&self) -> &Headers {
-        &self.headers
-    }
-
-    /// Get the collected body from the response.
-    pub fn body(&self) -> &Bytes {
-        &self.body
-    }
-
-    /// Create a collected HTTP response from a [`Response`].
-    pub async fn from_response(response: RawResponse) -> crate::Result<Self> {
-        let (status, headers, body) = response.deconstruct();
-        let body = body.collect().await?;
-        Ok(Self::new(status, headers, body))
-    }
-
-    /// Deserialize the JSON body into type `T`.
-    #[cfg(feature = "json")]
-    pub fn json(&self) -> crate::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        crate::json::from_json(&self.body)
-    }
-
-    /// Deserialize the XML body into type `T`.
-    #[cfg(feature = "xml")]
-    pub fn xml(&self) -> crate::Result<T>
-    where
-        T: DeserializeOwned,
-    {
-        crate::xml::read_xml(&self.body)
-    }
-}
-
-impl<T> AsRef<[u8]> for CollectedResponse<T> {
-    fn as_ref(&self) -> &[u8] {
-        self.body.as_ref()
     }
 }
 
@@ -228,8 +156,15 @@ impl<T> AsRef<[u8]> for CollectedResponse<T> {
 pub struct ResponseBody(#[pin] PinnedStream);
 
 impl ResponseBody {
+    /// Create a new [`ResponseBody`] from an async stream of bytes.
     fn new(stream: PinnedStream) -> Self {
         Self(stream)
+    }
+
+    /// Create a new [`ResponseBody`] from a byte slice.
+    fn from_bytes(bytes: impl Into<Bytes>) -> Self {
+        let bytes = bytes.into();
+        Self::new(Box::pin(futures::stream::once(async move { Ok(bytes) })))
     }
 
     /// Collect the stream into a [`Bytes`] collection.
@@ -288,5 +223,107 @@ impl Stream for ResponseBody {
 impl fmt::Debug for ResponseBody {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("ResponseBody")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    mod json {
+        use crate::http::headers::Headers;
+        use crate::http::Response;
+        use http_types::StatusCode;
+        use serde::Deserialize;
+
+        /// An example JSON-serialized response type.
+        #[derive(Deserialize)]
+        struct GetSecretResponse {
+            name: String,
+            value: String,
+        }
+        json_serializable!(GetSecretResponse);
+
+        /// A sample service client function.
+        fn get_secret() -> Response<GetSecretResponse> {
+            Response::from_bytes(
+                StatusCode::Ok,
+                Headers::new(),
+                "{\"name\":\"my_secret\",\"value\":\"my_value\"}",
+            )
+        }
+
+        #[tokio::test]
+        pub async fn deserialize_default_type() {
+            let response = get_secret();
+            let secret = response.read_body().await.unwrap();
+            assert_eq!(secret.name, "my_secret");
+            assert_eq!(secret.value, "my_value");
+        }
+
+        #[tokio::test]
+        pub async fn deserialize_alternate_type() {
+            #[derive(Deserialize)]
+            struct MySecretResponse {
+                #[serde(rename = "name")]
+                yon_name: String,
+                #[serde(rename = "value")]
+                yon_value: String,
+            }
+            json_serializable!(MySecretResponse);
+
+            let response = get_secret().map();
+            let secret: MySecretResponse = response.read_body().await.unwrap();
+            assert_eq!(secret.yon_name, "my_secret");
+            assert_eq!(secret.yon_value, "my_value");
+        }
+    }
+
+    #[cfg(feature = "xml")]
+    mod xml {
+        use crate::http::headers::Headers;
+        use crate::http::Response;
+        use http_types::StatusCode;
+        use serde::Deserialize;
+
+        /// An example XML-serialized response type.
+        #[derive(Deserialize)]
+        struct GetSecretResponse {
+            name: String,
+            value: String,
+        }
+        xml_serializable!(GetSecretResponse);
+
+        /// A sample service client function.
+        fn get_secret() -> Response<GetSecretResponse> {
+            Response::from_bytes(
+                StatusCode::Ok,
+                Headers::new(),
+                "<GetSecretResponse><name>my_secret</name><value>my_value</value></GetSecretResponse>",
+            )
+        }
+
+        #[tokio::test]
+        pub async fn deserialize_default_type() {
+            let response = get_secret();
+            let secret = response.read_body().await.unwrap();
+            assert_eq!(secret.name, "my_secret");
+            assert_eq!(secret.value, "my_value");
+        }
+
+        #[tokio::test]
+        pub async fn deserialize_alternate_type() {
+            #[derive(Deserialize)]
+            struct MySecretResponse {
+                #[serde(rename = "name")]
+                yon_name: String,
+                #[serde(rename = "value")]
+                yon_value: String,
+            }
+            xml_serializable!(MySecretResponse);
+
+            let response = get_secret().map();
+            let secret: MySecretResponse = response.read_body().await.unwrap();
+            assert_eq!(secret.yon_name, "my_secret");
+            assert_eq!(secret.yon_value, "my_value");
+        }
     }
 }


### PR DESCRIPTION
Ok, here's another approach for the `Response<T>` refactor that's primarily motivated by the fact that our latest attempt was stymied by the fact that Rust does not permit default values on type parameters for functions.

As a reminder, here are our goals:

* Allow the user to specify their own model type to deserialize in to
* Allow the user to to read status code and headers without requiring they wait for the body
* Retain a smooth and discoverable experience for the "default" use case of deserializing into the service-provided model.
* Allow us to model large streamed responses, like downloading a blob (being forced to load the entire response body at once is undesirable). 

So, given that I've made some refactorings:

1. Removed `RawResponse`, there is only `Response<T>`. A `RawResponse` is represented by `Response<()>`
2. As in the current `feature/track2` branch, the `Response<T>` does not _contain_ a `T`, it indicates that a `T` can be deserialized from the body of the response. A `Response<T>` contains the raw `PinnedStream` representing a stream of incoming bytes.
3. Since the `T` in `Response<T>` just indicates how the body can be read, it has a default of `()` (so `Response<()>` is what pipeline elements return since they don't know the intended return type).
4. The target type `T` can be changed using `map_body`: `let resp: Response<MyOtherType> = resp.map_body()`. This doesn't parse anything, it just changes the target type.
5. The body type `T` can be retrieved from a `Response<T>` using `read_body`. This is an `async` function that relies on `T` implementing the `FromResponseBody` trait.
6. We use `FromResponseBody` instead of `TryFrom` or `From` because we need an async version. I don't want to claim a name like `AsyncTryFrom` so it felt best to just limit the trait to our specific need.
7. A service client has flexibility in how it implements `FromResponseBody` because it doesn't have to wait for the entire body to be downloaded.
8. To simplify writing client models, there are two macros: `json_serializable!` and `xml_serializable!` which generate an automatic implementation of `FromResponseBody` for any type that implements `Deserialize`, using our `from_json` and `read_xml` helpers.

Here's an example client method, taken from my coming PR to implement the "read database metadata" API for Cosmos DB:

```rust
async fn read(
    &self,
    options: Option<ReadDatabaseOptions>,
) -> azure_core::Result<azure_core::Response<DatabaseProperties>> {
    let mut req = Request::new(self.base_url.clone(), azure_core::Method::Get);
    let ctx = Context::new().with_value(ResourceType::Databases);
    self.root_client.pipeline.send(&ctx, &mut req).await
}
```

The `Pipeline::send` method is generic, which allows for this fairly clean code that infers the `T` in `Response<T>` from the return type of the `read` function.

A user application would call this API like so:

```rust
let response = db_client.read(None).await?.read_body().await?;
```

The double-`await` is here but somewhat unavoidable without even more type machinations. The first one is for sending the request and receiving the headers. The second one is for loading the entire body. However, you could see some benefit from this in say, a fictious API like this:

```rust
blob_client.get(None).await?.save_to_file("/foo.txt").await?;
```

The `save_to_file` method has the ability to stream bytes directly from the `ResponseBody` to disk and doesn't require that you load it all into memory first.
 
A user can _also_ choose to use their own type, like so:

```rust
#[derive(Deserialize, Debug)]
struct MyDatabase {
    #[serde(rename = "id")]
    pub yon_id: String,
}
azure_core::json_serializable!(MyDatabase);
let response: MyDatabase = db_client.read(None).await?.map_body().read_body().await?;
```

Note the additional `map_body` call. It would be nice if `map_body` wasn't required, but we end up hitting exactly the same problem as we had before. Making the `read_body` method generic would require that the user **always** specify the target type, even when using the default (since it can't have a default type).