### PR TITLE
Created cplusplus feature to isolate C++ only elements

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -15,6 +15,7 @@
     "asyncoperation",
     "azsdk",
     "azurecli",
+    "cplusplus",
     "datalake",
     "datetime",
     "devicecode",

--- a/eng/common/spelling/package-lock.json
+++ b/eng/common/spelling/package-lock.json
@@ -11,7 +11,8 @@
         "@cspell/cspell-bundled-dicts": "^6.12.0",
         "@cspell/cspell-types": "^6.12.0",
         "cspell": "^6.12.0",
-        "cspell-lib": "^6.12.0"
+        "cspell-lib": "^6.12.0",
+        "cspell-version-pin": "file:"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -798,6 +799,10 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/cspell-version-pin": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/dot-prop": {
       "version": "5.3.0",
@@ -2236,6 +2241,1219 @@
         "@cspell/cspell-pipe": "6.31.1",
         "@cspell/cspell-types": "6.31.1",
         "gensequence": "^5.0.2"
+      }
+    },
+    "cspell-version-pin": {
+      "version": "file:",
+      "requires": {
+        "@cspell/cspell-bundled-dicts": "^6.12.0",
+        "@cspell/cspell-types": "^6.12.0",
+        "cspell": "^6.12.0",
+        "cspell-lib": "^6.12.0",
+        "cspell-version-pin": "file:"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.22.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+          "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+          "requires": {
+            "@babel/highlight": "^7.22.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.22.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+          "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ=="
+        },
+        "@babel/highlight": {
+          "version": "7.22.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+          "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.22.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@cspell/cspell-bundled-dicts": {
+          "version": "6.31.2",
+          "resolved": "https://registry.npmjs.org/@cspell/cspell-bundled-dicts/-/cspell-bundled-dicts-6.31.2.tgz",
+          "integrity": "sha512-rQ5y/U1Ah5AaduIh3NU2z371hRrOr1cmNdhhP8oiuz2E4VqmcoVHflXIct9DgY8uIJpwsSCdR6ypOQWZYXYnwA==",
+          "requires": {
+            "@cspell/dict-ada": "^4.0.1",
+            "@cspell/dict-aws": "^3.0.0",
+            "@cspell/dict-bash": "^4.1.1",
+            "@cspell/dict-companies": "^3.0.9",
+            "@cspell/dict-cpp": "^5.0.2",
+            "@cspell/dict-cryptocurrencies": "^3.0.1",
+            "@cspell/dict-csharp": "^4.0.2",
+            "@cspell/dict-css": "^4.0.5",
+            "@cspell/dict-dart": "^2.0.2",
+            "@cspell/dict-django": "^4.0.2",
+            "@cspell/dict-docker": "^1.1.6",
+            "@cspell/dict-dotnet": "^5.0.0",
+            "@cspell/dict-elixir": "^4.0.2",
+            "@cspell/dict-en_us": "^4.3.2",
+            "@cspell/dict-en-common-misspellings": "^1.0.2",
+            "@cspell/dict-en-gb": "1.1.33",
+            "@cspell/dict-filetypes": "^3.0.0",
+            "@cspell/dict-fonts": "^3.0.2",
+            "@cspell/dict-fullstack": "^3.1.5",
+            "@cspell/dict-gaming-terms": "^1.0.4",
+            "@cspell/dict-git": "^2.0.0",
+            "@cspell/dict-golang": "^6.0.1",
+            "@cspell/dict-haskell": "^4.0.1",
+            "@cspell/dict-html": "^4.0.3",
+            "@cspell/dict-html-symbol-entities": "^4.0.0",
+            "@cspell/dict-java": "^5.0.5",
+            "@cspell/dict-k8s": "^1.0.1",
+            "@cspell/dict-latex": "^4.0.0",
+            "@cspell/dict-lorem-ipsum": "^3.0.0",
+            "@cspell/dict-lua": "^4.0.1",
+            "@cspell/dict-node": "^4.0.2",
+            "@cspell/dict-npm": "^5.0.5",
+            "@cspell/dict-php": "^4.0.1",
+            "@cspell/dict-powershell": "^5.0.1",
+            "@cspell/dict-public-licenses": "^2.0.2",
+            "@cspell/dict-python": "^4.0.2",
+            "@cspell/dict-r": "^2.0.1",
+            "@cspell/dict-ruby": "^5.0.0",
+            "@cspell/dict-rust": "^4.0.1",
+            "@cspell/dict-scala": "^5.0.0",
+            "@cspell/dict-software-terms": "^3.1.6",
+            "@cspell/dict-sql": "^2.1.0",
+            "@cspell/dict-svelte": "^1.0.2",
+            "@cspell/dict-swift": "^2.0.1",
+            "@cspell/dict-typescript": "^3.1.1",
+            "@cspell/dict-vue": "^3.0.0"
+          }
+        },
+        "@cspell/cspell-pipe": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/@cspell/cspell-pipe/-/cspell-pipe-6.31.1.tgz",
+          "integrity": "sha512-zk1olZi4dr6GLm5PAjvsiZ01HURNSruUYFl1qSicGnTwYN8GaN4RhAwannAytcJ7zJPIcyXlid0YsB58nJf3wQ=="
+        },
+        "@cspell/cspell-service-bus": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/@cspell/cspell-service-bus/-/cspell-service-bus-6.31.1.tgz",
+          "integrity": "sha512-YyBicmJyZ1uwKVxujXw7sgs9x+Eps43OkWmCtDZmZlnq489HdTSuhF1kTbVi2yeFSeaXIS87+uHo12z97KkQpg=="
+        },
+        "@cspell/cspell-types": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/@cspell/cspell-types/-/cspell-types-6.31.1.tgz",
+          "integrity": "sha512-1KeTQFiHMssW1eRoF2NZIEg4gPVIfXLsL2+VSD/AV6YN7lBcuf6gRRgV5KWYarhxtEfjxhDdDTmu26l/iJEUtw=="
+        },
+        "@cspell/dict-ada": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-ada/-/dict-ada-4.0.1.tgz",
+          "integrity": "sha512-/E9o3nHrXOhYmQE43deKbxZcR3MIJAsa+66IzP9TXGHheKEx8b9dVMVVqydDDH8oom1H0U20NRPtu6KRVbT9xw=="
+        },
+        "@cspell/dict-aws": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-aws/-/dict-aws-3.0.0.tgz",
+          "integrity": "sha512-O1W6nd5y3Z00AMXQMzfiYrIJ1sTd9fB1oLr+xf/UD7b3xeHeMeYE2OtcWbt9uyeHim4tk+vkSTcmYEBKJgS5bQ=="
+        },
+        "@cspell/dict-bash": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-bash/-/dict-bash-4.1.1.tgz",
+          "integrity": "sha512-8czAa/Mh96wu2xr0RXQEGMTBUGkTvYn/Pb0o+gqOO1YW+poXGQc3gx0YPqILDryP/KCERrNvkWUJz3iGbvwC2A=="
+        },
+        "@cspell/dict-companies": {
+          "version": "3.0.17",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.0.17.tgz",
+          "integrity": "sha512-vo1jbozgZWSzz2evIL26kLd35tVb+5kW/UTvTzAwaWutSWRloRyKx38nj2CaLJ2IFxBdiATteCFGTzKCvJJl6A=="
+        },
+        "@cspell/dict-cpp": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-cpp/-/dict-cpp-5.0.3.tgz",
+          "integrity": "sha512-7sx/RFsf0hB3q8chx8OHYl9Kd+g0pqA1laphwaAQ+/jPwoAreYT3kNQWbJ3bIt/rMoORetFSQxckSbaJXwwqpw=="
+        },
+        "@cspell/dict-cryptocurrencies": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-cryptocurrencies/-/dict-cryptocurrencies-3.0.1.tgz",
+          "integrity": "sha512-Tdlr0Ahpp5yxtwM0ukC13V6+uYCI0p9fCRGMGZt36rWv8JQZHIuHfehNl7FB/Qc09NCF7p5ep0GXbL+sVTd/+w=="
+        },
+        "@cspell/dict-csharp": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-csharp/-/dict-csharp-4.0.2.tgz",
+          "integrity": "sha512-1JMofhLK+4p4KairF75D3A924m5ERMgd1GvzhwK2geuYgd2ZKuGW72gvXpIV7aGf52E3Uu1kDXxxGAiZ5uVG7g=="
+        },
+        "@cspell/dict-css": {
+          "version": "4.0.6",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.0.6.tgz",
+          "integrity": "sha512-2Lo8W2ezHmGgY8cWFr4RUwnjbndna5mokpCK/DuxGILQnuajR0J31ANQOXj/8iZM2phFB93ZzMNk/0c04TDfSQ=="
+        },
+        "@cspell/dict-dart": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-dart/-/dict-dart-2.0.2.tgz",
+          "integrity": "sha512-jigcODm7Z4IFZ4vParwwP3IT0fIgRq/9VoxkXfrxBMsLBGGM2QltHBj7pl+joX+c4cOHxfyZktGJK1B1wFtR4Q=="
+        },
+        "@cspell/dict-data-science": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-data-science/-/dict-data-science-1.0.7.tgz",
+          "integrity": "sha512-Q9VUFaarUpqM6CAmR8peP4o9alk0XQ4rgVoE2R2XalpC2cqPI8Hmg6QwMU2UPioSUcWMJCqLc/KzJti0gBMuxA=="
+        },
+        "@cspell/dict-django": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-django/-/dict-django-4.1.0.tgz",
+          "integrity": "sha512-bKJ4gPyrf+1c78Z0Oc4trEB9MuhcB+Yg+uTTWsvhY6O2ncFYbB/LbEZfqhfmmuK/XJJixXfI1laF2zicyf+l0w=="
+        },
+        "@cspell/dict-docker": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.6.tgz",
+          "integrity": "sha512-zCCiRTZ6EOQpBnSOm0/3rnKW1kCcAUDUA7SxJG3SuH6iZvKi3I8FEg8+O83WQUeXg0SyPNerD9F40JLnnJjJig=="
+        },
+        "@cspell/dict-dotnet": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-dotnet/-/dict-dotnet-5.0.0.tgz",
+          "integrity": "sha512-EOwGd533v47aP5QYV8GlSSKkmM9Eq8P3G/eBzSpH3Nl2+IneDOYOBLEUraHuiCtnOkNsz0xtZHArYhAB2bHWAw=="
+        },
+        "@cspell/dict-elixir": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-elixir/-/dict-elixir-4.0.3.tgz",
+          "integrity": "sha512-g+uKLWvOp9IEZvrIvBPTr/oaO6619uH/wyqypqvwpmnmpjcfi8+/hqZH8YNKt15oviK8k4CkINIqNhyndG9d9Q=="
+        },
+        "@cspell/dict-en_us": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.3.4.tgz",
+          "integrity": "sha512-mR2yqWmFip1zTKja2SqyVMbzuqEThqkEJk9M32bMDziPJpEyOIPvLA0UPmj3cyRKJkRuVF0bhDCE33O+at38hw=="
+        },
+        "@cspell/dict-en-common-misspellings": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-1.0.2.tgz",
+          "integrity": "sha512-jg7ZQZpZH7+aAxNBlcAG4tGhYF6Ksy+QS5Df73Oo+XyckBjC9QS+PrRwLTeYoFIgXy5j3ICParK5r3MSSoL4gw=="
+        },
+        "@cspell/dict-en-gb": {
+          "version": "1.1.33",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-en-gb/-/dict-en-gb-1.1.33.tgz",
+          "integrity": "sha512-tKSSUf9BJEV+GJQAYGw5e+ouhEe2ZXE620S7BLKe3ZmpnjlNG9JqlnaBhkIMxKnNFkLY2BP/EARzw31AZnOv4g=="
+        },
+        "@cspell/dict-filetypes": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.1.tgz",
+          "integrity": "sha512-8z8mY1IbrTyTRumx2vvD9yzRhNMk9SajM/GtI5hdMM2pPpNSp25bnuauzjRf300eqlqPY2MNb5MmhBFO014DJw=="
+        },
+        "@cspell/dict-fonts": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-fonts/-/dict-fonts-3.0.2.tgz",
+          "integrity": "sha512-Z5QdbgEI7DV+KPXrAeDA6dDm/vTzyaW53SGlKqz6PI5VhkOjgkBXv3YtZjnxMZ4dY2ZIqq+RUK6qa9Pi8rQdGQ=="
+        },
+        "@cspell/dict-fullstack": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-fullstack/-/dict-fullstack-3.1.5.tgz",
+          "integrity": "sha512-6ppvo1dkXUZ3fbYn/wwzERxCa76RtDDl5Afzv2lijLoijGGUw5yYdLBKJnx8PJBGNLh829X352ftE7BElG4leA=="
+        },
+        "@cspell/dict-gaming-terms": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-gaming-terms/-/dict-gaming-terms-1.0.4.tgz",
+          "integrity": "sha512-hbDduNXlk4AOY0wFxcDMWBPpm34rpqJBeqaySeoUH70eKxpxm+dvjpoRLJgyu0TmymEICCQSl6lAHTHSDiWKZg=="
+        },
+        "@cspell/dict-git": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-2.0.0.tgz",
+          "integrity": "sha512-n1AxyX5Kgxij/sZFkxFJlzn3K9y/sCcgVPg/vz4WNJ4K9YeTsUmyGLA2OQI7d10GJeiuAo2AP1iZf2A8j9aj2w=="
+        },
+        "@cspell/dict-golang": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.2.tgz",
+          "integrity": "sha512-5pyZn4AAiYukAW+gVMIMVmUSkIERFrDX2vtPDjg8PLQUhAHWiVeQSDjuOhq9/C5GCCEZU/zWSONkGiwLBBvV9A=="
+        },
+        "@cspell/dict-haskell": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-haskell/-/dict-haskell-4.0.1.tgz",
+          "integrity": "sha512-uRrl65mGrOmwT7NxspB4xKXFUenNC7IikmpRZW8Uzqbqcu7ZRCUfstuVH7T1rmjRgRkjcIjE4PC11luDou4wEQ=="
+        },
+        "@cspell/dict-html": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.3.tgz",
+          "integrity": "sha512-Gae8i8rrArT0UyG1I6DHDK62b7Be6QEcBSIeWOm4VIIW1CASkN9B0qFgSVnkmfvnu1Y3H7SSaaEynKjdj3cs8w=="
+        },
+        "@cspell/dict-html-symbol-entities": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.0.tgz",
+          "integrity": "sha512-HGRu+48ErJjoweR5IbcixxETRewrBb0uxQBd6xFGcxbEYCX8CnQFTAmKI5xNaIt2PKaZiJH3ijodGSqbKdsxhw=="
+        },
+        "@cspell/dict-java": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-java/-/dict-java-5.0.5.tgz",
+          "integrity": "sha512-X19AoJgWIBwJBSWGFqSgHaBR/FEykBHTMjL6EqOnhIGEyE9nvuo32tsSHjXNJ230fQxQptEvRZoaldNLtKxsRg=="
+        },
+        "@cspell/dict-k8s": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-k8s/-/dict-k8s-1.0.1.tgz",
+          "integrity": "sha512-gc5y4Nm3hVdMZNBZfU2M1AsAmObZsRWjCUk01NFPfGhFBXyVne41T7E62rpnzu5330FV/6b/TnFcPgRmak9lLw=="
+        },
+        "@cspell/dict-latex": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-latex/-/dict-latex-4.0.0.tgz",
+          "integrity": "sha512-LPY4y6D5oI7D3d+5JMJHK/wxYTQa2lJMSNxps2JtuF8hbAnBQb3igoWEjEbIbRRH1XBM0X8dQqemnjQNCiAtxQ=="
+        },
+        "@cspell/dict-lorem-ipsum": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-lorem-ipsum/-/dict-lorem-ipsum-3.0.0.tgz",
+          "integrity": "sha512-msEV24qEpzWZs2kcEicqYlhyBpR0amfDkJOs+iffC07si9ftqtQ+yP3lf1VFLpgqw3SQh1M1vtU7RD4sPrNlcQ=="
+        },
+        "@cspell/dict-lua": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-lua/-/dict-lua-4.0.1.tgz",
+          "integrity": "sha512-j0MFmeCouSoC6EdZTbvGe1sJ9V+ruwKSeF+zRkNNNload7R72Co5kX1haW2xLHGdlq0kqSy1ODRZKdVl0e+7hg=="
+        },
+        "@cspell/dict-node": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-node/-/dict-node-4.0.2.tgz",
+          "integrity": "sha512-FEQJ4TnMcXEFslqBQkXa5HposMoCGsiBv2ux4IZuIXgadXeHKHUHk60iarWpjhzNzQLyN2GD7NoRMd12bK3Llw=="
+        },
+        "@cspell/dict-npm": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.0.7.tgz",
+          "integrity": "sha512-6SegF0HsVaBTl6PlHjeErG8Av+tRYkUG1yaXUQIGWXU0A8oxhI0o4PuL65UWH5lkCKhJyGai69Cd0iytL0oVFg=="
+        },
+        "@cspell/dict-php": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-php/-/dict-php-4.0.1.tgz",
+          "integrity": "sha512-XaQ/JkSyq2c07MfRG54DjLi2CV+HHwS99DDCAao9Fq2JfkWroTQsUeek7wYZXJATrJVOULoV3HKih12x905AtQ=="
+        },
+        "@cspell/dict-powershell": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-powershell/-/dict-powershell-5.0.2.tgz",
+          "integrity": "sha512-IHfWLme3FXE7vnOmMncSBxOsMTdNWd1Vcyhag03WS8oANSgX8IZ+4lMI00mF0ptlgchf16/OU8WsV4pZfikEFw=="
+        },
+        "@cspell/dict-public-licenses": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-public-licenses/-/dict-public-licenses-2.0.2.tgz",
+          "integrity": "sha512-baKkbs/WGEV2lCWZoL0KBPh3uiPcul5GSDwmXEBAsR5McEW52LF94/b7xWM0EmSAc/y8ODc5LnPYC7RDRLi6LQ=="
+        },
+        "@cspell/dict-python": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.1.2.tgz",
+          "integrity": "sha512-Whcn4K8R0Ux/hcx/P9Fbx6i29GwTaXgT3LTt95AuCnV5RRLrzsqoyZkz851hcg5z4kjUQVMduDl3HECGgW/FNw==",
+          "requires": {
+            "@cspell/dict-data-science": "^1.0.0"
+          }
+        },
+        "@cspell/dict-r": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-r/-/dict-r-2.0.1.tgz",
+          "integrity": "sha512-KCmKaeYMLm2Ip79mlYPc8p+B2uzwBp4KMkzeLd5E6jUlCL93Y5Nvq68wV5fRLDRTf7N1LvofkVFWfDcednFOgA=="
+        },
+        "@cspell/dict-ruby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-ruby/-/dict-ruby-5.0.0.tgz",
+          "integrity": "sha512-ssb96QxLZ76yPqFrikWxItnCbUKhYXJ2owkoIYzUGNFl2CHSoHCb5a6Zetum9mQ/oUA3gNeUhd28ZUlXs0la2A=="
+        },
+        "@cspell/dict-rust": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-rust/-/dict-rust-4.0.1.tgz",
+          "integrity": "sha512-xJSSzHDK2z6lSVaOmMxl3PTOtfoffaxMo7fTcbZUF+SCJzfKbO6vnN9TCGX2sx1RHFDz66Js6goz6SAZQdOwaw=="
+        },
+        "@cspell/dict-scala": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-scala/-/dict-scala-5.0.0.tgz",
+          "integrity": "sha512-ph0twaRoV+ylui022clEO1dZ35QbeEQaKTaV2sPOsdwIokABPIiK09oWwGK9qg7jRGQwVaRPEq0Vp+IG1GpqSQ=="
+        },
+        "@cspell/dict-software-terms": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-3.2.0.tgz",
+          "integrity": "sha512-RI6sv4Bc4i42YH/ofVelv8lXpJRhCyS9IhI2BtejUoMXKhKA9gC01ATXOylx+oaQmj3t5ark4R50xKFRvC7ENA=="
+        },
+        "@cspell/dict-sql": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-sql/-/dict-sql-2.1.0.tgz",
+          "integrity": "sha512-Bb+TNWUrTNNABO0bmfcYXiTlSt0RD6sB2MIY+rNlaMyIwug43jUjeYmkLz2tPkn3+2uvySeFEOMVYhMVfcuDKg=="
+        },
+        "@cspell/dict-svelte": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-svelte/-/dict-svelte-1.0.2.tgz",
+          "integrity": "sha512-rPJmnn/GsDs0btNvrRBciOhngKV98yZ9SHmg8qI6HLS8hZKvcXc0LMsf9LLuMK1TmS2+WQFAan6qeqg6bBxL2Q=="
+        },
+        "@cspell/dict-swift": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-swift/-/dict-swift-2.0.1.tgz",
+          "integrity": "sha512-gxrCMUOndOk7xZFmXNtkCEeroZRnS2VbeaIPiymGRHj5H+qfTAzAKxtv7jJbVA3YYvEzWcVE2oKDP4wcbhIERw=="
+        },
+        "@cspell/dict-typescript": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.1.1.tgz",
+          "integrity": "sha512-N9vNJZoOXmmrFPR4ir3rGvnqqwmQGgOYoL1+y6D4oIhyr7FhaYiyF/d7QT61RmjZQcATMa6PSL+ZisCeRLx9+A=="
+        },
+        "@cspell/dict-vue": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@cspell/dict-vue/-/dict-vue-3.0.0.tgz",
+          "integrity": "sha512-niiEMPWPV9IeRBRzZ0TBZmNnkK3olkOPYxC1Ny2AX4TGlYRajcW0WUtoSHmvvjZNfWLSg2L6ruiBeuPSbjnG6A=="
+        },
+        "@cspell/dynamic-import": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/@cspell/dynamic-import/-/dynamic-import-6.31.1.tgz",
+          "integrity": "sha512-uliIUv9uZlnyYmjUlcw/Dm3p0xJOEnWJNczHAfqAl4Ytg6QZktw0GtUA9b1umbRXLv0KRTPtSC6nMq3cR7rRmQ==",
+          "requires": {
+            "import-meta-resolve": "^2.2.2"
+          }
+        },
+        "@cspell/strong-weak-map": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/@cspell/strong-weak-map/-/strong-weak-map-6.31.1.tgz",
+          "integrity": "sha512-z8AuWvUuSnugFKJOA9Ke0aiFuehcqLFqia9bk8XaQNEWr44ahPVn3sEWnAncTxPbpWuUw5UajoJa0egRAE1CCg=="
+        },
+        "@nodelib/fs.scandir": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+          "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+          "requires": {
+            "@nodelib/fs.stat": "2.0.5",
+            "run-parallel": "^1.1.9"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+          "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
+        },
+        "@nodelib/fs.walk": {
+          "version": "1.2.8",
+          "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+          "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+          "requires": {
+            "@nodelib/fs.scandir": "2.1.5",
+            "fastq": "^1.6.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "array-timsort": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+          "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ=="
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+          "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+          "requires": {
+            "fill-range": "^7.1.1"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "clear-module": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.2.tgz",
+          "integrity": "sha512-LWAxzHqdHsAZlPlEyJ2Poz6AIs384mPeqLVCru2p0BrP9G/kVGuhNyZYClLO6cXlnuJjzC8xtsJIuMjKqLXoAw==",
+          "requires": {
+            "parent-module": "^2.0.0",
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+        },
+        "comment-json": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.2.3.tgz",
+          "integrity": "sha512-SsxdiOf064DWoZLH799Ata6u7iV658A11PlWtZATDlXPpKGJnbJZ5Z24ybixAi+LUUqJ/GKowAejtC5GFUG7Tw==",
+          "requires": {
+            "array-timsort": "^1.0.3",
+            "core-util-is": "^1.0.3",
+            "esprima": "^4.0.1",
+            "has-own-prop": "^2.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "configstore": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+          "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^3.0.0",
+            "unique-string": "^2.0.0",
+            "write-file-atomic": "^3.0.0",
+            "xdg-basedir": "^4.0.0"
+          }
+        },
+        "core-util-is": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+          "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+        },
+        "cosmiconfig": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+          "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
+          "requires": {
+            "import-fresh": "^3.2.1",
+            "js-yaml": "^4.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+        },
+        "cspell": {
+          "version": "6.31.2",
+          "resolved": "https://registry.npmjs.org/cspell/-/cspell-6.31.2.tgz",
+          "integrity": "sha512-HJcQ8jqL/1N3Mj5dufFnIZCX3ACuRoFTSVY6h3Bo5wBqd2iiJTyeQ1SY9Zymlxtb2KyJ6jQRiFmkWeFx2HVs7w==",
+          "requires": {
+            "@cspell/cspell-pipe": "6.31.1",
+            "@cspell/cspell-types": "6.31.1",
+            "@cspell/dynamic-import": "6.31.1",
+            "chalk": "^4.1.2",
+            "commander": "^10.0.0",
+            "cspell-gitignore": "6.31.2",
+            "cspell-glob": "6.31.2",
+            "cspell-io": "6.31.2",
+            "cspell-lib": "6.31.2",
+            "fast-glob": "^3.2.12",
+            "fast-json-stable-stringify": "^2.1.0",
+            "file-entry-cache": "^6.0.1",
+            "get-stdin": "^8.0.0",
+            "imurmurhash": "^0.1.4",
+            "semver": "^7.3.8",
+            "strip-ansi": "^6.0.1",
+            "vscode-uri": "^3.0.7"
+          }
+        },
+        "cspell-dictionary": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/cspell-dictionary/-/cspell-dictionary-6.31.1.tgz",
+          "integrity": "sha512-7+K7aQGarqbpucky26wled7QSCJeg6VkLUWS+hLjyf0Cqc9Zew5xsLa4QjReExWUJx+a97jbiflITZNuWxgMrg==",
+          "requires": {
+            "@cspell/cspell-pipe": "6.31.1",
+            "@cspell/cspell-types": "6.31.1",
+            "cspell-trie-lib": "6.31.1",
+            "fast-equals": "^4.0.3",
+            "gensequence": "^5.0.2"
+          }
+        },
+        "cspell-gitignore": {
+          "version": "6.31.2",
+          "resolved": "https://registry.npmjs.org/cspell-gitignore/-/cspell-gitignore-6.31.2.tgz",
+          "integrity": "sha512-B1i8aiXCIbb/08u0K3xnDyXtg0qD+lb5B2itOOXi7KXlPkKvIuN4hWyXxhVDweWyYWEzyXD5wBpPrqICVrStHQ==",
+          "requires": {
+            "cspell-glob": "6.31.2",
+            "find-up": "^5.0.0"
+          }
+        },
+        "cspell-glob": {
+          "version": "6.31.2",
+          "resolved": "https://registry.npmjs.org/cspell-glob/-/cspell-glob-6.31.2.tgz",
+          "integrity": "sha512-ceTjHM4HaBgvG5S3oiB+PTPYq58EQYG6MmYpycDHzpR5I2H1NurK9lxWHfANmLbi0DsHn58tIZNDMUnnQj19Jw==",
+          "requires": {
+            "micromatch": "^4.0.5"
+          }
+        },
+        "cspell-grammar": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/cspell-grammar/-/cspell-grammar-6.31.1.tgz",
+          "integrity": "sha512-AsRVP0idcNFVSb9+p9XjMumFj3BUV67WIPWApaAzJl/dYyiIygQObRE+si0/QtFWGNw873b7hNhWZiKjqIdoaQ==",
+          "requires": {
+            "@cspell/cspell-pipe": "6.31.1",
+            "@cspell/cspell-types": "6.31.1"
+          }
+        },
+        "cspell-io": {
+          "version": "6.31.2",
+          "resolved": "https://registry.npmjs.org/cspell-io/-/cspell-io-6.31.2.tgz",
+          "integrity": "sha512-Lp7LsF/f35LaOneROb/9mWiprShz2ONxjYFAt3bYP7gIxq41lWi8QhO+SN6spoqPp/wQXjSqJ7MuTZsemxPRnA==",
+          "requires": {
+            "@cspell/cspell-service-bus": "6.31.1",
+            "node-fetch": "^2.6.9"
+          }
+        },
+        "cspell-lib": {
+          "version": "6.31.2",
+          "resolved": "https://registry.npmjs.org/cspell-lib/-/cspell-lib-6.31.2.tgz",
+          "integrity": "sha512-LqaB2ZfVfQHKL5aZzYoKU6/UxxAtWeXAYwpC9l+satXmajYyXtAh4kWmuW+y7kKRH2jA79rJQS3QE6ToeSqgQQ==",
+          "requires": {
+            "@cspell/cspell-bundled-dicts": "6.31.2",
+            "@cspell/cspell-pipe": "6.31.1",
+            "@cspell/cspell-types": "6.31.1",
+            "@cspell/strong-weak-map": "6.31.1",
+            "clear-module": "^4.1.2",
+            "comment-json": "^4.2.3",
+            "configstore": "^5.0.1",
+            "cosmiconfig": "8.0.0",
+            "cspell-dictionary": "6.31.1",
+            "cspell-glob": "6.31.2",
+            "cspell-grammar": "6.31.1",
+            "cspell-io": "6.31.2",
+            "cspell-trie-lib": "6.31.1",
+            "fast-equals": "^4.0.3",
+            "find-up": "^5.0.0",
+            "gensequence": "^5.0.2",
+            "import-fresh": "^3.3.0",
+            "resolve-from": "^5.0.0",
+            "resolve-global": "^1.0.0",
+            "vscode-languageserver-textdocument": "^1.0.8",
+            "vscode-uri": "^3.0.7"
+          }
+        },
+        "cspell-trie-lib": {
+          "version": "6.31.1",
+          "resolved": "https://registry.npmjs.org/cspell-trie-lib/-/cspell-trie-lib-6.31.1.tgz",
+          "integrity": "sha512-MtYh7s4Sbr1rKT31P2BK6KY+YfOy3dWsuusq9HnqCXmq6aZ1HyFgjH/9p9uvqGi/TboMqn1KOV8nifhXK3l3jg==",
+          "requires": {
+            "@cspell/cspell-pipe": "6.31.1",
+            "@cspell/cspell-types": "6.31.1",
+            "gensequence": "^5.0.2"
+          }
+        },
+        "dot-prop": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+          "requires": {
+            "is-obj": "^2.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+          "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "fast-equals": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-4.0.3.tgz",
+          "integrity": "sha512-G3BSX9cfKttjr+2o1O22tYMLq0DPluZnYtq1rXumE1SpL/F/SLIfHx08WYQoWSIpeMYf8sRbJ8++71+v6Pnxfg=="
+        },
+        "fast-glob": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+          "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+          "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "fastq": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+          "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+          "requires": {
+            "reusify": "^1.0.4"
+          }
+        },
+        "file-entry-cache": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+          "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "fill-range": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+          "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+          "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+          "requires": {
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "flatted": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+          "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+        },
+        "gensequence": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/gensequence/-/gensequence-5.0.2.tgz",
+          "integrity": "sha512-JlKEZnFc6neaeSVlkzBGGgkIoIaSxMgvdamRoPN8r3ozm2r9dusqxeKqYQ7lhzmj2UhFQP8nkyfCaiLQxiLrDA=="
+        },
+        "get-stdin": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+          "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg=="
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+          "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+          "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "has-own-prop": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-own-prop/-/has-own-prop-2.0.0.tgz",
+          "integrity": "sha512-Pq0h+hvsVm6dDEa8x82GnLSYHOzNDt7f0ddFa3FqcQlgzEiptPqL+XrOJNavjOzSYiYWIrgeVYYgGlLmnxwilQ=="
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          },
+          "dependencies": {
+            "parent-module": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+              "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+              "requires": {
+                "callsites": "^3.0.0"
+              }
+            },
+            "resolve-from": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+              "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+            }
+          }
+        },
+        "import-meta-resolve": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-2.2.2.tgz",
+          "integrity": "sha512-f8KcQ1D80V7RnqVm+/lirO9zkOxjGxhaTC1IPrBGd3MEfNgmNG67tSUO9gTi2F3Blr2Az6g1vocaxzkVnWl9MA=="
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+          "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+          "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "is-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+          "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "json-parse-even-better-errors": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+          "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
+        "lines-and-columns": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+          "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
+            }
+          }
+        },
+        "merge2": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+        },
+        "micromatch": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+          "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+          "requires": {
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+          "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "parent-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+          "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+          "requires": {
+            "callsites": "^3.1.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        },
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+        },
+        "queue-microtask": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+          "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+          "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        },
+        "resolve-global": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-global/-/resolve-global-1.0.0.tgz",
+          "integrity": "sha512-zFa12V4OLtT5XUX/Q4VLvTfBf+Ok0SPc1FNGM/z9ctUdiU618qwKpWnd0CHs3+RqROfyEg/DhuHbMWYqcgljEw==",
+          "requires": {
+            "global-dirs": "^0.1.1"
+          }
+        },
+        "reusify": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+          "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "run-parallel": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+          "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+          "requires": {
+            "queue-microtask": "^1.2.2"
+          }
+        },
+        "semver": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "signal-exit": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+          "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+          "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
+        },
+        "unique-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+          "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+          "requires": {
+            "crypto-random-string": "^2.0.0"
+          }
+        },
+        "vscode-languageserver-textdocument": {
+          "version": "1.0.8",
+          "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz",
+          "integrity": "sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q=="
+        },
+        "vscode-uri": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.7.tgz",
+          "integrity": "sha512-eOpPHogvorZRobNqJGhapa0JdwaxpjVvyBp0QIUMRMSf8ZAlqOdEquKuRmw9Qwu0qXtJIWqFtMkmvJjUZmMjVA=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        },
+        "write-file-atomic": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+          "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "is-typedarray": "^1.0.0",
+            "signal-exit": "^3.0.2",
+            "typedarray-to-buffer": "^3.1.5"
+          }
+        },
+        "xdg-basedir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+          "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+          "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+        }
       }
     },
     "dot-prop": {

--- a/eng/common/spelling/package.json
+++ b/eng/common/spelling/package.json
@@ -5,6 +5,7 @@
     "@cspell/cspell-bundled-dicts": "^6.12.0",
     "@cspell/cspell-types": "^6.12.0",
     "cspell": "^6.12.0",
-    "cspell-lib": "^6.12.0"
+    "cspell-lib": "^6.12.0",
+    "cspell-version-pin": "file:"
   }
 }

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -46,6 +46,7 @@ fe2o3-amqp = [
   "serde_amqp",
   "serde_bytes",
 ]
