### PR TITLE
fix azure_data_cosmos build with key_auth feature

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -28,6 +28,7 @@ tokio.workspace = true
 serde_json.workspace = true
 azure_identity.workspace = true
 clap.workspace = true
+time.workspace = true
 
 [lints]
 workspace = true

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -74,7 +74,9 @@ impl CosmosClient {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// let client = CosmosClient::with_shared_key("https://myaccount.documents.azure.com/", "my_key", None)?;
+    /// use azure_data_cosmos::CosmosClient;
+    ///
+    /// let client = CosmosClient::with_key("https://myaccount.documents.azure.com/", "my_key", None).unwrap();
     /// ```
     #[cfg(feature = "key_auth")]
     pub fn with_key(


### PR DESCRIPTION
Fixes the build for `azure_data_cosmos` when the `key_auth` feature is enabled. I missed a `use` statement, and I actually do need `time::Duration` which we don't re-export, so I added it as a _dev-dependency_ for `azure_data_cosmos` (since we only need it in a test)