### PR TITLE
update to typespec-rust 0.5.1

### DIFF
--- a/eng/emitter-package-lock.json
+++ b/eng/emitter-package-lock.json
@@ -5,12 +5,20 @@
   "packages": {
     "": {
       "dependencies": {
-        "@azure-tools/typespec-rust": "0.3.0"
+        "@azure-tools/typespec-rust": "0.5.1"
       },
       "devDependencies": {
-        "@azure-tools/typespec-client-generator-core": "0.48.4",
-        "@typespec/compiler": "0.62.0",
-        "@typespec/xml": "0.62.0"
+        "@azure-tools/typespec-autorest": "~0.49.0",
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
+        "@azure-tools/typespec-azure-rulesets": "~0.49.0",
+        "@azure-tools/typespec-client-generator-core": "0.49.0",
+        "@typespec/compiler": "0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/openapi": "~0.63.0",
+        "@typespec/rest": "~0.63.0",
+        "@typespec/versioning": "~0.63.0",
+        "@typespec/xml": "0.63.0"
       }
     },
     "node_modules/@azure-tools/async-io": {
@@ -65,24 +73,46 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.48.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.48.0.tgz",
-      "integrity": "sha512-80qyqgTgBbrnCGXtz6eWAMBdEAjYVVL780L0Ye+rBEd6VoA0m3JrgzUqf5bC0Iwju6lEtBAb8o6sefKD/NGA7g==",
-      "peer": true,
+    "node_modules/@azure-tools/typespec-autorest": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.49.0.tgz",
+      "integrity": "sha512-stwfhmEc3yPeXbM8yfLKVCtaX5mR0H+sL74Xy/eMdEWoJgiE3aJxkgRWESu/7/vo99vugzo/HRwIEO5ELnyfRg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0",
-        "@typespec/rest": "~0.62.0"
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
+        "@azure-tools/typespec-client-generator-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/openapi": "~0.63.0",
+        "@typespec/rest": "~0.63.0",
+        "@typespec/versioning": "~0.63.0"
       }
     },
-    "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.48.4",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.48.4.tgz",
-      "integrity": "sha512-TvX84FiQ3rax0e838m6kpVj8F24OzKAbyLgUXXZ/TjfxhvZb1u0ojMjSKAvmcal2klROJqRlj4d9tImidPYpgA==",
+    "node_modules/@azure-tools/typespec-azure-core": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.49.0.tgz",
+      "integrity": "sha512-hNKy+aePmPkB1brHQkO1tsJXqXPzt/9ehy10dv0rKdp9xq5dE3yBctHF5Aj3Nr8kr8GRG5z4KYpYPbV5guoT5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/rest": "~0.63.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-resource-manager": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.49.0.tgz",
+      "integrity": "sha512-1xWuG8OBJDykYM6BFD2owV9WH+oC32zt7XteXA0T4nH2T+D+sEFKppkCOMtIjX7ENBAlecmbdwgSNTZYQf4vaw==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
         "pluralize": "^8.0.0"
@@ -91,18 +121,57 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.48.0",
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0",
-        "@typespec/openapi": "~0.62.0",
-        "@typespec/rest": "~0.62.0",
-        "@typespec/versioning": "~0.62.0"
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/openapi": "~0.63.0",
+        "@typespec/rest": "~0.63.0",
+        "@typespec/versioning": "~0.63.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-rulesets": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.49.0.tgz",
+      "integrity": "sha512-qKynK3lp+eqlt6QPGFSptrt9uqJUfeuv6yVXYDuaX1Jqu7tbTAgGf0HtN8mqPzfu3eAb84bdq6VgNspxyXLDOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
+        "@azure-tools/typespec-client-generator-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-client-generator-core": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.49.0.tgz",
+      "integrity": "sha512-inFLRIeTU0mQg4PT19O3YwT/4YODLuTgIsXuhKDdG/sEsx8PG8AEFTabtnZJ0w3Lc4xuxKFJrzZ2ZH2iiAAbig==",
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "~5.4.4",
+        "pluralize": "^8.0.0",
+        "yaml": "~2.5.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "~0.49.0",
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0",
+        "@typespec/openapi": "~0.63.0",
+        "@typespec/rest": "~0.63.0",
+        "@typespec/versioning": "~0.63.0"
       }
     },
     "node_modules/@azure-tools/typespec-rust": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-rust/-/typespec-rust-0.3.0.tgz",
