### PR TITLE
Add serde helpers for base64 encoding/decoding

### DIFF
--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -61,11 +61,12 @@ where
 /// # Examples
 ///
 /// ```rust,no_run
-/// # use serde::{Deserialize}
+/// # use serde::{Deserialize};
+/// # use typespec_client_core::base64;
 /// #[derive(Deserialize)]
 /// struct SomeType {
 ///     #[serde(deserialize_with = "base64::deserialize")]
-///     pub value: Vec<u8>,
+///     pub value: Option<Vec<u8>>,
 /// }
 /// ```
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
@@ -91,10 +92,11 @@ where
 ///
 /// ```rust,no_run
 /// # use serde::{Deserialize};
+/// # use typespec_client_core::base64;
 /// #[derive(Deserialize)]
 /// struct SomeType {
 ///     #[serde(deserialize_with = "base64::deserialize_url_safe")]
-///     pub value: Vec<u8>,
+///     pub value: Option<Vec<u8>>,
 /// }
 /// ```
 pub fn deserialize_url_safe<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
@@ -120,10 +122,11 @@ where
 ///
 /// ```rust,no_run
 /// # use serde::{Serialize};
+/// # use typespec_client_core::base64;
 /// #[derive(Serialize)]
 /// struct SomeType {
 ///     #[serde(serialize_with = "base64::serialize")]
-///     pub value: Vec<u8>,
+///     pub value: Option<Vec<u8>>,
 /// }
 /// ```
 pub fn serialize<S>(to_serialize: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
@@ -143,10 +146,11 @@ where
 ///
 /// ```rust,no_run
 /// # use serde::{Serialize};
+/// # use typespec_client_core::base64;
 /// #[derive(Serialize)]
 /// struct SomeType {
 ///     #[serde(serialize_with = "base64::serialize_url_safe")]
-///     pub value: Vec<u8>,
+///     pub value: Option<Vec<u8>>,
 /// }
 /// ```
 pub fn serialize_url_safe<S>(

--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -53,6 +53,19 @@ where
     Ok(URL_SAFE.decode(input)?)
 }
 
+/// Helper that can be used in a serde deserialize_with derive macro
+/// for struct fields that contain base64 encoded data.
+/// 
+/// Uses the standard base64 decoder.
+/// 
+/// # Examples
+/// 
+/// ```rust,no_run
+/// struct SomeType {
+///     #[serde(deserialize_with = "base64::deserialize")]
+///     pub value: Vec<u8>,
+/// }
+/// ```
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
 where
     D: Deserializer<'de>,
@@ -67,6 +80,19 @@ where
     }
 }
 
+/// Helper that can be used in a serde deserialize_with derive macro
+/// for struct fields that contain base64 encoded data.
+/// 
+/// Uses the URL safe base64 decoder.
+/// 
+/// # Examples
+/// 
+/// ```rust,no_run
+/// struct SomeType {
+///     #[serde(deserialize_with = "base64::deserialize_url_safe")]
+///     pub value: Vec<u8>,
+/// }
+/// ```
 pub fn deserialize_url_safe<'de, D>(deserializer: D) -> Result<Option<Vec<u8>>, D::Error>
 where
     D: Deserializer<'de>,
@@ -81,6 +107,19 @@ where
     }
 }
 
+/// Helper that can be used in a serde serialize_with derive macro
+/// for struct fields that contain base64 encoded data.
+/// 
+/// Uses the standard base64 decoder.
+/// 
+/// # Examples
+/// 
+/// ```rust,no_run
+/// struct SomeType {
+///     #[serde(serialize_with = "base64::serialize")]
+///     pub value: Vec<u8>,
+/// }
+/// ```
 pub fn serialize<S>(to_serialize: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
@@ -89,6 +128,19 @@ where
     <Option<String>>::serialize(&encoded, serializer)
 }
 
