### PR TITLE
support user-assigned identities in VirtualMachineManagedIdentityCredential

### DIFF
--- a/sdk/identity/azure_identity/src/token_credentials/default_credentials.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/default_credentials.rs
@@ -5,7 +5,7 @@
 use crate::AzureCliCredential;
 use crate::{
     timeout::TimeoutExt, token_credentials::cache::TokenCache, AppServiceManagedIdentityCredential,
-    EnvironmentCredential, TokenCredentialOptions, VirtualMachineManagedIdentityCredential,
+    EnvironmentCredential, ImdsId, TokenCredentialOptions, VirtualMachineManagedIdentityCredential,
 };
 use azure_core::{
     auth::{AccessToken, TokenCredential},
@@ -132,7 +132,10 @@ impl DefaultAzureCredentialBuilder {
                 }
                 DefaultAzureCredentialType::VirtualMachine => {
                     sources.push(DefaultAzureCredentialKind::VirtualMachine(
-                        VirtualMachineManagedIdentityCredential::new(self.options.clone()),
+                        VirtualMachineManagedIdentityCredential::new(
+                            ImdsId::SystemAssigned,
+                            self.options.clone(),
+                        ),
                     ));
                 }
                 #[cfg(not(target_arch = "wasm32"))]

--- a/sdk/identity/azure_identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -16,14 +16,18 @@ use serde::{
 use std::{str, sync::Arc};
 use time::OffsetDateTime;
 
+/// An identifier for the Azure Instance Metadata Service (IMDS).
+/// IMDS provides information about currently running virtual machine instances.
+/// https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service
+/// https://learn.microsoft.com/azure/app-service/overview-managed-identity?tabs=portal%2Chttp#rest-endpoint-reference
 #[derive(Debug)]
 pub enum ImdsId {
     SystemAssigned,
-    #[allow(dead_code)]
+    /// The client ID of the user-assigned identity to be used.
     ClientId(String),
-    #[allow(dead_code)]
+    /// The principal ID of the user-assigned identity to be used.
     ObjectId(String),
-    #[allow(dead_code)]
+    /// The Azure resource ID of the user-assigned identity to be used.
     MsiResId(String),
 }
 
@@ -33,7 +37,7 @@ pub enum ImdsId {
 ///
 /// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
 #[derive(Debug)]
-pub struct ImdsManagedIdentityCredential {
+pub(crate) struct ImdsManagedIdentityCredential {
     http_client: Arc<dyn HttpClient>,
     endpoint: Url,
     api_version: String,

--- a/sdk/identity/azure_identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -17,7 +17,7 @@ use std::{str, sync::Arc};
 use time::OffsetDateTime;
 
 #[derive(Debug)]
-pub(crate) enum ImdsId {
+pub enum ImdsId {
     SystemAssigned,
     #[allow(dead_code)]
     ClientId(String),
@@ -33,7 +33,7 @@ pub(crate) enum ImdsId {
 ///
 /// Built up from docs at [https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol](https://docs.microsoft.com/azure/app-service/overview-managed-identity#using-the-rest-protocol)
 #[derive(Debug)]
-pub(crate) struct ImdsManagedIdentityCredential {
+pub struct ImdsManagedIdentityCredential {
     http_client: Arc<dyn HttpClient>,
     endpoint: Url,
     api_version: String,

--- a/sdk/identity/azure_identity/src/token_credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/imds_managed_identity_credentials.rs
@@ -17,9 +17,10 @@ use std::{str, sync::Arc};
 use time::OffsetDateTime;
 
 /// An identifier for the Azure Instance Metadata Service (IMDS).
-/// IMDS provides information about currently running virtual machine instances.
-/// https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service
-/// https://learn.microsoft.com/azure/app-service/overview-managed-identity?tabs=portal%2Chttp#rest-endpoint-reference
+///
+/// IMDS provides information about currently running virtual machine instances. For more information, see:
+/// * https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service
+/// * https://learn.microsoft.com/azure/app-service/overview-managed-identity#rest-endpoint-reference
 #[derive(Debug)]
 pub enum ImdsId {
     SystemAssigned,

--- a/sdk/identity/azure_identity/src/token_credentials/specific_azure_credential.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/specific_azure_credential.rs
@@ -7,7 +7,7 @@ use crate::AzureCliCredential;
 #[cfg(feature = "client_certificate")]
 use crate::ClientCertificateCredential;
 use crate::{
-    AppServiceManagedIdentityCredential, ClientSecretCredential, EnvironmentCredential,
+    AppServiceManagedIdentityCredential, ClientSecretCredential, EnvironmentCredential, ImdsId,
     TokenCredentialOptions, VirtualMachineManagedIdentityCredential, WorkloadIdentityCredential,
 };
 use azure_core::{
@@ -154,7 +154,7 @@ impl SpecificAzureCredential {
                 }
                 azure_credential_kinds::VIRTUAL_MACHINE => {
                     SpecificAzureCredentialKind::VirtualMachine(
-                        VirtualMachineManagedIdentityCredential::new(options),
+                        VirtualMachineManagedIdentityCredential::new(ImdsId::SystemAssigned, options),
                     )
                 }
                 #[cfg(not(target_arch = "wasm32"))]

--- a/sdk/identity/azure_identity/src/token_credentials/virtual_machine_managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/token_credentials/virtual_machine_managed_identity_credential.rs
@@ -19,7 +19,7 @@ pub struct VirtualMachineManagedIdentityCredential {
 }
 
 impl VirtualMachineManagedIdentityCredential {
-    pub fn new(options: impl Into<TokenCredentialOptions>) -> Self {
+    pub fn new(id: ImdsId, options: impl Into<TokenCredentialOptions>) -> Self {
         let endpoint = Url::parse(ENDPOINT).unwrap(); // valid url constant
         Self {
             credential: ImdsManagedIdentityCredential::new(
@@ -28,7 +28,7 @@ impl VirtualMachineManagedIdentityCredential {
                 API_VERSION,
                 SECRET_HEADER,
                 SECRET_ENV,
-                ImdsId::SystemAssigned,
+                id,
             ),
         }
     }


### PR DESCRIPTION
Same as #1660, but targeting new sdk branch.

Fixes https://github.com/Azure/azure-sdk-for-rust/issues/1659. As it points out, I think it was a bit too early to make ImdsManagedIdentityCredential private in https://github.com/Azure/azure-sdk-for-rust/pull/1532. I think it is the right direction after the credentials that use it like VirtualMachineManagedIdentityCredential and AppServiceManagedIdentityCredential add support for configurating user managed identities.