### PR TITLE
Add timeout waiting for test-proxy to start

### DIFF
--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -21,7 +21,7 @@ serde.workspace = true
 tracing.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { workspace = true, features = ["io-util", "process", "sync"] }
+tokio = { workspace = true, features = ["io-util", "process", "sync", "time"] }
 
 [dev-dependencies]
 clap.workspace = true


### PR DESCRIPTION
Mimics what Go is doing, defaulting to 5 seconds normally or 20 seconds if running in Azure Pipelines (presumably).