+/// Helper that can be used in a serde serialize_with derive macro
+/// for struct fields that contain base64 encoded data.
+/// 
+/// Uses the URL safe base64 decoder.
+/// 
+/// # Examples
+/// 
+/// ```rust,no_run
+/// struct SomeType {
+///     #[serde(serialize_with = "base64::serialize_url_safe")]
+///     pub value: Vec<u8>,
+/// }
+/// ```
 pub fn serialize_url_safe<S>(
     to_serialize: &Option<Vec<u8>>,
     serializer: S,

--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -60,7 +60,7 @@ where
     let decoded = <Option<String>>::deserialize(deserializer)?;
     match decoded {
         Some(d) => {
-            let d = decode(d).map_err(|e| serde::de::Error::custom(e))?;
+            let d = decode(d).map_err(serde::de::Error::custom)?;
             Ok(Some(d))
         }
         None => Ok(None),
@@ -74,7 +74,7 @@ where
     let decoded = <Option<String>>::deserialize(deserializer)?;
     match decoded {
         Some(d) => {
-            let d = decode_url_safe(d).map_err(|e| serde::de::Error::custom(e))?;
+            let d = decode_url_safe(d).map_err(serde::de::Error::custom)?;
             Ok(Some(d))
         }
         None => Ok(None),

--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -129,9 +129,10 @@ where
 ///     pub value: Option<Vec<u8>>,
 /// }
 /// ```
-pub fn serialize<S>(to_serialize: &Option<Vec<u8>>, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize<S, T>(to_serialize: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
+    T: AsRef<[u8]>,
 {
     let encoded = to_serialize.as_ref().map(encode);
     <Option<String>>::serialize(&encoded, serializer)
@@ -153,12 +154,10 @@ where
 ///     pub value: Option<Vec<u8>>,
 /// }
 /// ```
-pub fn serialize_url_safe<S>(
-    to_serialize: &Option<Vec<u8>>,
-    serializer: S,
-) -> Result<S::Ok, S::Error>
+pub fn serialize_url_safe<S, T>(to_serialize: &Option<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
+    T: AsRef<[u8]>,
 {
     let encoded = to_serialize.as_ref().map(encode_url_safe);
     <Option<String>>::serialize(&encoded, serializer)

--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -85,11 +85,7 @@ pub fn serialize<S>(to_serialize: &Option<Vec<u8>>, serializer: S) -> Result<S::
 where
     S: Serializer,
 {
-    let encoded = match to_serialize {
-        Some(s) => Some(encode(s)),
-        None => None,
-    };
-
+    let encoded = to_serialize.as_ref().map(encode);
     <Option<String>>::serialize(&encoded, serializer)
 }
 
@@ -100,10 +96,6 @@ pub fn serialize_url_safe<S>(
 where
     S: Serializer,
 {
-    let encoded = match to_serialize {
-        Some(s) => Some(encode_url_safe(s)),
-        None => None,
-    };
-
+    let encoded = to_serialize.as_ref().map(encode_url_safe);
     <Option<String>>::serialize(&encoded, serializer)
 }

--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -110,7 +110,7 @@ where
 /// Helper that can be used in a serde serialize_with derive macro
 /// for struct fields that contain base64 encoded data.
 /// 
-/// Uses the standard base64 decoder.
+/// Uses the standard base64 encoder.
 /// 
 /// # Examples
 /// 
@@ -131,7 +131,7 @@ where
 /// Helper that can be used in a serde serialize_with derive macro
 /// for struct fields that contain base64 encoded data.
 /// 
-/// Uses the URL safe base64 decoder.
+/// Uses the URL safe base64 encoder.
 /// 
 /// # Examples
 /// 

--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -55,11 +55,11 @@ where
 
 /// Helper that can be used in a serde deserialize_with derive macro
 /// for struct fields that contain base64 encoded data.
-/// 
+///
 /// Uses the standard base64 decoder.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```rust,no_run
 /// struct SomeType {
 ///     #[serde(deserialize_with = "base64::deserialize")]
@@ -82,11 +82,11 @@ where
 
 /// Helper that can be used in a serde deserialize_with derive macro
 /// for struct fields that contain base64 encoded data.
-/// 
+///
 /// Uses the URL safe base64 decoder.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```rust,no_run
 /// struct SomeType {
 ///     #[serde(deserialize_with = "base64::deserialize_url_safe")]
@@ -109,11 +109,11 @@ where
 
 /// Helper that can be used in a serde serialize_with derive macro
 /// for struct fields that contain base64 encoded data.
-/// 
+///
 /// Uses the standard base64 encoder.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```rust,no_run
 /// struct SomeType {
 ///     #[serde(serialize_with = "base64::serialize")]
@@ -130,11 +130,11 @@ where
 
 /// Helper that can be used in a serde serialize_with derive macro
 /// for struct fields that contain base64 encoded data.
-/// 
+///
 /// Uses the URL safe base64 encoder.
-/// 
+///
 /// # Examples
-/// 
+///
 /// ```rust,no_run
 /// struct SomeType {
 ///     #[serde(serialize_with = "base64::serialize_url_safe")]

--- a/sdk/typespec/typespec_client_core/src/base64.rs
+++ b/sdk/typespec/typespec_client_core/src/base64.rs
@@ -61,6 +61,8 @@ where
 /// # Examples
 ///
 /// ```rust,no_run
+/// # use serde::{Deserialize}
+/// #[derive(Deserialize)]
 /// struct SomeType {
 ///     #[serde(deserialize_with = "base64::deserialize")]
 ///     pub value: Vec<u8>,
@@ -88,6 +90,8 @@ where
 /// # Examples
 ///
 /// ```rust,no_run
+/// # use serde::{Deserialize};
+/// #[derive(Deserialize)]
 /// struct SomeType {
 ///     #[serde(deserialize_with = "base64::deserialize_url_safe")]
 ///     pub value: Vec<u8>,
@@ -115,6 +119,8 @@ where
 /// # Examples
 ///
 /// ```rust,no_run
+/// # use serde::{Serialize};
+/// #[derive(Serialize)]
 /// struct SomeType {
 ///     #[serde(serialize_with = "base64::serialize")]
 ///     pub value: Vec<u8>,
@@ -136,6 +142,8 @@ where
 /// # Examples
 ///
 /// ```rust,no_run
+/// # use serde::{Serialize};
+/// #[derive(Serialize)]
 /// struct SomeType {
 ///     #[serde(serialize_with = "base64::serialize_url_safe")]
 ///     pub value: Vec<u8>,


### PR DESCRIPTION
To be used in serde "with" derive macros for struct fields that contain base64 data.

```rust
pub struct Base64BytesProperty {
    #[serde(
        deserialize_with = "base64::deserialize",
        skip_serializing_if = "Option::is_none",
        serialize_with = "base64::serialize"
    )]
    pub value: Option<Vec<u8>>,
}
```