### PR TITLE
complete session implementation; C++ related changes

### DIFF
--- a/sdk/core/azure_core_amqp/src/cbs.rs
+++ b/sdk/core/azure_core_amqp/src/cbs.rs
@@ -74,9 +74,9 @@ impl AmqpClaimsBasedSecurityApis for AmqpClaimsBasedSecurity {
 }
 
 impl AmqpClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Self {
-        Self {
-            implementation: CbsImplementation::new(session),
-        }
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {
+            implementation: CbsImplementation::new(session)?,
+        })
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/cbs.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/cbs.rs
@@ -22,11 +22,11 @@ pub(crate) struct Fe2o3ClaimsBasedSecurity {
 }
 
 impl Fe2o3ClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Self {
-        Self {
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {
             cbs: OnceLock::new(),
-            session: session.implementation.get(),
-        }
+            session: session.implementation.get()?,
+        })
     }
 }
 
@@ -46,12 +46,12 @@ impl AmqpClaimsBasedSecurityApis for Fe2o3ClaimsBasedSecurity {
             .attach(session.borrow_mut())
             .await
             .map_err(AmqpManagementAttach::from)?;
-        self.cbs
-            .set(Mutex::new(cbs_client))
-            .map_err(azure_core::Error::message(
+        self.cbs.set(Mutex::new(cbs_client)).map_err(|_| {
+            azure_core::Error::message(
                 azure_core::error::ErrorKind::Other,
                 "Claims Based Security is already set.",
-            ))?;
+            )
+        })?;
         Ok(())
     }
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -58,9 +58,18 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
                         "Connection options are not set.",
                     )
                 })?;
+
+                // options.max_frame_size().inspect(move |s| {
+                //     builder.max_frame_size(*s);
+                // });
                 if options.max_frame_size.is_some() {
                     builder = builder.max_frame_size(options.max_frame_size.unwrap());
                 }
