### PR TITLE
[Cosmos] Query Databases, Query Containers, and expand ContainerProperties to include all relevant properties

### DIFF
--- a/sdk/cosmos/.dict.txt
+++ b/sdk/cosmos/.dict.txt
@@ -1,5 +1,7 @@
 colls
 documentdb
+dotproduct
+euclidian
 pkranges
 sprocs
 udfs

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
@@ -25,7 +25,7 @@ pub struct CreateCommand {
 }
 
 impl CreateCommand {
-    pub async fn run(&self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
         let container_client = db_client.container_client(&self.container);
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
@@ -26,7 +26,7 @@ pub struct DeleteCommand {
 }
 
 impl DeleteCommand {
-    pub async fn run(&self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
         let container_client = db_client.container_client(&self.container);
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use std::error::Error;
+
 use azure_data_cosmos::{
     clients::{ContainerClientMethods, DatabaseClientMethods},
     CosmosClient, CosmosClientMethods,
@@ -19,7 +21,7 @@ pub struct MetadataCommand {
 }
 
 impl MetadataCommand {
-    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
         if let Some(container_name) = &self.container {
             let container_client = db_client.container_client(container_name);

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
@@ -19,7 +19,7 @@ pub struct MetadataCommand {
 }
 
 impl MetadataCommand {
-    pub async fn run(&self, client: CosmosClient) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn std::error::Error>> {
         let db_client = client.database_client(&self.database);
         if let Some(container_name) = &self.container {
             let container_client = db_client.container_client(container_name);

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
@@ -34,6 +34,13 @@ enum Subcommands {
         /// The query to execute.
         query: String,
     },
+    Containers {
+        /// The database to query.
+        database: String,
+
+        /// The query to execute.
+        query: String,
+    },
 }
 
 impl QueryCommand {
@@ -69,6 +76,20 @@ impl QueryCommand {
                     let page = page?.deserialize_body().await?;
                     println!("Results Page");
                     println!("  Databases:");
+                    for item in page.items {
+                        println!("    * {:#?}", item);
+                    }
+                }
+                Ok(())
+            }
+            Subcommands::Containers { database, query } => {
+                let db_client = client.database_client(&database);
+                let mut dbs = db_client.query_containers(query, None)?;
+
+                while let Some(page) = dbs.next().await {
+                    let page = page?.deserialize_body().await?;
+                    println!("Results Page");
+                    println!("  Containers:");
                     for item in page.items {
                         println!("    * {:#?}", item);
                     }

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
@@ -76,7 +76,7 @@ impl QueryCommand {
                     let page = page?.deserialize_body().await?;
                     println!("Results Page");
                     println!("  Databases:");
-                    for item in page.items {
+                    for item in page.databases {
                         println!("    * {:#?}", item);
                     }
                 }
@@ -90,7 +90,7 @@ impl QueryCommand {
                     let page = page?.deserialize_body().await?;
                     println!("Results Page");
                     println!("  Containers:");
-                    for item in page.items {
+                    for item in page.containers {
                         println!("    * {:#?}", item);
                     }
                 }

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
@@ -4,43 +4,77 @@ use azure_data_cosmos::{
     clients::{ContainerClientMethods, DatabaseClientMethods},
     CosmosClient, CosmosClientMethods, PartitionKey,
 };
-use clap::Args;
+use clap::{Args, Subcommand};
 use futures::StreamExt;
 
 /// Run a single-partition query against a container.
 #[derive(Clone, Args)]
 pub struct QueryCommand {
-    /// The database to query.
-    database: String,
+    #[command(subcommand)]
+    subcommand: Subcommands,
+}
 
-    /// The container to query.
-    container: String,
+#[derive(Clone, Subcommand)]
+enum Subcommands {
+    Items {
+        /// The database to query.
+        database: String,
 
-    /// The query to execute.
-    query: String,
+        /// The container to query.
+        container: String,
 
-    /// The partition key to use when querying the container. Currently this only supports a single string partition key.
-    #[clap(long, short)]
-    partition_key: String,
+        /// The query to execute.
+        query: String,
+
+        /// The partition key to use when querying the container. Currently this only supports a single string partition key.
+        #[clap(long, short)]
+        partition_key: String,
+    },
+    Databases {
+        /// The query to execute.
+        query: String,
+    },
 }
 
 impl QueryCommand {
-    pub async fn run(&self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
-        let db_client = client.database_client(&self.database);
-        let container_client = db_client.container_client(&self.container);
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
+        match self.subcommand {
+            Subcommands::Items {
+                database,
+                container,
+                query,
+                partition_key,
+            } => {
+                let db_client = client.database_client(&database);
+                let container_client = db_client.container_client(&container);
 
-        let pk = PartitionKey::from(&self.partition_key);
-        let mut items_pager =
-            container_client.query_items::<serde_json::Value>(&self.query, pk, None)?;
+                let pk = PartitionKey::from(&partition_key);
+                let mut items =
+                    container_client.query_items::<serde_json::Value>(&query, pk, None)?;
 
-        while let Some(page) = items_pager.next().await {
-            let response = page?.deserialize_body().await?;
-            println!("Results Page");
-            println!("  Items:");
-            for item in response.items {
-                println!("    * {:#?}", item);
+                while let Some(page) = items.next().await {
+                    let page = page?.deserialize_body().await?;
+                    println!("Results Page");
+                    println!("  Items:");
+                    for item in page.items {
+                        println!("    * {:#?}", item);
+                    }
+                }
+                Ok(())
+            }
+            Subcommands::Databases { query } => {
+                let mut dbs = client.query_databases(query, None)?;
+
+                while let Some(page) = dbs.next().await {
+                    let page = page?.deserialize_body().await?;
+                    println!("Results Page");
+                    println!("  Databases:");
+                    for item in page.items {
+                        println!("    * {:#?}", item);
+                    }
+                }
+                Ok(())
             }
         }
-        Ok(())
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
@@ -26,7 +26,7 @@ pub struct ReadCommand {
 }
 
 impl ReadCommand {
-    pub async fn run(&self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
         let container_client = db_client.container_client(&self.container);
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
@@ -30,7 +30,7 @@ pub struct ReplaceCommand {
 }
 
 impl ReplaceCommand {
-    pub async fn run(&self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
         let container_client = db_client.container_client(&self.container);
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/upsert.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/upsert.rs
@@ -25,7 +25,7 @@ pub struct UpsertCommand {
 }
 
 impl UpsertCommand {
-    pub async fn run(&self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
         let db_client = client.database_client(&self.database);
         let container_client = db_client.container_client(&self.container);
 

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -12,7 +12,6 @@ use crate::{
 
 use azure_core::{Context, Pager, Request, Response};
 use serde::{de::DeserializeOwned, Serialize};
-use typespec_client_core::http::PagerResult;
 use url::Url;
 
 #[cfg(doc)]

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::clients::DatabaseClient;
-use crate::models::{DatabaseProperties, QueryResults};
+use crate::models::DatabaseQueryResults;
 use crate::pipeline::{AuthorizationPolicy, CosmosPipeline, ResourceType};
 use crate::utils::AppendPathSegments;
 use crate::{CosmosClientOptions, Query, QueryDatabasesOptions};
@@ -64,7 +64,7 @@ pub trait CosmosClientMethods {
         &self,
         query: impl Into<Query>,
         options: Option<QueryDatabasesOptions>,
-    ) -> azure_core::Result<azure_core::Pager<QueryResults<DatabaseProperties>>>;
+    ) -> azure_core::Result<azure_core::Pager<DatabaseQueryResults>>;
 }
 
 impl CosmosClient {
@@ -155,7 +155,7 @@ impl CosmosClientMethods for CosmosClient {
         #[allow(unused_variables)]
         // REASON: This is a documented public API so prefixing with '_' is undesirable.
         options: Option<QueryDatabasesOptions>,
-    ) -> azure_core::Result<azure_core::Pager<QueryResults<DatabaseProperties>>> {
+    ) -> azure_core::Result<azure_core::Pager<DatabaseQueryResults>> {
         let mut url = self.endpoint.clone();
         url.append_path_segments(["dbs"]);
         let base_request = Request::new(url, azure_core::Method::Post);

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -34,9 +34,32 @@ pub trait CosmosClientMethods {
     /// * `id` - The ID of the database.
     fn database_client(&self, id: impl AsRef<str>) -> DatabaseClient;
 
-    /// Gets the URL of the Cosmos DB Account this client is connected to.
+    /// Returns the endpoint used to create the client.
     fn endpoint(&self) -> &Url;
 
+    /// Executes a query against databases in the account.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query to execute.
+    /// * `options` - Optional parameters for the request.
+    ///
+    /// # Examples
+    ///
+    /// The `query` parameter accepts anything that can be transformed [`Into`] a [`Query`].
+    /// This allows simple queries without parameters to be expressed easily:
+    ///
+    /// ```rust,no_run
+    /// # async fn doc() {
+    /// # use azure_data_cosmos::{CosmosClient, CosmosClientMethods};
+    /// # let client: CosmosClient = panic!("this is a non-running example");
+    /// let dbs = client.query_databases(
+    ///     "SELECT * FROM dbs",
+    ///     None).unwrap();
+    /// # }
+    /// ```
+    ///
+    /// See [`Query`] for more information on how to specify a query.
     fn query_databases(
         &self,
         query: impl Into<Query>,

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -151,6 +151,9 @@ impl CosmosClientMethods for CosmosClient {
     fn query_databases(
         &self,
         query: impl Into<Query>,
+
+        #[allow(unused_variables)]
+        // REASON: This is a documented public API so prefixing with '_' is undesirable.
         options: Option<QueryDatabasesOptions>,
     ) -> azure_core::Result<azure_core::Pager<QueryResults<DatabaseProperties>>> {
         let mut url = self.endpoint.clone();

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -129,6 +129,9 @@ impl DatabaseClientMethods for DatabaseClient {
     fn query_containers(
         &self,
         query: impl Into<Query>,
+
+        #[allow(unused_variables)]
+        // REASON: This is a documented public API so prefixing with '_' is undesirable.
         options: Option<QueryContainersOptions>,
     ) -> azure_core::Result<Pager<QueryResults<ContainerProperties>>> {
         let mut url = self.database_url.clone();

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::models::{ContainerProperties, DatabaseProperties, QueryResults};
+use crate::models::{ContainerQueryResults, DatabaseProperties};
 use crate::options::ReadDatabaseOptions;
 use crate::pipeline::ResourceType;
 use crate::utils::AppendPathSegments;
@@ -79,7 +79,7 @@ pub trait DatabaseClientMethods {
         &self,
         query: impl Into<Query>,
         options: Option<QueryContainersOptions>,
-    ) -> azure_core::Result<Pager<QueryResults<ContainerProperties>>>;
+    ) -> azure_core::Result<Pager<ContainerQueryResults>>;
 }
 
 /// A client for working with a specific database in a Cosmos DB account.
@@ -133,7 +133,7 @@ impl DatabaseClientMethods for DatabaseClient {
         #[allow(unused_variables)]
         // REASON: This is a documented public API so prefixing with '_' is undesirable.
         options: Option<QueryContainersOptions>,
-    ) -> azure_core::Result<Pager<QueryResults<ContainerProperties>>> {
+    ) -> azure_core::Result<Pager<ContainerQueryResults>> {
         let mut url = self.database_url.clone();
         url.append_path_segments(["colls"]);
         let base_request = Request::new(url, azure_core::Method::Post);

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -81,7 +81,7 @@ pub struct VectorEmbedding {
     pub data_type: VectorDataType,
 
     /// The number of dimensions in the vector.
-    pub dimensions: u64,
+    pub dimensions: u32,
 
     /// The [`VectorDistanceFunction`] used to calculate the distance between vectors.
     pub distance_function: VectorDistanceFunction,

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -65,7 +65,8 @@ pub struct PartitionKeyDefinition {
     pub paths: Vec<String>,
 
     /// The version of the partition key hash in use.
-    pub version: Option<usize>,
+    #[serde(default)]
+    pub version: i32,
 }
 
 /// Represents the indexing policy for a container.

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -51,9 +51,74 @@ pub struct ContainerProperties {
     /// The conflict resolution policy for the container.
     pub conflict_resolution_policy: Option<ConflictResolutionPolicy>,
 
+    /// The vector embedding policy for the container.
+    pub vector_embedding_policy: Option<VectorEmbeddingPolicy>,
+
     /// A [`SystemProperties`] object containing common system properties for the container.
     #[serde(flatten)]
     pub system_properties: SystemProperties,
+}
+
+/// Represents the vector embedding policy for a container.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VectorEmbeddingPolicy {
+    /// The [`Embedding`]s that describe the vector embeddings of items in the container.
+    #[serde(rename = "vectorEmbeddings")]
+    pub embeddings: Vec<VectorEmbedding>,
+}
+
+/// Represents the vector embedding policy for a container.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VectorEmbedding {
+    /// The path to the property containing the vector.
+    pub path: String,
+
+    /// The data type of the elements stored in the vector.
+    pub data_type: VectorDataType,
+
+    /// The number of dimensions in the vector.
+    pub dimensions: u64,
+
+    /// The [`VectorDistanceFunction`] used to calculate the distance between vectors.
+    pub distance_function: VectorDistanceFunction,
+}
+
+/// Defines the data types of the elements of a vector.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum VectorDataType {
+    /// Represents the `float16` data type.
+    Float16,
+
+    /// Represents the `float32` data type.
+    Float32,
+
+    /// Represents the `uint8` data type.
+    Uint8,
+
+    /// Represents the `int8` data type.
+    Int8,
+}
+
+/// Defines the distance functions that can be used to calculate the distance between vectors.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum VectorDistanceFunction {
+    /// Represents the `euclidian` distance function.
+    Euclidean,
+
+    /// Represents the `cosine` distance function.
+    Cosine,
+
+    /// Represents the `dotproduct` distance function.
+    #[serde(rename = "dotproduct")]
+    DotProduct,
 }
 
 /// Represents the partition key definition for a container.

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -24,14 +24,14 @@ pub struct ContainerProperties {
 
     /// The time-to-live for items in the container.
     ///
-    /// For more information see https://docs.microsoft.com/azure/cosmos-db/time-to-live#time-to-live-configurations
+    /// For more information see <https://docs.microsoft.com/azure/cosmos-db/time-to-live#time-to-live-configurations>
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_ttl")]
     pub default_ttl: Option<Duration>,
 
     /// The time-to-live for the analytical store in the container.
     ///
-    /// For more information see https://docs.microsoft.com/azure/cosmos-db/analytical-store-introduction#analytical-ttl
+    /// For more information see <https://docs.microsoft.com/azure/cosmos-db/analytical-store-introduction#analytical-ttl>
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_ttl")]
     pub analytical_storage_ttl: Option<Duration>,
@@ -67,7 +67,7 @@ pub struct PartitionKeyDefinition {
 
 /// Represents the indexing policy for a container.
 ///
-/// For more information see https://docs.microsoft.com/azure/cosmos-db/index-policy
+/// For more information see <https://docs.microsoft.com/azure/cosmos-db/index-policy>
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -179,7 +179,7 @@ pub enum CompositeIndexOrder {
 
 /// Represents a unique key policy for a container.
 ///
-/// For more information see https://docs.microsoft.com/azure/cosmos-db/unique-keys
+/// For more information see <https://docs.microsoft.com/azure/cosmos-db/unique-keys>
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -199,7 +199,7 @@ pub struct UniqueKey {
 
 /// Represents a conflict resolution policy for a container
 ///
-/// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/conflict-resolution-policies
+/// For more information, see <https://learn.microsoft.com/en-us/azure/cosmos-db/conflict-resolution-policies>
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -230,7 +230,7 @@ pub enum ConflictResolutionMode {
 
 /// Represents a vector index
 ///
-/// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/index-policy#vector-indexes
+/// For more information, see <https://learn.microsoft.com/en-us/azure/cosmos-db/index-policy#vector-indexes>
 #[non_exhaustive]
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -16,7 +16,7 @@ where
 ///
 /// Returned by [`ContainerClient::read()`](crate::clients::ContainerClient::read()).
 #[non_exhaustive]
-#[derive(Model, Clone, Debug, Deserialize)]
+#[derive(Model, Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ContainerProperties {
     /// The ID of the container.
@@ -55,7 +55,7 @@ pub struct ContainerProperties {
 
 /// Represents the partition key definition for a container.
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PartitionKeyDefinition {
     /// The list of partition keys paths.
@@ -69,13 +69,15 @@ pub struct PartitionKeyDefinition {
 ///
 /// For more information see https://docs.microsoft.com/azure/cosmos-db/index-policy
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexingPolicy {
     /// Indicates that the indexing policy is automatic.
+    #[serde(default)]
     pub automatic: bool,
 
     /// The indexing mode in use.
+    #[serde(default)]
     pub indexing_mode: IndexingMode,
 
     /// The paths to be indexed.
@@ -93,20 +95,26 @@ pub struct IndexingPolicy {
     /// A list of composite indexes in the container
     #[serde(default)]
     pub composite_indexes: Vec<CompositeIndex>,
+
+    /// A list of vector indexes in the container
+    #[serde(default)]
+    pub vector_indexes: Vec<VectorIndex>,
 }
 
 /// Defines the indexing modes supported by Azure Cosmos DB.
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum IndexingMode {
     Consistent,
+
+    #[default]
     None,
 }
 
 /// Represents a JSON path.
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PropertyPath {
     // The path to the property referenced in this index.
@@ -115,7 +123,7 @@ pub struct PropertyPath {
 
 /// Represents a spatial index
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SpatialIndex {
     /// The path to the property referenced in this index.
@@ -127,7 +135,7 @@ pub struct SpatialIndex {
 
 /// Defines the types of spatial data that can be indexed.
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub enum SpatialType {
     Point,
@@ -138,16 +146,16 @@ pub enum SpatialType {
 
 /// Represents a composite index
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
 pub struct CompositeIndex {
     /// The properties in this composite index
-    pub members: Vec<CompositeIndexProperty>,
+    pub properties: Vec<CompositeIndexProperty>,
 }
 
 /// Describes a single property in a composite index.
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CompositeIndexProperty {
     /// The path to the property referenced in this index.
@@ -162,7 +170,7 @@ pub struct CompositeIndexProperty {
 
 /// Ordering values available for composite indexes.
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum CompositeIndexOrder {
     Ascending,
@@ -173,7 +181,7 @@ pub enum CompositeIndexOrder {
 ///
 /// For more information see https://docs.microsoft.com/azure/cosmos-db/unique-keys
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct UniqueKeyPolicy {
     /// The keys defined in this policy.
@@ -182,7 +190,7 @@ pub struct UniqueKeyPolicy {
 
 /// Represents a single unique key for a container.
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct UniqueKey {
     /// The set of paths which must be unique for each item.
@@ -193,7 +201,7 @@ pub struct UniqueKey {
 ///
 /// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/conflict-resolution-policies
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConflictResolutionPolicy {
     /// The conflict resolution mode.
@@ -210,7 +218,7 @@ pub struct ConflictResolutionPolicy {
 
 /// Defines conflict resolution types available in Azure Cosmos DB
 #[non_exhaustive]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "PascalCase")]
 pub enum ConflictResolutionMode {
     /// Conflict resolution will be performed by using the highest value of the property specified by [`ConflictResolutionPolicy::resolution_path`].
@@ -218,4 +226,174 @@ pub enum ConflictResolutionMode {
 
     /// Conflict resolution will be performed by executing the stored procedure specified by [`ConflictResolutionPolicy::resolution_procedure`].
     Custom,
+}
+
+/// Represents a vector index
+///
+/// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/index-policy#vector-indexes
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VectorIndex {
+    /// The path to the property referenced in this index.
+    pub path: String,
+
+    /// The type of the vector index.
+    #[serde(rename = "type")] // "type" is a reserved word in Rust.
+    pub index_type: VectorIndexType,
+}
+
+/// Types of vector indexes supported by Cosmos DB
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum VectorIndexType {
+    Flat,
+    QuantizedFlat,
+    DiskANN,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::{
+        CompositeIndex, CompositeIndexOrder, CompositeIndexProperty, IndexingMode, PropertyPath,
+        SpatialIndex, SpatialType, VectorIndex, VectorIndexType,
+    };
+
+    use super::IndexingPolicy;
+
+    #[test]
+    pub fn deserialize_indexing_policy() {
+        // A fairly complete deserialization test that covers most of the indexing policies described in our docs.
+        let policy = r#"
+            {
+                "indexingMode": "consistent",
+                "includedPaths": [
+                    {
+                        "path": "/*"
+                    }
+                ],
+                "excludedPaths": [
+                    {
+                        "path": "/path/to/single/excluded/property/?"
+                    },
+                    {
+                        "path": "/path/to/root/of/multiple/excluded/properties/*"
+                    }
+                ],
+                "spatialIndexes": [
+                    {
+                        "path": "/path/to/geojson/property/?",
+                        "types": [
+                            "Point",
+                            "Polygon",
+                            "MultiPolygon",
+                            "LineString"
+                        ]
+                    }
+                ],
+                "vectorIndexes": [
+                    {
+                        "path": "/vector1",
+                        "type": "quantizedFlat"
+                    },
+                    {
+                        "path": "/vector2",
+                        "type": "diskANN"
+                    }
+                ],
+                "compositeIndexes":[
+                    [
+                        {
+                            "path":"/name",
+                            "order":"ascending"
+                        },
+                        {
+                            "path":"/age",
+                            "order":"descending"
+                        }
+                    ],
+                    [
+                        {
+                            "path":"/name2",
+                            "order":"descending"
+                        },
+                        {
+                            "path":"/age2",
+                            "order":"ascending"
+                        }
+                    ]
+                ],
+                "extraValueNotCurrentlyPresentInModel": {
+                    "this": "should not fail"
+                }
+            }
+        "#;
+
+        let policy: IndexingPolicy = serde_json::from_str(policy).unwrap();
+
+        assert_eq!(
+            IndexingPolicy {
+                automatic: false,
+                indexing_mode: IndexingMode::Consistent,
+                included_paths: vec![PropertyPath {
+                    path: "/*".to_string(),
+                }],
+                excluded_paths: vec![
+                    PropertyPath {
+                        path: "/path/to/single/excluded/property/?".to_string()
+                    },
+                    PropertyPath {
+                        path: "/path/to/root/of/multiple/excluded/properties/*".to_string()
+                    },
+                ],
+                spatial_indexes: vec![SpatialIndex {
+                    path: "/path/to/geojson/property/?".to_string(),
+                    types: vec![
+                        SpatialType::Point,
+                        SpatialType::Polygon,
+                        SpatialType::MultiPolygon,
+                        SpatialType::LineString,
+                    ]
+                }],
+                composite_indexes: vec![
+                    CompositeIndex {
+                        properties: vec![
+                            CompositeIndexProperty {
+                                path: "/name".to_string(),
+                                order: CompositeIndexOrder::Ascending,
+                            },
+                            CompositeIndexProperty {
+                                path: "/age".to_string(),
+                                order: CompositeIndexOrder::Descending,
+                            },
+                        ]
+                    },
+                    CompositeIndex {
+                        properties: vec![
+                            CompositeIndexProperty {
+                                path: "/name2".to_string(),
+                                order: CompositeIndexOrder::Descending,
+                            },
+                            CompositeIndexProperty {
+                                path: "/age2".to_string(),
+                                order: CompositeIndexOrder::Ascending,
+                            },
+                        ]
+                    },
+                ],
+                vector_indexes: vec![
+                    VectorIndex {
+                        path: "/vector1".to_string(),
+                        index_type: VectorIndexType::QuantizedFlat,
+                    },
+                    VectorIndex {
+                        path: "/vector2".to_string(),
+                        index_type: VectorIndexType::DiskANN,
+                    }
+                ]
+            },
+            policy
+        );
+    }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -1,0 +1,221 @@
+use std::time::Duration;
+
+use azure_core::Model;
+use serde::{Deserialize, Deserializer};
+
+use crate::models::SystemProperties;
+
+fn deserialize_ttl<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<u64>::deserialize(deserializer)?.map(Duration::from_secs))
+}
+
+/// Properties of a Cosmos DB container.
+///
+/// Returned by [`ContainerClient::read()`](crate::clients::ContainerClient::read()).
+#[non_exhaustive]
+#[derive(Model, Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContainerProperties {
+    /// The ID of the container.
+    pub id: String,
+
+    /// The time-to-live for items in the container.
+    ///
+    /// For more information see https://docs.microsoft.com/azure/cosmos-db/time-to-live#time-to-live-configurations
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_ttl")]
+    pub default_ttl: Option<Duration>,
+
+    /// The time-to-live for the analytical store in the container.
+    ///
+    /// For more information see https://docs.microsoft.com/azure/cosmos-db/analytical-store-introduction#analytical-ttl
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_ttl")]
+    pub analytical_storage_ttl: Option<Duration>,
+
+    /// The definition of the partition key for the container.
+    pub partition_key: PartitionKeyDefinition,
+
+    /// The indexing policy for the container.
+    pub indexing_policy: Option<IndexingPolicy>,
+
+    /// The unique key policy for the container.
+    pub unique_key_policy: Option<UniqueKeyPolicy>,
+
+    /// The conflict resolution policy for the container.
+    pub conflict_resolution_policy: Option<ConflictResolutionPolicy>,
+
+    /// A [`SystemProperties`] object containing common system properties for the container.
+    #[serde(flatten)]
+    pub system_properties: SystemProperties,
+}
+
+/// Represents the partition key definition for a container.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PartitionKeyDefinition {
+    /// The list of partition keys paths.
+    pub paths: Vec<String>,
+
+    /// The version of the partition key hash in use.
+    pub version: Option<usize>,
+}
+
+/// Represents the indexing policy for a container.
+///
+/// For more information see https://docs.microsoft.com/azure/cosmos-db/index-policy
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexingPolicy {
+    /// Indicates that the indexing policy is automatic.
+    pub automatic: bool,
+
+    /// The indexing mode in use.
+    pub indexing_mode: IndexingMode,
+
+    /// The paths to be indexed.
+    #[serde(default)]
+    pub included_paths: Vec<PropertyPath>,
+
+    /// The paths to be excluded.
+    #[serde(default)]
+    pub excluded_paths: Vec<PropertyPath>,
+
+    /// A list of spatial indexes in the container.
+    #[serde(default)]
+    pub spatial_indexes: Vec<SpatialIndex>,
+
+    /// A list of composite indexes in the container
+    #[serde(default)]
+    pub composite_indexes: Vec<CompositeIndex>,
+}
+
+/// Defines the indexing modes supported by Azure Cosmos DB.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum IndexingMode {
+    Consistent,
+    None,
+}
+
+/// Represents a JSON path.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PropertyPath {
+    // The path to the property referenced in this index.
+    pub path: String,
+}
+
+/// Represents a spatial index
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpatialIndex {
+    /// The path to the property referenced in this index.
+    pub path: String,
+
+    /// The spatial types used in this index
+    pub types: Vec<SpatialType>,
+}
+
+/// Defines the types of spatial data that can be indexed.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum SpatialType {
+    Point,
+    Polygon,
+    LineString,
+    MultiPolygon,
+}
+
+/// Represents a composite index
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(transparent)]
+pub struct CompositeIndex {
+    /// The properties in this composite index
+    pub members: Vec<CompositeIndexProperty>,
+}
+
+/// Describes a single property in a composite index.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CompositeIndexProperty {
+    /// The path to the property referenced in this index.
+    pub path: String,
+
+    /// The order of the composite index.
+    ///
+    /// For example, if you want to run the query "SELECT * FROM c ORDER BY c.age asc, c.height desc",
+    /// then you'd specify the order for "/asc" to be *ascending* and the order for "/height" to be *descending*.
+    pub order: CompositeIndexOrder,
+}
+
+/// Ordering values available for composite indexes.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CompositeIndexOrder {
+    Ascending,
+    Descending,
+}
+
+/// Represents a unique key policy for a container.
+///
+/// For more information see https://docs.microsoft.com/azure/cosmos-db/unique-keys
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UniqueKeyPolicy {
+    /// The keys defined in this policy.
+    pub unique_keys: Vec<UniqueKey>,
+}
+
+/// Represents a single unique key for a container.
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UniqueKey {
+    /// The set of paths which must be unique for each item.
+    pub paths: Vec<String>,
+}
+
+/// Represents a conflict resolution policy for a container
+///
+/// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/conflict-resolution-policies
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConflictResolutionPolicy {
+    /// The conflict resolution mode.
+    pub mode: ConflictResolutionMode,
+
+    /// The path within the item to use to perform [`LastWriterWins`](ConflictResolutionMode::LastWriterWins) conflict resolution.
+    #[serde(rename = "conflictResolutionPath")]
+    pub resolution_path: String,
+
+    /// The stored procedure path to use to perform [`Custom`](ConflictResolutionMode::Custom) conflict resolution.
+    #[serde(rename = "conflictResolutionProcedure")]
+    pub resolution_procedure: String,
+}
+
+/// Defines conflict resolution types available in Azure Cosmos DB
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum ConflictResolutionMode {
+    /// Conflict resolution will be performed by using the highest value of the property specified by [`ConflictResolutionPolicy::resolution_path`].
+    LastWriterWins,
+
+    /// Conflict resolution will be performed by executing the stored procedure specified by [`ConflictResolutionPolicy::resolution_procedure`].
+    Custom,
+}

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Deserializer};
 
 use crate::models::SystemProperties;
 
+#[cfg(doc)]
+use crate::clients::ContainerClientMethods;
+
 fn deserialize_ttl<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
 where
     D: Deserializer<'de>,

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -64,7 +64,7 @@ pub struct ContainerProperties {
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct VectorEmbeddingPolicy {
-    /// The [`Embedding`]s that describe the vector embeddings of items in the container.
+    /// The [`VectorEmbedding`]s that describe the vector embeddings of items in the container.
     #[serde(rename = "vectorEmbeddings")]
     pub embeddings: Vec<VectorEmbedding>,
 }

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -37,13 +37,11 @@ where
     }
 }
 
-/// A page of query results, where each item is a document of type `T`.
+/// A page of query results, where each item is of type `T`.
 #[non_exhaustive]
 #[derive(Clone, Default, Debug, Deserialize)]
 pub struct QueryResults<T> {
     #[serde(alias = "Documents")]
-    #[serde(alias = "Databases")]
-    #[serde(alias = "DocumentCollections")]
     pub items: Vec<T>,
 }
 
@@ -53,6 +51,22 @@ impl<T: DeserializeOwned> azure_core::Model for QueryResults<T> {
     ) -> typespec_client_core::Result<Self> {
         body.json().await
     }
+}
+
+/// A page of results from [`CosmosClient::query_databases`](crate::clients::CosmosClient::query_databases())
+#[non_exhaustive]
+#[derive(Clone, Default, Debug, Deserialize, Model)]
+pub struct DatabaseQueryResults {
+    #[serde(alias = "Databases")]
+    pub databases: Vec<DatabaseProperties>,
+}
+
+/// A page of results from [`DatabaseClient::query_containers`](crate::clients::DatabaseClient::query_containers())
+#[non_exhaustive]
+#[derive(Clone, Default, Debug, Deserialize, Model)]
+pub struct ContainerQueryResults {
+    #[serde(alias = "DocumentCollections")]
+    pub containers: Vec<ContainerProperties>,
 }
 
 /// Common system properties returned for most Cosmos DB resources.

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -39,7 +39,8 @@ where
 #[non_exhaustive]
 #[derive(Clone, Default, Debug, Deserialize)]
 pub struct QueryResults<T> {
-    #[serde(rename = "Documents")]
+    #[serde(alias = "Documents")]
+    #[serde(alias = "Databases")]
     pub items: Vec<T>,
 }
 

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -41,6 +41,7 @@ where
 pub struct QueryResults<T> {
     #[serde(alias = "Documents")]
     #[serde(alias = "Databases")]
+    #[serde(alias = "DocumentCollections")]
     pub items: Vec<T>,
 }
 

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -3,8 +3,6 @@
 
 //! Model types sent to and received from the Cosmos DB API.
 
-use std::time::Duration;
-
 use azure_core::{date::OffsetDateTime, Model};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer};
 

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -3,6 +3,8 @@
 
 //! Model types sent to and received from the Cosmos DB API.
 
+use std::time::Duration;
+
 use azure_core::{date::OffsetDateTime, Model};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer};
 
@@ -12,8 +14,10 @@ use crate::{
     CosmosClientMethods,
 };
 
+mod container_properties;
 mod item;
 
+pub use container_properties::*;
 pub use item::*;
 
 fn deserialize_cosmos_timestamp<'de, D>(deserializer: D) -> Result<Option<OffsetDateTime>, D::Error>
@@ -85,20 +89,6 @@ pub struct DatabaseProperties {
     pub id: String,
 
     /// A [`SystemProperties`] object containing common system properties for the database.
-    #[serde(flatten)]
-    pub system_properties: SystemProperties,
-}
-
-/// Properties of a Cosmos DB container.
-///
-/// Returned by [`ContainerClient::read()`](crate::clients::ContainerClient::read()).
-#[non_exhaustive]
-#[derive(Model, Clone, Default, Debug, Deserialize)]
-pub struct ContainerProperties {
-    /// The ID of the container.
-    pub id: String,
-
-    /// A [`SystemProperties`] object containing common system properties for the container.
     #[serde(flatten)]
     pub system_properties: SystemProperties,
 }

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -57,7 +57,7 @@ impl<T: DeserializeOwned> azure_core::Model for QueryResults<T> {
 
 /// Common system properties returned for most Cosmos DB resources.
 #[non_exhaustive]
-#[derive(Clone, Default, Debug, Deserialize)]
+#[derive(Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 pub struct SystemProperties {
     /// The entity tag associated with the resource.
     #[serde(rename = "_etag")]
@@ -81,7 +81,7 @@ pub struct SystemProperties {
 ///
 /// Returned by [`DatabaseClient::read()`](crate::clients::DatabaseClient::read()).
 #[non_exhaustive]
-#[derive(Model, Clone, Default, Debug, Deserialize)]
+#[derive(Model, Clone, Default, Debug, Deserialize, PartialEq, Eq)]
 pub struct DatabaseProperties {
     /// The ID of the database.
     pub id: String,

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -3,6 +3,7 @@
 
 mod cosmos_client_options;
 mod item_options;
+mod query_containers_options;
 mod query_databases_options;
 mod query_options;
 mod read_container_options;
@@ -10,6 +11,7 @@ mod read_database_options;
 
 pub use cosmos_client_options::CosmosClientOptions;
 pub use item_options::ItemOptions;
+pub use query_containers_options::QueryContainersOptions;
 pub use query_databases_options::QueryDatabasesOptions;
 pub use query_options::QueryOptions;
 pub use read_container_options::ReadContainerOptions;
@@ -22,6 +24,7 @@ pub mod builders {
 
     pub use super::cosmos_client_options::CosmosClientOptionsBuilder;
     pub use super::item_options::ItemOptionsBuilder;
+    pub use super::query_containers_options::QueryContainersOptionsBuilder;
     pub use super::query_databases_options::QueryDatabasesOptionsBuilder;
     pub use super::query_options::QueryOptionsBuilder;
     pub use super::read_container_options::ReadContainerOptionsBuilder;

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -3,12 +3,14 @@
 
 mod cosmos_client_options;
 mod item_options;
+mod query_databases_options;
 mod query_options;
 mod read_container_options;
 mod read_database_options;
 
 pub use cosmos_client_options::CosmosClientOptions;
 pub use item_options::ItemOptions;
+pub use query_databases_options::QueryDatabasesOptions;
 pub use query_options::QueryOptions;
 pub use read_container_options::ReadContainerOptions;
 pub use read_database_options::ReadDatabaseOptions;
@@ -20,6 +22,7 @@ pub mod builders {
 
     pub use super::cosmos_client_options::CosmosClientOptionsBuilder;
     pub use super::item_options::ItemOptionsBuilder;
+    pub use super::query_databases_options::QueryDatabasesOptionsBuilder;
     pub use super::query_options::QueryOptionsBuilder;
     pub use super::read_container_options::ReadContainerOptionsBuilder;
     pub use super::read_database_options::ReadDatabaseOptionsBuilder;

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 
 #[cfg(doc)]
-use crate::CosmosClientMethods;
+use crate::clients::DatabaseClientMethods;
 
-/// Options to be passed to [`CosmosClient::query_databases()`]
+/// Options to be passed to [`DatabaseClient::query_containers()`](crate::clients::DatabaseClient)
 #[derive(Clone, Debug, Default)]
 pub struct QueryContainersOptions {}
 

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#[cfg(doc)]
+use crate::CosmosClientMethods;
+
+/// Options to be passed to [`CosmosClient::query_databases()`]
+#[derive(Clone, Debug, Default)]
+pub struct QueryContainersOptions {}
+
+impl QueryContainersOptions {
+    /// Creates a new [`QueryContainersOptionsBuilder`](QueryContainersOptionsBuilder) that can be used to construct a [`QueryContainersOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::QueryDatabaseOptions::builder().build();
+    /// ```
+    pub fn builder() -> QueryContainersOptionsBuilder {
+        QueryContainersOptionsBuilder::default()
+    }
+}
+
+/// Builder used to construct a [`QueryContainersOptions`].
+///
+/// Obtain a [`QueryContainersOptionsBuilder`] by calling [`QueryContainersOptions::builder()`]
+#[derive(Default)]
+pub struct QueryContainersOptionsBuilder(QueryContainersOptions);
+
+impl QueryContainersOptionsBuilder {
+    /// Builds a [`QueryContainersOptions`] from the builder.
+    ///
+    /// This does not consume the builder, and can be called multiple times.
+    pub fn build(&self) -> QueryContainersOptions {
+        self.0.clone()
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
@@ -14,7 +14,7 @@ impl QueryContainersOptions {
     /// # Examples
     ///
     /// ```rust
-    /// let options = azure_data_cosmos::QueryDatabaseOptions::builder().build();
+    /// let options = azure_data_cosmos::QueryContainersOptions::builder().build();
     /// ```
     pub fn builder() -> QueryContainersOptionsBuilder {
         QueryContainersOptionsBuilder::default()

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#[cfg(doc)]
+use crate::CosmosClientMethods;
+
+/// Options to be passed to [`CosmosClient::query_databases()`]
+#[derive(Clone, Debug, Default)]
+pub struct QueryDatabasesOptions {}
+
+impl QueryDatabasesOptions {
+    /// Creates a new [`QueryDatabasesOptionsBuilder`](QueryDatabasesOptionsBuilder) that can be used to construct a [`QueryDatabasesOptions`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// let options = azure_data_cosmos::QueryDatabaseOptions::builder().build();
+    /// ```
+    pub fn builder() -> QueryDatabasesOptionsBuilder {
+        QueryDatabasesOptionsBuilder::default()
+    }
+}
+
+/// Builder used to construct a [`QueryDatabasesOptions`].
+///
+/// Obtain a [`QueryDatabasesOptionsBuilder`] by calling [`QueryDatabasesOptions::builder()`]
+#[derive(Default)]
+pub struct QueryDatabasesOptionsBuilder(QueryDatabasesOptions);
+
+impl QueryDatabasesOptionsBuilder {
+    /// Builds a [`QueryDatabasesOptions`] from the builder.
+    ///
+    /// This does not consume the builder, and can be called multiple times.
+    pub fn build(&self) -> QueryDatabasesOptions {
+        self.0.clone()
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
@@ -14,7 +14,7 @@ impl QueryDatabasesOptions {
     /// # Examples
     ///
     /// ```rust
-    /// let options = azure_data_cosmos::QueryDatabaseOptions::builder().build();
+    /// let options = azure_data_cosmos::QueryDatabasesOptions::builder().build();
     /// ```
     pub fn builder() -> QueryDatabasesOptionsBuilder {
         QueryDatabasesOptionsBuilder::default()

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
@@ -4,7 +4,7 @@
 #[cfg(doc)]
 use crate::CosmosClientMethods;
 
-/// Options to be passed to [`CosmosClient::query_databases()`]
+/// Options to be passed to [`CosmosClient::query_databases()`](crate::CosmosClient)
 #[derive(Clone, Debug, Default)]
 pub struct QueryDatabasesOptions {}
 

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -6,6 +6,10 @@ mod authorization_policy;
 use std::sync::Arc;
 
 pub(crate) use authorization_policy::{AuthorizationPolicy, ResourceType};
+use azure_core::{Context, Pager, Request};
+use serde::de::DeserializeOwned;
+
+use crate::{constants, models::QueryResults, Query};
 
 /// Newtype that wraps an Azure Core pipeline to provide a Cosmos-specific pipeline which configures our authorization policy and enforces that a [`ResourceType`] is set on the context.
 #[derive(Debug, Clone)]
@@ -33,5 +37,40 @@ impl CosmosPipeline {
     ) -> azure_core::Result<azure_core::Response<T>> {
         let ctx = ctx.with_value(resource_type);
         self.0.send(&ctx, request).await
+    }
+
+    pub fn send_query_request<T: DeserializeOwned>(
+        &self,
+        query: Query,
+        mut base_request: Request,
+        resource_type: ResourceType,
+    ) -> azure_core::Result<Pager<QueryResults<T>>> {
+        base_request.insert_header(constants::QUERY, "True");
+        base_request.add_mandatory_header(&constants::QUERY_CONTENT_TYPE);
+        base_request.set_json(&query)?;
+
+        // We have to double-clone here.
+        // First we clone the pipeline to pass it in to the closure
+        let pipeline = self.0.clone();
+        let context = Context::new().with_value(resource_type);
+        Ok(Pager::from_callback(move |continuation| {
+            // Then we have to clone it again to pass it in to the async block.
+            // This is because Pageable can't borrow any data, it has to own it all.
+            // That's probably good, because it means a Pageable can outlive the client that produced it, but it requires some extra cloning.
+            let pipeline = pipeline.clone();
+            let mut req = base_request.clone();
+            let context = context.clone();
+            async move {
+                if let Some(continuation) = continuation {
+                    req.insert_header(constants::CONTINUATION, continuation);
+                }
+
+                let resp = pipeline.send(&context, &mut req).await?;
+                let continuation_token =
+                    resp.headers().get_optional_string(&constants::CONTINUATION);
+
+                Ok((resp, continuation_token))
+            }
+        }))
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 pub(crate) use authorization_policy::{AuthorizationPolicy, ResourceType};
 use azure_core::{Context, Pager, Request};
 use serde::de::DeserializeOwned;
+use typespec_client_core::http::PagerResult;
 
 use crate::{constants, models::QueryResults, Query};
 
@@ -66,10 +67,11 @@ impl CosmosPipeline {
                 }
 
                 let resp = pipeline.send(&context, &mut req).await?;
-                let continuation_token =
-                    resp.headers().get_optional_string(&constants::CONTINUATION);
 
-                Ok((resp, continuation_token))
+                Ok(PagerResult::from_response_header(
+                    resp,
+                    &constants::CONTINUATION,
+                ))
             }
         }))
     }

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -10,7 +10,7 @@ use azure_core::{Context, Pager, Request};
 use serde::de::DeserializeOwned;
 use typespec_client_core::http::PagerResult;
 
-use crate::{constants, models::QueryResults, Query};
+use crate::{constants, Query};
 
 /// Newtype that wraps an Azure Core pipeline to provide a Cosmos-specific pipeline which configures our authorization policy and enforces that a [`ResourceType`] is set on the context.
 #[derive(Debug, Clone)]
@@ -45,7 +45,7 @@ impl CosmosPipeline {
         query: Query,
         mut base_request: Request,
         resource_type: ResourceType,
-    ) -> azure_core::Result<Pager<QueryResults<T>>> {
+    ) -> azure_core::Result<Pager<T>> {
         base_request.insert_header(constants::QUERY, "True");
         base_request.add_mandatory_header(&constants::QUERY_CONTENT_TYPE);
         base_request.set_json(&query)?;


### PR DESCRIPTION
This PR adds the following new APIs:

* `CosmosClient::query_databases` to query across the databases in an account
* `DatabaseClient::query_containers` to query across the containers in an account

To do this, I was able to make a common `send_query_request` to our internal `CosmosPipeline` wrapper, which makes the individual query APIs fairly compact.

In addition, I added missing properties to `ContainerProperties`, based on the Go SDK. I also added Vector Indexing properties, which aren't currently in the Go SDK.

I took another attempt at removing the `#[allow(unused_variables)]` from our `options` parameters. As far as I can tell, there is no escaping it. If an impl is in the same crate as the trait it's implementing, the fact that the trait requires a parameter is not sufficient to suppress the `unused_variables` lint (see [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=e02381c4d1333ed9ab7ce48ee2516fad)). Annoying, but appears to be by-design, though I may follow up on the rust-lang users discourse board.