### PR TITLE
make scripts more portable across linux distros

### DIFF
--- a/eng/common/testproxy/apply-dev-cert.sh
+++ b/eng/common/testproxy/apply-dev-cert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 TMP_PATH=$CERT_FOLDER
 PFXFILE=$CERT_FOLDER/dotnet-devcert.pfx
 CRTFILE=$CERT_FOLDER/dotnet-devcert.crt

--- a/eng/scripts/all_tests.sh
+++ b/eng/scripts/all_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../

--- a/eng/scripts/check_wasm.sh
+++ b/eng/scripts/check_wasm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../

--- a/eng/scripts/clippy_all.sh
+++ b/eng/scripts/clippy_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ev
 

--- a/eng/scripts/code_style.sh
+++ b/eng/scripts/code_style.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../

--- a/eng/scripts/e2e_tests.sh
+++ b/eng/scripts/e2e_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../

--- a/eng/scripts/emulator_tests.sh
+++ b/eng/scripts/emulator_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 BUILD=${1:-stable}

--- a/eng/scripts/github-disk-cleanup.sh
+++ b/eng/scripts/github-disk-cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # avoid running out of disk space on GitHub Runners
 

--- a/eng/scripts/sdk_tests.sh
+++ b/eng/scripts/sdk_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eux -o pipefail
 cd $(dirname ${BASH_SOURCE[0]})/../../


### PR DESCRIPTION
For my previous PRs, I've been working on my Windows box, but I noticed that all the scripts for running tests and checks are POSIX scripts (which means I wasn't able to run them directly), so I'm presuming a Linux environment is preferred for development, which absolutely works for me :). However, my usual WSL environment runs [NixOS](https://nixos.org/) which doesn't have `bash` installed at `/bin/bash`. While most distros do put `bash` in `/bin/bash`, not all do, and the shebang `#!/bin/bash` can cause issues with portability across those distros.

This PR switches the shebang for scripts to `#!/usr/bin/env bash`, which is generally portable across distros, as it uses the `env` tool to resolve the path to `bash` using the `PATH` environment variable.