### PR TITLE
Add components to rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,10 @@
 [toolchain]
 channel = "1.76.0"
+components = [
+  "rustc",
+  "rustfmt",
+  "rust-std",
+  "cargo",
+  "clippy",
+  "rust-analyzer",
+]

--- a/sdk/typespec/Cargo.toml
+++ b/sdk/typespec/Cargo.toml
@@ -3,6 +3,7 @@ name = "typespec"
 version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 description = "Project root for all TypeSpec-related crates."
 homepage = "https://typespec.io"
 repository.workspace = true


### PR DESCRIPTION
Makes sure these components are always installed when running
    `rustup show` or other tools. Adding `rust-analyzer` is questionable,
    but enough dev UX uses it's probaby fine and not too slow to acquire on
    CI build machines.