+cplusplus = []
 test_e2e = []
 
 [package.metadata.docs.rs]

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -134,38 +134,32 @@ impl From<fe2o3_amqp_types::messaging::ApplicationProperties>
 
 impl From<fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
     fn from(header: fe2o3_amqp_types::messaging::Header) -> Self {
-        AmqpMessageHeader::builder()
+        println!("Source Header: {:?}", header);
+        let rv = AmqpMessageHeader::builder()
             .with_durable(header.durable)
             .with_priority(header.priority.into())
-            .with_time_to_live(std::time::Duration::from_millis(
-                header.ttl.unwrap_or(0) as u64
-            ))
+            .with_time_to_live(
+                header
+                    .ttl
+                    .map(|t| std::time::Duration::from_millis(t as u64)),
+            )
             .with_first_acquirer(header.first_acquirer)
             .with_delivery_count(header.delivery_count)
-            .build()
+            .build();
+        println!("Converted Header: {:?}", rv);
+        rv
     }
 }
 
 impl From<AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
     fn from(header: AmqpMessageHeader) -> Self {
-        let mut builder = fe2o3_amqp_types::messaging::Header::builder();
-
-        if let Some(durable) = header.durable() {
-            builder = builder.durable(*durable);
-        }
-        if let Some(priority) = header.priority() {
-            builder = builder.priority(fe2o3_amqp_types::messaging::Priority(*priority));
-        }
-        if let Some(time_to_live) = header.time_to_live() {
-            builder = builder.ttl(Some(time_to_live.as_millis() as u32));
-        }
-        if let Some(first_acquirer) = header.first_acquirer() {
-            builder = builder.first_acquirer(*first_acquirer);
-        }
-        if let Some(delivery_count) = header.delivery_count() {
-            builder = builder.delivery_count(*delivery_count);
-        }
-        builder.build()
+        fe2o3_amqp_types::messaging::Header::builder()
+            .durable(header.durable())
+            .priority(fe2o3_amqp_types::messaging::Priority(header.priority()))
+            .ttl(header.time_to_live().map(|t| t.as_millis() as u32))
+            .first_acquirer(header.first_acquirer())
+            .delivery_count(header.delivery_count())
+            .build()
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -57,22 +57,21 @@ where
     let mut amqp_message_builder = AmqpMessage::builder();
 
     if let Some(application_properties) = message.application_properties {
-        amqp_message_builder =
-            amqp_message_builder.with_application_properties(application_properties.into());
+        amqp_message_builder.with_application_properties(application_properties.into());
     }
 
     let body = message.body;
     if body.is_empty() {
         let body = AmqpMessageBody::Empty;
-        amqp_message_builder = amqp_message_builder.with_body(body);
+        amqp_message_builder.with_body(body);
     } else if body.is_data() {
         let data = body.try_into_data().unwrap();
         let body = AmqpMessageBody::Binary(data.map(|x| x.to_vec()).collect());
-        amqp_message_builder = amqp_message_builder.with_body(body);
+        amqp_message_builder.with_body(body);
     } else if body.is_value() {
         let value = body.try_into_value().unwrap();
         let value = value.try_into().unwrap();
-        amqp_message_builder = amqp_message_builder.with_body(AmqpMessageBody::Value(value));
+        amqp_message_builder.with_body(AmqpMessageBody::Value(value));
     } else if body.is_sequence() {
         let sequence = body.try_into_sequence().unwrap();
         let body = AmqpMessageBody::Sequence(
@@ -87,29 +86,27 @@ where
                 })
                 .collect(),
         );
