### PR TITLE
Add back missing public exports

### DIFF
--- a/sdk/core/azure_core/src/lib.rs
+++ b/sdk/core/azure_core/src/lib.rs
@@ -57,10 +57,11 @@ pub use typespec_client_core::xml;
 pub use typespec_client_core::{
     base64, date,
     http::{
-        headers::*, new_http_client, Body, Context, HttpClient, Method, Pageable, Request,
-        RequestContent, StatusCode, Url,
+        headers::Header, new_http_client, Body, Context, Continuable, HttpClient, Method, Pageable,
+        Request, RequestContent, StatusCode, Url,
     },
-    json, sleep,
+    json,
+    sleep::{self, sleep},
     stream::{BytesStream, SeekableStream},
 };
 

--- a/sdk/core/azure_core/src/lib.rs
+++ b/sdk/core/azure_core/src/lib.rs
@@ -58,7 +58,7 @@ pub use typespec_client_core::{
     base64, date,
     http::{
         headers::*, new_http_client, Body, Context, HttpClient, Method, Pageable, Request,
-        StatusCode, Url,
+        RequestContent, StatusCode, Url,
     },
     json, sleep,
     stream::{BytesStream, SeekableStream},

--- a/sdk/core/azure_core/src/options/mod.rs
+++ b/sdk/core/azure_core/src/options/mod.rs
@@ -4,4 +4,7 @@
 mod telemetry;
 pub use telemetry::*;
 
-pub use typespec_client_core::http::{builders, RetryOptions, TransportOptions};
+pub use typespec_client_core::http::{
+    builders, AsClientMethodOptions, AsClientOptions, ClientMethodOptions, ClientOptions,
+    ExponentialRetryOptions, FixedRetryOptions, RetryOptions, TransportOptions,
+};


### PR DESCRIPTION
@jhendrixMSFT I compared public docs and think I have them all. I also ended up removing a few types exported directly from `azure_core` that weren't before. Everything should still be in their respective modules, though.
