### PR TITLE
add a shell.nix to ease building on nixos

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+# Automatically enter 'nix-shell' when using direnv, and nix.
+use nix

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 *.swo
 *.swp
 *.vim
+
+# Ignore .direnv, which is where the direnv environment is built, if a user is using direnv.
+.direnv/

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+    nativeBuildInputs = [
+        pkgs.pkg-config
+    ];
+
+    buildInputs = [
+        pkgs.rustup
+        pkgs.openssl
+    ];
+}


### PR DESCRIPTION
@heaths we've had some conversations about NixOS and assorted development environment needs. I'm still totally game for keeping things super simple, but I have run into a snag. We use `openssl-sys` transitively (through `ring`, I believe). That gives us a build-time dependency on openssl **and** requires that it be available through `pkg-config`. In NixOS, the way to do that is through `nix-shell`, as even globally installing `openssl` does not add it to `pkg-config`. So, anyone building this repo on NixOS will have to run `nix-shell -p pkg-config openssl` in order to build the repo. We can simplify that a bit by adding our own `shell.nix` that specifies the native dependencies, allowing a user to run `nix-shell` alone to automatically enter the recommended shell environment for our repo.

In addition, I've added an `.envrc` which allows a user who uses [direnv](https://github.com/direnv/direnv) to automatically enter `nix-shell` when they change directory into the repo.

This is _purely optional_, it doesn't require other developers in this repo to use Nix, but it helps any developer who _does_ use Nix by having a clear specification of our native dependencies.

I'm OK if you'd rather not have this in the repo. I fully recognize I have become a 🤓 Full NixOS Nerd 🤓 and have to live with the consequences of my actions 😅. However, I do think there's some value on specifying our dependencies in a declarative and programmatic way. If it were just `rustup`, I wouldn't feel a need for this, but as long as we have dependencies _beyond_ the main language toolchain, I think this has value.