### PR TITLE
AMQP changes for C++ Claim Based Security - also fixed session close issue that affected reliability

### DIFF
--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -33,7 +33,6 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tokio.workspace = true
 
 [features]
 default = ["fe2o3-amqp"]

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio.workspace = true
 
 [features]
 default = ["fe2o3-amqp"]

--- a/sdk/core/azure_core_amqp/src/cbs.rs
+++ b/sdk/core/azure_core_amqp/src/cbs.rs
@@ -56,6 +56,13 @@ pub struct AmqpClaimsBasedSecurity<'a> {
     implementation: CbsImplementation<'a>,
 }
 
+impl<'a> AmqpClaimsBasedSecurity<'a> {
+    pub fn new(session: &'a AmqpSession) -> Result<Self> {
+        Ok(Self {
+            implementation: CbsImplementation::new(session)?,
+        })
+    }
+}
 impl<'a> AmqpClaimsBasedSecurityApis for AmqpClaimsBasedSecurity<'a> {
     async fn authorize_path(
         &self,
@@ -69,13 +76,5 @@ impl<'a> AmqpClaimsBasedSecurityApis for AmqpClaimsBasedSecurity<'a> {
     }
     async fn attach(&self) -> Result<()> {
         self.implementation.attach().await
-    }
-}
-
-impl<'a> AmqpClaimsBasedSecurity<'a> {
-    pub fn new(session: &'a AmqpSession) -> Result<Self> {
-        Ok(Self {
-            implementation: CbsImplementation::new(session)?,
-        })
     }
 }

--- a/sdk/core/azure_core_amqp/src/cbs.rs
+++ b/sdk/core/azure_core_amqp/src/cbs.rs
@@ -11,7 +11,7 @@ use super::session::AmqpSession;
 type CbsImplementation<'a> = super::fe2o3::cbs::Fe2o3ClaimsBasedSecurity<'a>;
 
 #[cfg(any(not(any(feature = "fe2o3-amqp")), target_arch = "wasm32"))]
-type CbsImplementation = super::noop::NoopAmqpClaimsBasedSecurity;
+type CbsImplementation<'a> = super::noop::NoopAmqpClaimsBasedSecurity<'a>;
 
 pub trait AmqpClaimsBasedSecurityApis {
     /// Asynchronously attaches the Claims-Based Security (CBS) node to the AMQP session.
@@ -75,7 +75,7 @@ impl<'a> AmqpClaimsBasedSecurityApis for AmqpClaimsBasedSecurity<'a> {
 impl<'a> AmqpClaimsBasedSecurity<'a> {
     pub fn new(session: &'a AmqpSession) -> Result<Self> {
         Ok(Self {
-            implementation: CbsImplementation::new(&session)?,
+            implementation: CbsImplementation::new(session)?,
         })
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/cbs.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/cbs.rs
@@ -9,38 +9,36 @@ use azure_core::error::Result;
 use fe2o3_amqp_cbs::token::CbsToken;
 use fe2o3_amqp_types::primitives::Timestamp;
 use std::borrow::BorrowMut;
-use std::{
-    fmt::Debug,
-    sync::{Arc, OnceLock},
-};
+use std::{fmt::Debug, sync::OnceLock};
 use tracing::{debug, trace};
 
 #[derive(Debug)]
-pub(crate) struct Fe2o3ClaimsBasedSecurity {
+pub(crate) struct Fe2o3ClaimsBasedSecurity<'a> {
     cbs: OnceLock<Mutex<fe2o3_amqp_cbs::client::CbsClient>>,
-    session: Arc<Mutex<fe2o3_amqp::session::SessionHandle<()>>>,
+    session: &'a AmqpSession,
 }
 
-impl Fe2o3ClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Result<Self> {
+impl<'a> Fe2o3ClaimsBasedSecurity<'a> {
+    pub fn new(session: &'a AmqpSession) -> Result<Self> {
         Ok(Self {
             cbs: OnceLock::new(),
-            session: session.implementation.get()?,
+            session,
         })
     }
 }
 
-impl Fe2o3ClaimsBasedSecurity {}
+impl<'a> Fe2o3ClaimsBasedSecurity<'a> {}
 
-impl Drop for Fe2o3ClaimsBasedSecurity {
+impl<'a> Drop for Fe2o3ClaimsBasedSecurity<'a> {
     fn drop(&mut self) {
         debug!("Dropping Fe2o3ClaimsBasedSecurity.");
     }
 }
 
-impl AmqpClaimsBasedSecurityApis for Fe2o3ClaimsBasedSecurity {
+impl<'a> AmqpClaimsBasedSecurityApis for Fe2o3ClaimsBasedSecurity<'a> {
     async fn attach(&self) -> Result<()> {
-        let mut session = self.session.lock().await;
+        let session = self.session.implementation.get()?;
+        let mut session = session.lock().await;
         let cbs_client = fe2o3_amqp_cbs::client::CbsClient::builder()
             .client_node_addr("rust_amqp_cbs")
             .attach(session.borrow_mut())

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -14,6 +14,7 @@ use super::{
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
 };
 use azure_core::{credentials::AccessToken, error::Result};
+use std::marker::PhantomData;
 
 #[derive(Debug, Default)]
 pub(crate) struct NoopAmqpConnection {}
@@ -31,7 +32,9 @@ pub(crate) struct NoopAmqpReceiver {}
 pub(crate) struct NoopAmqpSession {}
 
 #[derive(Debug, Default)]
-pub(crate) struct NoopAmqpClaimsBasedSecurity {}
+pub(crate) struct NoopAmqpClaimsBasedSecurity<'a> {
+    phantom: PhantomData<&'a AmqpSession>,
+}
 
 impl NoopAmqpConnection {
     pub fn new() -> Self {
@@ -81,13 +84,15 @@ impl AmqpSessionApis for NoopAmqpSession {
     }
 }
 
-impl NoopAmqpClaimsBasedSecurity {
-    pub fn new(session: &AmqpSession) -> Result<Self> {
-        Ok(Self {})
+impl<'a> NoopAmqpClaimsBasedSecurity<'a> {
+    pub fn new(session: &'a AmqpSession) -> Result<Self> {
+        Ok(Self {
+            phantom: PhantomData,
+        })
     }
 }
 
-impl AmqpClaimsBasedSecurityApis for NoopAmqpClaimsBasedSecurity {
+impl<'a> AmqpClaimsBasedSecurityApis for NoopAmqpClaimsBasedSecurity<'a> {
     async fn attach(&self) -> Result<()> {
         unimplemented!();
     }

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -82,7 +82,7 @@ impl AmqpSessionApis for NoopAmqpSession {
 }
 
 impl NoopAmqpClaimsBasedSecurity {
-    pub fn new(session: AmqpSession) -> Result<Self> {
+    pub fn new(session: &AmqpSession) -> Result<Self> {
         Ok(Self {})
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -491,7 +491,7 @@ impl ConsumerClient {
             let session = AmqpSession::new();
             session.begin(connection, None).await?;
 
-            let cbs = AmqpClaimsBasedSecurity::new(session)?;
+            let cbs = AmqpClaimsBasedSecurity::new(&session)?;
             cbs.attach().await?;
 
             debug!("Get Token.");

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -467,7 +467,7 @@ impl ProducerClient {
             let session = AmqpSession::new();
             session.begin(connection, None).await?;
 
-            let cbs = AmqpClaimsBasedSecurity::new(session)?;
+            let cbs = AmqpClaimsBasedSecurity::new(&session)?;
             cbs.attach().await?;
 
             debug!("Get Token.");


### PR DESCRIPTION
This pull request introduces several important changes to the `azure_core_amqp` and `azure_messaging_eventhubs` SDKs. The most significant updates involve adding lifetime parameters to various structs and implementations to ensure proper borrowing and memory management. Additionally, there are some minor improvements and refactorings to enhance code clarity and error handling.

### Lifetime Parameter Additions:
* [`sdk/core/azure_core_amqp/src/cbs.rs`](diffhunk://#diff-1ece8d44dc0336f6c37f7fbf8db9cf06ed4fde257cd679c7b9c007bc80c5c03aL11-R14): Added lifetime parameter `'a` to the `CbsImplementation` type alias and `AmqpClaimsBasedSecurity` struct to ensure proper borrowing of `AmqpSession`. [[1]](diffhunk://#diff-1ece8d44dc0336f6c37f7fbf8db9cf06ed4fde257cd679c7b9c007bc80c5c03aL11-R14) [[2]](diffhunk://#diff-1ece8d44dc0336f6c37f7fbf8db9cf06ed4fde257cd679c7b9c007bc80c5c03aL55-R66)
* [`sdk/core/azure_core_amqp/src/fe2o3/cbs.rs`](diffhunk://#diff-c569aa674a24402ed7f7942e3678f39323f51e9959097893621d26da589be33bL12-R41): Added lifetime parameter `'a` to `Fe2o3ClaimsBasedSecurity` struct and its methods to ensure proper borrowing of `AmqpSession`.
* [`sdk/core/azure_core_amqp/src/noop.rs`](diffhunk://#diff-534a5974e0ed69615e3d0b1a71d6e2b9d04ce036d40539bc8d4f9a5a53e1445dR17): Added lifetime parameter `'a` and a `PhantomData` field to `NoopAmqpClaimsBasedSecurity` struct to ensure proper borrowing of `AmqpSession`. [[1]](diffhunk://#diff-534a5974e0ed69615e3d0b1a71d6e2b9d04ce036d40539bc8d4f9a5a53e1445dR17) [[2]](diffhunk://#diff-534a5974e0ed69615e3d0b1a71d6e2b9d04ce036d40539bc8d4f9a5a53e1445dL34-R37) [[3]](diffhunk://#diff-534a5974e0ed69615e3d0b1a71d6e2b9d04ce036d40539bc8d4f9a5a53e1445dL84-R95)

### Refactorings and Improvements:
* [`sdk/core/azure_core_amqp/src/fe2o3/connection.rs`](diffhunk://#diff-3df1e5d2a77c38245c74ae9a38af5bcb7744b99d894b2e6936df1a4a6cc5905dL54-R54): Simplified error handling and removed unnecessary `unwrap` calls by using `if let` instead of `ok_or_else`. [[1]](diffhunk://#diff-3df1e5d2a77c38245c74ae9a38af5bcb7744b99d894b2e6936df1a4a6cc5905dL54-R54) [[2]](diffhunk://#diff-3df1e5d2a77c38245c74ae9a38af5bcb7744b99d894b2e6936df1a4a6cc5905dL108-R102)
* `sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs` and `sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs`: Updated `AmqpClaimsBasedSecurity::new` calls to pass a reference to `AmqpSession` instead of taking ownership. [[1]](diffhunk://#diff-0ab7a2a86e5b369a2ec23636e593d0db5011a00d9d293e78e2f4bd5e2d420303L494-R494) [[2]](diffhunk://#diff-54ea9d18e1d057631b17eee75b19dea5a1c57d7cf5251bb94e9b9d736c6d2adfL470-R470)