### PR TITLE
Add traits with getters for ClientOptions, ClientMethodOptions

### DIFF
--- a/sdk/core/azure_core/src/options/mod.rs
+++ b/sdk/core/azure_core/src/options/mod.rs
@@ -66,7 +66,7 @@ impl ClientOptions {
         self.retry = Some(retry.into());
     }
 
-    /// Set [`TelemetryOptions`] used by the client.
+    /// Set the [`TelemetryOptions`] used by the client.
     pub fn set_telemetry<P>(&mut self, telemetry: P)
     where
         P: Into<TelemetryOptions>,
@@ -83,6 +83,46 @@ impl ClientOptions {
     }
 }
 
+/// Trait for getting general client options from specific client options.
+pub trait AsClientOptions {
+    /// Gets policies for each call to a client method.
+    fn per_call_policies(&self) -> &Vec<Arc<dyn Policy>>;
+
+    /// Gets policies for each attempt to call a client method.
+    fn per_try_policies(&self) -> &Vec<Arc<dyn Policy>>;
+
+    /// Gets the default [`RetryOptions`] for every client method call.
+    fn retry(&self) -> Option<&RetryOptions>;
+
+    /// Gets the [`TelemetryOptions`] used by the client.
+    fn telemetry(&self) -> Option<&TelemetryOptions>;
+
+    /// Gets the [`TransportOptions`] used by the client.
+    fn transport(&self) -> Option<&TransportOptions>;
+}
+
+impl AsClientOptions for ClientOptions {
+    fn per_call_policies(&self) -> &Vec<Arc<dyn Policy>> {
+        &self.per_call_policies
+    }
+
+    fn per_try_policies(&self) -> &Vec<Arc<dyn Policy>> {
+        &self.per_try_policies
+    }
+
+    fn retry(&self) -> Option<&RetryOptions> {
+        self.retry.as_ref()
+    }
+
+    fn telemetry(&self) -> Option<&TelemetryOptions> {
+        self.telemetry.as_ref()
+    }
+
+    fn transport(&self) -> Option<&TransportOptions> {
+        self.transport.as_ref()
+    }
+}
+
 /// Method options allow customization of client method calls.
 #[derive(Clone, Debug, Default)]
 pub struct ClientMethodOptions<'a> {
@@ -93,5 +133,17 @@ impl<'a> ClientMethodOptions<'a> {
     /// Set optional [`Context`] for each client method call.
     pub fn set_context(&mut self, context: &Context<'a>) {
         self.context = context.clone();
+    }
+}
+
+/// Trait for getting general client method options from specific client method options.
+pub trait AsClientMethodOptions<'a> {
+    /// Gets optional [`Context`] for each client method call.
+    fn context(&self) -> &Context<'a>;
+}
+
+impl<'a> AsClientMethodOptions<'a> for ClientMethodOptions<'a> {
+    fn context(&self) -> &Context<'a> {
+        &self.context
     }
 }


### PR DESCRIPTION
Resolves #1734, at least temporarily.