### PR TITLE
Removed builders from AMQP

### DIFF
--- a/sdk/core/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure_core_amqp/src/connection.rs
@@ -15,21 +15,18 @@ type ConnectionImplementation = super::noop::NoopAmqpConnection;
 
 #[derive(Debug, Default, Clone)]
 pub struct AmqpConnectionOptions {
-    pub(crate) max_frame_size: Option<u32>,
-    pub(crate) channel_max: Option<u16>,
-    pub(crate) idle_timeout: Option<Duration>,
-    pub(crate) outgoing_locales: Option<Vec<String>>,
-    pub(crate) incoming_locales: Option<Vec<String>>,
-    pub(crate) offered_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(crate) desired_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(crate) properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    pub(crate) buffer_size: Option<usize>,
+    pub max_frame_size: Option<u32>,
+    pub channel_max: Option<u16>,
+    pub idle_timeout: Option<Duration>,
+    pub outgoing_locales: Option<Vec<String>>,
+    pub incoming_locales: Option<Vec<String>>,
+    pub offered_capabilities: Option<Vec<AmqpSymbol>>,
+    pub desired_capabilities: Option<Vec<AmqpSymbol>>,
+    pub properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
+    pub buffer_size: Option<usize>,
 }
 
 impl AmqpConnectionOptions {
-    pub fn builder() -> builders::AmqpConnectionOptionsBuilder {
-        builders::AmqpConnectionOptionsBuilder::new()
-    }
     pub fn max_frame_size(&self) -> Option<u32> {
         self.max_frame_size
     }
@@ -111,127 +108,69 @@ impl AmqpConnection {
     }
 }
 