-        amqp_message_builder = amqp_message_builder.with_body(body);
+        amqp_message_builder.with_body(body);
     }
 
     if let Some(header) = message.header {
-        amqp_message_builder = amqp_message_builder.with_header(header.into());
+        amqp_message_builder.with_header(header.into());
     }
 
     if let Some(properties) = message.properties {
-        amqp_message_builder = amqp_message_builder.with_properties(properties);
+        amqp_message_builder.with_properties(properties);
     }
 
     if let Some(delivery_annotations) = message.delivery_annotations {
-        amqp_message_builder =
-            amqp_message_builder.with_delivery_annotations(delivery_annotations.0.into());
+        amqp_message_builder.with_delivery_annotations(delivery_annotations.0.into());
     }
 
     if let Some(message_annotations) = message.message_annotations {
-        amqp_message_builder =
-            amqp_message_builder.with_message_annotations(message_annotations.0.into());
+        amqp_message_builder.with_message_annotations(message_annotations.0.into());
     }
 
     if let Some(footer) = message.footer {
-        amqp_message_builder = amqp_message_builder.with_footer(footer.0.into());
+        amqp_message_builder.with_footer(footer.0.into());
     }
 
     amqp_message_builder.build()
@@ -173,34 +170,33 @@ impl
             fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::messaging::message::EmptyBody>,
         >,
     ) -> Self {
-        let mut amqp_message_builder = AmqpMessage::builder().with_body(AmqpMessageBody::Empty);
+        let mut amqp_message_builder = AmqpMessage::builder();
+
+        amqp_message_builder.with_body(AmqpMessageBody::Empty);
 
         if let Some(application_properties) = message.application_properties {
-            amqp_message_builder =
-                amqp_message_builder.with_application_properties(application_properties.into());
+            amqp_message_builder.with_application_properties(application_properties.into());
         }
 
         if let Some(header) = message.header {
-            amqp_message_builder = amqp_message_builder.with_header(header.into());
+            amqp_message_builder.with_header(header.into());
         }
 
         if let Some(properties) = message.properties {
             info!("Converting properties to AmqpMessageProperties");
-            amqp_message_builder = amqp_message_builder.with_properties(properties);
+            amqp_message_builder.with_properties(properties);
         }
 
         if let Some(delivery_annotations) = message.delivery_annotations {
-            amqp_message_builder =
-                amqp_message_builder.with_delivery_annotations(delivery_annotations.0.into());
+            amqp_message_builder.with_delivery_annotations(delivery_annotations.0.into());
         }
 
         if let Some(message_annotations) = message.message_annotations {
-            amqp_message_builder =
-                amqp_message_builder.with_message_annotations(message_annotations.0.into());
+            amqp_message_builder.with_message_annotations(message_annotations.0.into());
         }
 
         if let Some(footer) = message.footer {
-            amqp_message_builder = amqp_message_builder.with_footer(footer.0.into());
+            amqp_message_builder.with_footer(footer.0.into());
         }
 
         amqp_message_builder.build()
@@ -488,7 +484,7 @@ mod tests {
                         .with_delivery_count(95)
                         .with_first_acquirer(true)
                         .with_durable(true)
-                        .with_time_to_live(std::time::Duration::from_millis(1000))
+                        .with_time_to_live(Some(std::time::Duration::from_millis(1000)))
                         .with_priority(3)
                         .build(),
                 )

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -185,6 +185,7 @@ impl From<AmqpValue> for fe2o3_amqp_types::primitives::Value {
             AmqpValue::Array(a) => fe2o3_amqp_types::primitives::Value::Array(
                 a.into_iter().map(|v| v.into()).collect(),
             ),
+            #[cfg(feature = "cplusplus")]
             AmqpValue::Composite(d) => fe2o3_amqp_types::primitives::Value::Described(Box::new(
                 serde_amqp::described::Described {
                     descriptor: d.descriptor.clone().into(),
@@ -356,6 +357,7 @@ impl PartialEq<AmqpValue> for fe2o3_amqp_types::primitives::Value {
                 _ => false,
             },
 
+            #[cfg(feature = "cplusplus")]
             AmqpValue::Composite(_) => panic!("Composite values are not supported in Fe2o3"),
 
             AmqpValue::Unknown => todo!(),

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -185,6 +185,12 @@ impl From<AmqpValue> for fe2o3_amqp_types::primitives::Value {
             AmqpValue::Array(a) => fe2o3_amqp_types::primitives::Value::Array(
                 a.into_iter().map(|v| v.into()).collect(),
             ),
+
+            // An AMQP Composite type is essentially a Described type with a specific descriptor which
+            // indicates which AMQP performative it is.
+            //
+            // Iron Oxide does not directly support Composite types (they're handled via macros), so when a C++
+            // component attempts to convert an AMQP Composite type to Iron Oxide, we convert it to a Described type
             #[cfg(feature = "cplusplus")]
             AmqpValue::Composite(d) => fe2o3_amqp_types::primitives::Value::Described(Box::new(
                 serde_amqp::described::Described {
@@ -357,8 +363,12 @@ impl PartialEq<AmqpValue> for fe2o3_amqp_types::primitives::Value {
                 _ => false,
             },
 
+            // An AMQP Composite type is essentially a Described type with a specific descriptor which
+            // indicates which AMQP performative it is.
+            //
+            // Iron Oxide does not directly support Composite types (they're handled via macros), so we always return false.
             #[cfg(feature = "cplusplus")]
-            AmqpValue::Composite(_) => panic!("Composite values are not supported in Fe2o3"),
+            AmqpValue::Composite(_) => false,
 
             AmqpValue::Unknown => todo!(),
         }

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -43,12 +43,14 @@ pub enum ReceiverSettleMode {
     Second = AMQP_RECEIVER_SETTLE_MODE_SECOND,
 }
 
+#[cfg(feature = "cplusplus")]
 pub trait Serializable {
     fn serialize(&self, buffer: &mut [u8]) -> azure_core::Result<()>;
 
     fn encoded_size(&self) -> usize;
 }
 
+#[cfg(feature = "cplusplus")]
 pub trait Deserializable<T> {
     fn decode(data: &[u8]) -> azure_core::Result<T>;
 }

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -3,8 +3,11 @@
 //cspell: words amqp SMALLUINT SMALLULONG
 
 use super::value::{AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
+#[cfg(feature = "cplusplus")]
+use crate::Deserializable;
+#[cfg(feature = "cplusplus")]
+use azure_core::error::ErrorKind;
 use azure_core::error::Result;
-use Deserializable;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TerminusDurability {

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -2028,7 +2028,10 @@ mod tests {
             assert_eq!(amqp_message, value.0);
         }
 
-        let deserialized = AmqpMessage::decode(&serialized).unwrap();
-        assert_eq!(deserialized, message);
+        #[cfg(feature = "cplusplus")]
+        {
+            let deserialized = AmqpMessage::decode(&serialized).unwrap();
+            assert_eq!(deserialized, message);
+        }
     }
 }

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license.
 //cspell: words amqp SMALLUINT SMALLULONG
 
-use crate::Deserializable;
-
 use super::value::{AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
-use azure_core::error::{ErrorKind, Result};
+use azure_core::error::Result;
+use Deserializable;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TerminusDurability {
@@ -1361,7 +1360,7 @@ pub mod builders {
             &mut self,
             time_to_live: Option<std::time::Duration>,
         ) -> &mut Self {
-            self.header.time_to_live = time_to_live.into();
+            self.header.time_to_live = time_to_live;
             self
         }
         pub fn with_first_acquirer(&mut self, first_acquirer: bool) -> &mut Self {

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -4,6 +4,7 @@
 
 use azure_core::Result;
 
+#[cfg(feature = "cplusplus")]
 use crate::{Deserializable, Serializable};
 
 #[derive(Debug, PartialEq, Clone, Default, Eq)]
@@ -182,6 +183,7 @@ pub enum AmqpValue {
     Unknown,
 }
 
+#[cfg(feature = "cplusplus")]
 impl Serializable for AmqpValue {
     fn encoded_size(&self) -> usize {
         #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
@@ -214,6 +216,7 @@ impl Serializable for AmqpValue {
     }
 }
 
+#[cfg(feature = "cplusplus")]
 impl Deserializable<AmqpValue> for AmqpValue {
     #[allow(unused_variables)]
     fn decode(data: &[u8]) -> azure_core::Result<AmqpValue> {

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 // cspell: words amqp
 
+#[cfg(feature = "cplusplus")]
 use azure_core::Result;
 
 #[cfg(feature = "cplusplus")]

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -176,8 +176,9 @@ pub enum AmqpValue {
     List(AmqpList),
     Map(AmqpOrderedMap<AmqpValue, AmqpValue>),
     Array(Vec<AmqpValue>),
-    Composite(Box<AmqpComposite>),
     Described(Box<AmqpDescribed>),
+    #[cfg(feature = "cplusplus")]
+    Composite(Box<AmqpComposite>),
     Unknown,
 }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
@@ -387,17 +387,16 @@ pub mod models {
                 if let Some(message_id) = event_data.message_id {
                     message_properties_builder.with_message_id(message_id);
                 }
-                message_builder =
-                    message_builder.with_properties(message_properties_builder.build());
+
+                message_builder.with_properties(message_properties_builder.build());
             }
             if let Some(properties) = event_data.properties {
                 for (key, value) in properties {
-                    message_builder = message_builder.add_application_property(key, value);
+                    message_builder.add_application_property(key, value);
                 }
             }
             if let Some(event_body) = event_data.body {
-                message_builder =
-                    message_builder.with_body(AmqpMessageBody::Binary(vec![event_body.to_vec()]));
+                message_builder.with_body(AmqpMessageBody::Binary(vec![event_body.to_vec()]));
             }
             message_builder.build()
         }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -310,25 +310,24 @@ impl<'a> EventDataBatch<'a> {
         let mut batch_builder = AmqpMessage::builder();
 
         if message.header().is_some() {
-            batch_builder = batch_builder.with_header(message.header().unwrap().clone());
+            batch_builder.with_header(message.header().unwrap().clone());
         }
         if message.properties().is_some() {
-            batch_builder = batch_builder.with_properties(message.properties().unwrap().clone());
+            batch_builder.with_properties(message.properties().unwrap().clone());
         }
         if message.application_properties().is_some() {
-            batch_builder = batch_builder
+            batch_builder
                 .with_application_properties(message.application_properties().unwrap().clone());
         }
         if message.delivery_annotations().is_some() {
-            batch_builder = batch_builder
+            batch_builder
                 .with_delivery_annotations(message.delivery_annotations().unwrap().clone());
         }
         if message.message_annotations().is_some() {
-            batch_builder = batch_builder
-                .with_message_annotations(message.message_annotations().unwrap().clone());
+            batch_builder.with_message_annotations(message.message_annotations().unwrap().clone());
         }
         if message.footer().is_some() {
-            batch_builder = batch_builder.with_footer(message.footer().unwrap().clone());
+            batch_builder.with_footer(message.footer().unwrap().clone());
         }
 
         batch_builder.build()


### PR DESCRIPTION
Isolate AMQP "composite" type to C++ only because it has no fe2o3 equivalent (the AMQP "composite" type is handled using macros in fe2o3).