### PR TITLE
[Cosmos] remove Methods traits

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
@@ -1,9 +1,8 @@
 use std::error::Error;
 
 use azure_data_cosmos::{
-    clients::{ContainerClientMethods, DatabaseClientMethods},
     models::{ContainerProperties, PartitionKeyDefinition},
-    CosmosClient, CosmosClientMethods, PartitionKey,
+    CosmosClient, PartitionKey,
 };
 use clap::{Args, Subcommand};
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
@@ -1,10 +1,7 @@
 use std::error::Error;
 
 use azure_core::StatusCode;
-use azure_data_cosmos::{
-    clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods,
-};
+use azure_data_cosmos::CosmosClient;
 use clap::{Args, Subcommand};
 
 /// Deletes an item, database, or container.

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/metadata.rs
@@ -3,10 +3,7 @@
 
 use std::error::Error;
 
-use azure_data_cosmos::{
-    clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods,
-};
+use azure_data_cosmos::CosmosClient;
 use clap::Args;
 
 /// Retrieves basic metadata about databases and containers.

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
@@ -1,9 +1,6 @@
 use std::error::Error;
 
-use azure_data_cosmos::{
-    clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods, PartitionKey,
-};
+use azure_data_cosmos::{CosmosClient, PartitionKey};
 use clap::{Args, Subcommand};
 use futures::StreamExt;
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
@@ -1,10 +1,7 @@
 use std::error::Error;
 
 use azure_core::StatusCode;
-use azure_data_cosmos::{
-    clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods,
-};
+use azure_data_cosmos::CosmosClient;
 use clap::Args;
 
 /// Reads a specific item.

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
@@ -1,10 +1,7 @@
 use std::error::Error;
 
 use azure_core::StatusCode;
-use azure_data_cosmos::{
-    clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods, PartitionKey,
-};
+use azure_data_cosmos::{CosmosClient, PartitionKey};
 use clap::Args;
 
 /// Creates a new item.

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/upsert.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/upsert.rs
@@ -1,9 +1,6 @@
 use std::error::Error;
 
-use azure_data_cosmos::{
-    clients::{ContainerClientMethods, DatabaseClientMethods},
-    CosmosClient, CosmosClientMethods, PartitionKey,
-};
+use azure_data_cosmos::{CosmosClient, PartitionKey};
 use clap::Args;
 
 /// Creates a new item or replaces an existing item, if a matching item already exists.

--- a/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/mod.rs
@@ -7,6 +7,6 @@ mod container_client;
 mod cosmos_client;
 mod database_client;
 
-pub use container_client::{ContainerClient, ContainerClientMethods};
-pub use cosmos_client::{CosmosClient, CosmosClientMethods};
-pub use database_client::{DatabaseClient, DatabaseClientMethods};
+pub use container_client::ContainerClient;
+pub use cosmos_client::CosmosClient;
+pub use database_client::DatabaseClient;

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -21,7 +21,7 @@ pub(crate) mod utils;
 pub mod models;
 
 #[doc(inline)]
-pub use clients::{CosmosClient, CosmosClientMethods};
+pub use clients::CosmosClient;
 
 pub use options::*;
 pub use partition_key::*;

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -8,9 +8,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::models::{IndexingPolicy, PartitionKeyDefinition, SystemProperties};
 
-#[cfg(doc)]
-use crate::clients::ContainerClientMethods;
-
 fn deserialize_ttl<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
 where
     D: Deserializer<'de>,

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -6,12 +6,6 @@
 use azure_core::{date::OffsetDateTime, Model};
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 
-#[cfg(doc)]
-use crate::{
-    clients::{ContainerClient, ContainerClientMethods, DatabaseClientMethods},
-    CosmosClientMethods,
-};
-
 mod container_properties;
 mod indexing_policy;
 mod item;
@@ -41,7 +35,7 @@ where
     }
 }
 
-/// A page of query results, where each item is of type `T`.
+/// A page of query results from [`ContainerClient::query_items`](crate::clients::ContainerClient::query_items()) where each item is of type `T`.
 #[non_exhaustive]
 #[derive(Clone, Default, Debug, Deserialize)]
 pub struct QueryResults<T> {
@@ -57,7 +51,7 @@ impl<T: DeserializeOwned> azure_core::Model for QueryResults<T> {
     }
 }
 