+
+                // options.channel_max.inspect(move |c| {
+                //     builder.channel_max(*c);
+                // });
+
                 if options.channel_max.is_some() {
                     builder = builder.channel_max(options.channel_max.unwrap());
                 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -51,69 +51,59 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
                 .container_id(id)
                 .max_frame_size(65536);
 
-            if options.is_some() {
-                let options = options.ok_or_else(|| {
-                    azure_core::Error::new(
-                        azure_core::error::ErrorKind::Other,
-                        "Connection options are not set.",
-                    )
-                })?;
+            let options = options.ok_or_else(|| {
+                azure_core::Error::new(
+                    azure_core::error::ErrorKind::Other,
+                    "Connection options are not set.",
+                )
+            })?;
 
-                // options.max_frame_size().inspect(move |s| {
-                //     builder.max_frame_size(*s);
-                // });
-                if options.max_frame_size.is_some() {
-                    builder = builder.max_frame_size(options.max_frame_size.unwrap());
-                }
+            if let Some(frame_size) = options.max_frame_size {
+                builder = builder.max_frame_size(frame_size);
+            }
 
-                // options.channel_max.inspect(move |c| {
-                //     builder.channel_max(*c);
-                // });
+            if let Some(channel_max) = options.channel_max {
+                builder = builder.channel_max(channel_max);
+            }
+            if let Some(idle_timeout) = options.idle_timeout {
+                builder = builder.idle_time_out(idle_timeout.whole_milliseconds() as u32);
+            }
+            if let Some(outgoing_locales) = options.outgoing_locales.as_ref() {
+                for locale in outgoing_locales {
+                    builder = builder.add_outgoing_locales(locale.as_str());
+                }
+            }
+            if let Some(incoming_locales) = options.incoming_locales {
+                for locale in incoming_locales {
+                    builder = builder.add_incoming_locales(locale.as_str());
+                }
+            }
+            if let Some(offered_capabilities) = options.offered_capabilities.as_ref() {
+                for capability in offered_capabilities {
+                    let capability: fe2o3_amqp_types::primitives::Symbol =
+                        capability.clone().into();
+                    builder = builder.add_offered_capabilities(capability);
+                }
+            }
+            if let Some(desired_capabilities) = options.desired_capabilities.as_ref() {
+                for capability in desired_capabilities {
+                    let capability: fe2o3_amqp_types::primitives::Symbol =
+                        capability.clone().into();
+                    builder = builder.add_desired_capabilities(capability);
+                }
+            }
+            if let Some(properties) = options.properties.as_ref() {
+                let mut fields = fe2o3_amqp::types::definitions::Fields::new();
+                for property in properties.iter() {
+                    let k = fe2o3_amqp_types::primitives::Symbol::from(property.0);
+                    let v = fe2o3_amqp_types::primitives::Value::from(property.1);
 
-                if options.channel_max.is_some() {
-                    builder = builder.channel_max(options.channel_max.unwrap());
+                    fields.insert(k, v);
                 }
-                if options.idle_timeout.is_some() {
-                    builder = builder
-                        .idle_time_out(options.idle_timeout.unwrap().whole_milliseconds() as u32);
-                }
-                if options.outgoing_locales.is_some() {
-                    for locale in options.outgoing_locales.as_ref().unwrap() {
-                        builder = builder.add_outgoing_locales(locale.as_str());
-                    }
-                }
-                if options.incoming_locales.is_some() {
-                    for locale in options.incoming_locales.as_ref().unwrap() {
-                        builder = builder.add_incoming_locales(locale.as_str());
-                    }
-                }
-                if options.offered_capabilities.is_some() {
-                    for capability in options.offered_capabilities.unwrap() {
-                        let capability: fe2o3_amqp_types::primitives::Symbol = capability.into();
-                        builder = builder.add_offered_capabilities(capability);
-                    }
-                }
-                if options.desired_capabilities.is_some() {
-                    for capability in options.desired_capabilities.unwrap() {
-                        let capability: fe2o3_amqp_types::primitives::Symbol = capability.into();
-                        builder = builder.add_desired_capabilities(capability);
-                    }
-                }
-                if options.properties.is_some() {
-                    let mut fields = fe2o3_amqp::types::definitions::Fields::new();
-                    for property in options.properties.unwrap().iter() {
-                        debug!("Property: {:?}, Value: {:?}", property.0, property.1);
-                        let k: fe2o3_amqp_types::primitives::Symbol = property.0.into();
-                        let v: fe2o3_amqp_types::primitives::Value = property.1.into();
-                        debug!("Property2: {:?}, Value: {:?}", k, v);
-
-                        fields.insert(k, v);
-                    }
-                    builder = builder.properties(fields);
-                }
-                if options.buffer_size.is_some() {
-                    builder = builder.buffer_size(options.buffer_size.unwrap());
-                }
+                builder = builder.properties(fields);
+            }
+            if let Some(buffer_size) = options.buffer_size {
+                builder = builder.buffer_size(buffer_size);
             }
 
             self.connection

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -109,7 +109,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
 
             self.connection
                 .set(Mutex::new(builder.open(url).await.map_err(AmqpOpen::from)?))
-                .map_err(|| {
+                .map_err(|_| {
                     azure_core::Error::new(
                         azure_core::error::ErrorKind::Other,
                         "Connection already set.",

--- a/sdk/core/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/management.rs
@@ -38,16 +38,16 @@ impl Fe2o3AmqpManagement {
         session: AmqpSession,
         client_node_name: impl Into<String>,
         access_token: AccessToken,
-    ) -> Self {
+    ) -> Result<Self> {
         // Session::get() returns a clone of the underlying session handle.
-        let session = session.implementation.get();
+        let session = session.implementation.get()?;
 
-        Self {
+        Ok(Self {
             access_token,
             client_node_name: client_node_name.into(),
             session,
             management: OnceLock::new(),
-        }
+        })
     }
 }
 
@@ -59,7 +59,7 @@ impl AmqpManagementApis for Fe2o3AmqpManagement {
             .await
             .map_err(AmqpManagementAttach::from)?;
 
-        self.management.set(Mutex::new(management)).map_err(|| {
+        self.management.set(Mutex::new(management)).map_err(|_| {
             azure_core::Error::message(
                 azure_core::error::ErrorKind::Other,
                 "Management is already set.",

--- a/sdk/core/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/management.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 use async_std::sync::Mutex;
-use azure_core::{auth::AccessToken, error::Result};
+use azure_core::{credentials::AccessToken, error::Result};
 use fe2o3_amqp_management::operations::ReadResponse;
 use fe2o3_amqp_types::{messaging::ApplicationProperties, primitives::SimpleValue};
 use std::sync::{Arc, OnceLock};

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -49,7 +49,7 @@ impl TryInto<AmqpValue> for Vec<Vec<serde_amqp::Value>> {
 
 fn amqp_message_from_fe2o3_message<T>(
     message: fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body<T>>,
-) -> AmqpMessage
+) -> Result<AmqpMessage>
 where
     T: std::fmt::Debug + Clone + TryInto<AmqpValue>,
     <T as TryInto<AmqpValue>>::Error: std::fmt::Debug,
@@ -109,7 +109,7 @@ where
         amqp_message_builder.with_footer(footer.0.into());
     }
 
-    amqp_message_builder.build()
+    Ok(amqp_message_builder.build())
 }
 
 impl From<fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body<Value>>>

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -49,7 +49,7 @@ impl TryInto<AmqpValue> for Vec<Vec<serde_amqp::Value>> {
 
 fn amqp_message_from_fe2o3_message<T>(
     message: fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body<T>>,
-) -> Result<AmqpMessage>
+) -> azure_core::Result<AmqpMessage>
 where
     T: std::fmt::Debug + Clone + TryInto<AmqpValue>,
     <T as TryInto<AmqpValue>>::Error: std::fmt::Debug,
@@ -118,7 +118,7 @@ impl From<fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body
     fn from(
         message: fe2o3_amqp_types::messaging::Message<fe2o3_amqp_types::messaging::Body<Value>>,
     ) -> Self {
-        amqp_message_from_fe2o3_message(message)
+        amqp_message_from_fe2o3_message(message).unwrap()
     }
 }
 
@@ -134,7 +134,7 @@ impl
             fe2o3_amqp_types::messaging::Body<TransparentVec<fe2o3_amqp_types::messaging::Data>>,
         >,
     ) -> Self {
-        amqp_message_from_fe2o3_message(message)
+        amqp_message_from_fe2o3_message(message).unwrap()
     }
 }
 
@@ -154,7 +154,7 @@ impl
             >,
         >,
     ) -> Self {
-        amqp_message_from_fe2o3_message(message)
+        amqp_message_from_fe2o3_message(message).unwrap()
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -55,7 +55,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .auto_accept(auto_accept)
             .properties(properties.into())
             .name(name)
-            .attach(session.implementation.get().lock().await.borrow_mut())
+            .attach(session.implementation.get()?.lock().await.borrow_mut())
             .await
             .map_err(AmqpReceiverAttach::from)?;
         self.receiver.set(Arc::new(Mutex::new(receiver))).unwrap();

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -116,10 +116,12 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
         let outcome = self
             .sender
             .get()
-            .ok_or_else(|| azure_core::Error::message(
-                azure_core::error::ErrorKind::Other,
-                "Message Sender not set.",
-            ))?
+            .ok_or_else(|| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Message Sender not set.",
+                )
+            })?
             .lock()
             .await
             .send(sendable)

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -64,7 +64,7 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
         let sender = session_builder
             .name(name.into())
             .target(target.into())
-            .attach(session.implementation.get().lock().await.borrow_mut())
+            .attach(session.implementation.get()?.lock().await.borrow_mut())
             .await
             .map_err(AmqpSenderAttach::from)?;
         self.sender.set(Arc::new(Mutex::new(sender))).unwrap();

--- a/sdk/core/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/session.rs
@@ -52,28 +52,30 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
         if options.is_some() {
             let options = options.unwrap();
 
-            if let Some(incoming_window) = options.incoming_window {
+            if let Some(incoming_window) = options.incoming_window() {
                 session_builder = session_builder.incoming_window(incoming_window);
             }
-            if let Some(outgoing_window) = options.outgoing_window {
+            if let Some(outgoing_window) = options.outgoing_window() {
                 session_builder = session_builder.outgoing_window(outgoing_window);
             }
-            if let Some(handle_max) = options.handle_max {
+            if let Some(handle_max) = options.handle_max() {
                 session_builder = session_builder.handle_max(handle_max);
             }
-            if let Some(offered_capabilities) = options.offered_capabilities.clone() {
+            if let Some(offered_capabilities) = options.offered_capabilities().clone() {
                 for capability in offered_capabilities {
-                    let capability: fe2o3_amqp_types::primitives::Symbol = capability.into();
+                    let capability: fe2o3_amqp_types::primitives::Symbol =
+                        capability.clone().into();
                     session_builder = session_builder.add_offered_capabilities(capability);
                 }
             }
-            if let Some(desired_capabilities) = options.desired_capabilities.clone() {
+            if let Some(desired_capabilities) = options.desired_capabilities().clone() {
                 for capability in desired_capabilities {
-                    let capability: fe2o3_amqp_types::primitives::Symbol = capability.into();
+                    let capability: fe2o3_amqp_types::primitives::Symbol =
+                        capability.clone().into();
                     session_builder = session_builder.add_desired_capabilities(capability);
                 }
             }
-            if let Some(properties) = options.properties.clone() {
+            if let Some(properties) = options.properties().clone() {
                 let mut fields = fe2o3_amqp::types::definitions::Fields::new();
                 for property in properties.iter() {
                     debug!("Property: {:?}, Value: {:?}", property.0, property.1);
@@ -85,7 +87,7 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
                 }
                 session_builder = session_builder.properties(fields);
             }
-            if let Some(buffer_size) = options.buffer_size {
+            if let Some(buffer_size) = options.buffer_size() {
                 session_builder = session_builder.buffer_size(buffer_size);
             }
         }
@@ -98,6 +100,14 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
     }
 
     async fn end(&self) -> Result<()> {
-        todo!()
+        self.session
+            .get()
+            .unwrap()
+            .lock()
+            .await
+            .end()
+            .await
+            .map_err(super::error::AmqpSession::from)?;
+        Ok(())
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/session.rs
@@ -61,21 +61,21 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
             if let Some(handle_max) = options.handle_max() {
                 session_builder = session_builder.handle_max(handle_max);
             }
-            if let Some(offered_capabilities) = options.offered_capabilities().clone() {
+            if let Some(offered_capabilities) = options.offered_capabilities() {
                 for capability in offered_capabilities {
                     let capability: fe2o3_amqp_types::primitives::Symbol =
                         capability.clone().into();
                     session_builder = session_builder.add_offered_capabilities(capability);
                 }
             }
-            if let Some(desired_capabilities) = options.desired_capabilities().clone() {
+            if let Some(desired_capabilities) = options.desired_capabilities() {
                 for capability in desired_capabilities {
                     let capability: fe2o3_amqp_types::primitives::Symbol =
                         capability.clone().into();
                     session_builder = session_builder.add_desired_capabilities(capability);
                 }
             }
-            if let Some(properties) = options.properties().clone() {
+            if let Some(properties) = options.properties() {
                 let mut fields = fe2o3_amqp::types::definitions::Fields::new();
                 for property in properties.iter() {
                     debug!("Property: {:?}, Value: {:?}", property.0, property.1);

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -47,7 +47,11 @@ impl From<fe2o3_amqp_types::primitives::Timestamp> for AmqpTimestamp {
 
 impl From<AmqpTimestamp> for fe2o3_amqp_types::primitives::Timestamp {
     fn from(timestamp: AmqpTimestamp) -> Self {
-        let t = timestamp.0.duration_since(UNIX_EPOCH).unwrap().as_millis();
+        let t = timestamp
+            .0
+            .duration_since(UNIX_EPOCH)
+            .expect("Could not convert timestamp to time since unix epoch")
+            .as_millis();
         fe2o3_amqp_types::primitives::Timestamp::from_milliseconds(t as i64)
     }
 }
@@ -325,7 +329,10 @@ impl PartialEq<AmqpValue> for fe2o3_amqp_types::primitives::Value {
             }
             AmqpValue::Char(c) => self == &fe2o3_amqp_types::primitives::Value::Char(*c),
             AmqpValue::TimeStamp(t) => {
-                let t: u64 = t.0.duration_since(UNIX_EPOCH).unwrap().as_millis() as u64;
+                let t: u64 =
+                    t.0.duration_since(UNIX_EPOCH)
+                        .expect("Could not convert timestamp into unix epoch")
+                        .as_millis() as u64;
                 self == &fe2o3_amqp_types::primitives::Value::Timestamp(
                     Timestamp::from_milliseconds(t as i64),
                 )

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -16,7 +16,7 @@ pub mod sender;
 pub mod session;
 pub mod value;
 
-pub type Uuid = uuid::Uuid;
+pub use uuid::Uuid;
 
 use std::fmt::Debug;
 

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -16,7 +16,7 @@ pub mod sender;
 pub mod session;
 pub mod value;
 
-pub use uuid::Uuid;
+pub type Uuid = uuid::Uuid;
 
 use std::fmt::Debug;
 

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -49,7 +49,7 @@ pub enum ReceiverSettleMode {
 pub trait Serializable {
     fn serialize(&self, buffer: &mut [u8]) -> azure_core::Result<()>;
 
-    fn encoded_size(&self) -> usize;
+    fn encoded_size(&self) -> azure_core::Result<usize>;
 }
 
 #[cfg(feature = "cplusplus")]

--- a/sdk/core/azure_core_amqp/src/management.rs
+++ b/sdk/core/azure_core_amqp/src/management.rs
@@ -6,7 +6,7 @@ use super::{
     session::AmqpSession,
     value::{AmqpOrderedMap, AmqpValue},
 };
-use azure_core::{credentials::AccessToken, error::Result};
+use azure_core::{auth::AccessToken, error::Result};
 use std::fmt::Debug;
 
 #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]

--- a/sdk/core/azure_core_amqp/src/management.rs
+++ b/sdk/core/azure_core_amqp/src/management.rs
@@ -6,7 +6,7 @@ use super::{
     session::AmqpSession,
     value::{AmqpOrderedMap, AmqpValue},
 };
-use azure_core::{auth::AccessToken, error::Result};
+use azure_core::{credentials::AccessToken, error::Result};
 use std::fmt::Debug;
 
 #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]

--- a/sdk/core/azure_core_amqp/src/management.rs
+++ b/sdk/core/azure_core_amqp/src/management.rs
@@ -51,9 +51,9 @@ impl AmqpManagement {
         session: AmqpSession,
         client_node_name: impl Into<String>,
         access_token: AccessToken,
-    ) -> Self {
-        Self {
-            implementation: ManagementImplementation::new(session, client_node_name, access_token),
-        }
+    ) -> Result<Self> {
+        Ok(Self {
+            implementation: ManagementImplementation::new(session, client_node_name, access_token)?,
+        })
     }
 }

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -212,7 +212,9 @@ impl AmqpTarget {
 
 impl From<AmqpTarget> for String {
     fn from(target: AmqpTarget) -> String {
-        target.address.unwrap()
+        target
+            .address
+            .expect("Target does not have an address set.")
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -13,7 +13,7 @@ use super::{
     session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions},
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
 };
-use azure_core::{credentials::AccessToken, error::Result};
+use azure_core::{auth::AccessToken, error::Result};
 
 #[derive(Debug, Default)]
 pub(crate) struct NoopAmqpConnection {}
@@ -56,7 +56,7 @@ impl AmqpConnectionApis for NoopAmqpConnection {
         condition: impl Into<AmqpSymbol>,
         description: Option<String>,
         info: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    ) -> Result<()> {
+    ) -> impl Result<()> {
         unimplemented!()
     }
 }

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -13,7 +13,7 @@ use super::{
     session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions},
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
 };
-use azure_core::{auth::AccessToken, error::Result};
+use azure_core::{credentials::AccessToken, error::Result};
 
 #[derive(Debug, Default)]
 pub(crate) struct NoopAmqpConnection {}

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -137,7 +137,7 @@ impl AmqpSenderApis for NoopAmqpSender {
         unimplemented!();
     }
 
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         unimplemented!();
     }
 
@@ -166,7 +166,7 @@ impl AmqpReceiverApis for NoopAmqpReceiver {
         unimplemented!();
     }
 
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         unimplemented!();
     }
 

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -82,8 +82,8 @@ impl AmqpSessionApis for NoopAmqpSession {
 }
 
 impl NoopAmqpClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Self {
-        Self {}
+    pub fn new(session: AmqpSession) -> Result<Self> {
+        Ok(Self {})
     }
 }
 
@@ -102,8 +102,12 @@ impl AmqpClaimsBasedSecurityApis for NoopAmqpClaimsBasedSecurity {
 }
 
 impl NoopAmqpManagement {
-    pub fn new(session: AmqpSession, name: impl Into<String>, access_token: AccessToken) -> Self {
-        Self {}
+    pub fn new(
+        session: AmqpSession,
+        name: impl Into<String>,
+        access_token: AccessToken,
+    ) -> Result<Self> {
+        Ok(Self {})
     }
 }
 impl AmqpManagementApis for NoopAmqpManagement {

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -56,7 +56,7 @@ impl AmqpConnectionApis for NoopAmqpConnection {
         condition: impl Into<AmqpSymbol>,
         description: Option<String>,
         info: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    ) -> impl Result<()> {
+    ) -> Result<()> {
         unimplemented!()
     }
 }

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -83,7 +83,7 @@ pub trait AmqpReceiverApis {
         source: impl Into<AmqpSource>,
         options: Option<AmqpReceiverOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
-    fn max_message_size(&self) -> impl std::future::Future<Output = Option<u64>>;
+    fn max_message_size(&self) -> impl std::future::Future<Output = Result<Option<u64>>>;
     fn receive(&self) -> impl std::future::Future<Output = Result<AmqpMessage>>;
 }
 
@@ -101,7 +101,7 @@ impl AmqpReceiverApis for AmqpReceiver {
     ) -> Result<()> {
         self.implementation.attach(session, source, options).await
     }
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         self.implementation.max_message_size().await
     }
     async fn receive(&self) -> Result<AmqpMessage> {

--- a/sdk/core/azure_core_amqp/src/sender.rs
+++ b/sdk/core/azure_core_amqp/src/sender.rs
@@ -40,7 +40,7 @@ pub trait AmqpSenderApis {
         target: impl Into<AmqpTarget>,
         options: Option<AmqpSenderOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
-    fn max_message_size(&self) -> impl std::future::Future<Output = Option<u64>>;
+    fn max_message_size(&self) -> impl std::future::Future<Output = Result<Option<u64>>>;
     fn send(
         &self,
         message: impl Into<AmqpMessage> + std::fmt::Debug,
@@ -65,7 +65,7 @@ impl AmqpSenderApis for AmqpSender {
             .attach(session, name, target, options)
             .await
     }
-    async fn max_message_size(&self) -> Option<u64> {
+    async fn max_message_size(&self) -> Result<Option<u64>> {
         self.implementation.max_message_size().await
     }
     async fn send(

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -4,7 +4,11 @@
 
 use crate::Uuid;
 
-#[cfg(all(feature="cplusplus", feature="fe2o3-amqp", not(target_arch = "wasm32")))]
+#[cfg(all(
+    feature = "cplusplus",
+    feature = "fe2o3-amqp",
+    not(target_arch = "wasm32")
+))]
 use crate::fe2o3::error::AmqpSerialization;
 #[cfg(feature = "cplusplus")]
 use crate::{Deserializable, Serializable};

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -3,6 +3,9 @@
 // cspell: words amqp
 
 use crate::Uuid;
+
+#[cfg(all(feature="cplusplus", feature="fe2o3-amqp", not(target_arch = "wasm32")))]
+use crate::fe2o3::error::AmqpSerialization;
 #[cfg(feature = "cplusplus")]
 use crate::{Deserializable, Serializable};
 #[cfg(feature = "cplusplus")]
@@ -186,11 +189,11 @@ pub enum AmqpValue {
 
 #[cfg(feature = "cplusplus")]
 impl Serializable for AmqpValue {
-    fn encoded_size(&self) -> usize {
+    fn encoded_size(&self) -> Result<usize> {
         #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
         {
             let fe2o3_value = fe2o3_amqp_types::primitives::Value::from(self.clone());
-            serde_amqp::serialized_size(&fe2o3_value).unwrap()
+            Ok(serde_amqp::serialized_size(&fe2o3_value).map_err(AmqpSerialization::from)?)
         }
         #[cfg(any(not(feature = "fe2o3-amqp"), target_arch = "wasm32"))]
         {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/mod.rs
@@ -37,21 +37,28 @@ impl ManagementInstance {
             .call("com.microsoft:eventhub", application_properties)
             .await?;
 
-        if !response.contains_key("name")
-            || !response.contains_key("type")
-            || !response.contains_key("created_at")
-            || !response.contains_key("partition_count")
-            || !response.contains_key("partition_ids")
-        {
+        if !response.contains_key("partition_count") {
             return Err(ErrorKind::InvalidManagementResponse.into());
         }
-        let name: String = response.get("name").unwrap().clone().into();
-        let created_at: SystemTime =
-            Into::<AmqpTimestamp>::into(response.get("created_at").unwrap().clone()).0;
+        let name: String = response
+            .get("name")
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
+            .clone()
+            .into();
+        let created_at: SystemTime = Into::<AmqpTimestamp>::into(
+            response
+                .get("created_at")
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
+                .clone(),
+        )
+        .0;
         //        let partition_count: i32 =
-        //            Into::<i32>::into(response.get("partition_count".to_string()).unwrap().clone());
+        //            Into::<i32>::into(response.get("partition_count".to_string()).ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?.clone());
 
-        let partition_ids = response.get("partition_ids").unwrap();
+        let partition_ids = response
+            .get("partition_ids")
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?;
+
         let partition_ids = match partition_ids {
             AmqpValue::Array(partition_ids) => partition_ids
                 .iter()
@@ -86,16 +93,8 @@ impl ManagementInstance {
             .await?;
 
         // Look for the required response properties
-        if !response.contains_key("name")
-            || !response.contains_key("type")
-            || !response.contains_key("partition")
-            || !response.contains_key("begin_sequence_number_epoch")
-            || !response.contains_key("begin_sequence_number")
+        if !response.contains_key("type")
             || !response.contains_key("last_enqueued_sequence_number_epoch")
-            || !response.contains_key("last_enqueued_sequence_number")
-            || !response.contains_key("last_enqueued_offset")
-            || !response.contains_key("last_enqueued_time_utc")
-            || !response.contains_key("is_partition_empty")
         {
             return Err(ErrorKind::InvalidManagementResponse.into());
         }
@@ -103,26 +102,42 @@ impl ManagementInstance {
         Ok(EventHubPartitionProperties {
             beginning_sequence_number: response
                 .get("begin_sequence_number")
-                .unwrap()
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
                 .clone()
                 .into(),
-            id: response.get("partition").unwrap().clone().into(),
-            eventhub: response.get("name").unwrap().clone().into(),
+            id: response
+                .get("partition")
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
+                .clone()
+                .into(),
+            eventhub: response
+                .get("name")
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
+                .clone()
+                .into(),
 
             last_enqueued_sequence_number: response
                 .get("last_enqueued_sequence_number")
-                .unwrap()
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
                 .clone()
                 .into(),
-            last_enqueued_offset: response.get("last_enqueued_offset").unwrap().clone().into(),
+            last_enqueued_offset: response
+                .get("last_enqueued_offset")
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
+                .clone()
+                .into(),
             last_enqueued_time_utc: Into::<AmqpTimestamp>::into(
                 response
                     .get("last_enqueued_time_utc".to_string())
-                    .unwrap()
+                    .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
                     .clone(),
             )
             .0,
-            is_empty: response.get("is_partition_empty").unwrap().clone().into(),
+            is_empty: response
+                .get("is_partition_empty")
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::InvalidManagementResponse))?
+                .clone()
+                .into(),
         })
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -430,7 +430,7 @@ impl ConsumerClient {
 
         trace!("Create management client.");
         let management =
-            AmqpManagement::new(session, "eventhubs_consumer_management", access_token);
+            AmqpManagement::new(session, "eventhubs_consumer_management", access_token)?;
         management.attach().await?;
         mgmt_client
             .set(ManagementInstance::new(management))
@@ -482,7 +482,7 @@ impl ConsumerClient {
             let session = AmqpSession::new();
             session.begin(connection, None).await?;
 
-            let cbs = AmqpClaimsBasedSecurity::new(session);
+            let cbs = AmqpClaimsBasedSecurity::new(session)?;
             cbs.attach().await?;
 
             debug!("Get Token.");

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -187,7 +187,11 @@ impl ConsumerClient {
     /// ```
     #[tracing::instrument]
     pub async fn close(self) -> Result<()> {
-        self.connection.get().unwrap().close().await?;
+        self.connection
+            .get()
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingConnection))?
+            .close()
+            .await?;
         Ok(())
     }
 
@@ -340,7 +344,7 @@ impl ConsumerClient {
             .lock()
             .await
             .get()
-            .unwrap()
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingManagementClient))?
             .get_eventhub_properties(&self.eventhub)
             .await
     }
@@ -398,7 +402,7 @@ impl ConsumerClient {
             .lock()
             .await
             .get()
-            .unwrap()
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingManagementClient))?
             .get_eventhub_partition_properties(&self.eventhub, partition_id)
             .await
     }
@@ -434,7 +438,7 @@ impl ConsumerClient {
         management.attach().await?;
         mgmt_client
             .set(ManagementInstance::new(management))
-            .unwrap();
+            .map_err(|_| azure_core::Error::from(ErrorKind::MissingManagementClient))?;
         trace!("Management client created.");
         Ok(())
     }
@@ -463,7 +467,9 @@ impl ConsumerClient {
                     ),
                 )
                 .await?;
-            self.connection.set(connection).unwrap();
+            self.connection
+                .set(connection)
+                .map_err(|_| azure_core::Error::from(ErrorKind::MissingManagementClient))?
         }
         Ok(())
     }
@@ -476,7 +482,10 @@ impl ConsumerClient {
             return Err(ErrorKind::MissingConnection.into());
         }
         if !scopes.contains_key(url.as_str()) {
-            let connection = self.connection.get().unwrap();
+            let connection = self
+                .connection
+                .get()
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingConnection))?;
 
             // Create an ephemeral session to host the authentication.
             let session = AmqpSession::new();
@@ -494,21 +503,32 @@ impl ConsumerClient {
             let expires_at = token.expires_on;
             cbs.authorize_path(&url, token.token.secret(), expires_at)
                 .await?;
-            scopes.insert(url.clone(), token);
+            scopes.insert(url.clone(), token).ok_or_else(|| {
+                azure_core::Error::from(ErrorKind::UnableToAddAuthenticationToken)
+            })?;
         }
-        Ok(scopes.get(url.as_str()).unwrap().clone())
+        Ok(scopes
+            .get(url.as_str())
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::UnableToAddAuthenticationToken))?
+            .clone())
     }
 
     async fn get_session(&self, partition_id: &String) -> Result<Arc<AmqpSession>> {
         let mut session_instances = self.session_instances.lock().await;
         if !session_instances.contains_key(partition_id) {
             debug!("Creating session for partition: {:?}", partition_id);
-            let connection = self.connection.get().unwrap();
+            let connection = self
+                .connection
+                .get()
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingConnection))?;
             let session = AmqpSession::new();
             session.begin(connection, None).await?;
             session_instances.insert(partition_id.clone(), Arc::new(session));
         }
-        let rv = session_instances.get(partition_id).unwrap().clone();
+        let rv = session_instances
+            .get(partition_id)
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingSession))?
+            .clone();
         debug!("Cloning session for partition {:?}: {:?}", partition_id, rv);
         Ok(rv)
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -64,7 +64,7 @@ impl std::error::Error for EventhubsError {
 impl std::fmt::Display for EventhubsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
-            ErrorKind::MissingMessageSender => write!(f,"Missing message sender."),
+            ErrorKind::MissingMessageSender => write!(f, "Missing message sender."),
             ErrorKind::ArithmeticError => write!(f, "Arithmetic overflow has occurred."),
             ErrorKind::InvalidManagementResponse => write!(f, "Invalid management response"),
             ErrorKind::UnableToAddAuthenticationToken => {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -6,6 +6,8 @@ use azure_core_amqp::error::Error;
 
 /// Represents the different kinds of errors that can occur in the Eventhubs module.
 pub enum ErrorKind {
+    /// An arithmetic overflow has occurred.
+    ArithmeticError,
     /// An invalid parameter was passed to a function.
     InvalidParameter(String),
 
@@ -18,14 +20,26 @@ pub enum ErrorKind {
     /// The endpoint is missing.
     MissingEndpoint,
 
+    /// The session was missing for the partition.
+    MissingSession,
+
     /// The host is missing in the endpoint.
     MissingHostInEndpoint,
+
+    /// Missing Message Sender
+    MissingMessageSender,
 
     /// The connection is not yet open.
     MissingConnection,
 
+    /// The management client is not yet open.
+    MissingManagementClient,
+
     /// The management response is invalid.
     InvalidManagementResponse,
+
+    /// Unable to add authentication token.
+    UnableToAddAuthenticationToken,
 
     /// Represents the source of the AMQP error.
     /// This is used to wrap an AMQP error in an Eventhubs error.
@@ -50,9 +64,18 @@ impl std::error::Error for EventhubsError {
 impl std::fmt::Display for EventhubsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
+            ErrorKind::MissingMessageSender => write!(f,"Missing message sender."),
+            ErrorKind::ArithmeticError => write!(f, "Arithmetic overflow has occurred."),
             ErrorKind::InvalidManagementResponse => write!(f, "Invalid management response"),
+            ErrorKind::UnableToAddAuthenticationToken => {
+                write!(f, "Unable to add authentication token")
+            }
+            ErrorKind::MissingSession => {
+                write!(f, "The session for the specified partition is missing.")
+            }
             ErrorKind::AmqpError(source) => write!(f, "AmqpError: {:?}", source),
             ErrorKind::MissingConnection => write!(f, "Connection is not yet open."),
+            ErrorKind::MissingManagementClient => write!(f, "Missing management client."),
             ErrorKind::InvalidParameter(s) => write!(f, "Invalid parameter: {}", s),
             ErrorKind::MissingConnectionString => write!(f, "Missing connection string"),
             ErrorKind::MissingSharedAccessKeyName => {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -34,6 +34,8 @@ use url::Url;
 /// Types used to collect messages into a "batch" before submitting them to an Event Hub.
 pub mod batch;
 
+const DEFAULT_EVENTHUBS_APPLICATION: &str = "DefaultApplicationName";
+
 /// Options used when creating an Event Hubs ProducerClient.
 #[derive(Default)]
 pub struct ProducerClientOptions {
@@ -140,7 +142,11 @@ impl ProducerClient {
     ///
     /// Note that dropping the ProducerClient will also close the connection.
     pub async fn close(self) -> Result<()> {
-        self.connection.get().unwrap().close().await?;
+        self.connection
+            .get()
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingConnection))?
+            .close()
+            .await?;
         Ok(())
     }
     const BATCH_MESSAGE_FORMAT: u32 = 0x80013700;
@@ -267,7 +273,7 @@ impl ProducerClient {
             .lock()
             .await
             .get()
-            .unwrap()
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingManagementClient))?
             .get_eventhub_properties(&self.eventhub)
             .await
     }
@@ -308,7 +314,7 @@ impl ProducerClient {
             .lock()
             .await
             .get()
-            .unwrap()
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingManagementClient))?
             .get_eventhub_partition_properties(&self.eventhub, partition_id)
             .await
     }
@@ -333,7 +339,11 @@ impl ProducerClient {
         }
 
         trace!("Create management session.");
-        let connection = self.connection.get().unwrap();
+        let connection = self
+            .connection
+            .get()
+            .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingConnection))?;
+
         let session = AmqpSession::new();
         session.begin(connection, None).await?;
         trace!("Session created.");
@@ -346,7 +356,7 @@ impl ProducerClient {
         management.attach().await?;
         mgmt_client
             .set(ManagementInstance::new(management))
-            .unwrap();
+            .map_err(|_| azure_core::Error::from(ErrorKind::MissingManagementClient))?;
         trace!("Management client created.");
         Ok(())
     }
@@ -374,7 +384,9 @@ impl ProducerClient {
                     ),
                 )
                 .await?;
-            self.connection.set(connection).unwrap();
+            self.connection
+                .set(connection)
+                .map_err(|_| azure_core::Error::from(ErrorKind::MissingConnection))?;
         }
         Ok(())
     }
@@ -384,7 +396,10 @@ impl ProducerClient {
         let mut sender_instances = self.sender_instances.lock().await;
         if !sender_instances.contains_key(&path) {
             self.ensure_connection(&path).await?;
-            let connection = self.connection.get().unwrap();
+            let connection = self
+                .connection
+                .get()
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingConnection))?;
 
             self.authorize_path(path.clone()).await?;
             let session = AmqpSession::new();
@@ -405,7 +420,7 @@ impl ProducerClient {
                     &session,
                     format!(
                         "{}-rust-sender",
-                        self.options.application_id.as_ref().unwrap()
+                        self.options.application_id.as_ref().unwrap_or(&DEFAULT_EVENTHUBS_APPLICATION.to_string())
                     ),
                     path.clone(),
                     Some(
@@ -425,7 +440,7 @@ impl ProducerClient {
                 },
             );
         }
-        Ok(sender_instances.get(&path).unwrap().sender.clone())
+        Ok(sender_instances.get(&path).ok_or_else(||Error::from(ErrorKind::MissingMessageSender))?.sender.clone())
     }
 
     async fn authorize_path(&self, url: impl Into<String>) -> Result<AccessToken> {
@@ -436,7 +451,10 @@ impl ProducerClient {
             return Err(ErrorKind::MissingConnection.into());
         }
         if !scopes.contains_key(url.as_str()) {
-            let connection = self.connection.get().unwrap();
+            let connection = self
+                .connection
+                .get()
+                .ok_or_else(|| azure_core::Error::from(ErrorKind::MissingConnection))?;
 
             // Create an ephemeral session to host the authentication.
             let session = AmqpSession::new();
@@ -454,9 +472,9 @@ impl ProducerClient {
             let expires_at = token.expires_on;
             cbs.authorize_path(&url, token.token.secret(), expires_at)
                 .await?;
-            scopes.insert(url.clone(), token);
+            scopes.insert(url.clone(), token).ok_or_else(||Error::from(ErrorKind::UnableToAddAuthenticationToken))?;
         }
-        Ok(scopes.get(url.as_str()).unwrap().clone())
+        Ok(scopes.get(url.as_str()).ok_or_else(||Error::from(ErrorKind::UnableToAddAuthenticationToken))?.clone())
     }
 }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -342,7 +342,7 @@ impl ProducerClient {
         let access_token = self.authorize_path(management_path).await?;
 
         trace!("Create management client.");
-        let management = AmqpManagement::new(session, "eventhubs_management", access_token);
+        let management = AmqpManagement::new(session, "eventhubs_management", access_token)?;
         management.attach().await?;
         mgmt_client
             .set(ManagementInstance::new(management))
@@ -442,7 +442,7 @@ impl ProducerClient {
             let session = AmqpSession::new();
             session.begin(connection, None).await?;
 
-            let cbs = AmqpClaimsBasedSecurity::new(session);
+            let cbs = AmqpClaimsBasedSecurity::new(session)?;
             cbs.attach().await?;
 
             debug!("Get Token.");

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -420,7 +420,10 @@ impl ProducerClient {
                     &session,
                     format!(
                         "{}-rust-sender",
-                        self.options.application_id.as_ref().unwrap_or(&DEFAULT_EVENTHUBS_APPLICATION.to_string())
+                        self.options
+                            .application_id
+                            .as_ref()
+                            .unwrap_or(&DEFAULT_EVENTHUBS_APPLICATION.to_string())
                     ),
                     path.clone(),
                     Some(
@@ -440,7 +443,11 @@ impl ProducerClient {
                 },
             );
         }
-        Ok(sender_instances.get(&path).ok_or_else(||Error::from(ErrorKind::MissingMessageSender))?.sender.clone())
+        Ok(sender_instances
+            .get(&path)
+            .ok_or_else(|| Error::from(ErrorKind::MissingMessageSender))?
+            .sender
+            .clone())
     }
 
     async fn authorize_path(&self, url: impl Into<String>) -> Result<AccessToken> {
@@ -472,9 +479,14 @@ impl ProducerClient {
             let expires_at = token.expires_on;
             cbs.authorize_path(&url, token.token.secret(), expires_at)
                 .await?;
-            scopes.insert(url.clone(), token).ok_or_else(||Error::from(ErrorKind::UnableToAddAuthenticationToken))?;
+            scopes
+                .insert(url.clone(), token)
+                .ok_or_else(|| Error::from(ErrorKind::UnableToAddAuthenticationToken))?;
         }
-        Ok(scopes.get(url.as_str()).ok_or_else(||Error::from(ErrorKind::UnableToAddAuthenticationToken))?.clone())
+        Ok(scopes
+            .get(url.as_str())
+            .ok_or_else(|| Error::from(ErrorKind::UnableToAddAuthenticationToken))?
+            .clone())
     }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `AmqpSessionApis` implementation and related components to improve functionality and code maintainability. The key changes involve refactoring how session options are accessed, implementing the `end` method, and modifying the `AmqpSessionOptions` builder.

### Improvements to session options access:
* Changed `AmqpSessionOptions` to use getter methods instead of directly accessing fields. (`sdk/core/azure_core_amqp/src/fe2o3/session.rs`, [[1]](diffhunk://#diff-786c4908e70ea4001d6ff44171a9e39bef40cf7c3b49303cc318602a03242d5fL55-R78) [[2]](diffhunk://#diff-786c4908e70ea4001d6ff44171a9e39bef40cf7c3b49303cc318602a03242d5fL88-R90)
* Updated `AmqpSessionOptions` to include getter methods for all fields. (`sdk/core/azure_core_amqp/src/session.rs`, [sdk/core/azure_core_amqp/src/session.rsL18-R65](diffhunk://#diff-00d41b21de5b22a65122dfb158fb613100a7729fe98102145d2eeef0be58be70L18-R65))

### Implementation of `end` method:
* Implemented the `end` method in `AmqpSessionApis` to properly end the session. (`sdk/core/azure_core_amqp/src/fe2o3/session.rs`, [sdk/core/azure_core_amqp/src/fe2o3/session.rsL101-R111](diffhunk://#diff-786c4908e70ea4001d6ff44171a9e39bef40cf7c3b49303cc318602a03242d5fL101-R111))

### Modifications to `AmqpSessionOptions` builder:
* Refactored the `AmqpSessionOptionsBuilder` to use mutable references and clone options for the `build` method. (`sdk/core/azure_core_amqp/src/session.rs`, [sdk/core/azure_core_amqp/src/session.rsL86-R167](diffhunk://#diff-00d41b21de5b22a65122dfb158fb613100a7729fe98102145d2eeef0be58be70L86-R167))
* Updated the `test_amqp_session_options_builder` test to reflect changes in the builder pattern. (`sdk/core/azure_core_amqp/src/session.rs`, [sdk/core/azure_core_amqp/src/session.rsL141-R180](diffhunk://#diff-00d41b21de5b22a65122dfb158fb613100a7729fe98102145d2eeef0be58be70L141-R180))

### Other changes:
* Changed the `Uuid` import to a type alias. (`sdk/core/azure_core_amqp/src/lib.rs`, [sdk/core/azure_core_amqp/src/lib.rsL19-R19](diffhunk://#diff-78b3c81b4d51cf0fa2b3cfa74f93bd2868269a62dea18469a016980bb1a212d0L19-R19))