### PR TITLE
Remove duplicate re-export of Model macro

### DIFF
--- a/sdk/core/azure_core/src/lib.rs
+++ b/sdk/core/azure_core/src/lib.rs
@@ -38,7 +38,6 @@ pub use models::*;
 pub use options::*;
 pub use pipeline::*;
 pub use policies::*;
-pub use typespec_client_core::http::response::{Model, PinnedStream, Response, ResponseBody};
 
 // Re-export typespec types that are not specific to Azure.
 pub use typespec::{Error, Result};
@@ -51,8 +50,11 @@ pub use typespec_client_core::xml;
 pub use typespec_client_core::{
     base64, date,
     http::{
-        headers::Header, new_http_client, AppendToUrlQuery, Body, Context, HttpClient, Method,
-        Pager, Request, RequestContent, StatusCode, Url,
+        headers::Header,
+        new_http_client,
+        response::{Model, PinnedStream, Response, ResponseBody},
+        AppendToUrlQuery, Body, Context, HttpClient, Method, Pager, Request, RequestContent,
+        StatusCode, Url,
     },
     json, parsing,
     sleep::{self, sleep},

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/response.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/response.rs
@@ -3,10 +3,9 @@
 
 #![allow(dead_code)]
 
-use azure_core::credentials::Secret;
+use azure_core::{credentials::Secret, Model};
 use serde::{Deserialize, Deserializer};
 use time::OffsetDateTime;
-use typespec_client_core::Model;
 
 #[derive(Debug, Clone, Deserialize)]
 struct RawLoginResponse {

--- a/sdk/identity/azure_identity/src/refresh_token.rs
+++ b/sdk/identity/azure_identity/src/refresh_token.rs
@@ -9,12 +9,11 @@ use azure_core::{
     error::{http_response_from_body, Error, ErrorKind, ResultExt},
     headers,
     json::from_json,
-    HttpClient, Method, Request, Url,
+    HttpClient, Method, Model, Request, Url,
 };
 use serde::Deserialize;
 use std::fmt;
 use std::sync::Arc;
-use typespec_client_core::Model;
 use url::form_urlencoded;
 
 /// Exchange a refresh token for a new access token and refresh token.

--- a/sdk/typespec/typespec_client_core/src/lib.rs
+++ b/sdk/typespec/typespec_client_core/src/lib.rs
@@ -20,6 +20,3 @@ pub mod xml;
 
 pub use crate::error::{Error, Result};
 pub use uuid::Uuid;
-
-#[cfg(feature = "derive")]
-pub use typespec_derive::Model;


### PR DESCRIPTION
Also re-exports `Model` from `azure_core` along with some other types that were exported from the crate root in track 1.
