### PR TITLE
Fix typespec_derive compilation tests

### DIFF
--- a/sdk/typespec/typespec_derive/tests/compilation-tests.rs
+++ b/sdk/typespec/typespec_derive/tests/compilation-tests.rs
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Stdio,
+};
+
 use cargo_metadata::{diagnostic::DiagnosticLevel, Message};
 use serde::Serialize;
-use std::{collections::HashMap, path::PathBuf, process::Stdio};
 
 #[derive(Serialize)]
 struct MessageExpectation {
@@ -67,11 +72,6 @@ pub fn compilation_tests() {
         p.pop(); // [root]/sdk/typespec
         p.pop(); // [root]/sdk
         p.pop(); // [root]
-        p
-    };
-    let src_root = {
-        let mut p = test_root.clone();
-        p.push("src");
         p
     };
 

--- a/sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.expected.json
+++ b/sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.expected.json
@@ -5,7 +5,7 @@
     "message": "invalid typespec attribute, expected attribute in form #[typespec(key = value)]",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 8
       }
     ]
@@ -16,7 +16,7 @@
     "message": "expected string literal",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 12
       }
     ]
@@ -27,7 +27,7 @@
     "message": "expected string literal",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 16
       }
     ]
@@ -38,7 +38,7 @@
     "message": "expected string literal",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 20
       }
     ]
@@ -49,7 +49,7 @@
     "message": "invalid module path: a b c",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 24
       }
     ]
@@ -60,7 +60,7 @@
     "message": "expected string literal",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 28
       }
     ]
@@ -71,7 +71,7 @@
     "message": "invalid typespec attribute, expected attribute in form #[typespec(key = value)]",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 32
       }
     ]
@@ -82,7 +82,7 @@
     "message": "invalid typespec attribute, expected attribute in form #[typespec(key = value)]",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/bad_attributes.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/bad_attributes.rs",
         "line": 36
       }
     ]

--- a/sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/not_derive_deserialize.expected.json
+++ b/sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/not_derive_deserialize.expected.json
@@ -5,7 +5,7 @@
     "message": null,
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/not_derive_deserialize.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/not_derive_deserialize.rs",
         "line": 6
       }
     ]

--- a/sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/unknown_format.expected.json
+++ b/sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/unknown_format.expected.json
@@ -5,7 +5,7 @@
     "message": "Unknown format 'foobar'",
     "spans": [
       {
-        "file_name": "sdk/typespec/typespec_derive/compilation-tests/src/model/unknown_format.rs",
+        "file_name": "sdk/typespec/typespec_derive/tests/data/compilation-tests/src/model/unknown_format.rs",
         "line": 8
       }
     ]


### PR DESCRIPTION
Fixes #1896 

There were two problems here, and I've fixed both:

1. The compilation tests have the wrong path in their path reference. I moved the compilation tests to a different directory and forgot to update this. However, because of the next issue, the tests didn't fail

2. The tests don't fail if a file produces _no errors_. We collect all errors, group by file, and then look for an `.expected.json` to compare/generate a baseline. However, if a file produces no errors but _has_ an `.expected.json` file, we don't fail.

Fixing 2 caused 1 to immediately start failing the test.

To fix 2, I went with a fairly simple approach for now of scanning for `.expected.json` files in the test project. Then we compare that list against the list of files the compiler found errors in (after sorting both consistently). This does mean that when adding a new file, you'll have to add an empty `.expected.json` file for it, but that should be OK given how infrequently we update these files.