### PR TITLE
[Cosmos] Add APIs to perform single-partition queries against a container

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -23,6 +23,7 @@
     "asyncoperation",
     "azsdk",
     "azurecli",
+    "Contoso",
     "cplusplus",
     "datalake",
     "datetime",

--- a/eng/dict/rust-custom.txt
+++ b/eng/dict/rust-custom.txt
@@ -3,3 +3,4 @@ newtype
 repr
 rustc
 rustls
+turbofish

--- a/sdk/cosmos/.dict.txt
+++ b/sdk/cosmos/.dict.txt
@@ -1,4 +1,5 @@
 colls
+documentdb
 pkranges
 sprocs
 udfs

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -22,13 +22,15 @@ typespec_client_core = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 url.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true
-serde_json.workspace = true
 azure_identity.workspace = true
 clap.workspace = true
 time.workspace = true
+futures.workspace = true
+tracing-subscriber = { workspace = true, features = [ "env-filter", "fmt" ] }
 
 [lints]
 workspace = true

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_metadata.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_metadata.rs
@@ -26,6 +26,10 @@ pub struct Args {
 
 #[tokio::main]
 pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
     let args = Args::parse();
 
     let client = create_client(&args);

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_metadata.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_metadata.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use azure_data_cosmos::{
     clients::{ContainerClientMethods, DatabaseClientMethods},
     CosmosClient, CosmosClientMethods,

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
@@ -1,6 +1,6 @@
 use azure_data_cosmos::{
     clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods, PartitionKey, PartitionKeyValue,
+    CosmosClient, CosmosClientMethods,
 };
 use clap::Parser;
 use futures::StreamExt;

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
@@ -1,0 +1,77 @@
+use azure_data_cosmos::{
+    clients::{ContainerClientMethods, DatabaseClientMethods},
+    CosmosClient, CosmosClientMethods, PartitionKey, PartitionKeyValue,
+};
+use clap::Parser;
+use futures::StreamExt;
+
+/// An example to show querying a Cosmos DB container.
+#[derive(Parser)]
+pub struct Args {
+    /// The Cosmos DB endpoint to connect to.
+    endpoint: String,
+
+    /// The database to query.
+    database: String,
+
+    /// The container to query.
+    container: String,
+
+    /// The query to execute.
+    #[clap(long, short)]
+    query: String,
+
+    /// The partition key to use when querying the container. Currently this only supports a single string partition key.
+    #[clap(long, short)]
+    partition_key: String,
+
+    /// An authentication key to use when connecting to the Cosmos DB account. If omitted, the connection will use Entra ID.
+    #[clap(long)]
+    #[cfg(feature = "key_auth")]
+    key: Option<String>,
+}
+
+#[tokio::main]
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = Args::parse();
+
+    let client = create_client(&args);
+
+    let db_client = client.database_client(&args.database);
+    let container_client = db_client.container_client(&args.container);
+
+    let mut items_pager =
+        container_client.query_items::<serde_json::Value>(&args.query, args.partition_key, None)?;
+
+    while let Some(page) = items_pager.next().await {
+        let response = page?;
+        println!("Results Page");
+        println!("  Query Metrics: {:?}", response.query_metrics);
+        println!("  Index Metrics: {:?}", response.index_metrics);
+        println!("  Items:");
+        for item in response.items {
+            println!("    * {:?}", item);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "key_auth")]
+fn create_client(args: &Args) -> CosmosClient {
+    if let Some(key) = args.key.as_ref() {
+        CosmosClient::with_key(&args.endpoint, key.clone(), None).unwrap()
+    } else {
+        let cred = azure_identity::create_default_credential().unwrap();
+        CosmosClient::new(&args.endpoint, cred, None).unwrap()
+    }
+}
+
+#[cfg(not(feature = "key_auth"))]
+fn create_client(args: &Args) -> CosmosClient {
+    let cred = azure_identity::create_default_credential().unwrap();
+    CosmosClient::new(&args.endpoint, cred, None).unwrap()
+}

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
@@ -3,7 +3,7 @@
 
 use azure_data_cosmos::{
     clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods,
+    CosmosClient, CosmosClientMethods, PartitionKey,
 };
 use clap::Parser;
 use futures::StreamExt;
@@ -47,8 +47,9 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db_client = client.database_client(&args.database);
     let container_client = db_client.container_client(&args.container);
 
+    let pk = PartitionKey::from(args.partition_key);
     let mut items_pager =
-        container_client.query_items::<serde_json::Value>(&args.query, args.partition_key, None)?;
+        container_client.query_items::<serde_json::Value>(&args.query, pk, None)?;
 
     while let Some(page) = items_pager.next().await {
         let response = page?;

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use azure_data_cosmos::{
     clients::{ContainerClientMethods, DatabaseClientMethods},
     CosmosClient, CosmosClientMethods,

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos_query.rs
@@ -5,8 +5,10 @@ use azure_data_cosmos::{
     clients::{ContainerClientMethods, DatabaseClientMethods},
     CosmosClient, CosmosClientMethods, PartitionKey,
 };
+use azure_identity::DefaultAzureCredential;
 use clap::Parser;
 use futures::StreamExt;
+use std::sync::Arc;
 
 /// An example to show querying a Cosmos DB container.
 #[derive(Parser)]
@@ -69,13 +71,13 @@ fn create_client(args: &Args) -> CosmosClient {
     if let Some(key) = args.key.as_ref() {
         CosmosClient::with_key(&args.endpoint, key.clone(), None).unwrap()
     } else {
-        let cred = azure_identity::create_default_credential().unwrap();
+        let cred = DefaultAzureCredential::new().map(Arc::new).unwrap();
         CosmosClient::new(&args.endpoint, cred, None).unwrap()
     }
 }
 
 #[cfg(not(feature = "key_auth"))]
 fn create_client(args: &Args) -> CosmosClient {
-    let cred = azure_identity::create_default_credential().unwrap();
+    let cred = DefaultAzureCredential::new().map(Arc::new).unwrap();
     CosmosClient::new(&args.endpoint, cred, None).unwrap()
 }

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -108,7 +108,7 @@ pub trait ContainerClientMethods {
     /// # }
     /// ```
     ///
-    /// See [`PartitionKey`] for more information on how to specify a partition key, and [`Query`] for more information on how to specify a query.
+    /// See [`PartitionKey`](crate::PartitionKey) for more information on how to specify a partition key, and [`Query`] for more information on how to specify a query.
     fn query_items<T: DeserializeOwned + Send>(
         &self,
         query: impl Into<Query>,

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -1,9 +1,10 @@
 use crate::{
     constants,
     models::{ContainerProperties, QueryResults},
+    options::{QueryOptions, ReadContainerOptions},
     pipeline::ResourceType,
     utils::WithAddedPathSegments,
-    CosmosClient, PartitionKey, Query, QueryItemsOptions, ReadContainerOptions,
+    CosmosClient, PartitionKey, Query,
 };
 
 use azure_core::{headers::HeaderValue, Context, Request};
@@ -57,13 +58,13 @@ pub trait ContainerClientMethods {
         &self,
         query: impl Into<Query>,
         partition_key: impl Into<PartitionKey>,
-        options: Option<QueryItemsOptions>,
+        options: Option<QueryOptions>,
     ) -> azure_core::Result<azure_core::Pageable<QueryResults<T>, azure_core::Error>>;
 }
 
 /// A client for working with a specific container in a Cosmos DB account.
 ///
-/// You can get a `Container` by calling [`DatabaseClient::container_client()`](DatabaseClient::container_client()).
+/// You can get a `Container` by calling [`DatabaseClient::container_client()`](crate::clients::DatabaseClient::container_client()).
 pub struct ContainerClient {
     base_url: Url,
     root_client: CosmosClient,
@@ -102,7 +103,7 @@ impl ContainerClientMethods for ContainerClient {
 
         #[allow(unused_variables)]
         // This is a documented public API so prefixing with '_' is undesirable.
-        options: Option<QueryItemsOptions>,
+        options: Option<QueryOptions>,
     ) -> azure_core::Result<azure_core::Pageable<QueryResults<T>, azure_core::Error>> {
         // Represents the raw response model from the server.
         // We'll use this to deserialize the response body and then convert it to a more user-friendly model.

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -6,13 +6,12 @@ use crate::{
     models::{ContainerProperties, QueryResults},
     options::{QueryOptions, ReadContainerOptions},
     pipeline::{CosmosPipeline, ResourceType},
-    utils::WithAddedPathSegments,
+    utils::AppendPathSegments,
     Query, QueryPartitionStrategy,
 };
 
 use azure_core::{headers::HeaderValue, Context, Request};
 use serde::{de::DeserializeOwned, Deserialize};
-use typespec_client_core::http::AppendPathSegments;
 use url::Url;
 
 #[cfg(doc)]
@@ -129,7 +128,7 @@ pub struct ContainerClient {
 impl ContainerClient {
     pub(crate) fn new(pipeline: CosmosPipeline, database_url: &Url, container_name: &str) -> Self {
         let mut container_url = database_url.clone();
-        container_url.append_path_segments(&["colls", container_name]);
+        container_url.append_path_segments(["colls", container_name]);
 
         Self {
             container_url,
@@ -179,7 +178,8 @@ impl ContainerClientMethods for ContainerClient {
             }
         }
 
-        let url = self.container_url.with_added_path_segments(vec!["docs"]);
+        let mut url = self.container_url.clone();
+        url.append_path_segments(["docs"]);
         let mut base_req = Request::new(url, azure_core::Method::Post);
 
         base_req.insert_header(constants::QUERY, "True");

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -32,11 +32,8 @@ pub trait ContainerClientMethods {
     ///
     /// ```rust,no_run
     /// # async fn doc() {
-    /// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods};
-    /// # let credential = azure_identity::create_default_credential().unwrap();
-    /// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-    /// # let db_client = client.database_client("my_database");
-    /// # let container_client = db_client.container_client("my_container");
+    /// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+    /// # let container_client: ContainerClient = panic!("this is a non-running example");
     /// let response = container_client.read(None)
     ///     .await.unwrap()
     ///     .deserialize_body()
@@ -71,11 +68,8 @@ pub trait ContainerClientMethods {
     ///
     /// ```rust,no_run
     /// # async fn doc() {
-    /// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods};
-    /// # let credential = azure_identity::create_default_credential().unwrap();
-    /// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-    /// # let db_client = client.database_client("my_database");
-    /// # let container_client = db_client.container_client("my_container");
+    /// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+    /// # let container_client: ContainerClient = panic!("this is a non-running example");
     /// #[derive(serde::Deserialize)]
     /// struct Customer {
     ///     id: u64,
@@ -92,11 +86,8 @@ pub trait ContainerClientMethods {
     ///
     /// ```rust,no_run
     /// # async fn doc() {
-    /// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods, Query};
-    /// # let credential = azure_identity::create_default_credential().unwrap();
-    /// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-    /// # let db_client = client.database_client("my_database");
-    /// # let container_client = db_client.container_client("my_container");
+    /// # use azure_data_cosmos::{Query, clients::{ContainerClient, ContainerClientMethods}};
+    /// # let container_client: ContainerClient = panic!("this is a non-running example");
     /// #[derive(serde::Deserialize)]
     /// struct Customer {
     ///     id: u64,

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -1,8 +1,13 @@
 use crate::{
-    models::ContainerProperties, pipeline::ResourceType, CosmosClient, ReadContainerOptions,
+    constants,
+    models::{ContainerProperties, QueryResults},
+    pipeline::ResourceType,
+    utils::WithAddedPathSegments,
+    CosmosClient, PartitionKey, Query, QueryItemsOptions, ReadContainerOptions,
 };
 
-use azure_core::{Context, Request};
+use azure_core::{headers::HeaderValue, Context, Request};
+use serde::{de::DeserializeOwned, Deserialize};
 use url::Url;
 
 #[cfg(doc)]
@@ -28,7 +33,7 @@ pub trait ContainerClientMethods {
     /// let credential = azure_identity::create_default_credential().unwrap();
     /// let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
     /// let db_client = client.database_client("my_database");
-    /// let container_client = client.container_client("my_container");
+    /// let container_client = db_client.container_client("my_container");
     /// let response = container_client.read(None)
     ///     .await.unwrap()
     ///     .deserialize_body()
@@ -40,6 +45,20 @@ pub trait ContainerClientMethods {
         &self,
         options: Option<ReadContainerOptions>,
     ) -> azure_core::Result<azure_core::Response<ContainerProperties>>;
+
+    /// Executes a single-partition query against items in the container.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query to execute.
+    /// * `partition_key` - The partition key to scope the query on.
+    /// * `options` - Optional parameters for the request.
+    fn query_items<T: DeserializeOwned + Send>(
+        &self,
+        query: impl Into<Query>,
+        partition_key: impl Into<PartitionKey>,
+        options: Option<QueryItemsOptions>,
+    ) -> azure_core::Result<azure_core::Pageable<QueryResults<T>, azure_core::Error>>;
 }
 
 /// A client for working with a specific container in a Cosmos DB account.
@@ -52,17 +71,7 @@ pub struct ContainerClient {
 
 impl ContainerClient {
     pub(crate) fn new(root_client: CosmosClient, database_url: &Url, container_name: &str) -> Self {
-        let base_url = {
-            let mut u = database_url.clone();
-            {
-                let mut segments = u
-                    .path_segments_mut()
-                    .expect("The root client should have validated the format of the URL");
-                segments.push("colls");
-                segments.push(container_name);
-            }
-            u
-        };
+        let base_url = database_url.with_added_path_segments(vec!["colls", container_name]);
 
         Self {
             base_url,
@@ -84,5 +93,79 @@ impl ContainerClientMethods for ContainerClient {
             .pipeline
             .send(Context::new(), &mut req, ResourceType::Containers)
             .await
+    }
+
+    fn query_items<T: DeserializeOwned + Send>(
+        &self,
+        query: impl Into<Query>,
+        partition_key: impl Into<PartitionKey>,
+
+        #[allow(unused_variables)]
+        // This is a documented public API so prefixing with '_' is undesirable.
+        options: Option<QueryItemsOptions>,
+    ) -> azure_core::Result<azure_core::Pageable<QueryResults<T>, azure_core::Error>> {
+        // Represents the raw response model from the server.
+        // We'll use this to deserialize the response body and then convert it to a more user-friendly model.
+        #[derive(Deserialize)]
+        struct QueryResponseModel<M> {
+            #[serde(rename = "Documents")]
+            documents: Vec<M>,
+        }
+
+        // We have to manually implement Model, because the derive macro doesn't support auto-inferring type and lifetime bounds.
+        // See https://github.com/Azure/azure-sdk-for-rust/issues/1803
+        impl<M: DeserializeOwned> azure_core::Model for QueryResponseModel<M> {
+            async fn from_response_body(
+                body: azure_core::ResponseBody,
+            ) -> typespec_client_core::Result<Self> {
+                body.json().await
+            }
+        }
+
+        let url = self.base_url.with_added_path_segments(vec!["docs"]);
+        let mut base_req = Request::new(url, azure_core::Method::Post);
+
+        base_req.insert_header(constants::QUERY, "True");
+        base_req.add_mandatory_header(&constants::QUERY_CONTENT_TYPE);
+        base_req.insert_header(
+            constants::PARTITION_KEY,
+            HeaderValue::from_cow(partition_key.into().into_header_value()?),
+        );
+        base_req.set_json(&query.into())?;
+
+        Ok(azure_core::Pageable::new(move |continuation| {
+            let mut req = base_req.clone();
+            async move {
+                if let Some(continuation) = continuation {
+                    req.insert_header(constants::CONTINUATION, continuation);
+                }
+
+                let resp = self
+                    .root_client
+                    .pipeline
+                    .send(Context::new(), &mut req, ResourceType::Items)
+                    .await?;
+
+                let query_metrics = resp
+                    .headers()
+                    .get_optional_string(&constants::QUERY_METRICS);
+                let index_metrics = resp
+                    .headers()
+                    .get_optional_string(&constants::INDEX_METRICS);
+                let continuation_token =
+                    resp.headers().get_optional_string(&constants::CONTINUATION);
+
+                let query_response: QueryResponseModel<T> = resp.deserialize_body().await?;
+
+                let query_results = QueryResults {
+                    items: query_response.documents,
+                    query_metrics,
+                    index_metrics,
+                    continuation_token,
+                };
+
+                Ok(query_results)
+            }
+        }))
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use crate::{
     constants,
     models::{ContainerProperties, QueryResults},

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -1,0 +1,88 @@
+use crate::{
+    models::ContainerProperties, pipeline::ResourceType, CosmosClient, ReadContainerOptions,
+};
+
+use azure_core::{Context, Request};
+use url::Url;
+
+#[cfg(doc)]
+use crate::clients::DatabaseClientMethods;
+
+/// Defines the methods provided by a [`ContainerClient`]
+///
+/// This trait is intended to allow you to mock out the `ContainerClient` when testing your application.
+/// Rather than depending on `ContainerClient`, you can depend on a generic parameter constrained by this trait, or an `impl ContainerClientMethods` type.
+pub trait ContainerClientMethods {
+    /// Reads the properties of the container.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional parameters for the request.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # async fn doc() {
+    /// use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods};
+    ///
+    /// let credential = azure_identity::create_default_credential().unwrap();
+    /// let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
+    /// let db_client = client.database_client("my_database");
+    /// let container_client = client.container_client("my_container");
+    /// let response = container_client.read(None)
+    ///     .await.unwrap()
+    ///     .deserialize_body()
+    ///     .await.unwrap();
+    /// # }
+    /// ```
+    #[allow(async_fn_in_trait)] // REASON: See https://github.com/Azure/azure-sdk-for-rust/issues/1796 for detailed justification
+    async fn read(
+        &self,
+        options: Option<ReadContainerOptions>,
+    ) -> azure_core::Result<azure_core::Response<ContainerProperties>>;
+}
+
+/// A client for working with a specific container in a Cosmos DB account.
+///
+/// You can get a `Container` by calling [`DatabaseClient::container_client()`](DatabaseClient::container_client()).
+pub struct ContainerClient {
+    base_url: Url,
+    root_client: CosmosClient,
+}
+
+impl ContainerClient {
+    pub(crate) fn new(root_client: CosmosClient, database_url: &Url, container_name: &str) -> Self {
+        let base_url = {
+            let mut u = database_url.clone();
+            {
+                let mut segments = u
+                    .path_segments_mut()
+                    .expect("The root client should have validated the format of the URL");
+                segments.push("colls");
+                segments.push(container_name);
+            }
+            u
+        };
+
+        Self {
+            base_url,
+            root_client,
+        }
+    }
+}
+
+impl ContainerClientMethods for ContainerClient {
+    async fn read(
+        &self,
+
+        #[allow(unused_variables)]
+        // This is a documented public API so prefixing with '_' is undesirable.
+        options: Option<ReadContainerOptions>,
+    ) -> azure_core::Result<azure_core::Response<ContainerProperties>> {
+        let mut req = Request::new(self.base_url.clone(), azure_core::Method::Get);
+        self.root_client
+            .pipeline
+            .send(Context::new(), &mut req, ResourceType::Containers)
+            .await
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -48,7 +48,7 @@ impl CosmosClient {
     /// # use std::sync::Arc;
     /// use azure_data_cosmos::CosmosClient;
     ///
-    /// let credential = Arc::new(azure_identity::DefaultAzureCredential::new().unwrap());
+    /// let credential = azure_identity::DefaultAzureCredential::new().map(Arc::new).unwrap();
     /// let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
     /// ```
     pub fn new(

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -111,6 +111,6 @@ impl CosmosClientMethods for CosmosClient {
     /// # Arguments
     /// * `id` - The ID of the database.
     fn database_client(&self, id: impl AsRef<str>) -> DatabaseClient {
-        DatabaseClient::new(self.clone(), id.as_ref())
+        DatabaseClient::new(self.pipeline.clone(), &self.endpoint, id.as_ref())
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use crate::clients::DatabaseClient;
 use crate::pipeline::{AuthorizationPolicy, CosmosPipeline};
 use crate::CosmosClientOptions;

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -1,8 +1,8 @@
-use crate::authorization_policy::AuthorizationPolicy;
 use crate::clients::DatabaseClient;
+use crate::pipeline::{AuthorizationPolicy, CosmosPipeline};
 use crate::CosmosClientOptions;
 use azure_core::credentials::TokenCredential;
-use azure_core::{Pipeline, Url};
+use azure_core::Url;
 use std::sync::Arc;
 
 #[cfg(feature = "key_auth")]
@@ -12,7 +12,7 @@ use azure_core::credentials::Secret;
 #[derive(Debug, Clone)]
 pub struct CosmosClient {
     endpoint: Url,
-    pub(crate) pipeline: Pipeline,
+    pub(crate) pipeline: CosmosPipeline,
 
     #[allow(dead_code)]
     options: CosmosClientOptions,
@@ -56,7 +56,7 @@ impl CosmosClient {
         let options = options.unwrap_or_default();
         Ok(Self {
             endpoint: endpoint.as_ref().parse()?,
-            pipeline: create_pipeline(
+            pipeline: CosmosPipeline::new(
                 AuthorizationPolicy::from_token_credential(credential),
                 options.client_options.clone(),
             ),
@@ -88,7 +88,7 @@ impl CosmosClient {
         let options = options.unwrap_or_default();
         Ok(Self {
             endpoint: endpoint.as_ref().parse()?,
-            pipeline: create_pipeline(
+            pipeline: CosmosPipeline::new(
                 AuthorizationPolicy::from_shared_key(key.into()),
                 options.client_options.clone(),
             ),
@@ -110,17 +110,4 @@ impl CosmosClientMethods for CosmosClient {
     fn database_client(&self, id: impl AsRef<str>) -> DatabaseClient {
         DatabaseClient::new(self.clone(), id.as_ref())
     }
-}
-
-fn create_pipeline(
-    auth_policy: AuthorizationPolicy,
-    client_options: azure_core::ClientOptions,
-) -> Pipeline {
-    Pipeline::new(
-        option_env!("CARGO_PKG_NAME"),
-        option_env!("CARGO_PKG_VERSION"),
-        client_options,
-        Vec::new(),
-        vec![Arc::new(auth_policy)],
-    )
 }

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -1,8 +1,9 @@
 use crate::clients::ContainerClient;
 use crate::models::DatabaseProperties;
+use crate::options::ReadDatabaseOptions;
 use crate::pipeline::ResourceType;
 use crate::utils::WithAddedPathSegments;
-use crate::{CosmosClient, ReadDatabaseOptions};
+use crate::CosmosClient;
 
 use azure_core::{Context, Request};
 use url::Url;
@@ -43,7 +44,7 @@ pub trait DatabaseClientMethods {
         options: Option<ReadDatabaseOptions>,
     ) -> azure_core::Result<azure_core::Response<DatabaseProperties>>;
 
-    /// Gets a [`CollectionClient`] that can be used to access the collection with the specified name.
+    /// Gets a [`ContainerClient`] that can be used to access the collection with the specified name.
     ///
     /// # Arguments
     /// * `name` - The name of the container.

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -27,14 +27,10 @@ pub trait DatabaseClientMethods {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use std::sync::Arc;
     /// # async fn doc() {
-    /// use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods};
-    ///
-    /// let credential = Arc::new(azure_identity::DefaultAzureCredential::new().unwrap());
-    /// let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-    /// let db_client = client.database_client("my_database");
-    /// let response = db_client.read(None)
+    /// # use azure_data_cosmos::clients::{DatabaseClient, DatabaseClientMethods};
+    /// # let database_client: DatabaseClient = panic!("this is a non-running example");
+    /// let response = database_client.read(None)
     ///     .await.unwrap()
     ///     .deserialize_body()
     ///     .await.unwrap();

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -4,10 +4,10 @@
 use crate::models::DatabaseProperties;
 use crate::options::ReadDatabaseOptions;
 use crate::pipeline::ResourceType;
+use crate::utils::AppendPathSegments;
 use crate::{clients::ContainerClient, pipeline::CosmosPipeline};
 
 use azure_core::{Context, Request};
-use typespec_client_core::http::AppendPathSegments;
 use url::Url;
 
 #[cfg(doc)]
@@ -64,7 +64,7 @@ pub struct DatabaseClient {
 impl DatabaseClient {
     pub(crate) fn new(pipeline: CosmosPipeline, base_url: &Url, database_id: &str) -> Self {
         let mut database_url = base_url.clone();
-        database_url.append_path_segments(vec!["dbs", database_id]);
+        database_url.append_path_segments(["dbs", database_id]);
 
         Self {
             database_url,

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -1,6 +1,7 @@
 use crate::clients::ContainerClient;
 use crate::models::DatabaseProperties;
 use crate::pipeline::ResourceType;
+use crate::utils::WithAddedPathSegments;
 use crate::{CosmosClient, ReadDatabaseOptions};
 
 use azure_core::{Context, Request};
@@ -59,17 +60,9 @@ pub struct DatabaseClient {
 
 impl DatabaseClient {
     pub(crate) fn new(root_client: CosmosClient, database_id: &str) -> Self {
-        let base_url = {
-            let mut u = root_client.endpoint().clone();
-            {
-                let mut segments = u
-                    .path_segments_mut()
-                    .expect("The root client should have validated the format of the URL");
-                segments.push("dbs");
-                segments.push(database_id);
-            }
-            u
-        };
+        let base_url = root_client
+            .endpoint()
+            .with_added_path_segments(vec!["dbs", database_id]);
 
         Self {
             base_url,

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use crate::clients::ContainerClient;
 use crate::models::DatabaseProperties;
 use crate::options::ReadDatabaseOptions;

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -55,7 +55,7 @@ pub trait DatabaseClientMethods {
 
 /// A client for working with a specific database in a Cosmos DB account.
 ///
-/// You can get a `DatabaseClient` by calling [`CosmosClient::database_client()`](CosmosClient::database_client()).
+/// You can get a `DatabaseClient` by calling [`CosmosClient::database_client()`](crate::CosmosClient::database_client()).
 pub struct DatabaseClient {
     database_url: Url,
     pipeline: CosmosPipeline,

--- a/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
@@ -1,5 +1,7 @@
+mod container_client;
 mod cosmos_client;
 mod database_client;
 
+pub use container_client::{ContainerClient, ContainerClientMethods};
 pub use cosmos_client::{CosmosClient, CosmosClientMethods};
 pub use database_client::{DatabaseClient, DatabaseClientMethods};

--- a/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
@@ -1,3 +1,5 @@
+//! Clients used to communicate with Azure Cosmos DB
+
 mod container_client;
 mod cosmos_client;
 mod database_client;

--- a/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 //! Clients used to communicate with Azure Cosmos DB
 
 mod container_client;

--- a/sdk/cosmos/azure_data_cosmos/src/constants.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/constants.rs
@@ -1,0 +1,12 @@
+// Don't spell-check header names (which should start with 'x-').
+// cSpell:ignoreRegExp /x-[^\s]+/
+
+use azure_core::{headers::HeaderName, request_options::ContentType};
+
+pub const QUERY: HeaderName = HeaderName::from_static("x-ms-documentdb-query");
+pub const PARTITION_KEY: HeaderName = HeaderName::from_static("x-ms-documentdb-partitionkey");
+pub const CONTINUATION: HeaderName = HeaderName::from_static("x-ms-continuation");
+pub const INDEX_METRICS: HeaderName = HeaderName::from_static("x-ms-cosmos-index-utilization");
+pub const QUERY_METRICS: HeaderName = HeaderName::from_static("x-ms-documentdb-query-metrics");
+
+pub const QUERY_CONTENT_TYPE: ContentType = ContentType::from_static("application/query+json");

--- a/sdk/cosmos/azure_data_cosmos/src/constants.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/constants.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 // Don't spell-check header names (which should start with 'x-').
 // cSpell:ignoreRegExp /x-[^\s]+/
 

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #![doc = include_str!("../README.md")]
 // Docs.rs build is done with the nightly compiler, so we can enable nightly features in that build.
 // In this case we enable two features:

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -21,3 +21,21 @@ pub use clients::{CosmosClient, CosmosClientMethods};
 pub use options::*;
 pub use partition_key::*;
 pub use query::*;
+use serde::Serialize;
+
+/// A zero-sized marker type that indicates a null value.
+///
+/// Used when specifying `null` for [`PartitionKey`] or [`Query`] parameter, when [`Option`] is not appropriate (for example, if you never intend to pass a non-null value).
+pub struct NullValue;
+
+impl Serialize for NullValue {
+    /// Serializes the [`NullValue`].
+    ///
+    /// This will always produce the value `null` (or equivalent in whatever format the type is being serialized to).
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_none()
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -15,7 +15,6 @@ pub(crate) mod pipeline;
 mod query;
 pub(crate) mod utils;
 
-/// Model types sent to and received from the Cosmos DB API.
 pub mod models;
 
 pub use clients::{CosmosClient, CosmosClientMethods};

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -7,9 +7,9 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(docsrs, feature(doc_cfg_hide))]
 
-mod authorization_policy;
 pub mod clients;
 mod options;
+pub(crate) mod pipeline;
 
 /// Model types sent to and received from the Cosmos DB API.
 pub mod models;

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -24,21 +24,3 @@ pub use clients::{CosmosClient, CosmosClientMethods};
 pub use options::*;
 pub use partition_key::*;
 pub use query::*;
-use serde::Serialize;
-
-/// A zero-sized marker type that indicates a null value.
-///
-/// Used when specifying `null` for [`PartitionKey`] or [`Query`] parameter, when [`Option`] is not appropriate (for example, if you never intend to pass a non-null value).
-pub struct NullValue;
-
-impl Serialize for NullValue {
-    /// Serializes the [`NullValue`].
-    ///
-    /// This will always produce the value `null` (or equivalent in whatever format the type is being serialized to).
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_none()
-    }
-}

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -8,11 +8,17 @@
 #![cfg_attr(docsrs, feature(doc_cfg_hide))]
 
 pub mod clients;
+pub(crate) mod constants;
 mod options;
+mod partition_key;
 pub(crate) mod pipeline;
+mod query;
+pub(crate) mod utils;
 
 /// Model types sent to and received from the Cosmos DB API.
 pub mod models;
 
 pub use clients::{CosmosClient, CosmosClientMethods};
 pub use options::*;
+pub use partition_key::*;
+pub use query::*;

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -5,7 +5,10 @@ use azure_core::{
 use serde::{Deserialize, Serialize};
 
 #[cfg(doc)]
-use crate::{clients::DatabaseClientMethods, CosmosClientMethods};
+use crate::{
+    clients::{ContainerClient, DatabaseClientMethods},
+    CosmosClientMethods,
+};
 
 /// Represents a timestamp in the format expected by Cosmos DB.
 ///
@@ -24,14 +27,9 @@ impl TryInto<OffsetDateTime> for CosmosTimestamp {
     }
 }
 
-/// Properties of a Cosmos DB database.
-///
-/// Returned by [`DatabaseClient::read()`](crate::clients::DatabaseClient::read()).
-#[derive(Model, Debug, Deserialize)]
-pub struct DatabaseProperties {
-    /// The ID of the database.
-    pub id: String,
-
+/// Common system properties returned for most Cosmos DB resources.
+#[derive(Debug, Deserialize)]
+pub struct SystemProperties {
     /// The entity tag associated with the resource.
     #[serde(rename = "_etag")]
     pub etag: Option<azure_core::Etag>,
@@ -47,4 +45,30 @@ pub struct DatabaseProperties {
     /// A [`CosmosTimestamp`] representing the last modified time of the resource.
     #[serde(rename = "_ts")]
     pub last_modified: Option<CosmosTimestamp>,
+}
+
+/// Properties of a Cosmos DB database.
+///
+/// Returned by [`DatabaseClient::read()`](crate::clients::DatabaseClient::read()).
+#[derive(Model, Debug, Deserialize)]
+pub struct DatabaseProperties {
+    /// The ID of the database.
+    pub id: String,
+
+    /// A [`SystemProperties`] object containing common system properties for the database.
+    #[serde(flatten)]
+    pub system_properties: SystemProperties,
+}
+
+/// Properties of a Cosmos DB container.
+///
+/// Returned by [`ContainerClient::read()`](crate::clients::ContainerClient::read()).
+#[derive(Model, Debug, Deserialize)]
+pub struct ContainerProperties {
+    /// The ID of the container.
+    pub id: String,
+
+    /// A [`SystemProperties`] object containing common system properties for the container.
+    #[serde(flatten)]
+    pub system_properties: SystemProperties,
 }

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 //! Model types sent to and received from the Cosmos DB API.
 
 use azure_core::{

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -1,3 +1,5 @@
+//! Model types sent to and received from the Cosmos DB API.
+
 use azure_core::{
     date::{ComponentRange, OffsetDateTime},
     Continuable, Model,
@@ -6,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 #[cfg(doc)]
 use crate::{
-    clients::{ContainerClient, DatabaseClientMethods},
+    clients::{ContainerClient, ContainerClientMethods, DatabaseClientMethods},
     CosmosClientMethods,
 };
 

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -1,6 +1,6 @@
 use azure_core::{
     date::{ComponentRange, OffsetDateTime},
-    Model,
+    Continuable, Model,
 };
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +24,23 @@ impl TryInto<OffsetDateTime> for CosmosTimestamp {
     /// Attempts to convert this [`CosmosTimestamp`] into a [`OffsetDateTime`].
     fn try_into(self) -> Result<OffsetDateTime, Self::Error> {
         OffsetDateTime::from_unix_timestamp(self.0)
+    }
+}
+
+/// A page of query results, where each item is a document of type `T`.
+#[derive(Debug)]
+pub struct QueryResults<T> {
+    pub items: Vec<T>,
+    pub query_metrics: Option<String>,
+    pub index_metrics: Option<String>,
+    pub continuation_token: Option<String>,
+}
+
+impl<T> Continuable for QueryResults<T> {
+    type Continuation = String;
+
+    fn continuation(&self) -> Option<Self::Continuation> {
+        self.continuation_token.clone()
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/src/options/cosmos_client_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/cosmos_client_options.rs
@@ -1,0 +1,75 @@
+use azure_core::{builders::ClientOptionsBuilder, ClientOptions};
+
+/// Options used when creating a [`CosmosClient`](crate::CosmosClient).
+#[derive(Clone, Debug, Default)]
+pub struct CosmosClientOptions {
+    pub(crate) client_options: ClientOptions,
+}
+
+impl CosmosClientOptions {
+    /// Creates a new [`CosmosClientOptionsBuilder`](CosmosClientOptionsBuilder) that can be used to construct a [`CosmosClientOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::ReadDatabaseOptions::builder().build();
+    /// ```
+    pub fn builder() -> CosmosClientOptionsBuilder {
+        CosmosClientOptionsBuilder::default()
+    }
+}
+
+/// Builder used to construct a [`CosmosClientOptions`].
+///
+/// Obtain a [`CosmosClientOptionsBuilder`] by calling [`CosmosClientOptions::builder()`]
+#[derive(Default)]
+pub struct CosmosClientOptionsBuilder(CosmosClientOptions);
+
+impl CosmosClientOptionsBuilder {
+    /// Builds a [`CosmosClientOptions`] from the builder.
+    ///
+    /// This does not consume the builder, and can be called multiple times.
+    pub fn build(&self) -> CosmosClientOptions {
+        self.0.clone()
+    }
+}
+
+impl ClientOptionsBuilder for CosmosClientOptionsBuilder {
+    fn with_per_call_policies<P>(mut self, per_call_policies: P) -> Self
+    where
+        P: Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+        Self: Sized,
+    {
+        self.0
+            .client_options
+            .set_per_call_policies(per_call_policies);
+        self
+    }
+
+    fn with_per_try_policies<P>(mut self, per_try_policies: P) -> Self
+    where
+        P: Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
+        Self: Sized,
+    {
+        self.0.client_options.set_per_try_policies(per_try_policies);
+        self
+    }
+
+    fn with_retry<P>(mut self, retry: P) -> Self
+    where
+        P: Into<azure_core::RetryOptions>,
+        Self: Sized,
+    {
+        self.0.client_options.set_retry(retry);
+        self
+    }
+
+    fn with_transport<P>(mut self, transport: P) -> Self
+    where
+        P: Into<azure_core::TransportOptions>,
+        Self: Sized,
+    {
+        self.0.client_options.set_transport(transport);
+        self
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/options/cosmos_client_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/cosmos_client_options.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use azure_core::{builders::ClientOptionsBuilder, ClientOptions};
 
 /// Options used when creating a [`CosmosClient`](crate::CosmosClient).

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -1,184 +1,20 @@
-use azure_core::ClientOptions;
+mod cosmos_client_options;
+mod query_items_options;
+mod read_container_options;
+mod read_database_options;
 
-/// Options used when creating a [`CosmosClient`](crate::CosmosClient).
-///
-/// NOTE: There are currently no options to set on this type.
-/// It exists to enable future extensibility.
-#[derive(Clone, Debug, Default)]
-pub struct CosmosClientOptions {
-    pub(crate) client_options: ClientOptions,
-}
+pub use cosmos_client_options::CosmosClientOptions;
+pub use query_items_options::QueryOptions;
+pub use read_container_options::ReadContainerOptions;
+pub use read_database_options::ReadDatabaseOptions;
 
-impl CosmosClientOptions {
-    /// Creates a new [`CosmosClientOptionsBuilder`](builders::CosmosClientOptionsBuilder) that can be used to construct a [`CosmosClientOptions`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let options = azure_data_cosmos::ReadDatabaseOptions::builder().build();
-    /// ```
-    pub fn builder() -> builders::CosmosClientOptionsBuilder {
-        builders::CosmosClientOptionsBuilder::default()
-    }
-}
-
-/// Options to be passed to [`DatabaseClientMethods::read()`](crate::clients::DatabaseClientMethods::read()).
-///
-/// NOTE: There are currently no options to set on this type.
-/// It exists to enable future extensibility.
-#[derive(Clone, Debug, Default)]
-pub struct ReadDatabaseOptions {}
-
-impl ReadDatabaseOptions {
-    /// Creates a new [`ReadDatabaseOptionsBuilder`](builders::ReadDatabaseOptionsBuilder) that can be used to construct a [`ReadDatabaseOptions`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let options = azure_data_cosmos::ReadDatabaseOptions::builder().build();
-    /// ```
-    pub fn builder() -> builders::ReadDatabaseOptionsBuilder {
-        builders::ReadDatabaseOptionsBuilder::default()
-    }
-}
-
-/// Options to be passed to [`ContainerClientMethods::read()`](crate::clients::ContainerClientMethods::read()).
-///
-/// NOTE: There are currently no options to set on this type.
-/// It exists to enable future extensibility.
-#[derive(Clone, Debug, Default)]
-pub struct ReadContainerOptions {}
-
-impl ReadContainerOptions {
-    /// Creates a new [`ReadContainerOptionsBuilder`](builders::ReadContainerOptionsBuilder) that can be used to construct a [`ReadContainerOptions`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let options = azure_data_cosmos::ReadContainerOptions::builder().build();
-    /// ```
-    pub fn builder() -> builders::ReadContainerOptionsBuilder {
-        builders::ReadContainerOptionsBuilder::default()
-    }
-}
-
-/// Options to be passed to [`ContainerClientMethods::query_items()`](crate::clients::ContainerClientMethods::query_items()).
-///
-/// NOTE: There are currently no options to set on this type.
-/// It exists to enable future extensibility.
-#[derive(Clone, Debug, Default)]
-pub struct QueryItemsOptions {}
-
-impl QueryItemsOptions {
-    /// Creates a new [`QueryItemsOptionsBuilder`](builders::QueryItemsOptionsBuilder) that can be used to construct a [`QueryItemsOptions`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// let options = azure_data_cosmos::QueryItemsOptions::builder().build();
-    /// ```
-    pub fn builder() -> builders::QueryItemsOptionsBuilder {
-        builders::QueryItemsOptionsBuilder::default()
-    }
-}
-
-/// Builders for Cosmos-related options structs.
 pub mod builders {
-    use azure_core::builders::ClientOptionsBuilder;
+    //! Builders used to create options types.
+    //!
+    //! You shouldn't need to construct these builders on your own. Instead, use the `builder()` method on the related options type to get an instance of the builder.
 
-    use crate::{
-        CosmosClientOptions, QueryItemsOptions, ReadContainerOptions, ReadDatabaseOptions,
-    };
-
-    /// Builder used to construct a [`CosmosClientOptions`].
-    #[derive(Default)]
-    pub struct CosmosClientOptionsBuilder(CosmosClientOptions);
-
-    impl CosmosClientOptionsBuilder {
-        /// Builds a [`CosmosClientOptions`] object from the builder.
-        ///
-        /// This does not consume the builder, and can be called multiple times.
-        pub fn build(&self) -> CosmosClientOptions {
-            self.0.clone()
-        }
-    }
-
-    impl ClientOptionsBuilder for CosmosClientOptionsBuilder {
-        fn with_per_call_policies<P>(mut self, per_call_policies: P) -> Self
-        where
-            P: Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
-            Self: Sized,
-        {
-            self.0
-                .client_options
-                .set_per_call_policies(per_call_policies);
-            self
-        }
-
-        fn with_per_try_policies<P>(mut self, per_try_policies: P) -> Self
-        where
-            P: Into<Vec<std::sync::Arc<dyn azure_core::Policy>>>,
-            Self: Sized,
-        {
-            self.0.client_options.set_per_try_policies(per_try_policies);
-            self
-        }
-
-        fn with_retry<P>(mut self, retry: P) -> Self
-        where
-            P: Into<azure_core::RetryOptions>,
-            Self: Sized,
-        {
-            self.0.client_options.set_retry(retry);
-            self
-        }
-
-        fn with_transport<P>(mut self, transport: P) -> Self
-        where
-            P: Into<azure_core::TransportOptions>,
-            Self: Sized,
-        {
-            self.0.client_options.set_transport(transport);
-            self
-        }
-    }
-
-    /// Builder used to construct a [`ReadDatabaseOptions`].
-    #[derive(Default)]
-    pub struct ReadDatabaseOptionsBuilder(ReadDatabaseOptions);
-
-    impl ReadDatabaseOptionsBuilder {
-        /// Builds a [`CosmosClientOptions`] object from the builder.
-        ///
-        /// This does not consume the builder, and can be called multiple times.
-        pub fn build(&self) -> ReadDatabaseOptions {
-            self.0.clone()
-        }
-    }
-
-    /// Builder used to construct a [`ReadContainerOptions`].
-    #[derive(Default)]
-    pub struct ReadContainerOptionsBuilder(ReadContainerOptions);
-
-    impl ReadContainerOptionsBuilder {
-        /// Builds a [`ReadContainerOptions`] object from the builder.
-        ///
-        /// This does not consume the builder, and can be called multiple times.
-        pub fn build(&self) -> ReadContainerOptions {
-            self.0.clone()
-        }
-    }
-
-    /// Builder used to construct a [`QueryItemsOptions`].
-    #[derive(Default)]
-    pub struct QueryItemsOptionsBuilder(QueryItemsOptions);
-
-    impl QueryItemsOptionsBuilder {
-        /// Builds a [`QueryItemsOptions`] object from the builder.
-        ///
-        /// This does not consume the builder, and can be called multiple times.
-        pub fn build(&self) -> QueryItemsOptions {
-            self.0.clone()
-        }
-    }
+    pub use super::cosmos_client_options::CosmosClientOptionsBuilder;
+    pub use super::query_items_options::QueryOptionsBuilder;
+    pub use super::read_container_options::ReadContainerOptionsBuilder;
+    pub use super::read_database_options::ReadDatabaseOptionsBuilder;
 }

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -62,11 +62,33 @@ impl ReadContainerOptions {
     }
 }
 
+/// Options to be passed to [`ContainerClientMethods::query_items()`](crate::clients::ContainerClientMethods::query_items()).
+///
+/// NOTE: There are currently no options to set on this type.
+/// It exists to enable future extensibility.
+#[derive(Clone, Debug, Default)]
+pub struct QueryItemsOptions {}
+
+impl QueryItemsOptions {
+    /// Creates a new [`QueryItemsOptionsBuilder`](builders::QueryItemsOptionsBuilder) that can be used to construct a [`QueryItemsOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::QueryItemsOptions::builder().build();
+    /// ```
+    pub fn builder() -> builders::QueryItemsOptionsBuilder {
+        builders::QueryItemsOptionsBuilder::default()
+    }
+}
+
 /// Builders for Cosmos-related options structs.
 pub mod builders {
     use azure_core::builders::ClientOptionsBuilder;
 
-    use crate::{CosmosClientOptions, ReadContainerOptions, ReadDatabaseOptions};
+    use crate::{
+        CosmosClientOptions, QueryItemsOptions, ReadContainerOptions, ReadDatabaseOptions,
+    };
 
     /// Builder used to construct a [`CosmosClientOptions`].
     #[derive(Default)]
@@ -139,10 +161,23 @@ pub mod builders {
     pub struct ReadContainerOptionsBuilder(ReadContainerOptions);
 
     impl ReadContainerOptionsBuilder {
-        /// Builds a [`CosmosClientOptions`] object from the builder.
+        /// Builds a [`ReadContainerOptions`] object from the builder.
         ///
         /// This does not consume the builder, and can be called multiple times.
         pub fn build(&self) -> ReadContainerOptions {
+            self.0.clone()
+        }
+    }
+
+    /// Builder used to construct a [`QueryItemsOptions`].
+    #[derive(Default)]
+    pub struct QueryItemsOptionsBuilder(QueryItemsOptions);
+
+    impl QueryItemsOptionsBuilder {
+        /// Builds a [`QueryItemsOptions`] object from the builder.
+        ///
+        /// This does not consume the builder, and can be called multiple times.
+        pub fn build(&self) -> QueryItemsOptions {
             self.0.clone()
         }
     }

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 mod cosmos_client_options;
 mod query_items_options;
 mod read_container_options;

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -42,11 +42,31 @@ impl ReadDatabaseOptions {
     }
 }
 
+/// Options to be passed to [`ContainerClientMethods::read()`](crate::clients::ContainerClientMethods::read()).
+///
+/// NOTE: There are currently no options to set on this type.
+/// It exists to enable future extensibility.
+#[derive(Clone, Debug, Default)]
+pub struct ReadContainerOptions {}
+
+impl ReadContainerOptions {
+    /// Creates a new [`ReadContainerOptionsBuilder`](builders::ReadContainerOptionsBuilder) that can be used to construct a [`ReadContainerOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::ReadContainerOptions::builder().build();
+    /// ```
+    pub fn builder() -> builders::ReadContainerOptionsBuilder {
+        builders::ReadContainerOptionsBuilder::default()
+    }
+}
+
 /// Builders for Cosmos-related options structs.
 pub mod builders {
     use azure_core::builders::ClientOptionsBuilder;
 
-    use crate::{CosmosClientOptions, ReadDatabaseOptions};
+    use crate::{CosmosClientOptions, ReadContainerOptions, ReadDatabaseOptions};
 
     /// Builder used to construct a [`CosmosClientOptions`].
     #[derive(Default)]
@@ -110,6 +130,19 @@ pub mod builders {
         ///
         /// This does not consume the builder, and can be called multiple times.
         pub fn build(&self) -> ReadDatabaseOptions {
+            self.0.clone()
+        }
+    }
+
+    /// Builder used to construct a [`ReadContainerOptions`].
+    #[derive(Default)]
+    pub struct ReadContainerOptionsBuilder(ReadContainerOptions);
+
+    impl ReadContainerOptionsBuilder {
+        /// Builds a [`CosmosClientOptions`] object from the builder.
+        ///
+        /// This does not consume the builder, and can be called multiple times.
+        pub fn build(&self) -> ReadContainerOptions {
             self.0.clone()
         }
     }

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_items_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_items_options.rs
@@ -1,0 +1,34 @@
+#[cfg(doc)]
+use crate::clients::ContainerClientMethods;
+
+/// Options to be passed to [`ContainerClient::query_items()`](crate::clients::ContainerClient::query_items()).
+#[derive(Clone, Debug, Default)]
+pub struct QueryOptions {}
+
+impl QueryOptions {
+    /// Creates a new [`QueryOptionsBuilder`](QueryOptionsBuilder) that can be used to construct a [`QueryOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::QueryOptions::builder().build();
+    /// ```
+    pub fn builder() -> QueryOptionsBuilder {
+        QueryOptionsBuilder::default()
+    }
+}
+
+/// Builder used to construct a [`QueryOptions`].
+///
+/// Obtain a [`QueryOptionsBuilder`] by calling [`QueryOptions::builder()`]
+#[derive(Default)]
+pub struct QueryOptionsBuilder(QueryOptions);
+
+impl QueryOptionsBuilder {
+    /// Builds a [`QueryOptions`] from the builder.
+    ///
+    /// This does not consume the builder, and can be called multiple times.
+    pub fn build(&self) -> QueryOptions {
+        self.0.clone()
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_items_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_items_options.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #[cfg(doc)]
 use crate::clients::ContainerClientMethods;
 

--- a/sdk/cosmos/azure_data_cosmos/src/options/read_container_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/read_container_options.rs
@@ -1,0 +1,32 @@
+#[cfg(doc)]
+use crate::clients::ContainerClientMethods;
+
+/// Options to be passed to [`ContainerClient::read()`](crate::clients::ContainerClient::read()).
+#[derive(Clone, Debug, Default)]
+pub struct ReadContainerOptions {}
+
+impl ReadContainerOptions {
+    /// Creates a new [`ReadContainerOptionsBuilder`](ReadContainerOptionsBuilder) that can be used to construct a [`ReadContainerOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::ReadContainerOptions::builder().build();
+    /// ```
+    pub fn builder() -> ReadContainerOptionsBuilder {
+        ReadContainerOptionsBuilder::default()
+    }
+}
+
+/// Builder used to construct a [`ReadContainerOptions`].
+#[derive(Default)]
+pub struct ReadContainerOptionsBuilder(ReadContainerOptions);
+
+impl ReadContainerOptionsBuilder {
+    /// Builds a [`ReadContainerOptions`] from the builder.
+    ///
+    /// This does not consume the builder, and can be called multiple times.
+    pub fn build(&self) -> ReadContainerOptions {
+        self.0.clone()
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/options/read_container_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/read_container_options.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #[cfg(doc)]
 use crate::clients::ContainerClientMethods;
 

--- a/sdk/cosmos/azure_data_cosmos/src/options/read_database_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/read_database_options.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #[cfg(doc)]
 use crate::clients::DatabaseClientMethods;
 

--- a/sdk/cosmos/azure_data_cosmos/src/options/read_database_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/read_database_options.rs
@@ -1,0 +1,32 @@
+#[cfg(doc)]
+use crate::clients::DatabaseClientMethods;
+
+/// Options to be passed to [`DatabaseClient::read()`](crate::clients::DatabaseClient::read()).
+#[derive(Clone, Debug, Default)]
+pub struct ReadDatabaseOptions {}
+
+impl ReadDatabaseOptions {
+    /// Creates a new [`ReadDatabaseOptionsBuilder`](ReadDatabaseOptionsBuilder) that can be used to construct a [`ReadDatabaseOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::ReadDatabaseOptions::builder().build();
+    /// ```
+    pub fn builder() -> ReadDatabaseOptionsBuilder {
+        ReadDatabaseOptionsBuilder::default()
+    }
+}
+
+/// Builder used to construct a [`ReadDatabaseOptions`].
+#[derive(Default)]
+pub struct ReadDatabaseOptionsBuilder(ReadDatabaseOptions);
+
+impl ReadDatabaseOptionsBuilder {
+    /// Builds a [`ReadDatabaseOptions`] from the builder.
+    ///
+    /// This does not consume the builder, and can be called multiple times.
+    pub fn build(&self) -> ReadDatabaseOptions {
+        self.0.clone()
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -14,11 +14,11 @@ use crate::NullValue;
 /// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
 /// # let db_client = client.database_client("my_database");
 /// # let container_client = db_client.container_client("my_container");
-/// container_client.query_items(
+/// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     "a single string partition key",
 ///     None).unwrap();
-/// container_client.query_items(
+/// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     42, // A numeric partition key
 ///     None).unwrap();
@@ -32,9 +32,9 @@ use crate::NullValue;
 /// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
 /// # let db_client = client.database_client("my_database");
 /// # let container_client = db_client.container_client("my_container");
-/// container_client.query_items(
+/// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
-///     ("parent", "child")
+///     ("parent", "child"),
 ///     None).unwrap();
 /// ```
 ///
@@ -47,11 +47,11 @@ use crate::NullValue;
 /// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
 /// # let db_client = client.database_client("my_database");
 /// # let container_client = db_client.container_client("my_container");
-/// container_client.query_items(
+/// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     NullValue, // A null value in a single-level partition key.
 ///     None).unwrap();
-/// container_client.query_items(
+/// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     ("a", NullValue, "b"), // A null value within a hierarchical partition key.
 ///     None).unwrap();
@@ -66,7 +66,7 @@ use crate::NullValue;
 /// # let db_client = client.database_client("my_database");
 /// # let container_client = db_client.container_client("my_container");
 /// let my_partition_key: Option<String> = None;
-/// container_client.query_items(
+/// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     my_partition_key,
 ///     None).unwrap();

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -1,0 +1,217 @@
+#[derive(Debug, Clone)]
+pub struct PartitionKey(Vec<PartitionKeyValue>); // TODO: A partition key can be any JSON value. Should we use serde_json::Value or define a custom enum?
+
+impl PartitionKey {
+    pub(crate) fn into_header_value(self) -> azure_core::Result<String> {
+        // We're going to write our JSON manually, because we need to escape non-ASCII characters in strings, because we're putting this value in an HTTP header.
+        let mut json = String::new();
+        let mut utf_buf = [0; 2]; // A buffer for encoding UTF-16 characters.
+        json.push('[');
+        for key in self.0 {
+            match key.0 {
+                serde_json::Value::String(string_key) => {
+                    // We have to manually escape the string to ensure non-ASCII characters are escaped.
+                    // Rust's escape_default function escapes characters as \u{XXXXX} (allowing a full Unicode code point in the "{}").
+                    // However, JSON doesn't support that and requires encoding the UTF-16 code units separately using `\uXXXX`.
+                    json.push('"');
+                    for char in string_key.chars() {
+                        match char {
+                            '\x08' => json.push_str(r#"\b"#),
+                            '\x0c' => json.push_str(r#"\f"#),
+                            '\n' => json.push_str(r#"\n"#),
+                            '\r' => json.push_str(r#"\r"#),
+                            '\t' => json.push_str(r#"\t"#),
+                            '"' => json.push_str(r#"\""#),
+                            '\\' => json.push('\\'),
+                            c if c.is_ascii() => json.push(c),
+                            c => {
+                                let encoded = c.encode_utf16(&mut utf_buf);
+                                for code_unit in encoded {
+                                    json.push_str(&format!(r#"\u{:04x}"#, code_unit));
+                                }
+                            }
+                        }
+                    }
+                    json.push('"');
+                }
+                x => {
+                    json.push_str(serde_json::to_string(&x)?.as_str());
+                }
+            }
+
+            json.push(',');
+        }
+
+        // Pop the trailing ','
+        json.pop();
+        json.push(']');
+
+        Ok(json)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PartitionKeyValue(serde_json::Value);
+
+impl PartitionKeyValue {
+    pub const NULL: PartitionKeyValue = PartitionKeyValue(serde_json::Value::Null);
+}
+
+pub struct NullPartitionKey;
+
+impl From<NullPartitionKey> for PartitionKeyValue {
+    fn from(_: NullPartitionKey) -> Self {
+        PartitionKeyValue(serde_json::Value::Null)
+    }
+}
+
+macro_rules! impl_from_json {
+    ($source_type: ty) => {
+        impl From<$source_type> for PartitionKeyValue {
+            fn from(value: $source_type) -> Self {
+                PartitionKeyValue(serde_json::Value::from(value))
+            }
+        }
+    };
+}
+
+impl_from_json!(&str);
+impl_from_json!(String);
+impl_from_json!(bool);
+impl_from_json!(f32);
+impl_from_json!(f64);
+impl_from_json!(i16);
+impl_from_json!(i32);
+impl_from_json!(i64);
+impl_from_json!(i8);
+impl_from_json!(isize);
+impl_from_json!(u16);
+impl_from_json!(u32);
+impl_from_json!(u64);
+impl_from_json!(u8);
+impl_from_json!(usize);
+impl_from_json!(serde_json::Value);
+
+impl<T: Into<PartitionKeyValue>> From<Option<T>> for PartitionKeyValue {
+    fn from(value: Option<T>) -> Self {
+        match value {
+            Some(t) => t.into(),
+            None => PartitionKeyValue(serde_json::Value::Null),
+        }
+    }
+}
+
+impl<T: Into<PartitionKeyValue>> From<T> for PartitionKey {
+    fn from(value: T) -> Self {
+        PartitionKey(vec![value.into()])
+    }
+}
+
+impl<T: Into<PartitionKeyValue>> From<Vec<T>> for PartitionKey {
+    fn from(value: Vec<T>) -> Self {
+        PartitionKey(value.into_iter().map(Into::into).collect())
+    }
+}
+
+macro_rules! impl_from_tuple {
+    ($($n:tt $name:ident)*) => {
+        impl<$($name: Into<PartitionKeyValue>),*> From<($($name,)*)> for PartitionKey {
+            fn from(value: ($($name,)*)) -> Self {
+                PartitionKey(vec![$(
+                    value.$n.into()
+                ),*])
+            }
+        }
+    };
+}
+
+impl_from_tuple!(0 A);
+impl_from_tuple!(0 A 1 B);
+impl_from_tuple!(0 A 1 B 2 C);
+impl_from_tuple!(0 A 1 B 2 C 3 D);
+impl_from_tuple!(0 A 1 B 2 C 3 D 4 E);
+impl_from_tuple!(0 A 1 B 2 C 3 D 4 E 5 F);
+impl_from_tuple!(0 A 1 B 2 C 3 D 4 E 5 F 6 G);
+impl_from_tuple!(0 A 1 B 2 C 3 D 4 E 5 F 6 G 7 H);
+
+#[cfg(test)]
+mod tests {
+    use crate::{NullPartitionKey, PartitionKey, PartitionKeyValue};
+
+    fn key_to_string(v: impl Into<PartitionKey>) -> String {
+        v.into().into_header_value().unwrap()
+    }
+
+    #[test]
+    pub fn static_str() {
+        assert_eq!(key_to_string("my_partition_key"), r#"["my_partition_key"]"#);
+    }
+
+    #[test]
+    pub fn integers() {
+        assert_eq!(key_to_string(42u8), r#"[42]"#);
+        assert_eq!(key_to_string(42u16), r#"[42]"#);
+        assert_eq!(key_to_string(42u32), r#"[42]"#);
+        assert_eq!(key_to_string(42u64), r#"[42]"#);
+        assert_eq!(key_to_string(42usize), r#"[42]"#);
+        assert_eq!(key_to_string(42i8), r#"[42]"#);
+        assert_eq!(key_to_string(42i16), r#"[42]"#);
+        assert_eq!(key_to_string(42i32), r#"[42]"#);
+        assert_eq!(key_to_string(42i64), r#"[42]"#);
+        assert_eq!(key_to_string(42isize), r#"[42]"#);
+    }
+
+    #[test]
+    pub fn floats() {
+        // The f32 gets up-cast to f64, which results in a rounding issue.
+        // It's serde_json's default behavior, so we expect it, even if it isn't ideal.
+        assert_eq!(key_to_string(4.2f32), r#"[4.199999809265137]"#);
+        assert_eq!(key_to_string(4.2f64), r#"[4.2]"#);
+    }
+
+    #[test]
+    pub fn options() {
+        let some: Option<&str> = Some("my_partition_key");
+        let none: Option<&str> = None;
+        assert_eq!(key_to_string(some), r#"["my_partition_key"]"#);
+        assert_eq!(key_to_string(none), r#"[null]"#);
+    }
+
+    #[test]
+    pub fn serde_json_values() {
+        assert_eq!(
+            key_to_string(serde_json::Value::String("my_partition_key".into())),
+            r#"["my_partition_key"]"#
+        );
+        assert_eq!(
+            key_to_string(serde_json::Value::Number(
+                serde_json::Number::from_f64(4.2).unwrap()
+            )),
+            r#"[4.2]"#
+        );
+        assert_eq!(key_to_string(serde_json::Value::Null), r#"[null]"#);
+    }
+
+    #[test]
+    pub fn null_value() {
+        assert_eq!(key_to_string(PartitionKeyValue::NULL), r#"[null]"#);
+        assert_eq!(key_to_string(NullPartitionKey), r#"[null]"#);
+    }
+
+    #[test]
+    pub fn non_ascii_string() {
+        let key = PartitionKey::from("smile 😀");
+        assert_eq!(
+            key.into_header_value().unwrap().as_str(),
+            r#"["smile \ud83d\ude00"]"#
+        );
+    }
+
+    #[test]
+    pub fn tuple() {
+        assert_eq!(
+            key_to_string((42u8, "my_partition_key", 4.2f64, PartitionKeyValue::NULL)),
+            r#"[42,"my_partition_key",4.2,null]"#
+        );
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use crate::NullValue;
 
 /// Specifies a partition key value, usually used when querying a specific partition.

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -29,11 +29,8 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// A single, non-hierarchical, partition key can be specified using the underlying type itself:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods};
-/// # let credential = azure_identity::create_default_credential().unwrap();
-/// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-/// # let db_client = client.database_client("my_database");
-/// # let container_client = db_client.container_client("my_container");
+/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     "a single string partition key",
@@ -47,11 +44,8 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// Hierarchical partition keys can be specified using tuples:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods};
-/// # let credential = azure_identity::create_default_credential().unwrap();
-/// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-/// # let db_client = client.database_client("my_database");
-/// # let container_client = db_client.container_client("my_container");
+/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     ("parent", "child"),
@@ -62,11 +56,8 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// First, you can use an empty tuple (`()`) anywhere a `PartitionKey` is expected:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods};
-/// # let credential = azure_identity::create_default_credential().unwrap();
-/// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-/// # let db_client = client.database_client("my_database");
-/// # let container_client = db_client.container_client("my_container");
+/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
 ///     (), // A null value in a single-level partition key.
@@ -80,11 +71,8 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// Or, if you have an [`Option<T>`], for some `T` that is valid as a partition key, it will automatically be serialized as `null` if it has the value [`Option::None`]:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods, clients::DatabaseClientMethods, clients::ContainerClientMethods};
-/// # let credential = azure_identity::create_default_credential().unwrap();
-/// # let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
-/// # let db_client = client.database_client("my_database");
-/// # let container_client = db_client.container_client("my_container");
+/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// let my_partition_key: Option<String> = None;
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
@@ -25,8 +25,8 @@ const VERSION_NUMBER: &str = "1.0";
 #[allow(dead_code)] // For the variants. Can be removed when we have them all implemented.
 pub(crate) enum ResourceType {
     Databases,
-    Collections,
-    Documents,
+    Containers,
+    Items,
     StoredProcedures,
     Users,
     Permissions,
@@ -249,8 +249,8 @@ fn string_to_sign(signature_target: SignatureTarget) -> String {
         },
         match signature_target.resource_type {
             ResourceType::Databases => "dbs",
-            ResourceType::Collections => "colls",
-            ResourceType::Documents => "docs",
+            ResourceType::Containers => "colls", // The rest API uses the old term "colls" (referring to 'collections') to refer to containers
+            ResourceType::Items => "docs", // The rest API uses the old term "docs" (referring to 'documents') to refer to items
             ResourceType::StoredProcedures => "sprocs",
             ResourceType::Users => "users",
             ResourceType::Permissions => "permissions",

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 //! Defines Cosmos DB's unique Authentication Policy.
 //!
 //! The Cosmos DB data plane doesn't use a standard `Authorization: Bearer` header for authentication.

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -1,0 +1,34 @@
+mod authorization_policy;
+
+use std::sync::Arc;
+
+pub(crate) use authorization_policy::{AuthorizationPolicy, ResourceType};
+
+/// Newtype that wraps an Azure Core pipeline to provide a Cosmos-specific pipeline which configures our authorization policy and enforces that a [`ResourceType`] is set on the context.
+#[derive(Debug, Clone)]
+pub struct CosmosPipeline(azure_core::Pipeline);
+
+impl CosmosPipeline {
+    pub fn new(
+        auth_policy: AuthorizationPolicy,
+        client_options: azure_core::ClientOptions,
+    ) -> Self {
+        CosmosPipeline(azure_core::Pipeline::new(
+            option_env!("CARGO_PKG_NAME"),
+            option_env!("CARGO_PKG_VERSION"),
+            client_options,
+            Vec::new(),
+            vec![Arc::new(auth_policy)],
+        ))
+    }
+
+    pub async fn send<T>(
+        &self,
+        ctx: azure_core::Context<'_>,
+        request: &mut azure_core::Request,
+        resource_type: ResourceType,
+    ) -> azure_core::Result<azure_core::Response<T>> {
+        let ctx = ctx.with_value(resource_type);
+        self.0.send(&ctx, request).await
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 mod authorization_policy;
 
 use std::sync::Arc;

--- a/sdk/cosmos/azure_data_cosmos/src/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query.rs
@@ -1,35 +1,68 @@
 use serde::Serialize;
 
 /// Represents a Cosmos DB Query, with optional parameters.
+///
+/// # Examples
+///
+/// Create a query using [`Query::from()`], and use  [`Query::with_parameter()`] to add parameters to it as needed.
+///
+/// ```rust
+/// # use azure_data_cosmos::{Query,NullValue};
+/// let query = Query::from("SELECT * FROM c WHERE c.id = @customer_id")
+///     .with_parameter("@customer_id", 42).unwrap();
+/// ```
+///
+/// # Specifying Parameters
+///
+/// Any JSON-serializable value, including the [`NullValue`](crate::NullValue) marker value, can be used as a parameter.
+/// The [`Query::with_parameter()`] method accepts any type that implements [`serde::Serialize`] as a value.
+/// Because the type needs to be serialized in order to be sent as a query parameter, the [`Query::with_parameter()`] method is fallible and may return [`Result::Err`].
+///
+/// ```rust
+/// # use azure_data_cosmos::{Query, NullValue};
+/// let query = Query::from("SELECT * FROM c WHERE ...")
+///     .with_parameter("@customer_id", 42).unwrap()
+///     .with_parameter("@customer_name", "Contoso").unwrap()
+///     .with_parameter("@is_active", true).unwrap()
+///     .with_parameter("@offer_code", NullValue).unwrap();
+/// ```
+///
+/// This includes arrays and objects, if they implement [`serde::Serialize`]:
+///
+/// ```rust
+/// # use azure_data_cosmos::{Query, NullValue};
+/// #[derive(serde::Serialize)]
+/// struct CustomerInfo {
+///     id: u64,
+///     name: String
+/// }
+/// let query = Query::from("SELECT * FROM c WHERE ...")
+///     .with_parameter("@customer_info", CustomerInfo { id: 42, name: "Contoso".into() }).unwrap();
+/// ```
 #[derive(Debug, Serialize)]
 pub struct Query {
     query: String,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")] // Don't serialize an empty array.
     parameters: Vec<QueryParameter>,
 }
 
 impl Query {
-    /// Creates a new [`Query`] with the same text, and parameters, but with the specified parameter added.
+    /// Creates a new [`Query`] with the same text and the same parameters, with one additional parameter added.
     ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// # use azure_data_cosmos::Query;
-    ///
-    /// let query = Query::from("SELECT * FROM c WHERE c.id = @customer_id")
-    ///     .with_parameter("customer_id", 42);
-    /// ```
+    /// Returns an error if the value cannot be serialized to JSON.
     pub fn with_parameter(
-        self,
+        mut self,
         name: impl Into<String>,
-        value: impl Into<serde_json::Value>,
-    ) -> Self {
+        value: impl Serialize,
+    ) -> azure_core::Result<Self> {
         let parameter = QueryParameter {
             name: name.into(),
-            value: value.into(),
+            value: QueryParameterValue(serde_json::to_value(value)?),
         };
-        let mut parameters = self.parameters;
-        parameters.push(parameter);
-        Self { parameters, ..self }
+        self.parameters.push(parameter);
+
+        Ok(self)
     }
 }
 
@@ -43,32 +76,79 @@ impl<T: Into<String>> From<T> for Query {
     }
 }
 
+/// Represents a single parameter in a Cosmos DB query.
 #[derive(Debug, Serialize)]
-pub struct QueryParameter {
+struct QueryParameter {
     name: String,
-    value: serde_json::Value,
+    value: QueryParameterValue,
 }
+
+/// Represents a value that can be provided to a query parameter.
+#[derive(Debug, Serialize)]
+#[serde(transparent)]
+struct QueryParameterValue(serde_json::Value);
 
 #[cfg(test)]
 mod tests {
-    use crate::Query;
+    use serde::Serialize;
+
+    use crate::{NullValue, Query};
 
     #[test]
     pub fn serialize_query_without_parameters() {
         let query: Query = "SELECT * FROM c".into();
         let serialized = serde_json::to_string(&query).unwrap();
-        assert_eq!(serialized, r#"{"query":"SELECT * FROM c","parameters":[]}"#);
+        assert_eq!(serialized, r#"{"query":"SELECT * FROM c"}"#);
     }
 
     #[test]
     pub fn serialize_query_with_string_parameters() {
         let query = Query::from("SELECT * FROM c")
             .with_parameter("name1", "value1")
-            .with_parameter("name2", "value2");
+            .unwrap()
+            .with_parameter("name2", "value2")
+            .unwrap();
         let serialized = serde_json::to_string(&query).unwrap();
         assert_eq!(
             serialized,
             r#"{"query":"SELECT * FROM c","parameters":[{"name":"name1","value":"value1"},{"name":"name2","value":"value2"}]}"#
+        );
+    }
+
+    #[test]
+    pub fn serialize_query_with_various_parameter_types() {
+        #[derive(Serialize)]
+        struct ObjectParameter {
+            name: String,
+            value: String,
+        }
+        let obj_param = ObjectParameter {
+            name: "foo".into(),
+            value: "bar".into(),
+        };
+        let null_option: Option<&str> = None;
+
+        let query = Query::from("SELECT * FROM c")
+            .with_parameter("string_param", "value1")
+            .unwrap()
+            .with_parameter("int_param", 42)
+            .unwrap()
+            .with_parameter("float_param", 4.2)
+            .unwrap()
+            .with_parameter("bool_param", true)
+            .unwrap()
+            .with_parameter("obj_param", obj_param)
+            .unwrap()
+            .with_parameter("arr_param", &["a", "b", "c"])
+            .unwrap()
+            .with_parameter("null_option", null_option)
+            .unwrap()
+            .with_parameter("null_value", NullValue)
+            .unwrap();
+        let serialized = serde_json::to_string(&query).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"query":"SELECT * FROM c","parameters":[{"name":"string_param","value":"value1"},{"name":"int_param","value":42},{"name":"float_param","value":4.2},{"name":"bool_param","value":true},{"name":"obj_param","value":{"name":"foo","value":"bar"}},{"name":"arr_param","value":["a","b","c"]},{"name":"null_option","value":null},{"name":"null_value","value":null}]}"#
         );
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query.rs
@@ -1,0 +1,59 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct Query {
+    query: String,
+    parameters: Vec<QueryParameter>,
+}
+
+impl Query {
+    pub fn with_parameter(self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        let parameter = QueryParameter {
+            name: name.into(),
+            value: value.into(),
+        };
+        let mut parameters = self.parameters;
+        parameters.push(parameter);
+        Self { parameters, ..self }
+    }
+}
+
+impl<T: Into<String>> From<T> for Query {
+    fn from(value: T) -> Self {
+        let query = value.into();
+        Self {
+            query,
+            parameters: vec![],
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct QueryParameter {
+    name: String,
+    value: String, // TODO: A parameter can be any JSON value. Should we use serde_json::Value or define a custom enum?
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Query;
+
+    #[test]
+    pub fn serialize_query_without_parameters() {
+        let query: Query = "SELECT * FROM c".into();
+        let serialized = serde_json::to_string(&query).unwrap();
+        assert_eq!(serialized, r#"{"query":"SELECT * FROM c","parameters":[]}"#);
+    }
+
+    #[test]
+    pub fn serialize_query_with_string_parameters() {
+        let query = Query::from("SELECT * FROM c")
+            .with_parameter("name1", "value1")
+            .with_parameter("name2", "value2");
+        let serialized = serde_json::to_string(&query).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"query":"SELECT * FROM c","parameters":[{"name":"name1","value":"value1"},{"name":"name2","value":"value2"}]}"#
+        );
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use serde::Serialize;
 
 /// Represents a Cosmos DB Query, with optional parameters.

--- a/sdk/cosmos/azure_data_cosmos/src/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+/// Represents a Cosmos DB Query, with optional parameters.
 #[derive(Debug, Serialize)]
 pub struct Query {
     query: String,
@@ -7,7 +8,21 @@ pub struct Query {
 }
 
 impl Query {
-    pub fn with_parameter(self, name: impl Into<String>, value: impl Into<String>) -> Self {
+    /// Creates a new [`Query`] with the same text, and parameters, but with the specified parameter added.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use azure_data_cosmos::Query;
+    ///
+    /// let query = Query::from("SELECT * FROM c WHERE c.id = @customer_id")
+    ///     .with_parameter("customer_id", 42);
+    /// ```
+    pub fn with_parameter(
+        self,
+        name: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
         let parameter = QueryParameter {
             name: name.into(),
             value: value.into(),
@@ -31,7 +46,7 @@ impl<T: Into<String>> From<T> for Query {
 #[derive(Debug, Serialize)]
 pub struct QueryParameter {
     name: String,
-    value: String, // TODO: A parameter can be any JSON value. Should we use serde_json::Value or define a custom enum?
+    value: serde_json::Value,
 }
 
 #[cfg(test)]

--- a/sdk/cosmos/azure_data_cosmos/src/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query.rs
@@ -23,7 +23,12 @@ use serde::Serialize;
 ///
 /// ```rust
 /// # use azure_data_cosmos::{Query, NullValue};
-/// let query = Query::from("SELECT * FROM c WHERE ...")
+/// let query = Query::from("
+///     SELECT * FROM c
+///     WHERE c.id = @customer_id
+///     AND c.name = @customer_name
+///     AND c.is_active = @is_active
+///     AND c.offer_code = @offer_code")
 ///     .with_parameter("@customer_id", 42).unwrap()
 ///     .with_parameter("@customer_name", "Contoso").unwrap()
 ///     .with_parameter("@is_active", true).unwrap()
@@ -51,7 +56,7 @@ pub struct Query {
 }
 
 impl Query {
-    /// Creates a new [`Query`] with the same text and the same parameters, with one additional parameter added.
+    /// Consumes this [`Query`] instance, adds a new parameter to it, and returns it.
     ///
     /// Returns an error if the value cannot be serialized to JSON.
     pub fn with_parameter(

--- a/sdk/cosmos/azure_data_cosmos/src/utils.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/utils.rs
@@ -1,0 +1,20 @@
+use url::Url;
+
+pub trait WithAddedPathSegments {
+    fn with_added_path_segments<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> Self;
+}
+
+impl WithAddedPathSegments for Url {
+    fn with_added_path_segments<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> Self {
+        let mut url = self.clone();
+        {
+            let mut path_segments = url
+                .path_segments_mut()
+                .expect("the URL must not be a 'cannot-be-a-base' URL");
+            for segment in segments.into_iter() {
+                path_segments.push(segment);
+            }
+        }
+        url
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/utils.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/utils.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use url::Url;
 
 pub trait WithAddedPathSegments {

--- a/sdk/cosmos/azure_data_cosmos/src/utils.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/utils.rs
@@ -3,21 +3,27 @@
 
 use url::Url;
 
-pub trait WithAddedPathSegments {
-    fn with_added_path_segments<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> Self;
+/// Appends new path segments to the target [`Url`].
+///
+/// # Examples
+/// ```rust
+/// use url::Url;
+///
+/// let mut url: Url = "https://example.com/foo".parse().unwrap();
+/// url.append_to_path(&["bar", "baz"]);
+/// assert_eq!("https://example.com/foo/bar/baz", url.to_string());
+/// ```
+pub trait AppendPathSegments {
+    fn append_path_segments<'a>(&mut self, segments: impl IntoIterator<Item = &'a str>);
 }
 
-impl WithAddedPathSegments for Url {
-    fn with_added_path_segments<'a>(&self, segments: impl IntoIterator<Item = &'a str>) -> Self {
-        let mut url = self.clone();
-        {
-            let mut path_segments = url
-                .path_segments_mut()
-                .expect("the URL must not be a 'cannot-be-a-base' URL");
-            for segment in segments.into_iter() {
-                path_segments.push(segment);
-            }
+impl AppendPathSegments for Url {
+    fn append_path_segments<'a>(&mut self, segments: impl IntoIterator<Item = &'a str>) {
+        let mut path_segments = self
+            .path_segments_mut()
+            .expect("the URL must not be a 'cannot-be-a-base' URL");
+        for segment in segments {
+            path_segments.push(segment.as_ref());
         }
-        url
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/utils.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/utils.rs
@@ -4,15 +4,6 @@
 use url::Url;
 
 /// Appends new path segments to the target [`Url`].
-///
-/// # Examples
-/// ```rust
-/// use url::Url;
-///
-/// let mut url: Url = "https://example.com/foo".parse().unwrap();
-/// url.append_to_path(&["bar", "baz"]);
-/// assert_eq!("https://example.com/foo/bar/baz", url.to_string());
-/// ```
 pub trait AppendPathSegments {
     fn append_path_segments<'a>(&mut self, segments: impl IntoIterator<Item = &'a str>);
 }

--- a/sdk/typespec/typespec_client_core/src/http/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/mod.rs
@@ -52,3 +52,39 @@ where
         }
     }
 }
+
+/// Appends new path segments to the target [`Url`].
+///
+/// # Examples
+/// ```rust
+/// use url::Url;
+///
+/// let mut url: Url = "https://example.com/foo".parse().unwrap();
+/// url.append_to_path(&["bar", "baz"]);
+/// assert_eq!("https://example.com/foo/bar/baz", url.to_string());
+/// ```
+pub trait AppendPathSegments {
+    fn append_path_segments<'a, T: AsRef<str>>(
+        &mut self,
+
+        // We have to use T:AsRef<str> here instead of just &str.
+        // We want to be able to pass a slice of strings, which is &[&str].
+        // Slices of T implement IntoIterator by producing an iterator that returns &T, which would be &&str in our case.
+        // An iterator that returns &&str is NOT compatible with IntoIterator<Item = &str>, but IS compatible with IntoIterator<Item = T> (where T: AsRef<str>)
+        segments: impl IntoIterator<Item = T>,
+    ) -> ();
+}
+
+impl AppendPathSegments for Url {
+    fn append_path_segments<'a, T: AsRef<str>>(
+        &mut self,
+        segments: impl IntoIterator<Item = T>,
+    ) -> () {
+        let mut path_segments = self
+            .path_segments_mut()
+            .expect("the URL must not be a 'cannot-be-a-base' URL");
+        for segment in segments {
+            path_segments.push(segment.as_ref());
+        }
+    }
+}

--- a/sdk/typespec/typespec_client_core/src/http/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/mod.rs
@@ -52,39 +52,3 @@ where
         }
     }
 }
-
-/// Appends new path segments to the target [`Url`].
-///
-/// # Examples
-/// ```rust
-/// use url::Url;
-///
-/// let mut url: Url = "https://example.com/foo".parse().unwrap();
-/// url.append_to_path(&["bar", "baz"]);
-/// assert_eq!("https://example.com/foo/bar/baz", url.to_string());
-/// ```
-pub trait AppendPathSegments {
-    fn append_path_segments<'a, T: AsRef<str>>(
-        &mut self,
-
-        // We have to use T:AsRef<str> here instead of just &str.
-        // We want to be able to pass a slice of strings, which is &[&str].
-        // Slices of T implement IntoIterator by producing an iterator that returns &T, which would be &&str in our case.
-        // An iterator that returns &&str is NOT compatible with IntoIterator<Item = &str>, but IS compatible with IntoIterator<Item = T> (where T: AsRef<str>)
-        segments: impl IntoIterator<Item = T>,
-    ) -> ();
-}
-
-impl AppendPathSegments for Url {
-    fn append_path_segments<'a, T: AsRef<str>>(
-        &mut self,
-        segments: impl IntoIterator<Item = T>,
-    ) -> () {
-        let mut path_segments = self
-            .path_segments_mut()
-            .expect("the URL must not be a 'cannot-be-a-base' URL");
-        for segment in segments {
-            path_segments.push(segment.as_ref());
-        }
-    }
-}

--- a/sdk/typespec/typespec_client_core/src/http/pageable.rs
+++ b/sdk/typespec/typespec_client_core/src/http/pageable.rs
@@ -32,22 +32,22 @@ macro_rules! declare {
             /// make repeated requests to the service yielding a new page each time.
             #[pin_project::pin_project]
             // This is to suppress the unused `project_ref` warning
-            pub struct Pageable<'a, T, E> {
+            pub struct Pageable<T, E> {
                 #[pin]
-                pub(crate) stream: ::std::pin::Pin<Box<dyn ::futures::Stream<Item = ::std::result::Result<T, E>> $($extra)* + 'a>>,
+                pub(crate) stream: ::std::pin::Pin<Box<dyn ::futures::Stream<Item = ::std::result::Result<T, E>> $($extra)*>>,
             }
         }
         pub use pageable::Pageable;
 
-        impl<'a, T, E> Pageable<'a, T, E>
+        impl<T, E> Pageable<T, E>
         where
             T: Continuable,
         {
             pub fn new<F>(
-                make_request: impl Fn(Option<T::Continuation>) -> F + Clone $($extra)* + 'a,
+                make_request: impl Fn(Option<T::Continuation>) -> F + Clone $($extra)* + 'static,
             ) -> Self
             where
-                F: ::std::future::Future<Output = Result<T, E>> $($extra)* + 'a,
+                F: ::std::future::Future<Output = Result<T, E>> $($extra)* + 'static,
             {
                 let stream = unfold(State::Init, move |state: State<T::Continuation>| {
                     let make_request = make_request.clone();
@@ -92,7 +92,7 @@ declare!(+ Send);
 #[cfg(target_arch = "wasm32")]
 declare!();
 
-impl<'a, T, E> Stream for Pageable<'a, T, E> {
+impl<T, E> Stream for Pageable<T, E> {
     type Item = Result<T, E>;
 
     fn poll_next(
@@ -104,7 +104,7 @@ impl<'a, T, E> Stream for Pageable<'a, T, E> {
     }
 }
 
-impl<'a, T, O> std::fmt::Debug for Pageable<'a, T, O> {
+impl<T, O> std::fmt::Debug for Pageable<T, O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Pageable").finish_non_exhaustive()
     }

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -26,7 +26,9 @@ pub trait Model: Sized {
     /// For example, a type representing a simple REST API response will want to wait for the entire body to be received and then parse the body.
     /// However, a type representing the download of a large file, may not want to do that and instead prepare to stream the body to a file or other destination.
     #[cfg(not(target_arch = "wasm32"))]
-    fn from_response_body(body: ResponseBody) -> impl Future<Output = crate::Result<Self>> + Send;
+    fn from_response_body(
+        body: ResponseBody,
+    ) -> impl Future<Output = crate::Result<Self>> + Send + Sync;
 
     #[cfg(target_arch = "wasm32")]
     fn from_response_body(body: ResponseBody) -> impl Future<Output = crate::Result<Self>>;

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -25,7 +25,7 @@ pub trait Model: Sized {
     /// The server may still be sending data, so it's up to implementors whether they want to wait for the entire body to be received or not.
     /// For example, a type representing a simple REST API response will want to wait for the entire body to be received and then parse the body.
     /// However, a type representing the download of a large file, may not want to do that and instead prepare to stream the body to a file or other destination.
-    fn from_response_body(body: ResponseBody) -> impl Future<Output = crate::Result<Self>>;
+    fn from_response_body(body: ResponseBody) -> impl Future<Output = crate::Result<Self>> + Send;
 }
 
 /// An HTTP response.

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -25,7 +25,11 @@ pub trait Model: Sized {
     /// The server may still be sending data, so it's up to implementors whether they want to wait for the entire body to be received or not.
     /// For example, a type representing a simple REST API response will want to wait for the entire body to be received and then parse the body.
     /// However, a type representing the download of a large file, may not want to do that and instead prepare to stream the body to a file or other destination.
+    #[cfg(not(target_arch = "wasm32"))]
     fn from_response_body(body: ResponseBody) -> impl Future<Output = crate::Result<Self>> + Send;
+
+    #[cfg(target_arch = "wasm32")]
+    fn from_response_body(body: ResponseBody) -> impl Future<Output = crate::Result<Self>>;
 }
 
 /// An HTTP response.


### PR DESCRIPTION
Closes #1809 

This adds the initial rudimentary APIs to perform a single-partition query against items in a container.

Some example code (see the `cosmos_query` example for a larger example):

```rust
let cosmos_client = CosmosClient::new(...);
let db_client = client.database_client("SampleDB");
let container_client = db_client.container_client("SampleContainer");
let mut items_pager =
    container_client.query_items::<serde_json::Value>("SELECT * FROM c", "some_partition_key", None)?;

// ".next()" requires importing futures::StreamExt
while let Some(page) = items_pager.next().await {
    for item in page?.items {
        println!("    * {:?}", item);
    }
}
```

A few pieces of note:

1. A query can be parameterized. To do that, instead of passing the raw string in, you'd call `Query::from("...")` and then call `.with_parameter("@name", "value")` on the resulting `Query` to build up the query and parameters

2. We only support single-partition queries. This is aligned with the support we currently provide in other SDKs that only support Gateway mode. Over time we can expand this to cross-partition queries, but there are significant limitations to those.

3. For serializing Partition Keys we have to do something a little custom and can't just use `serde_json` as-is. The partition key for a query is encoded as an HTTP header, which means we have to escape any non-ASCII characters because HTTP headers may not contain non-ASCII characters. Serde's default JSON serialization does not perform that escaping, it allows non-ASCII UTF-8 characters to pass through unescaped. Even Rust's built-in escaping is unsuitable because it uses the format `\u{XXXX}`, when JSON requires `\uXXXX` (sans-`{}`). So we do some custom stuff. Importantly, we still use the standard library's logic to encode characters as UTF-16, which handles surrogate pairs properly.

4. **UPDATE: I reverted this change and decided to leave `Pageable` as-is** I changed `Pageable` to include a lifetime parameter. Previously, it expected the provided closure to return a future with the `'static` lifetime, which would require the Future to own all necessary data. However, the implementation I used for `query_items` required that the future borrowed `self.pipeline`, so it could use the same HTTP pipeline to make the requests. That isn't _totally_ necessary. I could clone the pipeline and give the clone to the closure, but that seemed heavier to me, so I hesitated to do that. Though, after the conversations we've had about lifetimes, I'm waffling on that and considering rolling that change back and requiring that the `Pageable` hold its own HTTP pipeline and avoid being coupled to the lifetime of the client that created it. I'll continue to look into that.

There are also fairly substantial API docs in place. We don't have a great way to preview those docs (maybe we should? publish updated docs to an Azure Static Web App on PR build?) but you can run `cargo doc --package azure_data_cosmos --open`, if you're on a local machine or RDP, or use #1808, if on a codespace, to view them.