-      "integrity": "sha512-Y2JXWG33a5G/RbMsg2JRrFdbl4UxrUEAQUa+/h2mLmmEGJTqnv0SzqAAEpo663N72njgGoz5J3vqZDcFb3uOpw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-rust/-/typespec-rust-0.5.1.tgz",
+      "integrity": "sha512-9QRHW6m64mdIF5avx9Ud+61HZEc5jLM+DFLzddsxctRZWo+KK3V5F63v4BEwdStT0QnqxXiU3iaOxyYBLwiTWA==",
+      "license": "MIT",
       "dependencies": {
         "@azure-tools/codegen": "~2.9.2",
         "@azure-tools/linq": "~3.1.263",
@@ -115,8 +184,8 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-client-generator-core": ">=0.48.4 <1.0.0",
-        "@typespec/compiler": ">=0.62.0 <1.0.0"
+        "@azure-tools/typespec-client-generator-core": ">=0.49.0 <1.0.0",
+        "@typespec/compiler": ">=0.63.0 <1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -157,13 +226,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
       "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
-      "cpu": [
-        "ppc64"
-      ],
+      "cpu": ["ppc64"],
       "optional": true,
-      "os": [
-        "aix"
-      ],
+      "os": ["aix"],
       "engines": {
         "node": ">=12"
       }
@@ -172,13 +237,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
       "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=12"
       }
@@ -187,13 +248,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
       "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=12"
       }
@@ -202,13 +259,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
       "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "android"
-      ],
+      "os": ["android"],
       "engines": {
         "node": ">=12"
       }
@@ -217,13 +270,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
       "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">=12"
       }
@@ -232,13 +281,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
       "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": ">=12"
       }
@@ -247,13 +292,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
       "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "os": ["freebsd"],
       "engines": {
         "node": ">=12"
       }
@@ -262,13 +303,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
       "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "os": ["freebsd"],
       "engines": {
         "node": ">=12"
       }
@@ -277,13 +314,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
       "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -292,13 +325,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
       "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -307,13 +336,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
       "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -322,13 +347,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
       "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
-      "cpu": [
-        "loong64"
-      ],
+      "cpu": ["loong64"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -337,13 +358,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
       "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
-      "cpu": [
-        "mips64el"
-      ],
+      "cpu": ["mips64el"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -352,13 +369,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
       "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
-      "cpu": [
-        "ppc64"
-      ],
+      "cpu": ["ppc64"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -367,13 +380,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
       "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
-      "cpu": [
-        "riscv64"
-      ],
+      "cpu": ["riscv64"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -382,13 +391,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
       "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
-      "cpu": [
-        "s390x"
-      ],
+      "cpu": ["s390x"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -397,13 +402,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
       "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "linux"
-      ],
+      "os": ["linux"],
       "engines": {
         "node": ">=12"
       }
@@ -412,13 +413,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
       "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "netbsd"
-      ],
+      "os": ["netbsd"],
       "engines": {
         "node": ">=12"
       }
@@ -427,13 +424,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
       "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "openbsd"
-      ],
+      "os": ["openbsd"],
       "engines": {
         "node": ">=12"
       }
@@ -442,13 +435,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
       "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "sunos"
-      ],
+      "os": ["sunos"],
       "engines": {
         "node": ">=12"
       }
@@ -457,13 +446,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
       "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=12"
       }
@@ -472,13 +457,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
       "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=12"
       }
@@ -487,13 +468,9 @@
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
       "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "win32"
-      ],
+      "os": ["win32"],
       "engines": {
         "node": ">=12"
       }
@@ -550,229 +527,153 @@
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.1.tgz",
       "integrity": "sha512-2aZp8AES04KI2dy3Ss6/MDjXbwBzj+i0GqKtWXgw2/Ma6E4jJvujryO6gJAghIRVz7Vwr9Gtl/8na3nDUKpraQ==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "os": ["android"]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.1.tgz",
       "integrity": "sha512-EbkK285O+1YMrg57xVA+Dp0tDBRB93/BZKph9XhMjezf6F4TpYjaUSuPt5J0fZXlSag0LmZAsTmdGGqPp4pQFA==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "os": ["android"]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.1.tgz",
       "integrity": "sha512-prduvrMKU6NzMq6nxzQw445zXgaDBbMQvmKSJaxpaZ5R1QDM8w+eGxo6Y/jhT/cLoCvnZI42oEqf9KQNYz1fqQ==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "os": ["darwin"]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.1.tgz",
       "integrity": "sha512-WsvbOunsUk0wccO/TV4o7IKgloJ942hVFK1CLatwv6TJspcCZb9umQkPdvB7FihmdxgaKR5JyxDjWpCOp4uZlQ==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "darwin"
