### PR TITLE
Add codespaces/devcontainer config files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+  "name": "Rust",
+  "image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+  "onCreateCommand": ".devcontainer/oncreate",
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "installDirectlyFromGitHubRelease": true,
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "EditorConfig.EditorConfig"
+      ]
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,22 +5,16 @@
   "image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
   "onCreateCommand": ".devcontainer/oncreate",
   "features": {
-    "ghcr.io/devcontainers/features/azure-cli:1": {
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "installDirectlyFromGitHubRelease": true,
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    }
+    "ghcr.io/devcontainers/features/azure-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/sshd:1": {}
   },
   "customizations": {
     "vscode": {
       "extensions": [
         "rust-lang.rust-analyzer",
-        "EditorConfig.EditorConfig"
+        "EditorConfig.EditorConfig",
+        "streetsidesoftware.code-spell-checker"
       ]
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/rust
 {
-  "name": "Rust",
+  "name": "Azure SDK for Rust",
   "image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
   "onCreateCommand": ".devcontainer/oncreate",
   "features": {
@@ -12,9 +12,11 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        "tamasfe.even-better-toml",
+        "editorconfig.editorconfig",
         "rust-lang.rust-analyzer",
-        "EditorConfig.EditorConfig",
-        "streetsidesoftware.code-spell-checker"
+        "streetsidesoftware.code-spell-checker",
+        "vadimcn.vscode-lldb"
       ]
     }
   }

--- a/.devcontainer/oncreate
+++ b/.devcontainer/oncreate
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "Running Azure SDK for Rust devcontainer post create script..."
+
+MSRV=$(cargo metadata --format-version=1 --no-deps  | jq '.packages[] | select(.name == "azure_core").rust_version' -r)
+
+echo "Updating toolchains..."
+rustup toolchain update \
+    $MSRV \
+    stable \
+    nightly \
+    --component "rustc" \
+    --component "rustfmt" \
+    --component "rust-std" \
+    --component "cargo" \
+    --component "clippy" \
+    --component "rust-analyzer"
+
+echo "Performing an initial build to cache dependencies"
+
+for toolchain in "stable" "nightly" "$MSRV"; do
+    echo "Building for Rust $toolchain ..."
+    # It's not possible to tell cargo to build _only_ dependencies, so we just build the repo and ignore failures.
+    # When building the codespace against main (such as in prebuilds) the repo _should_ build successfully, but we don't care if this build fails.
+    # It's just to prime dependencies and make user compiles faster.
+    if ! cargo +$toolchain build --all; then
+        echo "Warning: Toolchain $toolchain failed to build. Continuing precreate script"
+    fi
+done

--- a/.devcontainer/oncreate
+++ b/.devcontainer/oncreate
@@ -4,28 +4,5 @@ set -euo pipefail
 
 echo "Running Azure SDK for Rust devcontainer post create script..."
 
-MSRV=$(cargo metadata --format-version=1 --no-deps  | jq '.packages[] | select(.name == "azure_core").rust_version' -r)
-
 echo "Updating toolchains..."
-rustup toolchain update \
-    $MSRV \
-    stable \
-    nightly \
-    --component "rustc" \
-    --component "rustfmt" \
-    --component "rust-std" \
-    --component "cargo" \
-    --component "clippy" \
-    --component "rust-analyzer"
-
-echo "Performing an initial build to cache dependencies"
-
-for toolchain in "stable" "nightly" "$MSRV"; do
-    echo "Building for Rust $toolchain ..."
-    # It's not possible to tell cargo to build _only_ dependencies, so we just build the repo and ignore failures.
-    # When building the codespace against main (such as in prebuilds) the repo _should_ build successfully, but we don't care if this build fails.
-    # It's just to prime dependencies and make user compiles faster.
-    if ! cargo +$toolchain build --all; then
-        echo "Warning: Toolchain $toolchain failed to build. Continuing precreate script"
-    fi
-done
+rustup show

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -9,6 +9,7 @@
     ".devcontainer/oncreate",
     ".github/dependabot.yml",
     ".vscode/cspell.json",
+    ".vscode/extensions.json",
     "NOTICE.txt",
     "eng/",
     "rust-toolchain.toml"

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -5,6 +5,8 @@
   "ignorePaths": [
     "**/test-resources.bicep",
     "**/test-resources.json",
+    ".devcontainer/devcontainer.json",
+    ".github/dependabot.yml",
     ".vscode/cspell.json",
     "NOTICE.txt",
     "eng/",

--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -6,6 +6,7 @@
     "**/test-resources.bicep",
     "**/test-resources.json",
     ".devcontainer/devcontainer.json",
+    ".devcontainer/oncreate",
     ".github/dependabot.yml",
     ".vscode/cspell.json",
     "NOTICE.txt",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
   "recommendations": [
     "tamasfe.even-better-toml",
     "editorconfig.editorconfig",
-    "rust-lang.rust-analyzer"
+    "rust-lang.rust-analyzer",
+    "streetsidesoftware.code-spell-checker",
+    "vadimcn.vscode-lldb"
   ]
 }


### PR DESCRIPTION
In my search for a fairly consistent and isolated development environment, we've agreed that [Nix ain't it](https://github.com/Azure/azure-sdk-for-rust/pull/1771). Honestly, while I like NixOS, I've drunk the kool-aid hard and I'm the first to admit it isn't even remotely accomodating to newcomers.

So, instead, how about Codespaces? I've noticed several other SDK repos use them and I've had great success working with Codespaces before.

This PR adds devcontainer config that should make building this repo relatively straightforward, and we can add/remove/update it as we go. The current config:

1. Is based on the devcontainer image using the [latest 1.x Rust official docker image](https://hub.docker.com/_/rust/) at the time you build it (so `1.80.1` as of today)
2. Includes the Azure CLI, GitHub CLI, and SSHD (to enable the `gh cs ssh` command from your local machine to SSH to a running codespace)
3. Has our MSRV toolchain (whatever is in `rust-toolchain.toml`), the latest stable (in case it's ahead of the docker image) and the latest nightly rust installed
4. Has all our dependencies built against all three toolchains (MSRV, latest stable, latest nightly) cached, to make your first build 
🚤 fast 🚤 .

I noticed that the VS Code "Add Devcontainer.json" config automatically added a dependabot.yml to keep the devcontainer up to date. I'm fine removing that if we don't want it.