### PR TITLE
Allow setting custom properties in service_bus send_message()

### DIFF
--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -16,9 +16,7 @@ use azure_core::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    str::FromStr,
-    time::Duration,
-    {ops::Add, sync::Arc},
+    collections::HashMap, ops::Add, str::FromStr, sync::Arc, time::Duration
 };
 use time::OffsetDateTime;
 use url::form_urlencoded::{self, Serializer};
@@ -315,6 +313,7 @@ impl FromStr for BrokerProperties {
 pub struct SendMessageOptions {
     pub content_type: Option<String>,
     pub broker_properties: Option<SettableBrokerProperties>,
+    pub custom_properties: Option<HashMap<String, String>>,
 }
 
 impl headers::AsHeaders for SendMessageOptions {
@@ -332,6 +331,10 @@ impl headers::AsHeaders for SendMessageOptions {
                 BROKER_PROPERTIES,
                 serde_json::to_string(broker_properties).unwrap().into(),
             ));
+        }
+        
+        if let Some(custom_properties) = &self.custom_properties {
+            headers.extend(custom_properties.iter().map(|(k, v)| (k.to_owned().into(), v.into())));
         }
 
         headers.into_iter()

--- a/sdk/messaging_servicebus/src/service_bus/mod.rs
+++ b/sdk/messaging_servicebus/src/service_bus/mod.rs
@@ -15,9 +15,7 @@ use azure_core::{
     CollectedResponse, HttpClient, Method, Request, StatusCode, Url,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap, ops::Add, str::FromStr, sync::Arc, time::Duration
-};
+use std::{collections::HashMap, ops::Add, str::FromStr, sync::Arc, time::Duration};
 use time::OffsetDateTime;
 use url::form_urlencoded::{self, Serializer};
 
@@ -332,9 +330,13 @@ impl headers::AsHeaders for SendMessageOptions {
                 serde_json::to_string(broker_properties).unwrap().into(),
             ));
         }
-        
+
         if let Some(custom_properties) = &self.custom_properties {
-            headers.extend(custom_properties.iter().map(|(k, v)| (k.to_owned().into(), v.into())));
+            headers.extend(
+                custom_properties
+                    .iter()
+                    .map(|(k, v)| (k.to_owned().into(), v.into())),
+            );
         }
 
         headers.into_iter()

--- a/sdk/messaging_servicebus/tests/service_bus.rs
+++ b/sdk/messaging_servicebus/tests/service_bus.rs
@@ -57,11 +57,13 @@ async fn send_message_with_custom_property_test() {
         .send_message(
             "hello, world!",
             Some(SendMessageOptions {
-                custom_properties: Some(std::collections::HashMap::from([(
-                    "custom_property_key".into(),
-                    "custom_property_value".into(),
-                )])
-                .into()),
+                custom_properties: Some(
+                    std::collections::HashMap::from([(
+                        "custom_property_key".into(),
+                        "custom_property_value".into(),
+                    )])
+                    .into(),
+                ),
                 ..Default::default()
             }),
         )

--- a/sdk/messaging_servicebus/tests/service_bus.rs
+++ b/sdk/messaging_servicebus/tests/service_bus.rs
@@ -51,6 +51,25 @@ async fn send_message_with_content_type() {
 }
 
 #[tokio::test]
+async fn send_message_with_custom_property_test() {
+    let client = create_client().unwrap();
+    client
+        .send_message(
+            "hello, world!",
+            Some(SendMessageOptions {
+                custom_properties: Some(std::collections::HashMap::from([(
+                    "custom_property_key".into(),
+                    "custom_property_value".into(),
+                )])
+                .into()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("Failed to send message");
+}
+
+#[tokio::test]
 async fn receive_and_delete_message_test() {
     let client = create_client().unwrap();
     send_message_test(); // send message to ensure we can receive something


### PR DESCRIPTION
Following on the recent broker_properties additions, it'd be nice to be able to set custom properties as well.