-      ]
+      "os": ["darwin"]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.1.tgz",
       "integrity": "sha512-HTDPdY1caUcU4qK23FeeGxCdJF64cKkqajU0iBnTVxS8F7H/7BewvYoG+va1KPSL63kQ1PGNyiwKOfReavzvNA==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "os": ["freebsd"]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.1.tgz",
       "integrity": "sha512-m/uYasxkUevcFTeRSM9TeLyPe2QDuqtjkeoTpP9SW0XxUWfcYrGDMkO/m2tTw+4NMAF9P2fU3Mw4ahNvo7QmsQ==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "os": ["freebsd"]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.1.tgz",
       "integrity": "sha512-QAg11ZIt6mcmzpNE6JZBpKfJaKkqTm1A9+y9O+frdZJEuhQxiugM05gnCWiANHj4RmbgeVJpTdmKRmH/a+0QbA==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.1.tgz",
       "integrity": "sha512-dRP9PEBfolq1dmMcFqbEPSd9VlRuVWEGSmbxVEfiq2cs2jlZAl0YNxFzAQS2OrQmsLBLAATDMb3Z6MFv5vOcXg==",
-      "cpu": [
-        "arm"
-      ],
+      "cpu": ["arm"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.1.tgz",
       "integrity": "sha512-uGr8khxO+CKT4XU8ZUH1TTEUtlktK6Kgtv0+6bIFSeiSlnGJHG1tSFSjm41uQ9sAO/5ULx9mWOz70jYLyv1QkA==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.1.tgz",
       "integrity": "sha512-QF54q8MYGAqMLrX2t7tNpi01nvq5RI59UBNx+3+37zoKX5KViPo/gk2QLhsuqok05sSCRluj0D00LzCwBikb0A==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.28.1.tgz",
       "integrity": "sha512-vPul4uodvWvLhRco2w0GcyZcdyBfpfDRgNKU+p35AWEbJ/HPs1tOUrkSueVbBS0RQHAf/A+nNtDpvw95PeVKOA==",
-      "cpu": [
-        "loong64"
-      ],
+      "cpu": ["loong64"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.1.tgz",
       "integrity": "sha512-pTnTdBuC2+pt1Rmm2SV7JWRqzhYpEILML4PKODqLz+C7Ou2apEV52h19CR7es+u04KlqplggmN9sqZlekg3R1A==",
-      "cpu": [
-        "ppc64"
-      ],
+      "cpu": ["ppc64"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.1.tgz",
       "integrity": "sha512-vWXy1Nfg7TPBSuAncfInmAI/WZDd5vOklyLJDdIRKABcZWojNDY0NJwruY2AcnCLnRJKSaBgf/GiJfauu8cQZA==",
-      "cpu": [
-        "riscv64"
-      ],
+      "cpu": ["riscv64"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.1.tgz",
       "integrity": "sha512-/yqC2Y53oZjb0yz8PVuGOQQNOTwxcizudunl/tFs1aLvObTclTwZ0JhXF2XcPT/zuaymemCDSuuUPXJJyqeDOg==",
-      "cpu": [
-        "s390x"
-      ],
+      "cpu": ["s390x"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.1.tgz",
       "integrity": "sha512-fzgeABz7rrAlKYB0y2kSEiURrI0691CSL0+KXwKwhxvj92VULEDQLpBYLHpF49MSiPG4sq5CK3qHMnb9tlCjBw==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.1.tgz",
       "integrity": "sha512-xQTDVzSGiMlSshpJCtudbWyRfLaNiVPXt1WgdWTwWz9n0U12cI2ZVtWe/Jgwyv/6wjL7b66uu61Vg0POWVfz4g==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "linux"
-      ]
+      "os": ["linux"]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.1.tgz",
       "integrity": "sha512-wSXmDRVupJstFP7elGMgv+2HqXelQhuNf+IS4V+nUpNVi/GUiBgDmfwD0UGN3pcAnWsgKG3I52wMOBnk1VHr/A==",
-      "cpu": [
-        "arm64"
-      ],
+      "cpu": ["arm64"],
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "os": ["win32"]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.1.tgz",
       "integrity": "sha512-ZkyTJ/9vkgrE/Rk9vhMXhf8l9D+eAhbAVbsGsXKy2ohmJaWg0LPQLnIxRdRp/bKyr8tXuPlXhIoGlEB5XpJnGA==",
-      "cpu": [
-        "ia32"
-      ],
+      "cpu": ["ia32"],
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "os": ["win32"]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.1.tgz",
       "integrity": "sha512-ZvK2jBafvttJjoIdKm/Q/Bh7IJ1Ose9IBOwpOXcOvW3ikGTQGmKDgxTC6oCAzW6PynbkKP8+um1du81XJHZ0JA==",
-      "cpu": [
-        "x64"
-      ],
+      "cpu": ["x64"],
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "os": ["win32"]
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -796,16 +697,17 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
     },
     "node_modules/@typespec/compiler": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.62.0.tgz",
-      "integrity": "sha512-RfKJ/rF2Wjxu7dl74oJE8yEfSkeL7NopFlyJ4dW1JQXpRN2IOJYPxas12qZA6H9ZEIB8rBjyrHNxJSQbvn/UDQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.63.0.tgz",
+      "integrity": "sha512-cC3YniwbFghn1fASX3r1IgNjMrwaY4gmzznkHT4f/NxE+HK4XoXWn4EG7287QgVMCaHUykzJCIfW9k7kIleW5A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.25.7",
         "ajv": "~8.17.1",
         "change-case": "~5.4.4",
         "globby": "~14.0.2",
         "mustache": "~4.2.0",
-        "picocolors": "~1.1.0",
+        "picocolors": "~1.1.1",
         "prettier": "~3.3.3",
         "prompts": "~2.4.2",
         "semver": "^7.6.3",
@@ -824,16 +726,16 @@
       }
     },
     "node_modules/@typespec/http": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.62.0.tgz",
-      "integrity": "sha512-6H9y9e32lb2s76MMy29ITCwSZNG42sa/qWthiByUvfbTEXMpu5a1fQHNj7RXg+xmDKmVIHv3gAfjGPAWfXhkaQ==",
-      "peer": true,
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.63.0.tgz",
+      "integrity": "sha512-SYVbBmLPAPdWZfdMs0QlbpTnFREDnkINu2FR+0kRX12qzbRgpRbLsdhg59qx4TfKoh4IAPgSV+Fq84w7BWGsyQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/streams": "~0.62.0"
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/streams": "~0.63.0"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -842,53 +744,54 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.62.0.tgz",
-      "integrity": "sha512-Xtm0Nd2BuSmEfSWGtc10ok22jyomYm9L2jY+kVTy+v5J89DrVh0o6+YpipUl1QhcItM1YMBphWHIHPfwkDRbnw==",
-      "peer": true,
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.63.0.tgz",
+      "integrity": "sha512-/KzR60mj3P/LnNWd/QfH0KTN/If4+mjrsWNSB7/uab6c8Qu/lNsGlZDkmWq4EFiwBR7VmpdFz9FP7d/m3O+tGw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0"
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.62.0.tgz",
-      "integrity": "sha512-ci5UjelEKFwsPTdpgysoUoDCcw02EnbG4GBuYJdR5mRrFCBZMxrbro+OJLgSN3g/TORSsWlW7dEOWLfbyrmlZQ==",
-      "peer": true,
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.63.0.tgz",
+      "integrity": "sha512-HftzMjSDHAYX+ILE9C6pFS4oAq7oBHMCtpA8QgSFPDF4V5a8l1k2K8c4x1B+7yl+GkREmIdtpc6S0xZm2G7hXg==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0",
-        "@typespec/http": "~0.62.0"
+        "@typespec/compiler": "~0.63.0",
+        "@typespec/http": "~0.63.0"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.62.0.tgz",
-      "integrity": "sha512-M5KTCVH5fBniZU8eQlw+NV13vAmPr58HyBLDIyxeOuV+SHNlx+f+qanUEDIPaJheKlaSSNTEZKsDhs83/iIMMA==",
-      "peer": true,
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.63.0.tgz",
+      "integrity": "sha512-BPvmPL+g20yEmSA8XRfbIHdToNOjssq4QfwOU6D7kKLLXnZHFb1hmuwW0tf0Wa/lYgoaUC60ONAeoXgNT1ZOIQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0"
+        "@typespec/compiler": "~0.63.0"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.62.0.tgz",
-      "integrity": "sha512-DexGTQHB75fncDcYfs5CIbNwO6NOhjwCaaNoHYAsVVzs4T8qwzw6WQdEEMzZRbgsxwnllFkxKwGhLtRMQdv/cQ==",
+      "version": "0.63.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.63.0.tgz",
+      "integrity": "sha512-2aQxWWqc5f4OTmC2nNafHi+ppr8GqwwMXx/2DnNjeshZF/JD0FNCYH8gV4gFZe7mfRfB9bAxNkcKj2AF01ntqA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.62.0"
+        "@typespec/compiler": "~0.63.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -1330,9 +1233,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "hasInstallScript": true,
       "optional": true,
-      "os": [
-        "darwin"
-      ],
+      "os": ["darwin"],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/eng/emitter-package.json
+++ b/eng/emitter-package.json
@@ -1,11 +1,19 @@
 {
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-rust": "0.3.0"
+    "@azure-tools/typespec-rust": "0.5.1"
   },
   "devDependencies": {
-    "@azure-tools/typespec-client-generator-core": "0.48.4",
-    "@typespec/compiler": "0.62.0",
-    "@typespec/xml": "0.62.0"
+    "@azure-tools/typespec-autorest": "~0.49.0",
+    "@azure-tools/typespec-azure-core": "~0.49.0",
+    "@azure-tools/typespec-client-generator-core": "0.49.0",
+    "@azure-tools/typespec-azure-resource-manager": "~0.49.0",
+    "@azure-tools/typespec-azure-rulesets": "~0.49.0",
+    "@typespec/compiler": "0.63.0",
+    "@typespec/http": "~0.63.0",
+    "@typespec/openapi": "~0.63.0",
+    "@typespec/rest": "~0.63.0",
+    "@typespec/versioning": "~0.63.0",
+    "@typespec/xml": "0.63.0"
   }
 }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -95,6 +95,14 @@ function Get-rust-EmitterName() {
   return "@azure-tools/typespec-rust"
 }
 
