### PR TITLE
retry_policy: verbose logging for io errors

### DIFF
--- a/sdk/core/src/policies/retry_policies/retry_policy.rs
+++ b/sdk/core/src/policies/retry_policies/retry_policy.rs
@@ -174,7 +174,7 @@ where
                 Err(error) => {
                     if error.kind() == &ErrorKind::Io {
                         debug!(
-                            "io error occurred when making request which will be retried: {}",
+                            "io error occurred when making request which will be retried: {:?}",
                             error
                         );
                         // IO error so no Retry-After headers - leave the retry period up to the policy


### PR DESCRIPTION
may contain information necessary for triaging the issue.

spent waay too much time debugging an issue where ca-certificates was not installed, here's an example of how that error looks.

before:
```
[2024-11-04T21:17:40Z DEBUG azure_core::policies::retry_policies::retry_policy] io error occurred when making request which will be retried: failed to execute `reqwest` request
```

after:
```
[2024-11-04T20:52:39Z DEBUG azure_core::policies::retry_policies::retry_policy] io error occurred when making request which will be retried: Error { context: Full(Custom { kind: Io, error: reqwest::Error { kind: Request, url: "REDACTED", source: hyper_util::client::legacy::Error(Connect, Ssl(Error { code: ErrorCode(1), cause: Some(Ssl(ErrorStack([Error { code: 167772294, library: "SSL routines", function: "tls_post_process_server_certificate", reason: "certificate verify failed", file: "../ssl/statem/statem_clnt.c", line: 1889 }]))) }, X509VerifyResult { code: 20, error: "unable to get local issuer certificate" })) } }, "failed to execute `reqwest` request") }
```