### PR TITLE
Add SafeDebug trait derive macro

### DIFF
--- a/sdk/typespec/typespec_client_core/src/fmt.rs
+++ b/sdk/typespec/typespec_client_core/src/fmt.rs
@@ -3,7 +3,29 @@
 
 //! Formatting helpers.
 
-use std::borrow::Cow;
+use std::{borrow::Cow, fmt::Debug};
+
+#[cfg(feature = "derive")]
+pub use typespec_derive::SafeDebug;
+
+/// When deriving this trait, helps prevent leaking personally identifiable information (PII) that deriving [`Debug`] might otherwise.
+///
+/// # Examples
+///
+/// ```
+/// use typespec_client_core::fmt::SafeDebug;
+///
+/// #[derive(SafeDebug)]
+/// struct MyModel {
+///     name: Option<String>,
+/// }
+///
+/// let model = MyModel {
+///     name: Some("Hal Warhol".to_string()),
+/// };
+/// assert_eq!(format!("{model:?}"), "MyModel { .. }");
+/// ```
+pub trait SafeDebug: Debug {}
 
 /// Converts ASCII characters in `value` to lowercase if required; otherwise, returns the original slice.
 ///

--- a/sdk/typespec/typespec_client_core/src/fmt.rs
+++ b/sdk/typespec/typespec_client_core/src/fmt.rs
@@ -13,7 +13,7 @@ pub use typespec_derive::SafeDebug;
 /// # Examples
 ///
 /// ```
-/// use typespec_client_core::fmt::SafeDebug;
+/// use typespec_derive::SafeDebug;
 ///
 /// #[derive(SafeDebug)]
 /// struct MyModel {

--- a/sdk/typespec/typespec_client_core/src/fmt.rs
+++ b/sdk/typespec/typespec_client_core/src/fmt.rs
@@ -21,7 +21,7 @@ pub use typespec_derive::SafeDebug;
 /// }
 ///
 /// let model = MyModel {
-///     name: Some("Hal Warhol".to_string()),
+///     name: Some("Kelly Smith".to_string()),
 /// };
 /// assert_eq!(format!("{model:?}"), "MyModel { .. }");
 /// ```

--- a/sdk/typespec/typespec_derive/src/lib.rs
+++ b/sdk/typespec/typespec_derive/src/lib.rs
@@ -6,6 +6,7 @@ use syn::{parse::ParseStream, parse_macro_input, spanned::Spanned, DeriveInput, 
 extern crate proc_macro;
 
 mod model;
+mod safe_debug;
 
 type Result<T> = ::std::result::Result<T, syn::Error>;
 
@@ -38,7 +39,7 @@ fn parse_literal_string(value: ParseStream) -> Result<LitStr> {
     }
 }
 
-/// Derive macro for implementing `Model` trait.
+/// Derive macro for implementing the `Model` trait.
 ///
 /// Deriving this trait allows a type to be deserialized from an HTTP response body.
 /// By default, the type must also implement `serde::Deserialize`, or the generated code will not compile.
@@ -82,4 +83,13 @@ fn parse_literal_string(value: ParseStream) -> Result<LitStr> {
 #[proc_macro_derive(Model, attributes(typespec))]
 pub fn derive_model(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     run_derive_macro(input, model::derive_model_impl)
+}
+
+/// Derive macro for implementing the `SafeDebug` trait.
+///
+/// Deriving this trait will derive a [`std::fmt::Debug`] implementation that should not leak personally identifiable information (PII).
+/// By default, only the structure or enumeration name will be returned.
+#[proc_macro_derive(SafeDebug)]
+pub fn derive_safe_debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    run_derive_macro(input, safe_debug::derive_safe_debug_impl)
 }

--- a/sdk/typespec/typespec_derive/src/lib.rs
+++ b/sdk/typespec/typespec_derive/src/lib.rs
@@ -89,6 +89,21 @@ pub fn derive_model(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 ///
 /// Deriving this trait will derive a [`std::fmt::Debug`] implementation that should not leak personally identifiable information (PII).
 /// By default, only the structure or enumeration name will be returned.
+///
+/// # Examples
+///
+/// ```
+/// # use typespec_derive::SafeDebug;
+/// #[derive(SafeDebug)]
+/// struct MyModel {
+///     name: Option<String>,
+/// }
+///
+/// let model = MyModel {
+///     name: Some("Hal Warhol".to_string()),
+/// };
+/// assert_eq!(format!("{model:?}"), "MyModel { .. }");
+/// ```
 #[proc_macro_derive(SafeDebug)]
 pub fn derive_safe_debug(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     run_derive_macro(input, safe_debug::derive_safe_debug_impl)

--- a/sdk/typespec/typespec_derive/src/lib.rs
+++ b/sdk/typespec/typespec_derive/src/lib.rs
@@ -100,7 +100,7 @@ pub fn derive_model(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// }
 ///
 /// let model = MyModel {
-///     name: Some("Hal Warhol".to_string()),
+///     name: Some("Kelly Smith".to_string()),
 /// };
 /// assert_eq!(format!("{model:?}"), "MyModel { .. }");
 /// ```

--- a/sdk/typespec/typespec_derive/src/safe_debug.rs
+++ b/sdk/typespec/typespec_derive/src/safe_debug.rs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use crate::Result;
+use proc_macro2::TokenStream;
+use syn::DeriveInput;
+
+pub fn derive_safe_debug_impl(ast: DeriveInput) -> Result<TokenStream> {
+    let body = generate_body(ast)?;
+
+    // We wrap the generated code in a const block to give it a unique scope.
+    let gen = quote::quote! {
+        #[doc(hidden)]
+        const _: () = {
+            #body
+        };
+    };
+    Ok(gen)
+}
+
+fn generate_body(ast: DeriveInput) -> Result<TokenStream> {
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let name = &ast.ident;
+
+    Ok(quote::quote! {
+        #[automatically_derived]
+        impl #impl_generics ::std::fmt::Debug for #name #ty_generics #where_clause {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.debug_struct(stringify!(#name)).finish_non_exhaustive()
+            }
+        }
+    })
+}

--- a/sdk/typespec/typespec_derive/src/safe_debug.rs
+++ b/sdk/typespec/typespec_derive/src/safe_debug.rs
@@ -29,5 +29,8 @@ fn generate_body(ast: DeriveInput) -> Result<TokenStream> {
                 f.debug_struct(stringify!(#name)).finish_non_exhaustive()
             }
         }
+
+        #[automatically_derived]
+        impl #impl_generics ::typespec_client_core::fmt::SafeDebug for #name #ty_generics #where_clause {}
     })
 }


### PR DESCRIPTION
SafeDebug is really just a marker trait. The associated derive macro implements `Debug` in a way to reduce potentially leaking PII. Currently it just outputs the struct or enum name with the non-exhaustive finish e.g., `MyModel { .. }` but we will expand that later.

Relates to #1707