+function Get-CrateVersion([string]$projectDirectory) {
+  return "0.1.0"
+}
+
+function Get-CrateName(){
+  return (Split-Path $projectDirectory -Leaf)
+}
+
 function Get-rust-EmitterAdditionalOptions([string]$projectDirectory) {
-  return "--option @azure-tools/typespec-rust.emitter-output-dir=$projectDirectory"
+  return "--option @azure-tools/typespec-rust.emitter-output-dir=$projectDirectory --option @azure-tools/typespec-rust.crate-name=$(Get-CrateName($projectDirectory)) --option @azure-tools/typespec-rust.crate-version=$(Get-CrateVersion($projectDirectory))"
 }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -96,5 +96,5 @@ function Get-rust-EmitterName() {
 }
 
 function Get-rust-EmitterAdditionalOptions([string]$projectDirectory) {
-  return "--option @azure-tools/typespec-rust.emitter-output-dir=$projectDirectory/src"
+  return "--option @azure-tools/typespec-rust.emitter-output-dir=$projectDirectory"
 }

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -90,3 +90,11 @@ function Get-AllPackageInfoFromRepo ([string] $ServiceDirectory) {
 
   return $allPackageProps
 }
+
+function Get-rust-EmitterName() {
+  return "@azure-tools/typespec-rust"
+}
+
+function Get-rust-EmitterAdditionalOptions([string]$projectDirectory) {
+  return "--option @azure-tools/typespec-rust.emitter-output-dir=$projectDirectory/src"
+}


