### PR TITLE
Implement Detach for AMQP message receiver; Remove MessageReceiver from an Arc because it doesn't need to be in one.

### DIFF
--- a/sdk/core/azure_core_amqp/README.md
+++ b/sdk/core/azure_core_amqp/README.md
@@ -8,7 +8,7 @@ This crate is part of a collection of crates: for more information please refer 
 
 ## Example
 
-```rust,no_run
+```rust no_run
 use azure_messaging::*;
 
 #[tokio::main]

--- a/sdk/core/azure_core_amqp/README.md
+++ b/sdk/core/azure_core_amqp/README.md
@@ -8,7 +8,7 @@ This crate is part of a collection of crates: for more information please refer 
 
 ## Example
 
-```rust no_run
+```rust,no_run
 use azure_messaging::*;
 
 #[tokio::main]

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -181,10 +181,6 @@ impl AmqpReceiverApis for NoopAmqpReceiver {
         unimplemented!();
     }
 
-    async fn max_message_size(&self) -> Result<Option<u64>> {
-        unimplemented!();
-    }
-
     #[allow(unused_variables)]
     async fn receive(&self) -> Result<AmqpMessage> {
         unimplemented!();

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -181,6 +181,10 @@ impl AmqpReceiverApis for NoopAmqpReceiver {
         unimplemented!();
     }
 
+    async fn detach(self) -> Result<()> {
+        unimplemented!();
+    }
+
     #[allow(unused_variables)]
     async fn receive(&self) -> Result<AmqpMessage> {
         unimplemented!();

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -55,7 +55,7 @@ pub trait AmqpReceiverApis {
         source: impl Into<AmqpSource>,
         options: Option<AmqpReceiverOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
-    fn max_message_size(&self) -> impl std::future::Future<Output = Result<Option<u64>>>;
+    fn detach(self) -> impl std::future::Future<Output = Result<()>>;
     fn receive(&self) -> impl std::future::Future<Output = Result<AmqpMessage>>;
 }
 
@@ -73,8 +73,8 @@ impl AmqpReceiverApis for AmqpReceiver {
     ) -> Result<()> {
         self.implementation.attach(session, source, options).await
     }
-    async fn max_message_size(&self) -> Result<Option<u64>> {
-        self.implementation.max_message_size().await
+    async fn detach(self) -> Result<()> {
+        self.implementation.detach().await
     }
     async fn receive(&self) -> Result<AmqpMessage> {
         self.implementation.receive().await


### PR DESCRIPTION
- Implemented `AmqpReceiver::detach` to allow clean shutdown of message receiver.
- Ignore ClosedByRemote error when handling a sender detach - that can happen.
- Removed a dead max_message_size method from AMQP Receiver.
- Minor tweaks to imports caused by removing blank lines to let rustfmt handle all imports consistently.

## Github Summary.
This pull request includes several changes to the `sdk/core/azure_core_amqp` crate, focusing on improving the handling of receiver and sender detachment, updating imports, and removing unused methods. The most important changes include modifying the detachment process for receivers and senders, updating import statements, and removing the `max_message_size` method from the `AmqpReceiverApis` trait.

Improvements to receiver and sender detachment:

* [`sdk/core/azure_core_amqp/src/fe2o3/receiver.rs`](diffhunk://#diff-7edae0d79194c90511b829f65add319a4668df84da79b1474f5c0b77b63321b4L72-R94): Modified the `detach` method in the `impl AmqpReceiverApis for Fe2o3AmqpReceiver` to handle errors more gracefully and log appropriate messages.
* [`sdk/core/azure_core_amqp/src/fe2o3/sender.rs`](diffhunk://#diff-76ff607b3937fe075233653a8f2f57295185066fff238ea7ad5832931b2ba9fcL87-R105): Modified the `detach` method in the `impl AmqpSenderApis for Fe2o3AmqpSender` to handle errors more gracefully and log appropriate messages.

Updates to imports:

* [`sdk/core/azure_core_amqp/src/fe2o3/receiver.rs`](diffhunk://#diff-7edae0d79194c90511b829f65add319a4668df84da79b1474f5c0b77b63321b4L5-R17): Updated import statements to include `AmqpLinkDetach` and additional logging utilities.
* [`sdk/core/azure_core_amqp/src/fe2o3/sender.rs`](diffhunk://#diff-76ff607b3937fe075233653a8f2f57295185066fff238ea7ad5832931b2ba9fcR5-R16): Updated import statements to include `AmqpLinkDetach` and additional logging utilities.

Removal of unused methods:

* [`sdk/core/azure_core_amqp/src/receiver.rs`](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L58-R58): Removed the `max_message_size` method from the `AmqpReceiverApis` trait.
* [`sdk/core/azure_core_amqp/src/noop.rs`](diffhunk://#diff-534a5974e0ed69615e3d0b1a71d6e2b9d04ce036d40539bc8d4f9a5a53e1445dL184-L187): Removed the `max_message_size` method from the `impl AmqpReceiverApis for NoopAmqpReceiver`.