### PR TITLE
move is_expired to be a method on AccessToken

### DIFF
--- a/sdk/core/azure_core/src/auth.rs
+++ b/sdk/core/azure_core/src/auth.rs
@@ -83,7 +83,7 @@ impl AccessToken {
     ///
     /// If no duration is provided, then the default duration of 30 seconds is used.
     pub fn is_expired(&self, window: Option<Duration>) -> bool {
-        self.expires_on < OffsetDateTime::now_utc() + skew.unwrap_or(Duration::from_secs(30))
+        self.expires_on < OffsetDateTime::now_utc() + window.unwrap_or(Duration::from_secs(30))
     }
 }
 

--- a/sdk/core/azure_core/src/auth.rs
+++ b/sdk/core/azure_core/src/auth.rs
@@ -1,7 +1,7 @@
 //! Azure authentication and authorization.
 
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, fmt::Debug};
+use std::{borrow::Cow, fmt::Debug, time::Duration};
 use time::OffsetDateTime;
 
 pub static DEFAULT_SCOPE_SUFFIX: &str = "/.default";
@@ -77,6 +77,14 @@ impl AccessToken {
             token: token.into(),
             expires_on,
         }
+    }
+
+    /// Check if the token is expired
+    ///
+    /// This checks if the token is expiring within the next 30 seconds to
+    /// address clock skew
+    pub fn is_expired(&self) -> bool {
+        self.expires_on < OffsetDateTime::now_utc() + Duration::from_secs(30)
     }
 }
 

--- a/sdk/core/azure_core/src/auth.rs
+++ b/sdk/core/azure_core/src/auth.rs
@@ -79,12 +79,11 @@ impl AccessToken {
         }
     }
 
-    /// Check if the token is expired
+    /// Check if the token is expired within a given duration.
     ///
-    /// This checks if the token is expiring within the next 30 seconds to
-    /// address clock skew
-    pub fn is_expired(&self) -> bool {
-        self.expires_on < OffsetDateTime::now_utc() + Duration::from_secs(30)
+    /// If no duration is provided, then the default duration of 30 seconds is used.
+    pub fn is_expired(&self, window: Option<Duration>) -> bool {
+        self.expires_on < OffsetDateTime::now_utc() + skew.unwrap_or(Duration::from_secs(30))
     }
 }
 

--- a/sdk/identity/azure_identity/src/token_credentials/cache.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/cache.rs
@@ -62,7 +62,8 @@ impl TokenCache {
 mod tests {
     use super::*;
     use azure_core::auth::Secret;
-    use std::sync::Mutex;
+    use std::{sync::Mutex, time::Duration};
+    use time::OffsetDateTime;
 
     #[derive(Debug)]
     struct MockCredential {

--- a/sdk/identity/azure_identity/src/token_credentials/cache.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/cache.rs
@@ -27,7 +27,7 @@ impl TokenCache {
         let token_cache = self.0.read().await;
         let scopes = scopes.iter().map(ToString::to_string).collect::<Vec<_>>();
         if let Some(token) = token_cache.get(&scopes) {
-            if token.is_expired() {
+            if !token.is_expired(None) {
                 trace!("returning cached token");
                 return Ok(token.clone());
             }
@@ -40,7 +40,7 @@ impl TokenCache {
         // check again in case another thread refreshed the token while we were
         // waiting on the write lock
         if let Some(token) = token_cache.get(&scopes) {
-            if token.is_expired() {
+            if !token.is_expired(None) {
                 trace!("returning token that was updated while waiting on write lock");
                 return Ok(token.clone());
             }

--- a/sdk/identity/azure_identity/src/token_credentials/cache.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/cache.rs
@@ -1,8 +1,7 @@
 use async_lock::RwLock;
 use azure_core::auth::AccessToken;
 use futures::Future;
-use std::{collections::HashMap, time::Duration};
-use time::OffsetDateTime;
+use std::collections::HashMap;
 use tracing::trace;
 
 #[derive(Debug)]


### PR DESCRIPTION
Checking if an access token is expired is needed by consumers.  rather than have users of the SDK recreate this, this makes the internal function accessible off of AccessToken.