### PR TITLE
[Cosmos] `ContainerClient::replace` and container integration tests

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/create.rs
@@ -139,7 +139,9 @@ impl CreateCommand {
                         }
 
                         ContainerProperties {
-                            id: id.expect("the ID is required when not using '--json'"),
+                            id: id
+                                .expect("the ID is required when not using '--json'")
+                                .into(),
                             partition_key: PartitionKeyDefinition::new(partition_key),
                             ..Default::default()
                         }

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -85,6 +85,7 @@ impl ContainerClient {
     /// ```rust,no_run
     /// # async fn doc() {
     /// # use azure_data_cosmos::clients::ContainerClient;
+    /// # use azure_data_cosmos::models::{ContainerProperties, IndexingPolicy};
     /// # let container_client: ContainerClient = panic!("this is a non-running example");
     /// let new_properties = ContainerProperties {
     ///     id: "MyContainer".into(),

--- a/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/container_properties.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use std::time::Duration;
+use std::{borrow::Cow, time::Duration};
 
 use azure_core::Model;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -34,7 +34,7 @@ where
 /// ```rust
 /// # use azure_data_cosmos::models::ContainerProperties;
 /// let properties = ContainerProperties {
-///     id: "NewContainer".to_string(),
+///     id: "NewContainer".into(),
 ///     partition_key: "/partitionKey".into(),
 ///     ..Default::default()
 /// };
@@ -52,7 +52,7 @@ where
 #[serde(rename_all = "camelCase")]
 pub struct ContainerProperties {
     /// The ID of the container.
-    pub id: String,
+    pub id: Cow<'static, str>,
 
     /// The definition of the partition key for the container.
     pub partition_key: PartitionKeyDefinition,
@@ -260,7 +260,7 @@ mod tests {
         // In rare cases, it's reasonable to update this test, if the new generated JSON is considered _equivalent_ to the original by the server.
         // But in general, a failure in this test means that the same user code will send an unexpected value in a new version of the SDK.
         let properties = ContainerProperties {
-            id: "MyContainer".to_string(),
+            id: "MyContainer".into(),
             partition_key: "/partitionKey".into(),
             ..Default::default()
         };

--- a/sdk/cosmos/azure_data_cosmos/src/models/indexing_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/indexing_policy.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Represents the indexing policy for a container.
 ///
 /// For more information see <https://docs.microsoft.com/azure/cosmos-db/index-policy>
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct IndexingPolicy {
     /// Indicates that the indexing policy is automatic.
@@ -58,6 +58,12 @@ pub enum IndexingMode {
 pub struct PropertyPath {
     // The path to the property referenced in this index.
     pub path: String,
+}
+
+impl<T: Into<String>> From<T> for PropertyPath {
+    fn from(value: T) -> Self {
+        PropertyPath { path: value.into() }
+    }
 }
 
 /// Represents a spatial index

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -18,6 +18,12 @@ pub struct CreateContainerOptions<'a> {
     pub throughput: Option<ThroughputProperties>,
 }
 
+/// Options to be passed to [`ContainerClient::replace()`](crate::clients::ContainerClient::replace()).
+#[derive(Clone, Default)]
+pub struct ReplaceContainerOptions<'a> {
+    pub method_options: ClientMethodOptions<'a>,
+}
+
 /// Options to be passed to [`CosmosClient::create_database()`](crate::CosmosClient::create_database()).
 #[derive(Clone, Default)]
 pub struct CreateDatabaseOptions<'a> {

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_containers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_containers.rs
@@ -1,0 +1,264 @@
+#![cfg(feature = "key_auth")]
+
+mod framework;
+
+use std::error::Error;
+
+use azure_core_test::{recorded, TestContext};
+use azure_data_cosmos::{
+    models::{
+        ContainerProperties, IndexingMode, IndexingPolicy, PartitionKeyKind, PropertyPath,
+        ThroughputProperties,
+    },
+    CreateContainerOptions, Query,
+};
+
+use framework::TestAccount;
+use futures::StreamExt;
+
+#[recorded::test(live)]
+pub async fn container_crud(context: TestContext) -> Result<(), Box<dyn Error>> {
+    use azure_data_cosmos::models::PartitionKeyKind;
+
+    let account = TestAccount::from_env(context, None)?;
+    let cosmos_client = account.connect_with_key(None)?;
+    let test_db_id = account.unique_db("DatabaseCRUD");
+    cosmos_client.create_database(&test_db_id, None).await?;
+    let db_client = cosmos_client.database_client(&test_db_id);
+
+    // Create the container
+    let properties = ContainerProperties {
+        id: "TheContainer".into(),
+        partition_key: "/id".into(),
+        indexing_policy: Some(IndexingPolicy {
+            included_paths: vec!["/*".into()],
+            excluded_paths: vec![r#"/"_etag"/?"#.into()],
+            automatic: true,
+            indexing_mode: Some(IndexingMode::Consistent),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let throughput = ThroughputProperties::manual(400);
+
+    let created_properties = db_client
+        .create_container(
+            properties.clone(),
+            Some(CreateContainerOptions {
+                throughput: Some(throughput),
+                ..Default::default()
+            }),
+        )
+        .await?
+        .deserialize_body()
+        .await?
+        .unwrap();
+
+    assert_eq!(&properties.id, &created_properties.id);
+    assert_eq!(
+        vec![String::from("/id")],
+        created_properties.partition_key.paths
+    );
+    assert_eq!(
+        PartitionKeyKind::Hash,
+        created_properties.partition_key.kind
+    );
+    let indexing_policy = created_properties
+        .indexing_policy
+        .expect("created container should have an indexing policy");
+    assert_eq!(
+        vec![PropertyPath::from("/*")],
+        indexing_policy.included_paths
+    );
+    assert_eq!(
+        vec![PropertyPath::from(r#"/"_etag"/?"#)],
+        indexing_policy.excluded_paths
+    );
+    assert!(indexing_policy.automatic);
+    assert_eq!(
+        IndexingMode::Consistent,
+        indexing_policy.indexing_mode.unwrap()
+    );
+
+    let mut query_pager = db_client.query_containers(
+        Query::from("SELECT * FROM root r WHERE r.id = @id")
+            .with_parameter("@id", &properties.id)?,
+        None,
+    )?;
+    let mut ids = vec![];
+    while let Some(response) = query_pager.next().await.transpose()? {
+        let results = response.deserialize_body().await?;
+        for db in results.containers {
+            ids.push(db.id);
+        }
+    }
+    assert_eq!(vec![properties.id.clone()], ids);
+
+    let container_client = db_client.container_client(&properties.id);
+    let updated_properties = ContainerProperties {
+        id: properties.id.clone(),
+        partition_key: properties.partition_key.clone(),
+        indexing_policy: Some(IndexingPolicy {
+            included_paths: vec![],
+            excluded_paths: vec![],
+            automatic: false,
+            indexing_mode: Some(IndexingMode::None),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let update_response = container_client
+        .replace(updated_properties, None)
+        .await?
+        .deserialize_body()
+        .await?
+        .unwrap();
+    let updated_indexing_policy = update_response.indexing_policy.unwrap();
+    assert!(updated_indexing_policy.included_paths.is_empty());
+    assert!(updated_indexing_policy.excluded_paths.is_empty());
+    assert!(!updated_indexing_policy.automatic);
+    assert_eq!(
+        Some(IndexingMode::None),
+        updated_indexing_policy.indexing_mode
+    );
+
+    let current_throughput = container_client
+        .read_throughput(None)
+        .await?
+        .expect("throughput should be present")
+        .deserialize_body()
+        .await?;
+
+    assert_eq!(Some(400), current_throughput.throughput());
+
+    let new_throughput = ThroughputProperties::manual(500);
+    let throughput_response = container_client
+        .replace_throughput(new_throughput, None)
+        .await?
+        .deserialize_body()
+        .await?;
+    assert_eq!(Some(500), throughput_response.throughput());
+
+    container_client.delete(None).await?;
+
+    query_pager = db_client.query_containers(
+        Query::from("SELECT * FROM root r WHERE r.id = @id")
+            .with_parameter("@id", &properties.id)?,
+        None,
+    )?;
+    let mut ids = vec![];
+    while let Some(response) = query_pager.next().await.transpose()? {
+        let results = response.deserialize_body().await?;
+        for db in results.containers {
+            ids.push(db.id);
+        }
+    }
+    assert!(ids.is_empty());
+
+    account.cleanup().await?;
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+pub async fn container_crud_autoscale(context: TestContext) -> Result<(), Box<dyn Error>> {
+    let account = TestAccount::from_env(context, None)?;
+    let cosmos_client = account.connect_with_key(None)?;
+    let test_db_id = account.unique_db("DatabaseCRUD");
+    cosmos_client.create_database(&test_db_id, None).await?;
+    let db_client = cosmos_client.database_client(&test_db_id);
+
+    // Create the container
+    let properties = ContainerProperties {
+        id: "TheContainer".into(),
+        partition_key: "/id".into(),
+        indexing_policy: Some(IndexingPolicy {
+            included_paths: vec!["/*".into()],
+            excluded_paths: vec![r#"/"_etag"/?"#.into()],
+            automatic: true,
+            indexing_mode: Some(IndexingMode::Consistent),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let throughput = ThroughputProperties::autoscale(5000, Some(42));
+
+    db_client
+        .create_container(
+            properties.clone(),
+            Some(CreateContainerOptions {
+                throughput: Some(throughput),
+                ..Default::default()
+            }),
+        )
+        .await?
+        .deserialize_body()
+        .await?
+        .unwrap();
+    let container_client = db_client.container_client(&properties.id);
+
+    let current_throughput = container_client
+        .read_throughput(None)
+        .await?
+        .expect("throughput should be present")
+        .deserialize_body()
+        .await?;
+
+    assert_eq!(Some(500), current_throughput.throughput());
+    assert_eq!(Some(5000), current_throughput.autoscale_maximum());
+    assert_eq!(Some(42), current_throughput.autoscale_increment());
+
+    account.cleanup().await?;
+
+    Ok(())
+}
+
+#[recorded::test(live)]
+pub async fn container_crud_hierarchical_pk(context: TestContext) -> Result<(), Box<dyn Error>> {
+    let account = TestAccount::from_env(context, None)?;
+    let cosmos_client = account.connect_with_key(None)?;
+    let test_db_id = account.unique_db("DatabaseCRUD");
+    cosmos_client.create_database(&test_db_id, None).await?;
+    let db_client = cosmos_client.database_client(&test_db_id);
+
+    // Create the container
+    let properties = ContainerProperties {
+        id: "TheContainer".into(),
+        partition_key: ("/parent", "/child", "/grandchild").into(),
+        indexing_policy: Some(IndexingPolicy {
+            included_paths: vec!["/*".into()],
+            excluded_paths: vec![r#"/"_etag"/?"#.into()],
+            automatic: true,
+            indexing_mode: Some(IndexingMode::Consistent),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let created_properties = db_client
+        .create_container(properties.clone(), None)
+        .await?
+        .deserialize_body()
+        .await?
+        .unwrap();
+
+    assert_eq!(&properties.id, &created_properties.id);
+    assert_eq!(
+        vec![
+            String::from("/parent"),
+            String::from("/child"),
+            String::from("/grandchild")
+        ],
+        created_properties.partition_key.paths
+    );
+    assert_eq!(
+        PartitionKeyKind::MultiHash,
+        created_properties.partition_key.kind
+    );
+
+    account.cleanup().await?;
+
+    Ok(())
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_databases.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_databases.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "key_auth")]
+
 mod framework;
 
 use std::error::Error;


### PR DESCRIPTION
This PR adds the missing `ContainerClient::replace` API, and integration tests for CRUD operations on container.

In addition, I changed `ContainerProperties::id` to a `Cow<'static, str>`. When creating a new container, it would be useful to be able to put a `&'static str` in without forcing it to be heap-allocated. When reading container properties, this will always be `Cow::Owned`, but creation will (I suspect) frequently use string literals and it'd be nice to avoid the heap allocation and copy there.