### PR TITLE
[Cosmos] Patch item APIs

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/main.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/main.rs
@@ -9,6 +9,7 @@ use std::error::Error;
 mod create;
 mod delete;
 mod metadata;
+mod patch;
 mod query;
 mod read;
 mod replace;
@@ -46,6 +47,7 @@ enum Subcommands {
     Read(read::ReadCommand),
     Replace(replace::ReplaceCommand),
     Upsert(upsert::UpsertCommand),
+    Patch(patch::PatchCommand),
 }
 
 #[tokio::main]
@@ -71,6 +73,7 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         Subcommands::Read(cmd) => cmd.run(client).await,
         Subcommands::Replace(cmd) => cmd.run(client).await,
         Subcommands::Upsert(cmd) => cmd.run(client).await,
+        Subcommands::Patch(cmd) => cmd.run(client).await,
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/patch.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/patch.rs
@@ -1,0 +1,59 @@
+use std::error::Error;
+
+use azure_core::StatusCode;
+use azure_data_cosmos::{
+    models::{PatchDocument, PatchOperation},
+    CosmosClient, PartitionKey,
+};
+use clap::Args;
+
+/// Creates a new item.
+#[derive(Clone, Args)]
+pub struct PatchCommand {
+    /// The database in which to create the item.
+    database: String,
+
+    /// The container in which to create the item.
+    container: String,
+
+    /// The ID of the item.
+    #[clap(long, short)]
+    item_id: String,
+
+    /// The partition key of the new item.
+    #[clap(long, short)]
+    partition_key: String,
+
+    /// A JSON patch operation to apply to the item, can be specified multiple times. See https://learn.microsoft.com/en-us/azure/cosmos-db/partial-document-update
+    #[clap(long, short)]
+    operation: Vec<String>,
+}
+
+impl PatchCommand {
+    pub async fn run(self, client: CosmosClient) -> Result<(), Box<dyn Error>> {
+        let db_client = client.database_client(&self.database);
+        let container_client = db_client.container_client(&self.container);
+
+        let pk = PartitionKey::from(&self.partition_key);
+        let operations: Vec<PatchOperation> = self
+            .operation
+            .iter()
+            .map(|op| serde_json::from_str(op).expect("Invalid JSON patch operation"))
+            .collect();
+        let patch = PatchDocument { operations };
+
+        let response = container_client
+            .patch_item(pk, &self.item_id, patch, None)
+            .await;
+        match response {
+            Err(e) if e.http_status() == Some(StatusCode::NotFound) => println!("Item not found!"),
+            Ok(r) => {
+                let item: serde_json::Value = r.deserialize_body_into().await?;
+                println!("Patched item:");
+                println!("{:#?}", item);
+            }
+            Err(e) => return Err(e.into()),
+        };
+        Ok(())
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -352,11 +352,11 @@ impl ContainerClient {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use azure_data_cosmos::{clients::ContainerClient, models::Item};
+    /// # use azure_data_cosmos::{clients::ContainerClient, models::PatchDocument};
     /// # use serde::{Deserialize, Serialize};
     /// # async fn doc() {
     /// # let container_client: ContainerClient = panic!("this is a non-running example");
-    /// let patch = PatchDocument::new().with_add("/some/path", "some value").unwrap();
+    /// let patch = PatchDocument::default().with_add("/some/path".to_string(), "some value").unwrap();
     /// container_client
     ///     .patch_item("partition1", "item1", patch, None)
     ///     .await.unwrap();
@@ -373,10 +373,12 @@ impl ContainerClient {
     ///
     /// ```rust,no_run
     /// # use azure_data_cosmos::{clients::ContainerClient, models::PatchDocument};
+    /// # async fn doc() {
     /// # let client: ContainerClient = panic!("this is a non-running example");
-    /// let patch = PatchDocument::new().with_add("/some/path", "some value").unwrap();
+    /// let patch = PatchDocument::default().with_add("/some/path".to_string(), "some value").unwrap();
     /// let response = client.patch_item("partition1", "item1", patch, None).await.unwrap();
     /// let patched_item: serde_json::Value = response.deserialize_body_into().await.unwrap();
+    /// # }
     /// ```
     pub async fn patch_item(
         &self,

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -10,11 +10,13 @@ mod container_properties;
 mod indexing_policy;
 mod item;
 mod partition_key_definition;
+mod patch_operations;
 
 pub use container_properties::*;
 pub use indexing_policy::*;
 pub use item::*;
 pub use partition_key_definition::*;
+pub use patch_operations::*;
 
 fn deserialize_cosmos_timestamp<'de, D>(deserializer: D) -> Result<Option<OffsetDateTime>, D::Error>
 where

--- a/sdk/cosmos/azure_data_cosmos/src/models/patch_operations.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/patch_operations.rs
@@ -1,0 +1,307 @@
+use azure_core::Model;
+use serde::{Deserialize, Serialize};
+
+// Cosmos' patch operations are _similar_ to JSON Patch (RFC 6902) in structure, but have different operations.
+
+/// Represents a patch document for Cosmos DB.
+///
+/// A patch document is made up of a collection of patch operations.
+/// Each operation describes how to modify a property of a document.
+/// See <https://learn.microsoft.com/en-us/azure/cosmos-db/partial-document-update> for more information on patch operations.
+#[derive(Model, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PatchDocument {
+    pub operations: Vec<PatchOperation>,
+}
+
+impl PatchDocument {
+    /// Creates a new empty patch document.
+    pub fn new() -> Self {
+        PatchDocument { operations: vec![] }
+    }
+
+    /// Adds a new "add" operation to the patch document.
+    ///
+    /// See the [type documentation](PatchDocument) for more information on patch operations.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the property to add.
+    /// * `value` - The value to add.
+    pub fn with_add(
+        mut self,
+        path: impl Into<String>,
+        value: impl Serialize,
+    ) -> Result<Self, serde_json::Error> {
+        self.operations.push(PatchOperation::Add {
+            path: path.into(),
+            value: serde_json::to_value(value)?,
+        });
+        Ok(self)
+    }
+
+    /// Adds a new "increment" operation to the patch document.
+    ///
+    /// See the [type documentation](PatchDocument) for more information on patch operations.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the property to increment.
+    /// * `value` - The amount to increment by. Integers can be specified directly in this parameter. Use [`serde_json::Number::from_f64`] to create a floating-point number.
+    pub fn with_increment(
+        mut self,
+        path: impl Into<String>,
+        value: impl Into<serde_json::Number>,
+    ) -> Result<Self, serde_json::Error> {
+        self.operations.push(PatchOperation::Increment {
+            path: path.into(),
+            value: value.into(),
+        });
+        Ok(self)
+    }
+
+    /// Adds a new "remove" operation to the patch document.
+    ///
+    /// See the [type documentation](PatchDocument) for more information on patch operations.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the property to remove.
+    pub fn with_remove(mut self, path: impl Into<String>) -> Result<Self, serde_json::Error> {
+        self.operations
+            .push(PatchOperation::Remove { path: path.into() });
+        Ok(self)
+    }
+
+    /// Adds a new "replace" operation to the patch document.
+    ///
+    /// See the [type documentation](PatchDocument) for more information on patch operations.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the property to remove.
+    /// * `value` - The value to replace the property with.
+    pub fn with_replace(
+        mut self,
+        path: impl Into<String>,
+        value: impl Serialize,
+    ) -> Result<Self, serde_json::Error> {
+        self.operations.push(PatchOperation::Replace {
+            path: path.into(),
+            value: serde_json::to_value(value)?,
+        });
+        Ok(self)
+    }
+
+    /// Adds a new "set" operation to the patch document.
+    ///
+    /// See the [type documentation](PatchDocument) for more information on patch operations.
+    ///
+    /// # Arguments
+    /// * `path` - The path to the property to remove.
+    /// * `value` - The value to set the property to.
+    pub fn with_set(
+        mut self,
+        path: impl Into<String>,
+        value: impl Serialize,
+    ) -> Result<Self, serde_json::Error> {
+        self.operations.push(PatchOperation::Set {
+            path: path.into(),
+            value: serde_json::to_value(value)?,
+        });
+        Ok(self)
+    }
+
+    /// Adds a new "move" operation to the patch document.
+    ///
+    /// See the [type documentation](PatchDocument) for more information on patch operations.
+    ///
+    /// # Arguments
+    /// * `from` - The path to the property to move.
+    /// * `to` - The path to move the property to.
+    pub fn with_move(
+        mut self,
+        from: impl Into<String>,
+        to: impl Into<String>,
+    ) -> Result<Self, serde_json::Error> {
+        self.operations.push(PatchOperation::Move {
+            from: from.into(),
+            to: to.into(),
+        });
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "op")]
+#[serde(rename_all = "camelCase")]
+pub enum PatchOperation {
+    Add {
+        path: String,
+        value: serde_json::Value,
+    },
+    #[serde(rename = "incr")]
+    Increment {
+        path: String,
+        value: serde_json::Number,
+    },
+    Remove {
+        path: String,
+    },
+    Replace {
+        path: String,
+        value: serde_json::Value,
+    },
+    Set {
+        path: String,
+        value: serde_json::Value,
+    },
+    Move {
+        from: String,
+        #[serde(rename = "path")]
+        to: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+    use serde_json::Number;
+
+    use crate::models::PatchDocument;
+
+    #[derive(Serialize)]
+    struct TestStruct {
+        foo: String,
+        bar: i32,
+    }
+
+    #[test]
+    pub fn serialize_empty_patch_document() -> Result<(), Box<dyn std::error::Error>> {
+        let patch_document = PatchDocument::new();
+
+        let serialized = serde_json::to_string(&patch_document).unwrap();
+        assert_eq!(serialized, "{\"operations\":[]}");
+        Ok(())
+    }
+
+    #[test]
+    pub fn serialize_add() -> Result<(), Box<dyn std::error::Error>> {
+        let patch_document = PatchDocument::new().with_add(
+            "/parent",
+            TestStruct {
+                foo: "test".to_string(),
+                bar: 42,
+            },
+        )?;
+
+        let serialized = serde_json::to_string(&patch_document).unwrap();
+        assert_eq!(
+            serialized,
+            "{\"operations\":[{\"op\":\"add\",\"path\":\"/parent\",\"value\":{\"bar\":42,\"foo\":\"test\"}}]}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn serialize_increment() -> Result<(), Box<dyn std::error::Error>> {
+        let patch_document = PatchDocument::new()
+            .with_increment("/count", 1)?
+            .with_increment("/sum", Number::from_f64(4.2).unwrap())?;
+        let serialized = serde_json::to_string(&patch_document).unwrap();
+        assert_eq!(
+            serialized,
+            "{\"operations\":[{\"op\":\"incr\",\"path\":\"/count\",\"value\":1},{\"op\":\"incr\",\"path\":\"/sum\",\"value\":4.2}]}",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn serialize_remove() -> Result<(), Box<dyn std::error::Error>> {
+        let patch_document = PatchDocument::new().with_remove("/value")?;
+
+        let serialized = serde_json::to_string(&patch_document).unwrap();
+        assert_eq!(
+            serialized,
+            "{\"operations\":[{\"op\":\"remove\",\"path\":\"/value\"}]}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn serialize_replace() -> Result<(), Box<dyn std::error::Error>> {
+        let patch_document = PatchDocument::new().with_replace(
+            "/parent",
+            TestStruct {
+                foo: "test".to_string(),
+                bar: 42,
+            },
+        )?;
+
+        let serialized = serde_json::to_string(&patch_document).unwrap();
+        assert_eq!(
+            serialized,
+            "{\"operations\":[{\"op\":\"replace\",\"path\":\"/parent\",\"value\":{\"bar\":42,\"foo\":\"test\"}}]}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn serialize_set() -> Result<(), Box<dyn std::error::Error>> {
+        let patch_document = PatchDocument::new().with_set(
+            "/parent",
+            TestStruct {
+                foo: "test".to_string(),
+                bar: 42,
+            },
+        )?;
+
+        let serialized = serde_json::to_string(&patch_document).unwrap();
+        assert_eq!(
+            serialized,
+            "{\"operations\":[{\"op\":\"set\",\"path\":\"/parent\",\"value\":{\"bar\":42,\"foo\":\"test\"}}]}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn serialize_move() -> Result<(), Box<dyn std::error::Error>> {
+        let patch_document = PatchDocument::new().with_move("/from", "/to")?;
+
+        let serialized = serde_json::to_string(&patch_document).unwrap();
+        assert_eq!(
+            serialized,
+            "{\"operations\":[{\"op\":\"move\",\"from\":\"/from\",\"path\":\"/to\"}]}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn cosmos_docs_example() -> Result<(), Box<dyn std::error::Error>> {
+        const TEST_DOC: &str = r#"{
+            "operations": [
+                { "op": "add", "path": "/color", "value": "silver" },
+                { "op": "remove", "path": "/used" },
+                { "op": "set", "path": "/price", "value": 355.45 },
+                { "op": "incr", "path": "/inventory/quantity", "value": 10 },
+                { "op": "add", "path": "/tags/-", "value": "featured-bikes" },
+                { "op": "move", "from": "/color", "path": "/inventory/color" }
+            ]
+        }"#;
+
+        let doc: PatchDocument = serde_json::from_str(TEST_DOC)?;
+
+        assert_eq!(
+            doc,
+            PatchDocument::new()
+                .with_add("/color", "silver")?
+                .with_remove("/used")?
+                .with_set("/price", serde_json::Number::from_f64(355.45).unwrap())?
+                .with_increment("/inventory/quantity", 10)?
+                .with_add("/tags/-", "featured-bikes")?
+                .with_move("/color", "/inventory/color")?
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds the `ContainerClient::patch_item` API, which allows you to specify a `PatchDocument` consisting of a list of `PatchOperations` to perform on the specified item.

Despite using the term "Patch" and similar syntax, it's important to note that Cosmos does NOT support [RFC 6902 JSON Patch](https://www.rfc-editor.org/rfc/rfc6902). It is a custom format with its own `op` values.

I'll add a few other comments inline. There are some API design questions that could use some attention since we don't have a lot of prior art or detailed guidelines yet.