-pub mod builders {
-    use super::*;
-    pub struct AmqpConnectionOptionsBuilder {
-        options: AmqpConnectionOptions,
-    }
-
-    impl AmqpConnectionOptionsBuilder {
-        pub(super) fn new() -> Self {
-            Self {
-                options: Default::default(),
-            }
-        }
-        pub fn build(self) -> AmqpConnectionOptions {
-            self.options
-        }
-        pub fn with_max_frame_size(mut self, max_frame_size: u32) -> Self {
-            self.options.max_frame_size = Some(max_frame_size);
-            self
-        }
-        pub fn with_channel_max(mut self, channel_max: u16) -> Self {
-            self.options.channel_max = Some(channel_max);
-            self
-        }
-        pub fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
-            self.options.idle_timeout = Some(idle_timeout);
-            self
-        }
-        pub fn with_outgoing_locales(mut self, outgoing_locales: Vec<String>) -> Self {
-            self.options.outgoing_locales = Some(outgoing_locales);
-            self
-        }
-        pub fn with_incoming_locales(mut self, incoming_locales: Vec<String>) -> Self {
-            self.options.incoming_locales = Some(incoming_locales);
-            self
-        }
-        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.offered_capabilities = Some(offered_capabilities);
-            self
-        }
-        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.desired_capabilities = Some(desired_capabilities);
-            self
-        }
-        pub fn with_properties<K, V>(mut self, properties: impl Into<AmqpOrderedMap<K, V>>) -> Self
-        where
-            K: Into<AmqpSymbol> + Debug + Clone + PartialEq,
-            V: Into<AmqpValue> + Debug + Clone,
-        {
-            let properties_map: AmqpOrderedMap<K, V> = properties.into();
-            let properties_map = properties_map
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
-                .collect();
-            self.options.properties = Some(properties_map);
-            self
-        }
-        pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
-            self.options.buffer_size = Some(buffer_size);
-            self
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_amqp_connection_builder_with_max_frame_size() {
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_max_frame_size(1024)
-            .build();
-
+    fn test_amqp_connection_options_with_max_frame_size() {
+        let connection_options = AmqpConnectionOptions {
+            max_frame_size: Some(1024),
+            ..Default::default()
+        };
         assert_eq!(connection_options.max_frame_size, Some(1024));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_channel_max() {
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_channel_max(16)
-            .build();
+    fn test_amqp_connection_options_with_channel_max() {
+        let connection_options = AmqpConnectionOptions {
+            channel_max: Some(16),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.channel_max, Some(16));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_idle_timeout() {
+    fn test_amqp_connection_options_with_idle_timeout() {
         let idle_timeout = time::Duration::seconds(60);
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_idle_timeout(idle_timeout)
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            idle_timeout: Some(idle_timeout),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.idle_timeout, Some(idle_timeout));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_outgoing_locales() {
+    fn test_amqp_connection_options_with_outgoing_locales() {
         let outgoing_locales = vec!["en-US".to_string()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_outgoing_locales(outgoing_locales.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            outgoing_locales: Some(outgoing_locales.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.outgoing_locales, Some(outgoing_locales));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_incoming_locales() {
+    fn test_amqp_connection_options_with_incoming_locales() {
         let incoming_locales = vec!["en-US".to_string()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_incoming_locales(incoming_locales.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            incoming_locales: Some(incoming_locales.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.incoming_locales, Some(incoming_locales));
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_offered_capabilities() {
+    fn test_amqp_connection_options_with_offered_capabilities() {
         let offered_capabilities = vec!["capability".into()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_offered_capabilities(offered_capabilities.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            offered_capabilities: Some(offered_capabilities.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(
             connection_options.offered_capabilities,
@@ -240,11 +179,12 @@ mod tests {
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_desired_capabilities() {
+    fn test_amqp_connection_options_with_desired_capabilities() {
         let desired_capabilities = vec!["capability".into()];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_desired_capabilities(desired_capabilities.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            desired_capabilities: Some(desired_capabilities.clone()),
+            ..Default::default()
+        };
 
         assert_eq!(
             connection_options.desired_capabilities,
@@ -253,11 +193,17 @@ mod tests {
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_properties() {
+    fn test_amqp_connection_options_with_properties() {
         let properties = vec![("key", "value")];
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_properties(properties.clone())
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            properties: Some(
+                properties
+                    .iter()
+                    .map(|(k, v)| (AmqpSymbol::from(*k), AmqpValue::from(*v)))
+                    .collect(),
+            ),
+            ..Default::default()
+        };
 
         let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
             .into_iter()
@@ -268,28 +214,34 @@ mod tests {
     }
 
     #[test]
-    fn test_amqp_connection_builder_with_buffer_size() {
+    fn test_amqp_connection_options_with_buffer_size() {
         let buffer_size = 1024;
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_buffer_size(buffer_size)
-            .build();
+        let connection_options = AmqpConnectionOptions {
+            buffer_size: Some(buffer_size),
+            ..Default::default()
+        };
 
         assert_eq!(connection_options.buffer_size, Some(buffer_size));
     }
 
     #[test]
-    fn test_amqp_connection_builder() {
-        let connection_options = AmqpConnectionOptions::builder()
-            .with_max_frame_size(1024)
-            .with_channel_max(16)
-            .with_idle_timeout(time::Duration::seconds(60))
-            .with_outgoing_locales(vec!["en-US".to_string()])
-            .with_incoming_locales(vec!["en-US".to_string()])
-            .with_offered_capabilities(vec!["capability".into()])
-            .with_desired_capabilities(vec!["capability".into()])
-            .with_properties(vec![("key", "value")])
-            .with_buffer_size(1024)
-            .build();
+    fn test_amqp_connection_options() {
+        let connection_options = AmqpConnectionOptions {
+            max_frame_size: Some(1024),
+            channel_max: Some(16),
+            idle_timeout: Some(time::Duration::seconds(60)),
+            outgoing_locales: Some(vec!["en-US".to_string()]),
+            incoming_locales: Some(vec!["en-US".to_string()]),
+            offered_capabilities: Some(vec!["capability".into()]),
+            desired_capabilities: Some(vec!["capability".into()]),
+            properties: Some(
+                vec![("key", "value")]
+                    .into_iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect(),
+            ),
+            buffer_size: Some(1024),
+        };
 
         assert_eq!(connection_options.max_frame_size, Some(1024));
         assert_eq!(connection_options.channel_max, Some(16));

--- a/sdk/core/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure_core_amqp/src/connection.rs
@@ -26,35 +26,7 @@ pub struct AmqpConnectionOptions {
     pub buffer_size: Option<usize>,
 }
 
-impl AmqpConnectionOptions {
-    pub fn max_frame_size(&self) -> Option<u32> {
-        self.max_frame_size
-    }
-    pub fn channel_max(&self) -> Option<u16> {
-        self.channel_max
-    }
-    pub fn idle_timeout(&self) -> Option<&Duration> {
-        self.idle_timeout.as_ref()
-    }
-    pub fn outgoing_locales(&self) -> Option<&Vec<String>> {
-        self.outgoing_locales.as_ref()
-    }
-    pub fn incoming_locales(&self) -> Option<&Vec<String>> {
-        self.incoming_locales.as_ref()
-    }
-    pub fn offered_capabilities(&self) -> Option<&Vec<AmqpSymbol>> {
-        self.offered_capabilities.as_ref()
-    }
-    pub fn desired_capabilities(&self) -> Option<&Vec<AmqpSymbol>> {
-        self.desired_capabilities.as_ref()
-    }
-    pub fn properties(&self) -> Option<&AmqpOrderedMap<AmqpSymbol, AmqpValue>> {
-        self.properties.as_ref()
-    }
-    pub fn buffer_size(&self) -> Option<usize> {
-        self.buffer_size
-    }
-}
+impl AmqpConnectionOptions {}
 
 pub trait AmqpConnectionApis {
     fn open(

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -135,32 +135,27 @@ impl From<fe2o3_amqp_types::messaging::ApplicationProperties>
 
 impl From<fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
     fn from(header: fe2o3_amqp_types::messaging::Header) -> Self {
-        println!("Source Header: {:?}", header);
-        let rv = AmqpMessageHeader::builder()
-            .with_durable(header.durable)
-            .with_priority(header.priority.into())
-            .with_time_to_live(
-                header
-                    .ttl
-                    .map(|t| std::time::Duration::from_millis(t as u64)),
-            )
-            .with_first_acquirer(header.first_acquirer)
-            .with_delivery_count(header.delivery_count)
-            .build();
-        println!("Converted Header: {:?}", rv);
-        rv
+        AmqpMessageHeader {
+            durable: header.durable,
+            priority: header.priority.into(),
+            time_to_live: header
+                .ttl
+                .map(|t| std::time::Duration::from_millis(t as u64)),
+            first_acquirer: (header.first_acquirer),
+            delivery_count: (header.delivery_count),
+        }
     }
 }
 
 impl From<AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
     fn from(header: AmqpMessageHeader) -> Self {
-        fe2o3_amqp_types::messaging::Header::builder()
-            .durable(header.durable())
-            .priority(fe2o3_amqp_types::messaging::Priority(header.priority()))
-            .ttl(header.time_to_live().map(|t| t.as_millis() as u32))
-            .first_acquirer(header.first_acquirer())
-            .delivery_count(header.delivery_count())
-            .build()
+        fe2o3_amqp_types::messaging::Header {
+            durable: header.durable,
+            priority: fe2o3_amqp_types::messaging::Priority(header.priority),
+            ttl: header.time_to_live.map(|t| t.as_millis() as u32),
+            first_acquirer: header.first_acquirer,
+            delivery_count: header.delivery_count,
+        }
     }
 }
 
@@ -337,59 +332,48 @@ fn test_message_annotation_conversion() {
 
 impl From<fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
     fn from(properties: fe2o3_amqp_types::messaging::Properties) -> Self {
-        let mut amqp_message_properties_builder = AmqpMessageProperties::builder();
+        let mut amqp_message_properties = AmqpMessageProperties::default();
 
         if let Some(message_id) = properties.message_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_message_id(message_id);
+            amqp_message_properties.message_id = Some(message_id.into());
         }
         if let Some(user_id) = properties.user_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_user_id(user_id.to_vec());
+            amqp_message_properties.user_id = Some(user_id.to_vec());
         }
         if let Some(to) = properties.to {
-            amqp_message_properties_builder = amqp_message_properties_builder.with_to(to);
+            amqp_message_properties.to = Some(to);
         }
         if let Some(subject) = properties.subject {
-            amqp_message_properties_builder = amqp_message_properties_builder.with_subject(subject);
+            amqp_message_properties.subject = Some(subject);
         }
         if let Some(reply_to) = properties.reply_to {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_reply_to(reply_to);
+            amqp_message_properties.reply_to = Some(reply_to);
         }
         if let Some(correlation_id) = properties.correlation_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_correlation_id(correlation_id);
+            amqp_message_properties.correlation_id = Some(correlation_id.into());
         }
         if let Some(content_type) = properties.content_type {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_content_type(content_type.into());
+            amqp_message_properties.content_type = Some(content_type.into());
         }
         if let Some(content_encoding) = properties.content_encoding {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_content_encoding(content_encoding.into());
+            amqp_message_properties.content_encoding = Some(content_encoding.into());
         }
         if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_absolute_expiry_time(absolute_expiry_time);
+            amqp_message_properties.absolute_expiry_time = Some(absolute_expiry_time.into());
         }
         if let Some(creation_time) = properties.creation_time {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_creation_time(creation_time);
+            amqp_message_properties.creation_time = Some(creation_time.into());
         }
         if let Some(group_id) = properties.group_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_group_id(group_id);
+            amqp_message_properties.group_id = Some(group_id);
         }
         if let Some(group_sequence) = properties.group_sequence {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_group_sequence(group_sequence);
+            amqp_message_properties.group_sequence = Some(group_sequence);
         }
         if let Some(reply_to_group_id) = properties.reply_to_group_id {
-            amqp_message_properties_builder =
-                amqp_message_properties_builder.with_reply_to_group_id(reply_to_group_id);
+            amqp_message_properties.reply_to_group_id = Some(reply_to_group_id);
         }
-        amqp_message_properties_builder.build()
+        amqp_message_properties
     }
 }
 
@@ -397,45 +381,45 @@ impl From<AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
     fn from(properties: AmqpMessageProperties) -> Self {
         let mut properties_builder = fe2o3_amqp_types::messaging::Properties::builder();
 
-        if let Some(message_id) = properties.message_id() {
+        if let Some(message_id) = &properties.message_id {
             properties_builder = properties_builder.message_id(message_id.clone());
         }
-        if let Some(user_id) = properties.user_id() {
+        if let Some(user_id) = &properties.user_id {
             properties_builder = properties_builder.user_id(user_id.clone());
         }
-        if let Some(to) = properties.to() {
+        if let Some(to) = properties.to {
             properties_builder = properties_builder.to(to.clone());
         }
-        if let Some(subject) = properties.subject() {
+        if let Some(subject) = properties.subject {
             properties_builder = properties_builder.subject(subject.clone());
         }
-        if let Some(reply_to) = properties.reply_to() {
+        if let Some(reply_to) = properties.reply_to {
             properties_builder = properties_builder.reply_to(reply_to.clone());
         }
-        if let Some(correlation_id) = properties.correlation_id() {
+        if let Some(correlation_id) = properties.correlation_id {
             properties_builder = properties_builder.correlation_id(correlation_id.clone());
         }
-        if let Some(content_type) = properties.content_type() {
+        if let Some(content_type) = properties.content_type {
             properties_builder = properties_builder.content_type(content_type.clone());
         }
-        if let Some(content_encoding) = properties.content_encoding() {
+        if let Some(content_encoding) = properties.content_encoding {
             properties_builder = properties_builder.content_encoding(content_encoding.clone());
         }
-        if let Some(absolute_expiry_time) = properties.absolute_expiry_time() {
+        if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
             properties_builder =
                 properties_builder.absolute_expiry_time(Some(absolute_expiry_time.clone().into()));
         }
-        if let Some(creation_time) = properties.creation_time() {
+        if let Some(creation_time) = properties.creation_time {
             properties_builder =
                 properties_builder.creation_time(Some(creation_time.clone().into()));
         }
-        if let Some(group_id) = properties.group_id() {
+        if let Some(group_id) = properties.group_id {
             properties_builder = properties_builder.group_id(group_id.clone());
         }
-        if let Some(group_sequence) = properties.group_sequence() {
-            properties_builder = properties_builder.group_sequence(*group_sequence);
+        if let Some(group_sequence) = properties.group_sequence {
+            properties_builder = properties_builder.group_sequence(group_sequence);
         }
-        if let Some(reply_to_group_id) = properties.reply_to_group_id() {
+        if let Some(reply_to_group_id) = properties.reply_to_group_id {
             properties_builder = properties_builder.reply_to_group_id(reply_to_group_id.clone());
         }
         properties_builder.build()
@@ -478,21 +462,21 @@ fn test_properties_conversion() {
         let time_now: std::time::SystemTime =
             std::time::UNIX_EPOCH + std::time::Duration::from_millis(time_now as u64);
 
-        let properties = AmqpMessageProperties::builder()
-            .with_absolute_expiry_time(time_now)
-            .with_content_encoding(crate::value::AmqpSymbol("content_encoding".to_string()))
-            .with_content_type(crate::value::AmqpSymbol("content_type".to_string()))
-            .with_correlation_id("correlation_id")
-            .with_creation_time(time_now)
-            .with_group_id("group_id".to_string())
-            .with_group_sequence(3)
-            .with_message_id("test")
-            .with_reply_to("reply_to".to_string())
-            .with_reply_to_group_id("reply_to_group_id".to_string())
-            .with_subject("subject".to_string())
-            .with_to("to".to_string())
-            .with_user_id(vec![1, 2, 3])
-            .build();
+        let properties = AmqpMessageProperties {
+            absolute_expiry_time: Some(time_now.into()),
+            content_encoding: Some(crate::value::AmqpSymbol("content_encoding".to_string())),
+            content_type: Some(crate::value::AmqpSymbol("content_type".to_string())),
+            correlation_id: Some("correlation_id".into()),
+            creation_time: Some(time_now.into()),
+            group_id: Some("group_id".to_string()),
+            group_sequence: Some(3),
+            message_id: Some("test".into()),
+            reply_to: Some("reply_to".to_string()),
+            reply_to_group_id: Some("reply_to_group_id".to_string()),
+            subject: Some("subject".to_string()),
+            to: Some("to".to_string()),
+            user_id: Some(vec![1, 2, 3]),
+        };
 
         let fe2o3_properties: fe2o3_amqp_types::messaging::Properties = properties.clone().into();
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -524,32 +524,28 @@ mod tests {
                 .add_application_property("abc".to_string(), "23 skiddoo")
                 .add_application_property("What?".to_string(), 29.5)
                 .with_body(AmqpValue::from("hello"))
-                .with_properties(
-                    AmqpMessageProperties::builder()
-                        .with_absolute_expiry_time(timestamp)
-                        .with_content_encoding(AmqpSymbol::from("utf-8"))
-                        .with_content_type(AmqpSymbol::from("text/plain"))
-                        .with_correlation_id("abc")
-                        .with_creation_time(timestamp)
-                        .with_group_id("group".to_string())
-                        .with_group_sequence(5)
-                        .with_message_id("message")
-                        .with_reply_to("reply".to_string())
-                        .with_reply_to_group_id("reply_group".to_string())
-                        .with_subject("subject".to_string())
-                        .with_to("to".to_string())
-                        .with_user_id(vec![39, 20, 54])
-                        .build(),
-                )
-                .with_header(
-                    AmqpMessageHeader::builder()
-                        .with_delivery_count(95)
-                        .with_first_acquirer(true)
-                        .with_durable(true)
-                        .with_time_to_live(Some(std::time::Duration::from_millis(1000)))
-                        .with_priority(3)
-                        .build(),
-                )
+                .with_properties(AmqpMessageProperties {
+                    absolute_expiry_time: Some(timestamp.into()),
+                    content_encoding: Some(AmqpSymbol::from("utf-8")),
+                    content_type: Some(AmqpSymbol::from("text/plain")),
+                    correlation_id: Some("abc".into()),
+                    creation_time: Some(timestamp.into()),
+                    group_id: Some("group".to_string()),
+                    group_sequence: Some(5),
+                    message_id: Some("message".into()),
+                    reply_to: Some("reply".to_string()),
+                    reply_to_group_id: Some("reply_group".to_string()),
+                    subject: Some("subject".to_string()),
+                    to: Some("to".to_string()),
+                    user_id: Some(vec![39, 20, 54]),
+                })
+                .with_header(AmqpMessageHeader {
+                    delivery_count: 95,
+                    first_acquirer: true,
+                    durable: true,
+                    time_to_live: Some(std::time::Duration::from_millis(1000)),
+                    priority: 3,
+                })
                 .with_delivery_annotations(AmqpAnnotations::from(vec![
                     (AmqpAnnotationKey::from(93), 123),
                     (AmqpAnnotationKey::from(128), 95),

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -42,10 +42,10 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .into());
         }
         let options = options.unwrap_or_default();
-        let name = options.name().clone().unwrap_or_default();
-        let credit_mode = options.credit_mode().clone().unwrap_or_default();
-        let auto_accept = options.auto_accept();
-        let properties = options.properties().clone().unwrap_or_default();
+        let name = options.name.unwrap_or_default();
+        let credit_mode = options.credit_mode.clone().unwrap_or_default();
+        let auto_accept = options.auto_accept;
+        let properties = options.properties.clone().unwrap_or_default();
         let source = source.into();
 
         let receiver = fe2o3_amqp::Receiver::builder()

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -523,13 +523,14 @@ impl From<AmqpSource> for AmqpList {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct AmqpMessageHeader {
-    durable: bool,
-    priority: u8,
-    time_to_live: Option<std::time::Duration>,
-    first_acquirer: bool,
-    delivery_count: u32,
+    pub durable: bool,
+    pub priority: u8,
+    pub time_to_live: Option<std::time::Duration>,
+    pub first_acquirer: bool,
+    pub delivery_count: u32,
 }
 
+// The AMQP protocol specification
 impl Default for AmqpMessageHeader {
     fn default() -> Self {
         Self {
@@ -542,31 +543,7 @@ impl Default for AmqpMessageHeader {
     }
 }
 
-impl AmqpMessageHeader {
-    pub fn builder() -> builders::AmqpMessageHeaderBuilder {
-        builders::AmqpMessageHeaderBuilder::new()
-    }
-
-    pub fn durable(&self) -> bool {
-        self.durable
-    }
-
-    pub fn priority(&self) -> u8 {
-        self.priority
-    }
-
-    pub fn time_to_live(&self) -> Option<&std::time::Duration> {
-        self.time_to_live.as_ref()
-    }
-
-    pub fn first_acquirer(&self) -> bool {
-        self.first_acquirer
-    }
-
-    pub fn delivery_count(&self) -> u32 {
-        self.delivery_count
-    }
-}
+impl AmqpMessageHeader {}
 
 /// Extract an AmqpMessageHeader from an AmqpList.
 ///
@@ -579,36 +556,34 @@ impl AmqpMessageHeader {
 #[cfg(feature = "cplusplus")]
 impl From<AmqpList> for AmqpMessageHeader {
     fn from(list: AmqpList) -> Self {
-        let mut builder = AmqpMessageHeader::builder();
+        let mut header = AmqpMessageHeader::default();
         let field_count = list.len();
         if field_count >= 1 {
             if let Some(AmqpValue::Boolean(durable)) = list.0.first() {
-                builder = builder.with_durable(*durable);
+                header.durable = *durable;
             }
         }
         if field_count >= 2 {
             if let Some(AmqpValue::UByte(priority)) = list.0.get(1) {
-                builder = builder.with_priority(*priority);
+                header.priority = *priority;
             }
         }
         if field_count >= 3 {
             if let Some(AmqpValue::UInt(time_to_live)) = list.0.get(2) {
-                builder = builder.with_time_to_live(Some(std::time::Duration::from_millis(
-                    *time_to_live as u64,
-                )));
+                header.time_to_live = Some(std::time::Duration::from_millis(*time_to_live as u64));
             }
         }
         if field_count >= 4 {
             if let Some(AmqpValue::Boolean(first_acquirer)) = list.0.get(3) {
-                builder = builder.with_first_acquirer(*first_acquirer);
+                header.first_acquirer = *first_acquirer;
             }
         }
         if field_count >= 5 {
             if let Some(AmqpValue::UInt(delivery_count)) = list.0.get(4) {
-                builder = builder.with_delivery_count(*delivery_count);
+                header.delivery_count = *delivery_count;
             }
         }
-        builder.build()
+        header
     }
 }
 
@@ -621,7 +596,7 @@ impl From<AmqpMessageHeader> for AmqpList {
         // value if there are other values to serialize.
 
         if header.durable {
-            list[0] = AmqpValue::Boolean(header.durable())
+            list[0] = AmqpValue::Boolean(header.durable)
         };
         if header.priority != 4 {
             list[1] = AmqpValue::UByte(header.priority)
@@ -650,82 +625,22 @@ impl From<AmqpMessageHeader> for AmqpList {
 
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct AmqpMessageProperties {
-    message_id: Option<AmqpMessageId>,
-    user_id: Option<Vec<u8>>,
-    to: Option<String>,
-    subject: Option<String>,
-    reply_to: Option<String>,
-    correlation_id: Option<AmqpMessageId>,
-    content_type: Option<AmqpSymbol>,
-    content_encoding: Option<AmqpSymbol>,
-    absolute_expiry_time: Option<AmqpTimestamp>,
-    creation_time: Option<AmqpTimestamp>,
-    group_id: Option<String>,
-    group_sequence: Option<u32>,
-    reply_to_group_id: Option<String>,
+    pub message_id: Option<AmqpMessageId>,
+    pub user_id: Option<Vec<u8>>,
+    pub to: Option<String>,
+    pub subject: Option<String>,
+    pub reply_to: Option<String>,
+    pub correlation_id: Option<AmqpMessageId>,
+    pub content_type: Option<AmqpSymbol>,
+    pub content_encoding: Option<AmqpSymbol>,
+    pub absolute_expiry_time: Option<AmqpTimestamp>,
+    pub creation_time: Option<AmqpTimestamp>,
+    pub group_id: Option<String>,
+    pub group_sequence: Option<u32>,
+    pub reply_to_group_id: Option<String>,
 }
 
-impl AmqpMessageProperties {
-    pub fn builder() -> builders::AmqpMessagePropertiesBuilder {
-        builders::AmqpMessagePropertiesBuilder::new()
-    }
-
-    pub fn message_id(&self) -> Option<&AmqpMessageId> {
-        self.message_id.as_ref()
-    }
-
-    pub fn user_id(&self) -> Option<&Vec<u8>> {
-        self.user_id.as_ref()
-    }
-
-    pub fn to(&self) -> Option<&String> {
-        self.to.as_ref()
-    }
-
-    pub fn subject(&self) -> Option<&String> {
-        self.subject.as_ref()
-    }
-
-    pub fn reply_to(&self) -> Option<&String> {
-        self.reply_to.as_ref()
-    }
-
-    pub fn correlation_id(&self) -> Option<&AmqpMessageId> {
-        self.correlation_id.as_ref()
-    }
-
-    pub fn content_type(&self) -> Option<&AmqpSymbol> {
-        self.content_type.as_ref()
-    }
-
-    pub fn content_encoding(&self) -> Option<&AmqpSymbol> {
-        self.content_encoding.as_ref()
-    }
-
-    pub fn absolute_expiry_time(&self) -> Option<&AmqpTimestamp> {
-        self.absolute_expiry_time.as_ref()
-    }
-
-    pub fn creation_time(&self) -> Option<&AmqpTimestamp> {
-        self.creation_time.as_ref()
-    }
-
-    pub fn group_id(&self) -> Option<&String> {
-        self.group_id.as_ref()
-    }
-
-    pub fn group_sequence(&self) -> Option<&u32> {
-        self.group_sequence.as_ref()
-    }
-
-    pub fn reply_to_group_id(&self) -> Option<&String> {
-        self.reply_to_group_id.as_ref()
-    }
-
-    pub fn set_message_id(&mut self, message_id: impl Into<AmqpMessageId>) {
-        self.message_id = Some(message_id.into());
-    }
-}
+impl AmqpMessageProperties {}
 
 /// Extract an AmqpMessageProperties from an AmqpList.
 ///
@@ -738,101 +653,100 @@ impl AmqpMessageProperties {
 #[cfg(feature = "cplusplus")]
 impl From<AmqpList> for AmqpMessageProperties {
     fn from(list: AmqpList) -> Self {
-        let mut builder = AmqpMessageProperties::builder();
+        let mut message_properties = AmqpMessageProperties::default();
         let field_count = list.len();
         if field_count >= 1 {
             match &list.0[0] {
                 AmqpValue::ULong(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::Ulong(*message_id));
+                    message_properties.message_id = Some(AmqpMessageId::Ulong(*message_id));
                 }
                 AmqpValue::Uuid(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::Uuid(*message_id));
+                    message_properties.message_id = Some(AmqpMessageId::Uuid(*message_id));
                 }
                 AmqpValue::Binary(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::Binary(message_id.clone()));
+                    message_properties.message_id = Some(AmqpMessageId::Binary(message_id.clone()));
                 }
                 AmqpValue::String(message_id) => {
-                    builder = builder.with_message_id(AmqpMessageId::String(message_id.clone()));
+                    message_properties.message_id = Some(AmqpMessageId::String(message_id.clone()));
                 }
                 _ => {}
             }
         }
         if field_count >= 2 {
             if let AmqpValue::Binary(user_id) = &list.0[1] {
-                builder = builder.with_user_id(user_id.clone());
+                message_properties.user_id = Some(user_id.clone());
             }
         }
         if field_count >= 3 {
             if let AmqpValue::String(to) = &list.0[2] {
-                builder = builder.with_to(to.clone());
+                message_properties.to = Some(to.clone());
             }
         }
         if field_count >= 4 {
             if let AmqpValue::String(subject) = &list.0[3] {
-                builder = builder.with_subject(subject.clone());
+                message_properties.subject = Some(subject.clone());
             }
         }
         if field_count >= 5 {
             if let AmqpValue::String(reply_to) = &list.0[4] {
-                builder = builder.with_reply_to(reply_to.clone());
+                message_properties.reply_to = Some(reply_to.clone());
             }
         }
         if field_count >= 6 {
             match &list.0[5] {
                 AmqpValue::ULong(correlation_id) => {
-                    builder = builder.with_correlation_id(AmqpMessageId::Ulong(*correlation_id));
+                    message_properties.correlation_id = Some(AmqpMessageId::Ulong(*correlation_id));
                 }
                 AmqpValue::Uuid(correlation_id) => {
-                    builder = builder.with_correlation_id(AmqpMessageId::Uuid(*correlation_id));
+                    message_properties.correlation_id = Some(AmqpMessageId::Uuid(*correlation_id));
                 }
                 AmqpValue::Binary(correlation_id) => {
-                    builder =
-                        builder.with_correlation_id(AmqpMessageId::Binary(correlation_id.clone()));
+                    message_properties.correlation_id =
+                        Some(AmqpMessageId::Binary(correlation_id.clone()));
                 }
                 AmqpValue::String(correlation_id) => {
-                    builder =
-                        builder.with_correlation_id(AmqpMessageId::String(correlation_id.clone()));
+                    message_properties.correlation_id =
+                        Some(AmqpMessageId::String(correlation_id.clone()));
                 }
                 _ => {}
             }
         }
         if field_count >= 7 {
             if let AmqpValue::Symbol(content_type) = &list.0[6] {
-                builder = builder.with_content_type(content_type.clone());
+                message_properties.content_type = Some(content_type.clone());
             }
         }
         if field_count >= 8 {
             if let AmqpValue::Symbol(content_encoding) = &list.0[7] {
-                builder = builder.with_content_encoding(content_encoding.clone());
+                message_properties.content_encoding = Some(content_encoding.clone());
             }
         }
         if field_count >= 9 {
             if let AmqpValue::TimeStamp(absolute_expiry_time) = &list.0[8] {
-                builder = builder.with_absolute_expiry_time(absolute_expiry_time.clone());
+                message_properties.absolute_expiry_time = Some(absolute_expiry_time.clone());
             }
         }
         if field_count >= 10 {
             if let AmqpValue::TimeStamp(creation_time) = &list.0[9] {
-                builder = builder.with_creation_time(creation_time.clone());
+                message_properties.creation_time = Some(creation_time.clone());
             }
         }
         if field_count >= 11 {
             if let AmqpValue::String(group_id) = &list.0[10] {
-                builder = builder.with_group_id(group_id.clone());
+                message_properties.group_id = Some(group_id.clone());
             }
         }
         if field_count >= 12 {
             if let AmqpValue::UInt(group_sequence) = &list.0[11] {
-                builder = builder.with_group_sequence(*group_sequence);
+                message_properties.group_sequence = Some(*group_sequence);
             }
         }
         if field_count >= 13 {
             if let AmqpValue::String(reply_to_group_id) = &list.0[12] {
-                builder = builder.with_reply_to_group_id(reply_to_group_id.clone());
+                message_properties.reply_to_group_id = Some(reply_to_group_id.clone());
             }
         }
-
-        builder.build()
+        message_properties
     }
 }
 
@@ -1126,14 +1040,13 @@ impl AmqpMessage {
     ///
     pub fn set_message_id(&mut self, message_id: impl Into<AmqpMessageId>) {
         if let Some(properties) = self.properties.as_mut() {
-            properties.set_message_id(message_id);
+            properties.message_id = Some(message_id.into());
             self.properties = Some(properties.clone());
         } else {
-            self.properties = Some(
-                AmqpMessageProperties::builder()
-                    .with_message_id(message_id)
-                    .build(),
-            );
+            self.properties = Some(AmqpMessageProperties {
+                message_id: Some(message_id.into()),
+                ..Default::default()
+            });
         }
     }
 
@@ -1390,111 +1303,6 @@ pub mod builders {
         }
     }
 
-    pub struct AmqpMessageHeaderBuilder {
-        header: AmqpMessageHeader,
-    }
-
-    impl AmqpMessageHeaderBuilder {
-        pub fn build(&self) -> AmqpMessageHeader {
-            self.header.clone()
-        }
-        pub(super) fn new() -> AmqpMessageHeaderBuilder {
-            AmqpMessageHeaderBuilder {
-                header: Default::default(),
-            }
-        }
-        pub fn with_durable(mut self, durable: bool) -> Self {
-            self.header.durable = durable;
-            self
-        }
-        pub fn with_priority(mut self, priority: u8) -> Self {
-            self.header.priority = priority;
-            self
-        }
-        pub fn with_time_to_live(mut self, time_to_live: Option<std::time::Duration>) -> Self {
-            self.header.time_to_live = time_to_live;
-            self
-        }
-        pub fn with_first_acquirer(mut self, first_acquirer: bool) -> Self {
-            self.header.first_acquirer = first_acquirer;
-            self
-        }
-        pub fn with_delivery_count(mut self, delivery_count: u32) -> Self {
-            self.header.delivery_count = delivery_count;
-            self
-        }
-    }
-
-    pub struct AmqpMessagePropertiesBuilder {
-        properties: AmqpMessageProperties,
-    }
-
-    impl AmqpMessagePropertiesBuilder {
-        pub fn build(&self) -> AmqpMessageProperties {
-            self.properties.clone()
-        }
-        pub(super) fn new() -> AmqpMessagePropertiesBuilder {
-            AmqpMessagePropertiesBuilder {
-                properties: Default::default(),
-            }
-        }
-        pub fn with_message_id(mut self, message_id: impl Into<AmqpMessageId>) -> Self {
-            self.properties.message_id = Some(message_id.into());
-            self
-        }
-        pub fn with_user_id(mut self, user_id: impl Into<Vec<u8>>) -> Self {
-            self.properties.user_id = Some(user_id.into());
-            self
-        }
-        pub fn with_to(mut self, to: String) -> Self {
-            self.properties.to = Some(to);
-            self
-        }
-        pub fn with_subject(mut self, subject: String) -> Self {
-            self.properties.subject = Some(subject);
-            self
-        }
-        pub fn with_reply_to(mut self, reply_to: String) -> Self {
-            self.properties.reply_to = Some(reply_to);
-            self
-        }
-        pub fn with_correlation_id(mut self, correlation_id: impl Into<AmqpMessageId>) -> Self {
-            self.properties.correlation_id = Some(correlation_id.into());
-            self
-        }
-        pub fn with_content_type(mut self, content_type: AmqpSymbol) -> Self {
-            self.properties.content_type = Some(content_type);
-            self
-        }
-        pub fn with_content_encoding(mut self, content_encoding: AmqpSymbol) -> Self {
-            self.properties.content_encoding = Some(content_encoding);
-            self
-        }
-        pub fn with_absolute_expiry_time(
-            mut self,
-            absolute_expiry_time: impl Into<AmqpTimestamp>,
-        ) -> Self {
-            self.properties.absolute_expiry_time = Some(absolute_expiry_time.into());
-            self
-        }
-        pub fn with_creation_time(mut self, creation_time: impl Into<AmqpTimestamp>) -> Self {
-            self.properties.creation_time = Some(creation_time.into());
-            self
-        }
-        pub fn with_group_id(mut self, group_id: String) -> Self {
-            self.properties.group_id = Some(group_id);
-            self
-        }
-        pub fn with_group_sequence(mut self, group_sequence: u32) -> Self {
-            self.properties.group_sequence = Some(group_sequence);
-            self
-        }
-        pub fn with_reply_to_group_id(mut self, reply_to_group_id: String) -> Self {
-            self.properties.reply_to_group_id = Some(reply_to_group_id);
-            self
-        }
-    }
-
     pub struct AmqpMessageBuilder {
         message: AmqpMessage,
     }
@@ -1596,14 +1404,13 @@ mod tests {
 
     #[test]
     fn test_amqp_message_header_builder() {
-        let header = AmqpMessageHeader::builder()
-            .with_durable(true)
-            .with_priority(5)
-            .with_time_to_live(Some(std::time::Duration::from_millis(1000)))
-            .with_first_acquirer(false)
-            .with_delivery_count(3)
-            .build();
-
+        let header = AmqpMessageHeader {
+            durable: true,
+            priority: 5,
+            time_to_live: Some(std::time::Duration::from_millis(1000)),
+            first_acquirer: false,
+            delivery_count: 3,
+        };
         assert!(header.durable);
         assert_eq!(header.priority, 5);
         assert_eq!(
@@ -1643,21 +1450,21 @@ mod tests {
         let time_now = SystemTime::now();
         let test_uuid1 = Uuid::new_v4();
         let test_uuid2 = Uuid::new_v4();
-        let properties = AmqpMessageProperties::builder()
-            .with_message_id(test_uuid1)
-            .with_user_id(vec![1, 2, 3])
-            .with_to("destination".to_string())
-            .with_subject("subject".to_string())
-            .with_reply_to("reply_to".to_string())
-            .with_correlation_id(test_uuid2)
-            .with_content_type(AmqpSymbol::from("content_type"))
-            .with_content_encoding(AmqpSymbol::from("content_encoding"))
-            .with_absolute_expiry_time(time_now)
-            .with_creation_time(time_now)
-            .with_group_id("group_id".to_string())
-            .with_group_sequence(1)
-            .with_reply_to_group_id("reply_to_group_id".to_string())
-            .build();
+        let properties = AmqpMessageProperties {
+            message_id: Some(test_uuid1.into()),
+            user_id: Some(vec![1, 2, 3]),
+            to: Some("destination".to_string()),
+            subject: Some("subject".to_string()),
+            reply_to: Some("reply_to".to_string()),
+            correlation_id: Some(test_uuid2.into()),
+            content_type: Some(AmqpSymbol::from("content_type")),
+            content_encoding: Some(AmqpSymbol::from("content_encoding")),
+            absolute_expiry_time: Some(time_now.into()),
+            creation_time: Some(time_now.into()),
+            group_id: Some("group_id".to_string()),
+            group_sequence: Some(1),
+            reply_to_group_id: Some("reply_to_group_id".to_string()),
+        };
 
         assert_eq!(properties.message_id, Some(test_uuid1.into()));
         assert_eq!(properties.user_id, Some(vec![1, 2, 3]));
@@ -1687,26 +1494,23 @@ mod tests {
     fn test_amqp_message_builder() {
         let message = AmqpMessage::builder()
             .with_body(AmqpMessageBody::Binary(vec![vec![1, 2, 3]]))
-            .with_header(AmqpMessageHeader::builder().build())
+            .with_header(AmqpMessageHeader::default())
             .with_application_properties(AmqpApplicationProperties::new())
             .add_application_property("key".to_string(), AmqpValue::from(123))
             .with_message_annotations(AmqpAnnotations::new())
             .with_delivery_annotations(AmqpAnnotations::new())
-            .with_properties(AmqpMessageProperties::builder().build())
+            .with_properties(AmqpMessageProperties::default())
             .with_footer(AmqpAnnotations::new())
             .build();
 
         assert_eq!(message.body, AmqpMessageBody::Binary(vec![vec![1, 2, 3]]));
-        assert_eq!(message.header, Some(AmqpMessageHeader::builder().build()));
+        assert_eq!(message.header, Some(AmqpMessageHeader::default()));
         let mut properties = AmqpApplicationProperties::new();
         properties.insert("key".to_string(), AmqpValue::from(123));
         assert_eq!(message.application_properties, Some(properties));
         assert_eq!(message.message_annotations, Some(AmqpAnnotations::new()));
         assert_eq!(message.delivery_annotations, Some(AmqpAnnotations::new()));
-        assert_eq!(
-            message.properties,
-            Some(AmqpMessageProperties::builder().build())
-        );
+        assert_eq!(message.properties, Some(AmqpMessageProperties::default()));
         assert_eq!(message.footer, Some(AmqpAnnotations::new()));
     }
 
@@ -1852,11 +1656,10 @@ mod tests {
         }
         {
             let message = AmqpMessage::builder()
-                .with_header(
-                    AmqpMessageHeader::builder()
-                        .with_time_to_live(Some(std::time::Duration::from_millis(23)))
-                        .build(),
-                )
+                .with_header(AmqpMessageHeader {
+                    time_to_live: (Some(std::time::Duration::from_millis(23))),
+                    ..Default::default()
+                })
                 .build();
             let serialized = AmqpMessage::serialize(&message).unwrap();
 
@@ -2028,13 +1831,15 @@ mod tests {
     #[test]
     fn test_message_with_header_serialization() {
         let message = AmqpMessage::builder()
-            .with_header(AmqpMessageHeader::builder().with_priority(5).build())
+            .with_header(AmqpMessageHeader {
+                priority: 5,
+                ..Default::default()
+            })
             .with_body(AmqpValue::from("String Value Body."))
-            .with_properties(
-                AmqpMessageProperties::builder()
-                    .with_message_id("12345")
-                    .build(),
-            )
+            .with_properties(AmqpMessageProperties {
+                message_id: Some("12345".into()),
+                ..Default::default()
+            })
             .build();
 
         let serialized = AmqpMessage::serialize(&message).unwrap();

--- a/sdk/core/azure_core_amqp/src/sender.rs
+++ b/sdk/core/azure_core_amqp/src/sender.rs
@@ -16,20 +16,16 @@ type SenderImplementation = super::noop::NoopAmqpSender;
 
 #[derive(Debug, Default, Clone)]
 pub struct AmqpSenderOptions {
-    pub(super) sender_settle_mode: Option<SenderSettleMode>,
-    pub(super) receiver_settle_mode: Option<ReceiverSettleMode>,
-    pub(super) source: Option<AmqpSource>,
-    pub(super) offered_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(super) desired_capabilities: Option<Vec<AmqpSymbol>>,
-    pub(super) properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    pub(super) initial_delivery_count: Option<u32>,
-    pub(super) max_message_size: Option<u64>,
+    pub sender_settle_mode: Option<SenderSettleMode>,
+    pub receiver_settle_mode: Option<ReceiverSettleMode>,
+    pub source: Option<AmqpSource>,
+    pub offered_capabilities: Option<Vec<AmqpSymbol>>,
+    pub desired_capabilities: Option<Vec<AmqpSymbol>>,
+    pub properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
+    pub initial_delivery_count: Option<u32>,
+    pub max_message_size: Option<u64>,
 }
-impl AmqpSenderOptions {
-    pub fn builder() -> builders::AmqpSenderOptionsBuilder {
-        builders::AmqpSenderOptionsBuilder::new()
-    }
-}
+impl AmqpSenderOptions {}
 
 #[allow(unused_variables)]
 pub trait AmqpSenderApis {
@@ -100,105 +96,7 @@ pub struct AmqpSendOptions {
     pub settled: Option<bool>,
 }
 
-impl AmqpSendOptions {
-    pub fn builder() -> builders::AmqpSendOptionsBuilder {
-        builders::AmqpSendOptionsBuilder::new()
-    }
-}
-
-pub mod builders {
-    use super::*;
-
-    pub struct AmqpSendOptionsBuilder {
-        options: AmqpSendOptions,
-    }
-
-    impl AmqpSendOptionsBuilder {
-        pub(super) fn new() -> Self {
-            AmqpSendOptionsBuilder {
-                options: Default::default(),
-            }
-        }
-        #[allow(dead_code)]
-        pub fn with_message_format(mut self, message_format: u32) -> Self {
-            self.options.message_format = Some(message_format);
-            self
-        }
-        #[allow(dead_code)]
-        pub fn with_settled(mut self, settled: bool) -> Self {
-            self.options.settled = Some(settled);
-            self
-        }
-        pub fn build(self) -> Option<AmqpSendOptions> {
-            Some(self.options)
-        }
-    }
-
-    #[derive(Clone)]
-    pub struct AmqpSenderOptionsBuilder {
-        options: AmqpSenderOptions,
-    }
-
-    impl AmqpSenderOptionsBuilder {
-        pub(super) fn new() -> Self {
-            AmqpSenderOptionsBuilder {
-                options: Default::default(),
-            }
-        }
-
-        pub fn with_sender_settle_mode(mut self, sender_settle_mode: SenderSettleMode) -> Self {
-            self.options.sender_settle_mode = Some(sender_settle_mode);
-            self
-        }
-
-        pub fn with_receiver_settle_mode(
-            mut self,
-            receiver_settle_mode: ReceiverSettleMode,
-        ) -> Self {
-            self.options.receiver_settle_mode = Some(receiver_settle_mode);
-            self
-        }
-
-        pub fn with_source(mut self, source: impl Into<AmqpSource>) -> Self {
-            self.options.source = Some(source.into());
-            self
-        }
-        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.offered_capabilities = Some(offered_capabilities);
-            self
-        }
-        #[allow(dead_code)]
-        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.desired_capabilities = Some(desired_capabilities);
-            self
-        }
-
-        pub fn with_properties(
-            mut self,
-            properties: impl Into<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-        ) -> Self {
-            let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> =
-                properties.into().iter().collect();
-
-            self.options.properties = Some(properties_map);
-            self
-        }
-
-        pub fn with_initial_delivery_count(mut self, initial_delivery_count: u32) -> Self {
-            self.options.initial_delivery_count = Some(initial_delivery_count);
-            self
-        }
-
-        pub fn with_max_message_size(mut self, max_message_size: u64) -> Self {
-            self.options.max_message_size = Some(max_message_size);
-            self
-        }
-
-        pub fn build(self) -> AmqpSenderOptions {
-            self.options
-        }
-    }
-}
+impl AmqpSendOptions {}
 
 #[cfg(test)]
 mod tests {
@@ -209,23 +107,20 @@ mod tests {
         let mut properties: AmqpOrderedMap<AmqpSymbol, AmqpValue> = AmqpOrderedMap::new();
         properties.insert(AmqpSymbol::from("key"), AmqpValue::from("value"));
 
-        let sender_options = AmqpSenderOptions::builder()
-            .with_sender_settle_mode(SenderSettleMode::Unsettled)
-            .with_sender_settle_mode(SenderSettleMode::Settled)
-            .with_sender_settle_mode(SenderSettleMode::Mixed)
-            .with_receiver_settle_mode(ReceiverSettleMode::Second)
-            .with_receiver_settle_mode(ReceiverSettleMode::First)
-            .with_source(
+        let sender_options = AmqpSenderOptions {
+            sender_settle_mode: Some(SenderSettleMode::Mixed),
+            receiver_settle_mode: Some(ReceiverSettleMode::First),
+            source: Some(
                 AmqpSource::builder()
                     .with_address("address".to_string())
                     .build(),
-            )
-            .with_offered_capabilities(vec!["capability".into()])
-            .with_desired_capabilities(vec!["capability".into()])
-            .with_properties(properties)
-            .with_initial_delivery_count(27)
-            .with_max_message_size(1024)
-            .build();
+            ),
+            offered_capabilities: Some(vec!["capability".into()]),
+            desired_capabilities: Some(vec!["capability".into()]),
+            properties: Some(properties),
+            initial_delivery_count: Some(27),
+            max_message_size: Some(1024),
+        };
 
         assert_eq!(
             sender_options.sender_settle_mode,

--- a/sdk/core/azure_core_amqp/src/session.rs
+++ b/sdk/core/azure_core_amqp/src/session.rs
@@ -17,21 +17,17 @@ type SessionImplementation = super::noop::NoopAmqpSession;
 
 #[derive(Debug, Default, Clone)]
 pub struct AmqpSessionOptions {
-    next_outgoing_id: Option<u32>,
-    incoming_window: Option<u32>,
-    outgoing_window: Option<u32>,
-    handle_max: Option<u32>,
-    offered_capabilities: Option<Vec<AmqpSymbol>>,
-    desired_capabilities: Option<Vec<AmqpSymbol>>,
-    properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
-    buffer_size: Option<usize>,
+    pub next_outgoing_id: Option<u32>,
+    pub incoming_window: Option<u32>,
+    pub outgoing_window: Option<u32>,
+    pub handle_max: Option<u32>,
+    pub offered_capabilities: Option<Vec<AmqpSymbol>>,
+    pub desired_capabilities: Option<Vec<AmqpSymbol>>,
+    pub properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
+    pub buffer_size: Option<usize>,
 }
 
 impl AmqpSessionOptions {
-    pub fn builder() -> builders::AmqpSessionOptionsBuilder {
-        builders::AmqpSessionOptionsBuilder::new()
-    }
-
     pub fn next_outgoing_id(&self) -> Option<u32> {
         self.next_outgoing_id
     }
@@ -102,82 +98,27 @@ impl AmqpSession {
     }
 }
 
-pub mod builders {
-    use super::*;
-
-    pub struct AmqpSessionOptionsBuilder {
-        options: AmqpSessionOptions,
-    }
-
-    impl AmqpSessionOptionsBuilder {
-        pub(super) fn new() -> Self {
-            Self {
-                options: Default::default(),
-            }
-        }
-        pub fn build(&self) -> AmqpSessionOptions {
-            self.options.clone()
-        }
-        pub fn with_next_outgoing_id(mut self, next_outgoing_id: u32) -> Self {
-            self.options.next_outgoing_id = Some(next_outgoing_id);
-            self
-        }
-        pub fn with_incoming_window(mut self, incoming_window: u32) -> Self {
-            self.options.incoming_window = Some(incoming_window);
-            self
-        }
-        pub fn with_outgoing_window(mut self, outgoing_window: u32) -> Self {
-            self.options.outgoing_window = Some(outgoing_window);
-            self
-        }
-        pub fn with_handle_max(mut self, handle_max: u32) -> Self {
-            self.options.handle_max = Some(handle_max);
-            self
-        }
-        pub fn with_offered_capabilities(mut self, offered_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.offered_capabilities = Some(offered_capabilities);
-            self
-        }
-        pub fn with_desired_capabilities(mut self, desired_capabilities: Vec<AmqpSymbol>) -> Self {
-            self.options.desired_capabilities = Some(desired_capabilities);
-            self
-        }
-        pub fn with_properties<K, V>(mut self, properties: impl Into<AmqpOrderedMap<K, V>>) -> Self
-        where
-            K: Into<AmqpSymbol> + PartialEq + Clone,
-            V: Into<AmqpValue> + Clone,
-        {
-            let properties_map: AmqpOrderedMap<AmqpSymbol, AmqpValue> = properties
-                .into()
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
-                .collect();
-            self.options.properties = Some(properties_map);
-            self
-        }
-        pub fn with_buffer_size(mut self, buffer_size: usize) -> Self {
-            self.options.buffer_size = Some(buffer_size);
-            self
-        }
-    }
-}
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_amqp_session_options_builder() {
-        let session_options = AmqpSessionOptions::builder()
-            .with_next_outgoing_id(1)
-            .with_incoming_window(1)
-            .with_outgoing_window(1)
-            .with_handle_max(1)
-            .with_offered_capabilities(vec!["capability".into()])
-            .with_desired_capabilities(vec!["capability".into()])
-            .with_properties(vec![("key", "value")])
-            .with_buffer_size(1024)
-            .build();
-
+        let session_options = AmqpSessionOptions {
+            next_outgoing_id: Some(1),
+            incoming_window: Some(1),
+            outgoing_window: Some(1),
+            handle_max: Some(1),
+            offered_capabilities: Some(vec!["capability".into()]),
+            desired_capabilities: Some(vec!["capability".into()]),
+            properties: Some(
+                vec![("key", "value")]
+                    .into_iter()
+                    .map(|(k, v)| (AmqpSymbol::from(k), AmqpValue::from(v)))
+                    .collect(),
+            ),
+            buffer_size: Some(1024),
+        };
         assert_eq!(session_options.next_outgoing_id, Some(1));
         assert_eq!(session_options.incoming_window, Some(1));
         assert_eq!(session_options.outgoing_window, Some(1));

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
@@ -356,22 +356,18 @@ pub mod models {
                 || event_data.correlation_id.is_some()
                 || event_data.message_id.is_some()
             {
-                let mut message_properties_builder = AmqpMessageProperties::builder();
+                let mut message_properties = AmqpMessageProperties::default();
                 if let Some(content_type) = event_data.content_type {
-                    message_properties_builder =
-                        message_properties_builder.with_content_type(content_type.into());
+                    message_properties.content_type = Some(content_type.into());
                 }
                 if let Some(correlation_id) = event_data.correlation_id {
-                    message_properties_builder =
-                        message_properties_builder.with_correlation_id(correlation_id);
+                    message_properties.correlation_id = Some(correlation_id.into());
                 }
                 if let Some(message_id) = event_data.message_id {
-                    message_properties_builder =
-                        message_properties_builder.with_message_id(message_id);
+                    message_properties.message_id = Some(message_id.into());
                 }
 
-                message_builder =
-                    message_builder.with_properties(message_properties_builder.build());
+                message_builder = message_builder.with_properties(message_properties);
             }
             if let Some(properties) = event_data.properties {
                 for (key, value) in properties {
@@ -469,15 +465,15 @@ pub mod models {
             }
 
             if let Some(properties) = message.properties() {
-                if let Some(content_type) = properties.content_type() {
+                if let Some(content_type) = &properties.content_type {
                     event_data_builder = event_data_builder
                         .with_content_type(Into::<String>::into(content_type.clone()));
                 }
-                if let Some(correlation_id) = properties.correlation_id() {
+                if let Some(correlation_id) = &properties.correlation_id {
                     event_data_builder =
                         event_data_builder.with_correlation_id(correlation_id.clone());
                 }
-                if let Some(message_id) = properties.message_id() {
+                if let Some(message_id) = &properties.message_id {
                     event_data_builder = event_data_builder.with_message_id(message_id.clone());
                 }
             }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -229,7 +229,7 @@ impl<'a> EventDataBatch<'a> {
         #[allow(unused_variables)] options: Option<AddEventDataOptions>,
     ) -> Result<bool> {
         let mut message = message.into();
-        if message.properties().is_none() || message.properties().unwrap().message_id().is_none() {
+        if message.properties().is_none() || message.properties().unwrap().message_id.is_none() {
             message.set_message_id(Uuid::new_v4());
         }
         if let Some(partition_key) = self.partition_key.as_ref() {

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
@@ -79,7 +79,10 @@ async fn test_round_trip_batch() {
             AmqpMessage::builder()
                 .with_body(AmqpValue::from("Hello, World!"))
                 .add_application_property("Message#".to_string(), 2)
-                .with_properties(AmqpMessageProperties::builder().with_message_id(2).build())
+                .with_properties(AmqpMessageProperties {
+                    message_id: Some(2.into()),
+                    ..Default::default()
+                })
                 .build(),
             None,
         )
@@ -94,7 +97,10 @@ async fn test_round_trip_batch() {
                     5.into()
                 ]))
                 .add_application_property("Message#".to_string(), 3)
-                .with_properties(AmqpMessageProperties::builder().with_message_id(3).build())
+                .with_properties(AmqpMessageProperties {
+                    message_id: Some(3.into()),
+                    ..Default::default()
+                })
                 .build(),
             None,
         )
@@ -104,7 +110,10 @@ async fn test_round_trip_batch() {
         .try_add_amqp_message(
             AmqpMessage::builder()
                 .add_application_property("Message#".to_string(), 4)
-                .with_properties(AmqpMessageProperties::builder().with_message_id(4).build())
+                .with_properties(AmqpMessageProperties {
+                    message_id: Some(4.into()),
+                    ..Default::default()
+                })
                 .build(),
             None
         )


### PR DESCRIPTION
# Removed Options builders from AMQP library.

Kept builders for more complicated types (`AmqpSource`, `AmqpTarget`, `AmqpMessageHeader`, `AmqpMessageProperties`, and AmqpMessage`).

`AmqpMessageHeader` and `AmqpMessageProperties` may be candidates for removing the builder as well, that will be revisited in a later iteration. 

## Github Copilot Summary.
This pull request involves significant changes to the `sdk/core/azure_core_amqp` module, primarily focusing on simplifying the configuration options and removing the builder pattern. The primary changes include making the fields of the options structs public and eliminating the builder structs and methods.

### Simplification of Configuration Options:

* [`sdk/core/azure_core_amqp/src/connection.rs`](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L18-L32): Made fields in `AmqpConnectionOptions` public and removed the `builders::AmqpConnectionOptionsBuilder` struct and its methods. Updated tests to directly instantiate `AmqpConnectionOptions` instead of using the builder. [[1]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L18-L32) [[2]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L114-R173) [[3]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L243-R187) [[4]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L256-R206) [[5]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L271-R244)

* [`sdk/core/azure_core_amqp/src/receiver.rs`](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L38-R48): Made fields in `AmqpReceiverOptions` public and removed the `builders::AmqpReceiverOptionsBuilder` struct and its methods. Updated tests to directly instantiate `AmqpReceiverOptions` instead of using the builder. [[1]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L38-R48) [[2]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L120-L189) [[3]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L199-R110) [[4]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L225-R134) [[5]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L242-R159) [[6]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L265-R173) [[7]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L280-R197)

* [`sdk/core/azure_core_amqp/src/sender.rs`](diffhunk://#diff-61e307ece369d94ac0f3171fa3832e6ec97eae8ba2d387adbe94399d6ff71c76L19-R28): Made fields in `AmqpSenderOptions` public and removed the `builders::AmqpSenderOptionsBuilder` struct and its methods.

### Code Adjustments:

* [`sdk/core/azure_core_amqp/src/fe2o3/receiver.rs`](diffhunk://#diff-7edae0d79194c90511b829f65add319a4668df84da79b1474f5c0b77b63321b4L45-R48): Updated usage of `AmqpReceiverOptions` to reflect the removal of the builder pattern.