-/// A page of results from [`CosmosClient::query_databases`](crate::clients::CosmosClient::query_databases())
+/// A page of results from [`CosmosClient::query_databases`](crate::CosmosClient::query_databases())
 #[non_exhaustive]
 #[derive(Clone, Default, Debug, Deserialize, Model)]
 pub struct DatabaseQueryResults {

--- a/sdk/cosmos/azure_data_cosmos/src/options/create_container_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/create_container_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::DatabaseClientMethods;
-
 /// Options to be passed to [`DatabaseClient::create_container()`](crate::clients::DatabaseClient::create_container()).
 #[derive(Clone, Debug, Default)]
 pub struct CreateContainerOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/create_database_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/create_database_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::CosmosClientMethods;
-
 /// Options to be passed to [`CosmosClient::create_database()`](crate::CosmosClient::create_database()).
 #[derive(Clone, Debug, Default)]
 pub struct CreateDatabaseOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/delete_container_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/delete_container_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::ContainerClientMethods;
-
 /// Options to be passed to [`ContainerClient::delete()`](crate::clients::ContainerClient::delete()).
 #[derive(Clone, Debug, Default)]
 pub struct DeleteContainerOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/delete_database_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/delete_database_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::DatabaseClientMethods;
-
 /// Options to be passed to [`DatabaseClient::delete()`](crate::clients::DatabaseClient::delete()).
 #[derive(Clone, Debug, Default)]
 pub struct DeleteDatabaseOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/item_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/item_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::ContainerClientMethods;
-
 /// Options to be passed to APIs that manipulate items.
 #[derive(Clone, Debug, Default)]
 pub struct ItemOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_containers_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::DatabaseClientMethods;
-
 /// Options to be passed to [`DatabaseClient::query_containers()`](crate::clients::DatabaseClient)
 #[derive(Clone, Debug, Default)]
 pub struct QueryContainersOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_databases_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::CosmosClientMethods;
-
 /// Options to be passed to [`CosmosClient::query_databases()`](crate::CosmosClient)
 #[derive(Clone, Debug, Default)]
 pub struct QueryDatabasesOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/query_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/query_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::ContainerClientMethods;
-
 /// Options to be passed to [`ContainerClient::query_items()`](crate::clients::ContainerClient::query_items()).
 #[derive(Clone, Debug, Default)]
 pub struct QueryOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/read_container_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/read_container_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::ContainerClientMethods;
-
 /// Options to be passed to [`ContainerClient::read()`](crate::clients::ContainerClient::read()).
 #[derive(Clone, Debug, Default)]
 pub struct ReadContainerOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/options/read_database_options.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/read_database_options.rs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#[cfg(doc)]
-use crate::clients::DatabaseClientMethods;
-
 /// Options to be passed to [`DatabaseClient::read()`](crate::clients::DatabaseClient::read()).
 #[derive(Clone, Debug, Default)]
 pub struct ReadDatabaseOptions {}

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -32,7 +32,7 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// A single, non-hierarchical, partition key can be specified using the underlying type itself:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # use azure_data_cosmos::clients::ContainerClient;
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
@@ -47,7 +47,7 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// Hierarchical partition keys can be specified using tuples:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # use azure_data_cosmos::clients::ContainerClient;
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
@@ -59,7 +59,7 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// First, you can use an empty tuple (`()`) anywhere a `PartitionKey` is expected:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # use azure_data_cosmos::clients::ContainerClient;
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
@@ -74,7 +74,7 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// Or, if you have an [`Option<T>`], for some `T` that is valid as a partition key, it will automatically be serialized as `null` if it has the value [`Option::None`]:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::clients::{ContainerClient, ContainerClientMethods};
+/// # use azure_data_cosmos::clients::ContainerClient;
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// let my_partition_key: Option<String> = None;
 /// container_client.query_items::<serde_json::Value>(


### PR DESCRIPTION
After some discussion with the SDK team, we've decided to remove the `...Methods` traits that were the initial mechanism by which we provided "mockability". Traits in Rust aren't quite as straightforward to use as interfaces in .NET/Java and came with a few downsides.

So, for now, we're removing them, since adding them later (or taking one of a few other alternative paths to "mockability") can be done without introducing a breaking change, plus we're not GA yet and could take a potential breaking change.

This PR removes all the `...Methods` traits from `azure_data_cosmos` and converts the methods that _were_ implemented through those traits to be directly implemented on the client types themselves. No functional changes to the implementations themselves, just code re-organization.