### PR TITLE
Implement rust management APIs

### DIFF
--- a/sdk/core/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure_core_amqp/src/connection.rs
@@ -124,47 +124,47 @@ pub mod builders {
                 options: Default::default(),
             }
         }
-        pub fn build(&mut self) -> AmqpConnectionOptions {
-            self.options.clone()
+        pub fn build(self) -> AmqpConnectionOptions {
+            self.options
         }
-        pub fn with_max_frame_size(&mut self, max_frame_size: u32) -> &mut Self {
+        pub fn with_max_frame_size(mut self, max_frame_size: u32) -> Self {
             self.options.max_frame_size = Some(max_frame_size);
             self
         }
-        pub fn with_channel_max(&mut self, channel_max: u16) -> &mut Self {
+        pub fn with_channel_max(mut self, channel_max: u16) -> Self {
             self.options.channel_max = Some(channel_max);
             self
         }
-        pub fn with_idle_timeout(&mut self, idle_timeout: Duration) -> &mut Self {
+        pub fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
             self.options.idle_timeout = Some(idle_timeout);
             self
         }
-        pub fn with_outgoing_locales(&mut self, outgoing_locales: Vec<String>) -> &mut Self {
+        pub fn with_outgoing_locales(mut self, outgoing_locales: Vec<String>) ->  Self {
             self.options.outgoing_locales = Some(outgoing_locales);
             self
         }
-        pub fn with_incoming_locales(&mut self, incoming_locales: Vec<String>) -> &mut Self {
+        pub fn with_incoming_locales(mut self, incoming_locales: Vec<String>) -> Self {
             self.options.incoming_locales = Some(incoming_locales);
             self
         }
         pub fn with_offered_capabilities(
-            &mut self,
+            mut self,
             offered_capabilities: Vec<AmqpSymbol>,
-        ) -> &mut Self {
+        ) ->  Self {
             self.options.offered_capabilities = Some(offered_capabilities);
             self
         }
         pub fn with_desired_capabilities(
-            &mut self,
+            mut self,
             desired_capabilities: Vec<AmqpSymbol>,
-        ) -> &mut Self {
+        ) -> Self {
             self.options.desired_capabilities = Some(desired_capabilities);
             self
         }
         pub fn with_properties<K, V>(
-            &mut self,
+            mut self,
             properties: impl Into<AmqpOrderedMap<K, V>>,
-        ) -> &mut Self
+        ) -> Self
         where
             K: Into<AmqpSymbol> + Debug + Default + PartialEq,
             V: Into<AmqpValue> + Debug + Default,
@@ -177,7 +177,7 @@ pub mod builders {
             self.options.properties = Some(properties_map);
             self
         }
-        pub fn with_buffer_size(&mut self, buffer_size: usize) -> &mut Self {
+        pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
             self.options.buffer_size = Some(buffer_size);
             self
         }

--- a/sdk/core/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure_core_amqp/src/connection.rs
@@ -30,7 +30,6 @@ impl AmqpConnectionOptions {
     pub fn builder() -> builders::AmqpConnectionOptionsBuilder {
         builders::AmqpConnectionOptionsBuilder::new()
     }
-
     pub fn max_frame_size(&self) -> Option<u32> {
         self.max_frame_size
     }
@@ -139,7 +138,7 @@ pub mod builders {
             self.options.idle_timeout = Some(idle_timeout);
             self
         }
-        pub fn with_outgoing_locales(mut self, outgoing_locales: Vec<String>) ->  Self {
+        pub fn with_outgoing_locales(mut self, outgoing_locales: Vec<String>) -> Self {
             self.options.outgoing_locales = Some(outgoing_locales);
             self
         }
@@ -147,24 +146,15 @@ pub mod builders {
             self.options.incoming_locales = Some(incoming_locales);
             self
         }
-        pub fn with_offered_capabilities(
-            mut self,
-            offered_capabilities: Vec<AmqpSymbol>,
-        ) ->  Self {
+        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.offered_capabilities = Some(offered_capabilities);
             self
         }
-        pub fn with_desired_capabilities(
-            mut self,
-            desired_capabilities: Vec<AmqpSymbol>,
-        ) -> Self {
+        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.desired_capabilities = Some(desired_capabilities);
             self
         }
-        pub fn with_properties<K, V>(
-            mut self,
-            properties: impl Into<AmqpOrderedMap<K, V>>,
-        ) -> Self
+        pub fn with_properties<K, V>(mut self, properties: impl Into<AmqpOrderedMap<K, V>>) -> Self
         where
             K: Into<AmqpSymbol> + Debug + Default + PartialEq,
             V: Into<AmqpValue> + Debug + Default,

--- a/sdk/core/azure_core_amqp/src/management.rs
+++ b/sdk/core/azure_core_amqp/src/management.rs
@@ -17,6 +17,7 @@ type ManagementImplementation = super::noop::NoopAmqpManagement;
 
 pub trait AmqpManagementApis {
     fn attach(&self) -> impl std::future::Future<Output = Result<()>>;
+    fn detach(self) -> impl std::future::Future<Output = Result<()>>;
 
     #[allow(unused_variables)]
     fn call(
@@ -34,6 +35,9 @@ pub struct AmqpManagement {
 impl AmqpManagementApis for AmqpManagement {
     async fn attach(&self) -> Result<()> {
         self.implementation.attach().await
+    }
+    async fn detach(self) -> Result<()> {
+        self.implementation.detach().await
     }
     async fn call(
         &self,

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -148,11 +148,9 @@ impl AmqpSenderApis for NoopAmqpSender {
     ) -> Result<()> {
         unimplemented!();
     }
-
     async fn detach(self) -> Result<()> {
         unimplemented!();
     }
-
     fn max_message_size(&self) -> Result<Option<u64>> {
         unimplemented!();
     }

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -123,6 +123,10 @@ impl AmqpManagementApis for NoopAmqpManagement {
         unimplemented!();
     }
 
+    async fn detach(self) -> Result<()> {
+        unimplemented!();
+    }
+
     async fn call(
         &self,
         operation_type: impl Into<String>,

--- a/sdk/core/azure_core_amqp/src/sender.rs
+++ b/sdk/core/azure_core_amqp/src/sender.rs
@@ -146,46 +146,37 @@ pub mod builders {
             }
         }
 
-        pub fn with_sender_settle_mode(
-            &mut self,
-            sender_settle_mode: SenderSettleMode,
-        ) -> &mut Self {
+        pub fn with_sender_settle_mode(mut self, sender_settle_mode: SenderSettleMode) -> Self {
             self.options.sender_settle_mode = Some(sender_settle_mode);
             self
         }
 
         pub fn with_receiver_settle_mode(
-            &mut self,
+            mut self,
             receiver_settle_mode: ReceiverSettleMode,
-        ) -> &mut Self {
+        ) -> Self {
             self.options.receiver_settle_mode = Some(receiver_settle_mode);
             self
         }
 
-        pub fn with_source(&mut self, source: impl Into<AmqpSource>) -> &mut Self {
+        pub fn with_source(mut self, source: impl Into<AmqpSource>) -> Self {
             self.options.source = Some(source.into());
             self
         }
-        pub fn with_offered_capabilities(
-            &mut self,
-            offered_capabilities: Vec<AmqpSymbol>,
-        ) -> &mut Self {
+        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.offered_capabilities = Some(offered_capabilities);
             self
         }
         #[allow(dead_code)]
-        pub fn with_desired_capabilities(
-            &mut self,
-            desired_capabilities: Vec<AmqpSymbol>,
-        ) -> &mut Self {
+        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
             self.options.desired_capabilities = Some(desired_capabilities);
             self
         }
 
         pub fn with_properties(
-            &mut self,
+            mut self,
             properties: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-        ) -> &mut Self {
+        ) -> Self {
             let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> =
                 properties.into().iter().collect();
 
@@ -193,18 +184,18 @@ pub mod builders {
             self
         }
 
-        pub fn with_initial_delivery_count(&mut self, initial_delivery_count: u32) -> &mut Self {
+        pub fn with_initial_delivery_count(mut self, initial_delivery_count: u32) -> Self {
             self.options.initial_delivery_count = Some(initial_delivery_count);
             self
         }
 
-        pub fn with_max_message_size(&mut self, max_message_size: u64) -> &mut Self {
+        pub fn with_max_message_size(mut self, max_message_size: u64) -> Self {
             self.options.max_message_size = Some(max_message_size);
             self
         }
 
-        pub fn build(&mut self) -> AmqpSenderOptions {
-            self.options.clone()
+        pub fn build(self) -> AmqpSenderOptions {
+            self.options
         }
     }
 }


### PR DESCRIPTION

There are twomajor changes in this PR:

1) Implement "detach" for AMQP management APIs
1) Convert ConnectionOptions and SenderOptions to use an immutable self builder pattern rather than a mutable self builder pattern.


## Copilot summary

This pull request includes several changes aimed at improving the API design and error handling in the `azure_core_amqp` module. The most important changes include modifying builder methods to take ownership of `self`, adding a `detach` method to the `AmqpManagementApis` trait, and enhancing error handling in the `fe2o3` management module.

### API Design Improvements:

* [`sdk/core/azure_core_amqp/src/connection.rs`](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L127-R167): Modified builder methods to take ownership of `self` instead of using mutable references. This change streamlines the builder pattern and ensures immutability after building. [[1]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L127-R167) [[2]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L180-R180)
* [`sdk/core/azure_core_amqp/src/sender.rs`](diffhunk://#diff-61e307ece369d94ac0f3171fa3832e6ec97eae8ba2d387adbe94399d6ff71c76L149-R198): Similar modifications were made to the builder methods in the sender module to take ownership of `self`.

### Error Handling Enhancements:

* [`sdk/core/azure_core_amqp/src/fe2o3/management.rs`](diffhunk://#diff-f3f68245298c5cd5e5d0ce7ddd3d484777acb642e1f48c230b72868b7f76d4faL14-R24): Enhanced error handling by adding the `ErrorKind` and `Error` types from `azure_core`. This change improves the granularity and clarity of error messages.
* [`sdk/core/azure_core_amqp/src/fe2o3/management.rs`](diffhunk://#diff-f3f68245298c5cd5e5d0ce7ddd3d484777acb642e1f48c230b72868b7f76d4faR74-R85): Added a `detach` method to the `AmqpManagementApis` trait and its implementations to properly handle the detachment of management clients. [[1]](diffhunk://#diff-f3f68245298c5cd5e5d0ce7ddd3d484777acb642e1f48c230b72868b7f76d4faR74-R85) [[2]](diffhunk://#diff-d2e024aff1c9a3e898bca74e3fb57a3a90b894762c3de406099ce9029807f04aR20) [[3]](diffhunk://#diff-d2e024aff1c9a3e898bca74e3fb57a3a90b894762c3de406099ce9029807f04aR39-R41)

### Other Changes:

* [`sdk/core/azure_core_amqp/src/noop.rs`](diffhunk://#diff-534a5974e0ed69615e3d0b1a71d6e2b9d04ce036d40539bc8d4f9a5a53e1445dL151-L155): Implemented the `detach` method for `NoopAmqpSender` to ensure consistency across different implementations.