### PR TITLE
Give CODEOWNERS file an owner in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,3 +35,4 @@
 # Eng Sys
 ###########
 /eng/                    @weshaggard @heaths @RickWinter
+/.github/CODEOWNERS      @RickWinter @ronniegeraghty @Azure/azure-sdk-eng


### PR DESCRIPTION
Give the CODEOWNERS file owners. 

@RickWinter as per your instructions you and @ronniegeraghty, along with azure-sdk-eng are added to the owners.

When the linter pipeline and github actions have been added to the repository, those owners will also need to be added as part of the same block.