### PR TITLE
Update Rust's CODEOWNERS baseline files to remove a couple of invalid path entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,9 +31,6 @@
 # GitHub integration and bot rules
 /.github/                @heaths @RickWinter @ronniegeraghty @LarryOsterman
 
-# PRLabel: %EngSys
-/sdk/template/           @weshaggard @heaths @RickWinter
-
 ###########
 # SDK
 ###########
@@ -70,10 +67,8 @@
 ###########
 /eng/                    @weshaggard @heaths @RickWinter
 /eng/common/             @Azure/azure-sdk-eng
-/.config/1espt/          @benbp @weshaggard
 /.github/workflows/      @Azure/azure-sdk-eng
 /.github/CODEOWNERS      @RickWinter @ronniegeraghty @Azure/azure-sdk-eng
 
 # Add owners for notifications for specific pipelines
 /eng/common/pipelines/codeowners-linter.yml       @rickwinter
-/eng/pipelines/aggregate-reports.yml              @rickwinter                


### PR DESCRIPTION
I discovered these entries when I was generating the CODEOWNERS_baseline_errors.txt file for Rust in preparation for creating Rust's codeowners-linter pipeline. As it turns out, these were the only errors because their paths do not exist in the repository.

As per @heaths's guidance the entires for /sdk/template/ and /eng/pipelines/aggregate-reports.yml were removed.

As per @weshaggard's explanation, the /.config/1espt/ doesn't exist yet but will when we start auto-baselining functionality from the 1ES template. The entry should be recreated at that time.

@RickWinter - Congratulations! With the above errors being fixed in this PR, Rust does not yet need a baseline error file making it only repository that doesn't.