### PR TITLE
Improve support for typed HTTP headers

### DIFF
--- a/sdk/core/azure_core/src/request_options/range.rs
+++ b/sdk/core/azure_core/src/request_options/range.rs
@@ -51,9 +51,10 @@ impl From<RangeFrom<usize>> for Range {
 }
 
 impl AsHeaders for Range {
+    type Error = std::convert::Infallible;
     type Iter = std::vec::IntoIter<(HeaderName, HeaderValue)>;
 
-    fn as_headers(&self) -> Self::Iter {
+    fn as_headers(&self) -> Result<Self::Iter, Self::Error> {
         let mut headers = vec![(headers::MS_RANGE, format!("{self}").into())];
         if let Some(len) = self.optional_len() {
             if len < 1024 * 1024 * 4 {
@@ -63,7 +64,7 @@ impl AsHeaders for Range {
                 ));
             }
         }
-        headers.into_iter()
+        Ok(headers.into_iter())
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -10,7 +10,7 @@ use crate::{
     Query, QueryPartitionStrategy,
 };
 
-use azure_core::{headers::HeaderValue, Context, Request};
+use azure_core::{Context, Request};
 use serde::{de::DeserializeOwned, Deserialize};
 use url::Url;
 
@@ -136,9 +136,9 @@ impl ContainerClientMethods for ContainerClient {
         // This is a documented public API so prefixing with '_' is undesirable.
         options: Option<ReadContainerOptions>,
     ) -> azure_core::Result<azure_core::Response<ContainerProperties>> {
-        let mut req = Request::new(self.container_url.clone(), azure_core::Method::Get);
+        let req = Request::new(self.container_url.clone(), azure_core::Method::Get);
         self.pipeline
-            .send(Context::new(), &mut req, ResourceType::Containers)
+            .send(Context::new(), req, ResourceType::Containers)
             .await
     }
 
@@ -177,10 +177,7 @@ impl ContainerClientMethods for ContainerClient {
         base_req.add_mandatory_header(&constants::QUERY_CONTENT_TYPE);
 
         let QueryPartitionStrategy::SinglePartition(partition_key) = partition_key.into();
-        base_req.insert_header(
-            constants::PARTITION_KEY,
-            HeaderValue::from_cow(partition_key.into_header_value()?),
-        );
+        base_req.insert_headers(&partition_key)?;
 
         base_req.set_json(&query.into())?;
 
@@ -199,7 +196,7 @@ impl ContainerClientMethods for ContainerClient {
                 }
 
                 let resp = pipeline
-                    .send(Context::new(), &mut req, ResourceType::Items)
+                    .send(Context::new(), req, ResourceType::Items)
                     .await?;
 
                 let query_metrics = resp

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -136,9 +136,9 @@ impl ContainerClientMethods for ContainerClient {
         // This is a documented public API so prefixing with '_' is undesirable.
         options: Option<ReadContainerOptions>,
     ) -> azure_core::Result<azure_core::Response<ContainerProperties>> {
-        let req = Request::new(self.container_url.clone(), azure_core::Method::Get);
+        let mut req = Request::new(self.container_url.clone(), azure_core::Method::Get);
         self.pipeline
-            .send(Context::new(), req, ResourceType::Containers)
+            .send(Context::new(), &mut req, ResourceType::Containers)
             .await
     }
 
@@ -196,7 +196,7 @@ impl ContainerClientMethods for ContainerClient {
                 }
 
                 let resp = pipeline
-                    .send(Context::new(), req, ResourceType::Items)
+                    .send(Context::new(), &mut req, ResourceType::Items)
                     .await?;
 
                 let query_metrics = resp

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use azure_core::headers::{AsHeaders, HeaderName, HeaderValue};
+
+use crate::constants;
+
 /// Describes the partition strategy that will be used when querying.
 ///
 /// Currently, the only supported strategy is [`QueryPartitionStrategy::SinglePartition`], which executes the query against a single partition, specified by the [`PartitionKey`] provided.
@@ -90,8 +94,11 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 #[derive(Debug, Clone)]
 pub struct PartitionKey(Vec<PartitionKeyValue>);
 
-impl PartitionKey {
-    pub(crate) fn into_header_value(self) -> azure_core::Result<String> {
+impl AsHeaders for PartitionKey {
+    type Error = azure_core::Error;
+    type Iter = std::iter::Once<(HeaderName, HeaderValue)>;
+
+    fn as_headers(&self) -> Result<std::iter::Once<(HeaderName, HeaderValue)>, Self::Error> {
         // We have to do some manual JSON serialization here.
         // The partition key is sent in an HTTP header, when used to set the partition key for a query.
         // It's not safe to use non-ASCII characters in HTTP headers, and serde_json will not escape non-ASCII characters if they are otherwise valid as UTF-8.
@@ -100,10 +107,10 @@ impl PartitionKey {
         let mut json = String::new();
         let mut utf_buf = [0; 2]; // A buffer for encoding UTF-16 characters.
         json.push('[');
-        for key in self.0 {
+        for key in &self.0 {
             match key.0 {
                 InnerPartitionKeyValue::Null => json.push_str("null"),
-                InnerPartitionKeyValue::String(string_key) => {
+                InnerPartitionKeyValue::String(ref string_key) => {
                     json.push('"');
                     for char in string_key.chars() {
                         match char {
@@ -125,8 +132,10 @@ impl PartitionKey {
                     }
                     json.push('"');
                 }
-                InnerPartitionKeyValue::Number(num) => {
-                    json.push_str(serde_json::to_string(&serde_json::Value::Number(num))?.as_str());
+                InnerPartitionKeyValue::Number(ref num) => {
+                    json.push_str(
+                        serde_json::to_string(&serde_json::Value::Number(num.clone()))?.as_str(),
+                    );
                 }
             }
 
@@ -137,7 +146,10 @@ impl PartitionKey {
         json.pop();
         json.push(']');
 
-        Ok(json)
+        Ok(std::iter::once((
+            constants::PARTITION_KEY,
+            HeaderValue::from_cow(json),
+        )))
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -98,7 +98,7 @@ impl AsHeaders for PartitionKey {
     type Error = azure_core::Error;
     type Iter = std::iter::Once<(HeaderName, HeaderValue)>;
 
-    fn as_headers(&self) -> Result<std::iter::Once<(HeaderName, HeaderValue)>, Self::Error> {
+    fn as_headers(&self) -> Result<Self::Iter, Self::Error> {
         // We have to do some manual JSON serialization here.
         // The partition key is sent in an HTTP header, when used to set the partition key for a query.
         // It's not safe to use non-ASCII characters in HTTP headers, and serde_json will not escape non-ASCII characters if they are otherwise valid as UTF-8.

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -277,19 +277,22 @@ impl_from_tuple!(0 A 1 B 2 C);
 
 #[cfg(test)]
 mod tests {
-    use crate::PartitionKey;
-
-    use super::QueryPartitionStrategy;
+    use crate::{constants, PartitionKey, QueryPartitionStrategy};
+    use typespec_client_core::http::headers::AsHeaders;
 
     fn key_to_string(v: impl Into<PartitionKey>) -> String {
-        v.into().into_header_value().unwrap()
+        let key = v.into();
+        let mut headers_iter = key.as_headers().unwrap();
+        let (name, value) = headers_iter.next().unwrap();
+        assert_eq!(constants::PARTITION_KEY, name);
+        value.as_str().into()
     }
 
     /// Validates that a given value is `impl Into<QueryPartitionStrategy>` and works as-expected.
     fn key_to_single_partition_strategy_string(v: impl Into<QueryPartitionStrategy>) -> String {
         let strategy = v.into();
         let QueryPartitionStrategy::SinglePartition(key) = strategy;
-        key.into_header_value().unwrap()
+        key_to_string(key)
     }
 
     #[test]
@@ -339,10 +342,7 @@ mod tests {
     #[test]
     pub fn non_ascii_string() {
         let key = PartitionKey::from("smile 😀");
-        assert_eq!(
-            key.into_header_value().unwrap().as_str(),
-            r#"["smile \ud83d\ude00"]"#
-        );
+        assert_eq!(key_to_string(key), r#"["smile \ud83d\ude00"]"#);
     }
 
     #[test]

--- a/sdk/typespec/typespec_client_core/src/http/headers/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/headers/mod.rs
@@ -102,12 +102,7 @@ impl Headers {
                 || {
                     let required_headers = H::header_names();
                     format!(
-                        "required {} not found: {}",
-                        if required_headers.len() == 1 {
-                            "header"
-                        } else {
-                            "headers"
-                        },
+                        "required header(s) not found: {}",
                         required_headers.join(", ")
                     )
                 },
@@ -406,7 +401,7 @@ mod tests {
 
         // The "Display" implementation is the canonical way to get an error's "message"
         assert_eq!(
-            "required header not found: content-location",
+            "required header(s) not found: content-location",
             format!("{}", err)
         );
     }
@@ -434,7 +429,7 @@ mod tests {
 
         // The "Display" implementation is the canonical way to get an error's "message"
         assert_eq!(
-            "required headers not found: header-a, header-b",
+            "required header(s) not found: header-a, header-b",
             format!("{}", err)
         );
     }

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -126,10 +126,11 @@ impl Request {
         &self.method
     }
 
-    pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) {
-        for (name, value) in headers.as_headers() {
+    pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), T::Error> {
+        for (name, value) in headers.as_headers()? {
             self.insert_header(name, value);
         }
+        Ok(())
     }
 
     pub fn headers(&self) -> &Headers {


### PR DESCRIPTION
Closes #1826 

This has two changes to improve support for typed HTTP headers:

1. The `AsHeaders` trait, used to convert a type into a set of HTTP headers, is now fallible. Types which can be infallibly converted to headers should set their error type to `std::convert::Infallible` (which will eventually be an alias for the `never` type `!`).
2. Added a new `FromHeaders` trait, which allows for reading a type _out_ of a set of HTTP headers. It's fallible **and** allows for returning `None` if the headers are simply not present. There are now two more methods on `Headers`: `get` and `get_optional` which allow for reading a required or optional value out of the headers.

I've put a few notes inline that I wanted to specifically call attention to. I also updated `Range` (the only "built-in" type that implements `AsHeaders`) and switched Cosmos' `PartitionKey` to implement `AsHeaders` now that there's a way to return an error.