### PR TITLE
Give CODEOWNERS owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,3 +41,4 @@
 # Eng Sys
 ###########
 /eng/                   @weshaggard @heaths @RickWinter
+/.github/CODEOWNERS      @RickWinter @ronniegeraghty @Azure/azure-sdk-eng


### PR DESCRIPTION
Same as the closed [PR](https://github.com/Azure/azure-sdk-for-rust/pull/1818) except targeting feature/track2 instead of main.