### PR DESCRIPTION
This updates the dependencies, matching devDependencies from [azure-sdk-for-python emitter-package.json](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/emitter-package.json).

This allowed me to get further when attempting to generate a client for AVS:
```
~/ms/azure-sdk-for-rust> pwsh ./eng/common/scripts/TypeSpec-Project-Process.ps1 /Users/cataggar/ms/azure-rest-api-specs/specification/vmware/Microsoft.AVS.Management 64f6997950d8bee63f314563cedaa20148db2186 https://github.com/Azure/azure-rest-api-specs
```

I set SaveInput to true to debug. With this PR, the generated tspconfig.yaml 
```yaml
  "@azure-tools/typespec-rust":
    package-dir: "azure_mgmt_avs"
```

But it will need setting for `crate-name` and `crate-version`. I'm assuming those will be loaded from the directory. I'm also not sure what the new naming convention will be.
```yaml
  "@azure-tools/typespec-rust":
    package-dir: "azure_mgmt_avs"
    crate-name: "azure_mgmt_avs"
    crate-version: "0.1.0"
```

I hit a bug and will file a separate issue for:
```
Emitter "@azure-tools/typespec-rust" crashed! This is a bug.
Please file an issue at https://github.com/Azure/typespec-rust/issues

Error: unhandled tcgc type enumvalue
    at Adapter.getType (file:///Users/cataggar/ms/azure-sdk-for-rust/sdk/avs/azure_mgmt_avs/TempTypeSpecFiles/Microsoft.AVS.(file:///Users/cataggar/ms/azure-sdk-for-rust/sdk/avs/azure_mgmt_avs/TempTypeSpecFiles/Microsoft.AVS.
```