### PR TITLE
Use inline variable content check for SkipPackageAnalysis switch

### DIFF
--- a/eng/pipelines/templates/steps/analyze.yml
+++ b/eng/pipelines/templates/steps/analyze.yml
@@ -23,4 +23,4 @@ steps:
       arguments: >
         -Toolchain '$(Toolchain)'
         -PackageInfoPath '$(Build.ArtifactStagingDirectory)/PackageInfo'
-        -SkipPackageAnalysis:$$(NoPackagesChanged)
+        -SkipPackageAnalysis:('$(NoPackagesChanged)' -eq 'true')


### PR DESCRIPTION
The analyze job is currently failing for PRs that contain changes to packages.
The failure is caused by the way we use a pipeline variable to control a powershell script switch:
```powershell
-SkipPackages:$$(NoPackagesChanged)
```

This was intended to convert a string based variable into a powershell boolean by using the $ prefix:
```powershell
-SkipPackages:$true #when NoPackagesChanged == 'true'

-SkipPackages:$false #when NoPackagesChanged == 'false'
```

When the variable isn't set, ADO just doesn't replace the token, passing it to powershell unchanged.  Now we pass an inline string comparison.  Powershell evaluates the condition before passing the result to the switch

```powershell
-SkipPackages:('$(NoPackagesChanged)' -eq 'true')

transpiles to

-SkipPackages:('true' -eq 'true') #when NoPackagesChanged == 'true'

-SkipPackages:('$(NoPackagesChanged)' -eq 'true') #when NoPackagesChanged not set
```