### PR TITLE
Add binary request example

### DIFF
--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -50,7 +50,7 @@ hmac_openssl = ["dep:openssl"]
 test_e2e = []
 azurite_workaround = []
 xml = ["typespec_client_core/xml"]
-tokio_fs = ["tokio/fs", "tokio/sync", "tokio/io-util"]
+tokio_fs = ["typespec_client_core/tokio_fs"]
 tokio_sleep = ["typespec_client_core/tokio_sleep"]
 
 [package.metadata.docs.rs]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -41,25 +41,25 @@ tokio = { workspace = true, features = ["macros", "rt", "time"] }
 [dev-dependencies]
 once_cell.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 typespec_derive.workspace = true
 
 [features]
-default = [
-  "http",
-  "json",
-  "reqwest",
-  "reqwest_gzip",
-  "reqwest_rustls",
-  "tokio_sleep",
-]
+default = ["http", "json", "reqwest", "reqwest_gzip", "reqwest_rustls"]
 derive = ["dep:typespec_derive"]
 http = ["dep:http-types", "typespec/http"]
 json = ["typespec/json"]
 reqwest = ["dep:reqwest", "reqwest/default-tls"]
 reqwest_gzip = ["reqwest/gzip"]
 reqwest_rustls = ["reqwest/rustls-tls"]
+tokio_fs = ["tokio/fs", "tokio/sync", "tokio/io-util"]
 tokio_sleep = ["tokio/time"]
 xml = ["dep:quick-xml"]
+
+[[example]]
+name = "binary_data_request"
+required-features = ["tokio_fs", "tokio_sleep"]
 
 [[example]]
 name = "stream_response"

--- a/sdk/typespec/typespec_client_core/examples/binary_data_request.rs
+++ b/sdk/typespec/typespec_client_core/examples/binary_data_request.rs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use tokio::fs;
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use typespec_client_core::{
+    fs::FileStreamBuilder,
+    http::{Body, RequestContent},
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Log traces to stdout.
+    let _log = tracing_subscriber::fmt()
+        .with_span_events(FmtSpan::ENTER | FmtSpan::EXIT)
+        .with_max_level(LevelFilter::DEBUG)
+        .init();
+
+    // Asynchronously read the whole file into memory.
+    let body = RequestContent::from(fs::read(file!()).await?);
+    client::put_binary_data(body).await?;
+
+    // Asynchronously stream the file with the service client request.
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let file = fs::File::open(file!()).await?;
+        let file = FileStreamBuilder::new(file)
+            // Simulate a slow, chunky request.
+            .buffer_size(256usize)
+            .build()
+            .await?;
+        let body: Body = file.into();
+        client::put_binary_data(body.into()).await?;
+    }
+
+    Ok(())
+}
+
+mod client {
+    use futures::StreamExt;
+    use tracing::debug;
+    use typespec_client_core::{
+        http::{headers::Headers, Body, RequestContent, Response, StatusCode},
+        stream::BytesStream,
+    };
+
+    #[tracing::instrument(skip(body))]
+    pub async fn put_binary_data(
+        body: RequestContent<()>,
+    ) -> typespec_client_core::Result<Response<()>> {
+        let body: RequestContent<()> = body.into();
+        let body: Body = body.into();
+
+        let content = match body {
+            Body::Bytes(ref bytes) => {
+                debug!("received bytes");
+                bytes.to_owned()
+            }
+            Body::SeekableStream(mut stream) => {
+                debug!("received stream");
+                let stream = stream.as_mut();
+
+                let mut bytes = Vec::new();
+                while let Some(buf) = stream.next().await {
+                    debug!("reading partial request...");
+                    bytes.extend(buf?);
+                }
+
+                bytes.into()
+            }
+        };
+
+        // Assume bytes are a string in this example.
+        let content = String::from_utf8(content.into())?;
+        println!("{content}");
+
+        Ok(Response::new(
+            StatusCode::NoContent,
+            Headers::new(),
+            Box::pin(BytesStream::new_empty()),
+        ))
+    }
+}

--- a/sdk/typespec/typespec_client_core/examples/binary_data_request.rs
+++ b/sdk/typespec/typespec_client_core/examples/binary_data_request.rs
@@ -4,10 +4,7 @@
 use tokio::fs;
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
-use typespec_client_core::{
-    fs::FileStreamBuilder,
-    http::{Body, RequestContent},
-};
+use typespec_client_core::{fs::FileStreamBuilder, http::RequestContent};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -30,8 +27,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .buffer_size(256usize)
             .build()
             .await?;
-        let body: Body = file.into();
-        client::put_binary_data(body.into()).await?;
+        client::put_binary_data(file.into()).await?;
     }
 
     Ok(())

