### PR TITLE
Always return `Result<Arc<Self>>` from `new` credential constructors

### DIFF
--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -655,7 +655,7 @@ mod tests {
             >::new(
                 seq.into_iter()
                     .map(|x| {
-                        let iter = x.into_iter().map(|y| y.into());
+                        let iter = x.into_iter().map(Into::into);
                         iter.collect::<fe2o3_amqp_types::primitives::List<fe2o3_amqp_types::primitives::Value>>().into()
                     })
                     .collect::<Vec<
@@ -678,7 +678,7 @@ mod tests {
         //     AmqpMessageBody::Sequence(
         //         test_body
         //             .into_iter()
-        //             .map(|x| x.into_iter().map(|y| y.into()).collect())
+        //             .map(|x| x.into_iter().map(Into::into).collect())
         //             .collect()
         //     )
         // );

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -892,6 +892,7 @@ impl From<AmqpMessageProperties> for AmqpList {
     }
 }
 
+#[allow(clippy::vec_init_then_push)]
 #[test]
 fn test_size_of_serialized_timestamp() {
     let timestamp = fe2o3_amqp_types::primitives::Timestamp::from_milliseconds(12345);
@@ -1544,13 +1545,13 @@ mod tests {
             .with_delivery_count(3)
             .build();
 
-        assert_eq!(header.durable, true);
+        assert!(header.durable);
         assert_eq!(header.priority, 5);
         assert_eq!(
             header.time_to_live,
             Some(std::time::Duration::from_millis(1000))
         );
-        assert_eq!(header.first_acquirer, false);
+        assert!(!header.first_acquirer);
         assert_eq!(header.delivery_count, 3);
     }
 
@@ -1559,7 +1560,7 @@ mod tests {
         {
             let c_serialized = vec![0x00, 0x53, 0x70, 0xc0, 0x04, 0x02, 0x40, 0x50, 0x05];
             let deserialized_from_c: fe2o3_amqp_types::messaging::Header =
-                serde_amqp::de::from_slice(&c_serialized.as_slice()).unwrap();
+                serde_amqp::de::from_slice(c_serialized.as_slice()).unwrap();
 
             let header = fe2o3_amqp_types::messaging::Header::builder()
                 .priority(Priority::from(5))
@@ -1568,7 +1569,7 @@ mod tests {
 
             assert_eq!(c_serialized, serialized);
             let deserialized: fe2o3_amqp_types::messaging::Header =
-                serde_amqp::de::from_slice(&serialized.as_slice()).unwrap();
+                serde_amqp::de::from_slice(serialized.as_slice()).unwrap();
 
             assert_eq!(c_serialized, serialized);
             assert_eq!(header, deserialized);

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -257,7 +257,7 @@ mod tests {
             .with_auto_accept(true)
             .build();
 
-        assert_eq!(receiver_options.auto_accept, true);
+        assert!(receiver_options.auto_accept);
     }
 
     #[test]
@@ -297,6 +297,6 @@ mod tests {
             receiver_options.credit_mode.unwrap(),
             ReceiverCreditMode::Manual
         );
-        assert_eq!(receiver_options.auto_accept, false);
+        assert!(!receiver_options.auto_accept);
     }
 }

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -594,8 +594,7 @@ mod tests {
             let v: AmqpValue = AmqpValue::Null;
             assert_eq!(v, AmqpValue::Null);
             assert_eq!(AmqpValue::Null, v);
-            let b: () = v.into();
-            assert_eq!(b, ());
+            let _: () = v.into();
         }
 
         {
@@ -604,6 +603,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::approx_constant)]
     #[test]
     fn test_amqp_ordered_map() {
         let mut map = AmqpOrderedMap::new();
@@ -621,21 +621,21 @@ mod tests {
         assert_eq!(map.get("key1"), None);
     }
 
+    #[allow(clippy::approx_constant)]
     #[test]
     fn test_amqp_value() {
         // Test AmqpValue::Null
         let null_value: AmqpValue = AmqpValue::Null;
         assert_eq!(null_value, AmqpValue::Null);
         assert_eq!(AmqpValue::Null, null_value);
-        let null_unit: () = null_value.into();
-        assert_eq!(null_unit, ());
+        let _: () = null_value.into();
 
         // Test AmqpValue::Boolean
         let bool_value: AmqpValue = AmqpValue::Boolean(true);
         assert_eq!(bool_value, AmqpValue::Boolean(true));
         assert_eq!(AmqpValue::Boolean(true), bool_value);
         let bool_val: bool = bool_value.into();
-        assert_eq!(bool_val, true);
+        assert!(bool_val);
 
         // Test AmqpValue::UByte
         let ubyte_value: AmqpValue = AmqpValue::UByte(255);

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -48,7 +48,7 @@ impl CosmosClient {
     /// # use std::sync::Arc;
     /// use azure_data_cosmos::CosmosClient;
     ///
-    /// let credential = azure_identity::DefaultAzureCredential::new().map(Arc::new).unwrap();
+    /// let credential = azure_identity::DefaultAzureCredential::new().unwrap();
     /// let client = CosmosClient::new("https://myaccount.documents.azure.com/", credential, None).unwrap();
     /// ```
     pub fn new(

--- a/sdk/cosmos/azure_data_cosmos/src/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query.rs
@@ -150,7 +150,7 @@ mod tests {
             .with_parameter("float_param", 4.2)?
             .with_parameter("bool_param", true)?
             .with_parameter("obj_param", obj_param)?
-            .with_parameter("arr_param", &["a", "b", "c"])?
+            .with_parameter("arr_param", ["a", "b", "c"])?
             .with_parameter("null_option", null_option)?
             .with_parameter("null_value", ())?;
         let serialized = serde_json::to_string(&query).unwrap();

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
@@ -17,7 +17,7 @@ async fn main() -> Result<()> {
     let host = env::var("EVENTHUBS_HOST").unwrap();
     let eventhub = env::var("EVENTHUB_NAME").unwrap();
 
-    let credential = DefaultAzureCredential::new().unwrap();
+    let credential = DefaultAzureCredential::new()?;
 
     let client = ProducerClient::new(
         host,

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<()> {
     let host = env::var("EVENTHUBS_HOST").unwrap();
     let eventhub = env::var("EVENTHUB_NAME").unwrap();
 
-    let credential = DefaultAzureCredential::new().unwrap();
+    let credential = DefaultAzureCredential::new()?;
 
     let client = ProducerClient::new(
         host,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -45,7 +45,7 @@ pub struct ConsumerClient {
     session_instances: Mutex<HashMap<String, Arc<AmqpSession>>>,
     mgmt_client: Mutex<OnceLock<ManagementInstance>>,
     connection: OnceLock<AmqpConnection>,
-    credential: Box<dyn azure_core::credentials::TokenCredential>,
+    credential: Arc<dyn azure_core::credentials::TokenCredential>,
     eventhub: String,
     url: String,
     authorization_scopes: Mutex<HashMap<String, AccessToken>>,
@@ -84,7 +84,7 @@ impl ConsumerClient {
         fully_qualified_namespace: impl Into<String> + Debug,
         eventhub_name: impl Into<String> + Debug,
         consumer_group: Option<String>,
-        credential: impl TokenCredential + 'static,
+        credential: Arc<dyn TokenCredential>,
         options: Option<ConsumerClientOptions>,
     ) -> Self {
         let eventhub_name = eventhub_name.into();
@@ -100,7 +100,7 @@ impl ConsumerClient {
             session_instances: Mutex::new(HashMap::new()),
             mgmt_client: Mutex::new(OnceLock::new()),
             connection: OnceLock::new(),
-            credential: Box::new(credential),
+            credential,
             eventhub: eventhub_name,
             url,
             authorization_scopes: Mutex::new(HashMap::new()),

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -1,6 +1,6 @@
 # azure_identity
 
-Azure Identity crate for the unofficial Microsoft Azure SDK for Rust. This crate is part of a collection of crates: for more information please refer to [https://github.com/azure/azure-sdk-for-rust](https://github.com/azure/azure-sdk-for-rust).
+Azure Identity crate for the unofficial Microsoft Azure SDK for Rust. This crate is part of a collection of crates: for more information please refer to <https://github.com/Azure/azure-sdk-for-rust>.
 
 This crate provides several implementations of the [azure_core::auth::TokenCredential](https://docs.rs/azure_core/latest/azure_core/auth/trait.TokenCredential.html) trait.
 It is recommended to start with `azure_identity::create_credential()?`, which will create an instance of `DefaultAzureCredential` by default. If you want to use a specific credential type, the `AZURE_CREDENTIAL_KIND` environment variable may be set to a value from `azure_credential_kinds`, such as `azurecli` or `virtualmachine`.
@@ -40,8 +40,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-The supported authentication flows are:
+## Design
 
-* [Authorization code flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow).
-* [Client credentials flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow).
-* [Device code flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code).
+Each `TokenCredential` implementation provides a `new` constructor that returns an `azure_core::Result<Arc<Self>>`. The credential provider is contained within an `Arc` because these are designed to be reused by multiple clients for efficiency e.g.:
+
+```rust
+use azure_core::credentials::TokenCredential;
+use azure_identity::DefaultAzureCredential;
+# use azure_core::{ClientOptions, Result};
+# use std::sync::Arc;
+# struct StorageAccountClient;
+# impl StorageAccountClient {
+#     fn new(_endpoint: &str, _credential: Arc<dyn TokenCredential>, _options: Option<ClientOptions>) -> Result<Arc<Self>> {
+#         Ok(Arc::new(StorageAccountClient))
+#     }
+# }
+# struct SecretClient;
+# impl SecretClient {
+#     fn new(_endpoint: &str, _credential: Arc<dyn TokenCredential>, _options: Option<ClientOptions>) -> Result<Arc<Self>> {
+#         Ok(Arc::new(SecretClient))
+#     }
+# }
+
+let credential = DefaultAzureCredential::new().unwrap();
+let storage_client = StorageAccountClient::new(
+    "https://myaccount.blob.storage.azure.net",
+    credential.clone(),
+    None,
+);
+let secret_client = SecretClient::new("https://myvault.keyvault.azure.net",
+    credential.clone(),
+    None,
+);
+```
+
+Credentials are cached in memory and refreshed as needed. Using the same credentials in multiple clients prevents authenticating and refreshing tokens numerous times for each client otherwise.

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -5,41 +5,43 @@ Azure Identity crate for the unofficial Microsoft Azure SDK for Rust. This crate
 This crate provides several implementations of the [azure_core::auth::TokenCredential](https://docs.rs/azure_core/latest/azure_core/auth/trait.TokenCredential.html) trait.
 It is recommended to start with `azure_identity::create_credential()?`, which will create an instance of `DefaultAzureCredential` by default. If you want to use a specific credential type, the `AZURE_CREDENTIAL_KIND` environment variable may be set to a value from `azure_credential_kinds`, such as `azurecli` or `virtualmachine`.
 
-```rust
+```rust,no_run
+use azure_core::credentials::TokenCredential;
+use std::sync::Arc;
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-   let subscription_id =
-       std::env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID required");
+    let subscription_id =
+        std::env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID required");
 
-   let credential = azure_identity::create_credential()?;
+    let credential: Arc<dyn TokenCredential> = azure_identity::DefaultAzureCredential::new()?;
 
-   // Let's enumerate the Azure storage accounts in the subscription using the REST API directly.
-   // This is just an example. It is easier to use the Azure SDK for Rust crates.
-   let url = url::Url::parse(&format!("https://management.azure.com/subscriptions/{subscription_id}/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"))?;
+    // Let's enumerate the Azure storage accounts in the subscription using the REST API directly.
+    // This is just an example. It is easier to use the Azure SDK for Rust crates.
+    let url = url::Url::parse(&format!("https://management.azure.com/subscriptions/{subscription_id}/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"))?;
 
-   let access_token = credential
-       .get_token(&["https://management.azure.com/.default"])
-       .await?;
+    let access_token = credential
+        .get_token(&["https://management.azure.com/.default"])
+        .await?;
 
-   let response = reqwest::Client::new()
-       .get(url)
-       .header(
-           "Authorization",
-           format!("Bearer {}", access_token.token.secret()),
-       )
-       .send()
-       .await?
-       .text()
-       .await?;
+    let response = reqwest::Client::new()
+        .get(url)
+        .header(
+            "Authorization",
+            format!("Bearer {}", access_token.token.secret()),
+        )
+        .send()
+        .await?
+        .text()
+        .await?;
 
-   println!("{response}");
-   Ok(())
+    println!("{response}");
+    Ok(())
 }
 ```
 
 The supported authentication flows are:
+
 * [Authorization code flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow).
 * [Client credentials flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow).
 * [Device code flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code).
-
-License: MIT

--- a/sdk/identity/azure_identity/examples/azure_cli_credentials.rs
+++ b/sdk/identity/azure_identity/examples/azure_cli_credentials.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let sub_id = AzureCliCredential::get_subscription().await?;
     println!("Azure cli subscription: {sub_id}");
 
-    let credentials = AzureCliCredential::new();
+    let credentials = AzureCliCredential::new()?;
     let res = credentials
         .get_token(&["https://management.azure.com/.default"])
         .await?;

--- a/sdk/identity/azure_identity/examples/default_credentials.rs
+++ b/sdk/identity/azure_identity/examples/default_credentials.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let subscription_id =
         std::env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID required");
 
-    let credential = DefaultAzureCredential::new().map(|cred| Arc::new(cred))?;
+    let credential = DefaultAzureCredential::new().map(Arc::new)?;
 
     // Enumerate the Azure storage accounts in the subscription using the REST API directly.
     // This is just an example: you would normally pass in an `Arc::new(credential)` to an Azure SDK client.

--- a/sdk/identity/azure_identity/src/credentials/app_service_managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/credentials/app_service_managed_identity_credential.rs
@@ -6,6 +6,7 @@ use azure_core::credentials::{AccessToken, TokenCredential};
 use azure_core::error::{ErrorKind, ResultExt};
 use azure_core::headers::HeaderName;
 use azure_core::Url;
+use std::sync::Arc;
 
 const ENDPOINT_ENV: &str = "IDENTITY_ENDPOINT";
 const API_VERSION: &str = "2019-08-01";
@@ -18,7 +19,7 @@ pub struct AppServiceManagedIdentityCredential {
 }
 
 impl AppServiceManagedIdentityCredential {
-    pub fn create(options: impl Into<TokenCredentialOptions>) -> azure_core::Result<Self> {
+    pub fn new(options: impl Into<TokenCredentialOptions>) -> azure_core::Result<Arc<Self>> {
         let options = options.into();
         let env = options.env();
         let endpoint = &env
@@ -35,7 +36,7 @@ impl AppServiceManagedIdentityCredential {
                 ENDPOINT_ENV
             )
         })?;
-        Ok(Self {
+        Ok(Arc::new(Self {
             credential: ImdsManagedIdentityCredential::new(
                 options,
                 endpoint,
@@ -44,7 +45,7 @@ impl AppServiceManagedIdentityCredential {
                 SECRET_ENV,
                 ImdsId::SystemAssigned,
             ),
-        })
+        }))
     }
 }
 

--- a/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
@@ -9,7 +9,7 @@ use azure_core::{
     json::from_json,
 };
 use serde::Deserialize;
-use std::str;
+use std::{str, sync::Arc};
 use time::OffsetDateTime;
 use tracing::trace;
 
@@ -153,23 +153,13 @@ pub struct AzureCliCredential {
     cache: TokenCache,
 }
 
-impl Default for AzureCliCredential {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl AzureCliCredential {
-    pub fn create() -> azure_core::Result<Self> {
+    /// Create a new `AzureCliCredential`.
+    pub fn new() -> azure_core::Result<Arc<Self>> {
         // TODO check `az version` to see if it's installed
-        Ok(AzureCliCredential::new())
-    }
-
-    /// Create a new `AzureCliCredential`
-    pub fn new() -> Self {
-        Self {
+        Ok(Arc::new(Self {
             cache: TokenCache::new(),
-        }
+        }))
     }
 
     /// Get an access token for an optional resource

--- a/sdk/identity/azure_identity/src/credentials/virtual_machine_managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/credentials/virtual_machine_managed_identity_credential.rs
@@ -7,6 +7,7 @@ use azure_core::{
     headers::HeaderName,
     Url,
 };
+use std::sync::Arc;
 
 const ENDPOINT: &str = "http://169.254.169.254/metadata/identity/oauth2/token";
 const API_VERSION: &str = "2019-08-01";
@@ -19,9 +20,12 @@ pub struct VirtualMachineManagedIdentityCredential {
 }
 
 impl VirtualMachineManagedIdentityCredential {
-    pub fn new(id: ImdsId, options: impl Into<TokenCredentialOptions>) -> Self {
+    pub fn new(
+        id: ImdsId,
+        options: impl Into<TokenCredentialOptions>,
+    ) -> azure_core::Result<Arc<Self>> {
         let endpoint = Url::parse(ENDPOINT).unwrap(); // valid url constant
-        Self {
+        Ok(Arc::new(Self {
             credential: ImdsManagedIdentityCredential::new(
                 options,
                 endpoint,
@@ -30,7 +34,7 @@ impl VirtualMachineManagedIdentityCredential {
                 SECRET_ENV,
                 id,
             ),
-        }
+        }))
     }
 }
 

--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -1,50 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//! Azure Identity crate for the unofficial Microsoft Azure SDK for Rust. This crate is part of a collection of crates: for more information please refer to <https://github.com/azure/azure-sdk-for-rust>.
-//!
-//! This crate provides several implementations of the [azure_core::auth::TokenCredential](https://docs.rs/azure_core/latest/azure_core/auth/trait.TokenCredential.html) trait.
-//! It is recommended to start with `azure_identity::create_credential()?`, which will create an instance of `DefaultAzureCredential` by default. If you want to use a specific credential type, the `AZURE_CREDENTIAL_KIND` environment variable may be set to a value from `azure_credential_kinds`, such as `azurecli` or `virtualmachine`.
-//!
-//! ```no_run
-//!use azure_core::credentials::TokenCredential;
-//!use std::sync::Arc;
-//!#[tokio::main]
-//!async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!    let subscription_id =
-//!        std::env::var("AZURE_SUBSCRIPTION_ID").expect("AZURE_SUBSCRIPTION_ID required");
-//!
-//!    let credential = azure_identity::DefaultAzureCredential::new()
-//!        .map(|cred| Arc::new(cred) as Arc<dyn TokenCredential>)?;
-//!
-//!    // Let's enumerate the Azure storage accounts in the subscription using the REST API directly.
-//!    // This is just an example. It is easier to use the Azure SDK for Rust crates.
-//!    let url = url::Url::parse(&format!("https://management.azure.com/subscriptions/{subscription_id}/providers/Microsoft.Storage/storageAccounts?api-version=2019-06-01"))?;
-//!
-//!    let access_token = credential
-//!        .get_token(&["https://management.azure.com/.default"])
-//!        .await?;
-//!
-//!    let response = reqwest::Client::new()
-//!        .get(url)
-//!        .header(
-//!            "Authorization",
-//!            format!("Bearer {}", access_token.token.secret()),
-//!        )
-//!        .send()
-//!        .await?
-//!        .text()
-//!        .await?;
-//!
-//!    println!("{response}");
-//!    Ok(())
-//!}
-//! ```
-//!
-//! The supported authentication flows are:
-//! * [Authorization code flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-auth-code-flow).
-//! * [Client credentials flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-client-creds-grant-flow).
-//! * [Device code flow](https://docs.microsoft.com/azure/active-directory/develop/v2-oauth2-device-code).
+#![doc = include_str!("../README.md")]
 
 mod authorization_code_flow;
 mod credentials;

--- a/sdk/typespec/typespec_derive/tests/compilation-tests.rs
+++ b/sdk/typespec/typespec_derive/tests/compilation-tests.rs
@@ -80,6 +80,7 @@ pub fn compilation_tests() {
                     }
                     assert!(span_file_name.is_absolute());
 
+                    #[allow(clippy::expect_fun_call)]
                     let relative_span_path = span_file_name
                         .strip_prefix(&repo_root)
                         .expect(&format!(
@@ -169,7 +170,7 @@ pub fn compilation_tests() {
         }
     }
 
-    if errors.len() > 0 {
+    if !errors.is_empty() {
         panic!("{}", errors);
     }
 }


### PR DESCRIPTION
Resolves #1825. Also cleans up a few clippy warnings since I was running running clippy over the entire workspace.