--- a/sdk/typespec/typespec_client_core/src/fs/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/fs/mod.rs
@@ -2,4 +2,7 @@
 // Licensed under the MIT License.
 
 #[cfg(feature = "tokio_fs")]
-pub use typespec_client_core::fs::*;
+mod tokio;
+
+#[cfg(feature = "tokio_fs")]
+pub use tokio::*;

--- a/sdk/typespec/typespec_client_core/src/fs/tokio.rs
+++ b/sdk/typespec/typespec_client_core/src/fs/tokio.rs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use crate::{
+    http::Body,
+    setters,
+    stream::{SeekableStream, DEFAULT_BUFFER_SIZE},
+};
 use futures::{task::Poll, Future};
 use std::{cmp::min, io::SeekFrom, pin::Pin, sync::Arc, task::Context};
 use tokio::{
@@ -9,11 +14,6 @@ use tokio::{
     sync::Mutex,
 };
 use tracing::debug;
-use typespec_client_core::{
-    http::Body,
-    setters,
-    stream::{SeekableStream, DEFAULT_BUFFER_SIZE},
-};
 
 #[derive(Debug)]
 pub struct FileStreamBuilder {

--- a/sdk/typespec/typespec_client_core/src/fs/tokio.rs
+++ b/sdk/typespec/typespec_client_core/src/fs/tokio.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    http::Body,
+    http::{Body, RequestContent},
     setters,
     stream::{SeekableStream, DEFAULT_BUFFER_SIZE},
 };
@@ -166,5 +166,19 @@ impl From<&FileStream> for Body {
 impl From<FileStream> for Body {
     fn from(stream: FileStream) -> Self {
         Body::SeekableStream(Box::new(stream))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T> From<&FileStream> for RequestContent<T> {
+    fn from(stream: &FileStream) -> Self {
+        Body::from(stream).into()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T> From<FileStream> for RequestContent<T> {
+    fn from(stream: FileStream) -> Self {
+        Body::from(stream).into()
     }
 }

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -217,6 +217,26 @@ impl<T> From<Body> for RequestContent<T> {
     }
 }
 
+#[cfg(all(feature = "tokio_fs", not(target_arch = "wasm32")))]
+impl<T> From<crate::fs::FileStream> for RequestContent<T> {
+    fn from(body: crate::fs::FileStream) -> Self {
+        Self {
+            body: body.into(),
+            phantom: PhantomData,
+        }
+    }
+}
+
+#[cfg(all(feature = "tokio_fs", not(target_arch = "wasm32")))]
+impl<T> From<&crate::fs::FileStream> for RequestContent<T> {
+    fn from(body: &crate::fs::FileStream) -> Self {
+        Self {
+            body: body.into(),
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<T> TryFrom<Bytes> for RequestContent<T> {
     type Error = crate::Error;
     fn try_from(body: Bytes) -> Result<Self, Self::Error> {

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -208,6 +208,15 @@ impl<T> From<RequestContent<T>> for Body {
     }
 }
 
+impl<T> From<Body> for RequestContent<T> {
+    fn from(body: Body) -> Self {
+        Self {
+            body,
+            phantom: PhantomData,
+        }
+    }
+}
+
 impl<T> TryFrom<Bytes> for RequestContent<T> {
     type Error = crate::Error;
     fn try_from(body: Bytes) -> Result<Self, Self::Error> {

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -217,26 +217,6 @@ impl<T> From<Body> for RequestContent<T> {
     }
 }
 
-#[cfg(all(feature = "tokio_fs", not(target_arch = "wasm32")))]
-impl<T> From<crate::fs::FileStream> for RequestContent<T> {
-    fn from(body: crate::fs::FileStream) -> Self {
-        Self {
-            body: body.into(),
-            phantom: PhantomData,
-        }
-    }
-}
-
-#[cfg(all(feature = "tokio_fs", not(target_arch = "wasm32")))]
-impl<T> From<&crate::fs::FileStream> for RequestContent<T> {
-    fn from(body: &crate::fs::FileStream) -> Self {
-        Self {
-            body: body.into(),
-            phantom: PhantomData,
-        }
-    }
-}
-
 impl<T> TryFrom<Bytes> for RequestContent<T> {
     type Error = crate::Error;
     fn try_from(body: Bytes) -> Result<Self, Self::Error> {

--- a/sdk/typespec/typespec_client_core/src/lib.rs
+++ b/sdk/typespec/typespec_client_core/src/lib.rs
@@ -8,6 +8,7 @@ mod macros;
 pub mod base64;
 pub mod date;
 pub mod error;
+pub mod fs;
 #[cfg(feature = "http")]
 pub mod http;
 #[cfg(feature = "json")]


### PR DESCRIPTION
Also refactors `FileStream` from `azure_core` to `typespec_client_core`, plus some trait implementations on necessary request structures to make it all work.