### PR TITLE
Changed AMQP message receive model to require explicit delivery accept/reject.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "serde_amqp",
  "serde_bytes",
  "time",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -33,6 +33,7 @@ uuid = { workspace = true }
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tokio = { workspace = true }
 
 [features]
 default = ["fe2o3-amqp"]

--- a/sdk/core/azure_core_amqp/examples/connection.rs
+++ b/sdk/core/azure_core_amqp/examples/connection.rs
@@ -1,4 +1,18 @@
-//    #[tokio::test]
+// Copyright (c) Microsoft Corporation. All Rights reserved
+// Licensed under the MIT license.
+
+// These tests assume that the AmqpTestBroker is running on localhost:25672.
+// The AmqpTestBroker can be installed by the following steps:
+// 1. Clone the repository:
+//      git clone https://github.com/Azure/azure-amqp
+// 2. Build the project:
+//      dotnet restore
+//      dotnet build
+// 3. Run the broker:
+//      dotnet run --project .\test\TestAmqpBroker\TestAmqpBroker.csproj --framework net462 amqp://localhost:25672
+// 4. Run the tests (from the root of the azure-sdk-for-rust repository):
+//      cargo run --example connection --package azure_core_amqp
+
 use azure_core::Url;
 use azure_core_amqp::{
     connection::{AmqpConnection, AmqpConnectionApis},
@@ -15,7 +29,6 @@ async fn amqp_connection_open() {
         .unwrap();
 }
 
-//    #[tokio::test]
 async fn amqp_connection_open_with_error() {
     let connection = AmqpConnection::new();
     let url = Url::parse("amqp://localhost:32767").unwrap();
@@ -25,7 +38,6 @@ async fn amqp_connection_open_with_error() {
         .is_err());
 }
 
-//    #[tokio::test]
 async fn amqp_connection_close() {
     let connection = AmqpConnection::new();
     let url = Url::parse("amqp://localhost:25672").unwrap();
@@ -36,7 +48,6 @@ async fn amqp_connection_close() {
     connection.close().await.unwrap();
 }
 
-//    #[tokio::test]
 async fn amqp_connection_close_with_error() {
     let connection = AmqpConnection::new();
     let url = Url::parse("amqp://localhost:25672").unwrap();

--- a/sdk/core/azure_core_amqp/examples/connection.rs
+++ b/sdk/core/azure_core_amqp/examples/connection.rs
@@ -1,0 +1,70 @@
+//    #[tokio::test]
+use azure_core::Url;
+use azure_core_amqp::{
+    connection::{AmqpConnection, AmqpConnectionApis},
+    value::AmqpSymbol,
+};
+
+async fn amqp_connection_open() {
+    let connection = AmqpConnection::new();
+
+    let url = Url::parse("amqp://localhost:25672").unwrap();
+    connection
+        .open("test".to_string(), url, None)
+        .await
+        .unwrap();
+}
+
+//    #[tokio::test]
+async fn amqp_connection_open_with_error() {
+    let connection = AmqpConnection::new();
+    let url = Url::parse("amqp://localhost:32767").unwrap();
+    assert!(connection
+        .open("test".to_string(), url, None)
+        .await
+        .is_err());
+}
+
+//    #[tokio::test]
+async fn amqp_connection_close() {
+    let connection = AmqpConnection::new();
+    let url = Url::parse("amqp://localhost:25672").unwrap();
+    connection
+        .open("test".to_string(), url, None)
+        .await
+        .unwrap();
+    connection.close().await.unwrap();
+}
+
+//    #[tokio::test]
+async fn amqp_connection_close_with_error() {
+    let connection = AmqpConnection::new();
+    let url = Url::parse("amqp://localhost:25672").unwrap();
+    connection
+        .open("test".to_string(), url, None)
+        .await
+        .unwrap();
+    let res = connection
+        .close_with_error(
+            AmqpSymbol::from("amqp:internal-error"),
+            Some("Internal error.".to_string()),
+            None,
+        )
+        .await;
+    match res {
+        Ok(_) => {}
+        Err(err) => {
+            assert!(err.to_string().contains("Internal error."));
+        }
+    }
+}
+
+#[tokio::main]
+pub async fn main() {
+    tracing_subscriber::fmt::init();
+
+    amqp_connection_open().await;
+    amqp_connection_open_with_error().await;
+    amqp_connection_close().await;
+    amqp_connection_close_with_error().await;
+}

--- a/sdk/core/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure_core_amqp/src/connection.rs
@@ -85,7 +85,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_amqp_connection_options_with_max_frame_size() {
+    fn amqp_connection_options_with_max_frame_size() {
         let connection_options = AmqpConnectionOptions {
             max_frame_size: Some(1024),
             ..Default::default()
@@ -197,7 +197,7 @@ mod tests {
     }
 
     #[test]
-    fn test_amqp_connection_options() {
+    fn amqp_connection_options() {
         let connection_options = AmqpConnectionOptions {
             max_frame_size: Some(1024),
             channel_max: Some(16),
@@ -243,5 +243,69 @@ mod tests {
                 vec![("key".into(), "value".into())].into_iter().collect() // convert to AmqpOrderedMap
             )
         );
+    }
+
+    // Tests disabled until we have a way to start the AMQP test broker in CI
+    #[allow(dead_code)]
+    mod disabled {
+        use super::super::*;
+
+        //    #[tokio::test]
+        async fn amqp_connection_open() {
+            tracing_subscriber::fmt::init();
+            let connection = AmqpConnection::new();
+
+            let url = Url::parse("amqp://localhost:25672").unwrap();
+            connection
+                .open("test".to_string(), url, None)
+                .await
+                .unwrap();
+        }
+
+        //    #[tokio::test]
+        async fn amqp_connection_open_with_error() {
+            tracing_subscriber::fmt::try_init().unwrap();
+            let connection = AmqpConnection::new();
+            let url = Url::parse("amqp://localhost:32767").unwrap();
+            assert!(connection
+                .open("test".to_string(), url, None)
+                .await
+                .is_err());
+        }
+
+        //    #[tokio::test]
+        async fn amqp_connection_close() {
+            let connection = AmqpConnection::new();
+            let url = Url::parse("amqp://localhost:25672").unwrap();
+            connection
+                .open("test".to_string(), url, None)
+                .await
+                .unwrap();
+            connection.close().await.unwrap();
+        }
+
+        //    #[tokio::test]
+        async fn amqp_connection_close_with_error() {
+            tracing_subscriber::fmt::try_init().unwrap();
+            let connection = AmqpConnection::new();
+            let url = Url::parse("amqp://localhost:25672").unwrap();
+            connection
+                .open("test".to_string(), url, None)
+                .await
+                .unwrap();
+            let res = connection
+                .close_with_error(
+                    AmqpSymbol::from("amqp:internal-error"),
+                    Some("Internal error.".to_string()),
+                    None,
+                )
+                .await;
+            match res {
+                Ok(_) => {}
+                Err(err) => {
+                    assert!(err.to_string().contains("Internal error."));
+                }
+            }
+        }
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -131,6 +131,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             .map_err(AmqpConnection::from)?;
         Ok(())
     }
+
     async fn close_with_error(
         &self,
         condition: AmqpSymbol,
@@ -166,7 +167,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             Err(e) => match e.0 {
                 fe2o3_amqp::connection::Error::TransportError(e) => {
                     info!(
-                        "Transport Error closing connection with error: {:?} - ignored",
+                        "Transport error closing connection with error: {:?} - ignored",
                         e
                     );
                     Ok(())

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -4,6 +4,12 @@
 
 use crate::messaging::{AmqpOutcome, DistributionMode, TerminusDurability, TerminusExpiryPolicy};
 
+pub(crate) struct AmqpDelivery(
+    pub(crate)  fe2o3_amqp::link::delivery::Delivery<
+        fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
+    >,
+);
+
 impl From<fe2o3_amqp_types::messaging::Outcome> for AmqpOutcome {
     fn from(outcome: fe2o3_amqp_types::messaging::Outcome) -> Self {
         match outcome {

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 
 use crate::messaging::{
     AmqpDelivery, AmqpDeliveryApis, AmqpMessage, AmqpOutcome, DeliveryNumber, DeliveryTag,
-    DistributionMode, Handle, TerminusDurability, TerminusExpiryPolicy,
+    DistributionMode, TerminusDurability, TerminusExpiryPolicy,
 };
 
 pub(crate) struct Fe2o3AmqpDelivery {
@@ -38,10 +38,7 @@ impl
 }
 
 impl AmqpDeliveryApis for Fe2o3AmqpDelivery {
-    fn handle(&self) -> Handle {
-        Handle(self.delivery.handle().0)
-    }
-
+    // Return a reference to the message contained in the delivery.
     fn message(&self) -> &AmqpMessage {
         self.message
             .get_or_init(|| AmqpMessage::from(self.delivery.message().clone()))

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -107,32 +107,25 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
         }
     }
 
-    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) {
-        let receiver = self
-            .receiver
-            .get()
-            .ok_or_else(|| {
-                azure_core::Error::message(
-                    azure_core::error::ErrorKind::Other,
-                    "Message receiver is not set.",
-                )
-            })
-            .unwrap();
+    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) -> Result<()> {
+        let receiver = self.receiver.get().ok_or_else(|| {
+            azure_core::Error::message(
+                azure_core::error::ErrorKind::Other,
+                "Message receiver is not set.",
+            )
+        })?;
         receiver.lock_blocking().set_credit_mode(credit_mode.into());
+        Ok(())
     }
 
-    fn get_credit_mode(&self) -> ReceiverCreditMode {
-        let receiver = self
-            .receiver
-            .get()
-            .ok_or_else(|| {
-                azure_core::Error::message(
-                    azure_core::error::ErrorKind::Other,
-                    "Message receiver is not set.",
-                )
-            })
-            .unwrap();
-        receiver.lock_blocking().credit_mode().into()
+    fn credit_mode(&self) -> Result<ReceiverCreditMode> {
+        let receiver = self.receiver.get().ok_or_else(|| {
+            azure_core::Error::message(
+                azure_core::error::ErrorKind::Other,
+                "Message receiver is not set.",
+            )
+        })?;
+        Ok(receiver.lock_blocking().credit_mode().into())
     }
 
     async fn receive_delivery(&self) -> Result<AmqpDelivery> {
@@ -175,7 +168,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .accept(&delivery.0.delivery)
             .await
             .map_err(AmqpIllegalLinkState::from)?;
-        trace!("Accepted delivery");
+        trace!("Accepted delivery.");
 
         Ok(())
     }
@@ -198,7 +191,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .reject(&delivery.0.delivery, None)
             .await
             .map_err(AmqpIllegalLinkState::from)?;
-        trace!("Rejected delivery");
+        trace!("Rejected delivery.");
 
         Ok(())
     }
@@ -221,7 +214,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
             .release(&delivery.0.delivery)
             .await
             .map_err(AmqpIllegalLinkState::from)?;
-        trace!("Released delivery");
+        trace!("Released delivery.");
 
         Ok(())
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -4,7 +4,7 @@
 
 use super::error::{AmqpIllegalLinkState, AmqpLinkDetach, AmqpReceiver, AmqpReceiverAttach};
 use crate::{
-    messaging::{AmqpDelivery, AmqpDeliveryApis, AmqpSource},
+    messaging::{AmqpDelivery, AmqpSource},
     receiver::{AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode},
     session::AmqpSession,
 };
@@ -118,8 +118,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
         Ok(delivery.into())
     }
 
-    async fn accept_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
-        let delivery = delivery.0;
+    async fn accept_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         let receiver = self
             .receiver
             .get()
@@ -134,7 +133,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
 
         trace!("Accepting delivery.");
         receiver
-            .accept(delivery.delivery)
+            .accept(&delivery.0.delivery)
             .await
             .map_err(AmqpIllegalLinkState::from)?;
         trace!("Accepted delivery");
@@ -142,8 +141,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
         Ok(())
     }
 
-    async fn reject_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
-        let delivery = delivery.0.delivery;
+    async fn reject_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         let receiver = self
             .receiver
             .get()
@@ -158,7 +156,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
 
         trace!("Rejecting delivery.");
         receiver
-            .reject(delivery, None)
+            .reject(&delivery.0.delivery, None)
             .await
             .map_err(AmqpIllegalLinkState::from)?;
         trace!("Rejected delivery");
@@ -166,8 +164,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
         Ok(())
     }
 
-    async fn release_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
-        let delivery = delivery.0.delivery;
+    async fn release_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         let receiver = self
             .receiver
             .get()
@@ -182,7 +179,7 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
 
         trace!("Releasing delivery.");
         receiver
-            .release(delivery)
+            .release(&delivery.0.delivery)
             .await
             .map_err(AmqpIllegalLinkState::from)?;
         trace!("Released delivery");

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -5,18 +5,16 @@
 use super::value::{AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
 #[cfg(feature = "cplusplus")]
 use crate::Deserializable;
-use crate::Uuid;
+use crate::{ReceiverSettleMode, Uuid};
 #[cfg(feature = "cplusplus")]
 use azure_core::error::ErrorKind;
 use azure_core::Result;
 
 #[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
-type DeliveryImplementation = super::fe2o3::messaging::messaging_types::AmqpDelivery;
+type DeliveryImplementation = super::fe2o3::messaging::messaging_types::Fe2o3AmqpDelivery;
 
 #[cfg(any(not(feature = "fe2o3-amqp"), target_arch = "wasm32"))]
 type DeliveryImplementation = super::noop::NoopAmqpDelivery;
-
-pub struct AmqpDelivery(pub(crate) DeliveryImplementation);
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TerminusDurability {
@@ -88,6 +86,59 @@ impl From<AmqpSymbol> for DistributionMode {
             "copy" => DistributionMode::Copy,
             _ => panic!("Invalid symbol for DistributionMode"),
         }
+    }
+}
+
+pub struct AmqpDelivery(pub(crate) DeliveryImplementation);
+
+impl AmqpDelivery {
+    pub(crate) fn new(delivery: DeliveryImplementation) -> AmqpDelivery {
+        AmqpDelivery(delivery)
+    }
+}
+
+pub(crate) struct Handle(pub(crate) u32);
+pub type DeliveryNumber = u32;
+pub type DeliveryTag = Vec<u8>;
+
+pub trait AmqpDeliveryApis {
+    fn handle(&self) -> Handle;
+    fn message(&self) -> &AmqpMessage;
+    fn delivery_id(&self) -> DeliveryNumber;
+    fn delivery_tag(&self) -> &DeliveryTag;
+    fn message_format(&self) -> &Option<u32>;
+    fn into_message(self) -> AmqpMessage;
+}
+
+impl AmqpDeliveryApis for AmqpDelivery {
+    /// Get the link output handle
+    fn handle(&self) -> Handle {
+        self.0.handle()
+    }
+
+    /// Get the message
+    fn message(&self) -> &AmqpMessage {
+        &self.0.message()
+    }
+
+    /// Get the delivery ID
+    fn delivery_id(&self) -> DeliveryNumber {
+        self.0.delivery_id()
+    }
+
+    /// Get the delivery tag
+    fn delivery_tag(&self) -> &DeliveryTag {
+        &self.0.delivery_tag()
+    }
+
+    /// Get the message format
+    fn message_format(&self) -> &Option<u32> {
+        &self.0.message_format()
+    }
+
+    /// Consume the delivery into the message
+    fn into_message(self) -> AmqpMessage {
+        self.0.into_message()
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -5,7 +5,7 @@
 use super::value::{AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
 #[cfg(feature = "cplusplus")]
 use crate::Deserializable;
-use crate::{ReceiverSettleMode, Uuid};
+use crate::Uuid;
 #[cfg(feature = "cplusplus")]
 use azure_core::error::ErrorKind;
 use azure_core::Result;
@@ -97,12 +97,10 @@ impl AmqpDelivery {
     }
 }
 
-pub(crate) struct Handle(pub(crate) u32);
 pub type DeliveryNumber = u32;
 pub type DeliveryTag = Vec<u8>;
 
 pub trait AmqpDeliveryApis {
-    fn handle(&self) -> Handle;
     fn message(&self) -> &AmqpMessage;
     fn delivery_id(&self) -> DeliveryNumber;
     fn delivery_tag(&self) -> &DeliveryTag;
@@ -111,14 +109,9 @@ pub trait AmqpDeliveryApis {
 }
 
 impl AmqpDeliveryApis for AmqpDelivery {
-    /// Get the link output handle
-    fn handle(&self) -> Handle {
-        self.0.handle()
-    }
-
     /// Get the message
     fn message(&self) -> &AmqpMessage {
-        &self.0.message()
+        self.0.message()
     }
 
     /// Get the delivery ID
@@ -128,12 +121,12 @@ impl AmqpDeliveryApis for AmqpDelivery {
 
     /// Get the delivery tag
     fn delivery_tag(&self) -> &DeliveryTag {
-        &self.0.delivery_tag()
+        self.0.delivery_tag()
     }
 
     /// Get the message format
     fn message_format(&self) -> &Option<u32> {
-        &self.0.message_format()
+        self.0.message_format()
     }
 
     /// Consume the delivery into the message

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -5,11 +5,18 @@
 use super::value::{AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
 #[cfg(feature = "cplusplus")]
 use crate::Deserializable;
+use crate::Uuid;
 #[cfg(feature = "cplusplus")]
 use azure_core::error::ErrorKind;
 use azure_core::Result;
 
-use crate::Uuid;
+#[cfg(all(feature = "fe2o3-amqp", not(target_arch = "wasm32")))]
+type DeliveryImplementation = super::fe2o3::messaging::messaging_types::AmqpDelivery;
+
+#[cfg(any(not(feature = "fe2o3-amqp"), target_arch = "wasm32"))]
+type DeliveryImplementation = super::noop::NoopAmqpDelivery;
+
+pub struct AmqpDelivery(pub(crate) DeliveryImplementation);
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TerminusDurability {
@@ -967,7 +974,6 @@ impl AmqpApplicationProperties {
         self.0.insert(key, value.into());
     }
 }
-
 /// An AMQP message.
 ///
 /// This is a simplified version of the AMQP message

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -92,6 +92,7 @@ impl From<AmqpSymbol> for DistributionMode {
 pub struct AmqpDelivery(pub(crate) DeliveryImplementation);
 
 impl AmqpDelivery {
+    #[allow(dead_code)]
     pub(crate) fn new(delivery: DeliveryImplementation) -> AmqpDelivery {
         AmqpDelivery(delivery)
     }

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -7,8 +7,11 @@ use super::{
     cbs::AmqpClaimsBasedSecurityApis,
     connection::{AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions},
     management::AmqpManagementApis,
-    messaging::{AmqpMessage, AmqpSource, AmqpTarget},
-    receiver::{AmqpReceiverApis, AmqpReceiverOptions},
+    messaging::{
+        AmqpDelivery, AmqpDeliveryApis, AmqpMessage, AmqpSource, AmqpTarget, DeliveryNumber,
+        DeliveryTag,
+    },
+    receiver::{AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode},
     sender::{AmqpSendOptions, AmqpSenderApis, AmqpSenderOptions},
     session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions},
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
@@ -30,6 +33,8 @@ pub(crate) struct NoopAmqpReceiver {}
 
 #[derive(Default, Clone)]
 pub(crate) struct NoopAmqpSession {}
+
+pub(crate) struct NoopAmqpDelivery {}
 
 #[derive(Default)]
 pub(crate) struct NoopAmqpClaimsBasedSecurity<'a> {
@@ -186,7 +191,45 @@ impl AmqpReceiverApis for NoopAmqpReceiver {
     }
 
     #[allow(unused_variables)]
-    async fn receive(&self) -> Result<AmqpMessage> {
+    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) {
+        unimplemented!();
+    }
+
+    fn get_credit_mode(&self) -> ReceiverCreditMode {
+        unimplemented!();
+    }
+
+    #[allow(unused_variables)]
+    async fn receive_delivery(&self) -> Result<AmqpDelivery> {
+        unimplemented!();
+    }
+
+    async fn accept_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
+        unimplemented!();
+    }
+    async fn reject_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
+        unimplemented!();
+    }
+    async fn release_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
+        unimplemented!();
+    }
+}
+
+impl AmqpDeliveryApis for NoopAmqpDelivery {
+    fn message(&self) -> &AmqpMessage {
+        unimplemented!();
+    }
+    fn delivery_id(&self) -> DeliveryNumber {
+        unimplemented!();
+    }
+    fn delivery_tag(&self) -> &DeliveryTag {
+        unimplemented!();
+    }
+
+    fn message_format(&self) -> &Option<u32> {
+        unimplemented!();
+    }
+    fn into_message(self) -> AmqpMessage {
         unimplemented!();
     }
 }

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -191,11 +191,11 @@ impl AmqpReceiverApis for NoopAmqpReceiver {
     }
 
     #[allow(unused_variables)]
-    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) {
+    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) -> Result<()> {
         unimplemented!();
     }
 
-    fn get_credit_mode(&self) -> ReceiverCreditMode {
+    fn credit_mode(&self) -> Result<ReceiverCreditMode> {
         unimplemented!();
     }
 

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -55,8 +55,10 @@ pub trait AmqpReceiverApis {
         source: impl Into<AmqpSource>,
         options: Option<AmqpReceiverOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
+
     fn detach(self) -> impl std::future::Future<Output = Result<()>>;
-    //    fn receive(&self) -> impl std::future::Future<Output = Result<AmqpMessage>>;
+    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode);
+    fn get_credit_mode(&self) -> ReceiverCreditMode;
     fn receive_delivery(&self) -> impl std::future::Future<Output = Result<AmqpDelivery>>;
     fn accept_delivery(
         &self,
@@ -90,9 +92,13 @@ impl AmqpReceiverApis for AmqpReceiver {
         self.implementation.detach().await
     }
 
-    // async fn receive(&self) -> Result<AmqpMessage> {
-    //     self.implementation.receive().await
-    // }
+    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) {
+        self.implementation.set_credit_mode(credit_mode);
+    }
+
+    fn get_credit_mode(&self) -> ReceiverCreditMode {
+        self.implementation.get_credit_mode()
+    }
 
     async fn receive_delivery(&self) -> Result<AmqpDelivery> {
         self.implementation.receive_delivery().await
@@ -121,6 +127,7 @@ impl AmqpReceiver {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     #[test]
@@ -250,4 +257,25 @@ mod tests {
         );
         assert!(!receiver_options.auto_accept);
     }
+
+    // #[test]
+    // async fn test_amqp_receiver_set_credit_mode() {
+    //     let receiver = AmqpReceiver::new();
+
+    //     receiver.attach(session, source, options)
+    //     receiver.set_credit_mode(ReceiverCreditMode::Manual);
+
+    //     // Assuming the implementation has a method to get the current credit mode for testing purposes
+    //     assert_eq!(
+    //         receiver.implementation.get_credit_mode(),
+    //         ReceiverCreditMode::Manual
+    //     );
+
+    //     receiver.set_credit_mode(ReceiverCreditMode::Auto(100));
+
+    //     assert_eq!(
+    //         receiver.implementation.get_credit_mode(),
+    //         ReceiverCreditMode::Auto(100)
+    //     );
+    // }
 }

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 //cspell: words amqp
 
-use super::messaging::{AmqpMessage, AmqpSource, AmqpTarget};
+use super::messaging::{AmqpDelivery, AmqpMessage, AmqpSource, AmqpTarget};
 use super::session::AmqpSession;
 use super::value::{AmqpOrderedMap, AmqpSymbol, AmqpValue};
 use super::ReceiverSettleMode;
@@ -57,6 +57,19 @@ pub trait AmqpReceiverApis {
     ) -> impl std::future::Future<Output = Result<()>>;
     fn detach(self) -> impl std::future::Future<Output = Result<()>>;
     fn receive(&self) -> impl std::future::Future<Output = Result<AmqpMessage>>;
+    fn receive_delivery(&self) -> impl std::future::Future<Output = Result<AmqpDelivery>>;
+    fn accept_delivery(
+        &self,
+        delivery: AmqpDelivery,
+    ) -> impl std::future::Future<Output = Result<()>>;
+    fn reject_delivery(
+        &self,
+        delivery: AmqpDelivery,
+    ) -> impl std::future::Future<Output = Result<()>>;
+    fn release_delivery(
+        &self,
+        delivery: AmqpDelivery,
+    ) -> impl std::future::Future<Output = Result<()>>;
 }
 
 #[derive(Default)]
@@ -78,6 +91,22 @@ impl AmqpReceiverApis for AmqpReceiver {
     }
     async fn receive(&self) -> Result<AmqpMessage> {
         self.implementation.receive().await
+    }
+
+    async fn receive_delivery(&self) -> Result<AmqpDelivery> {
+        self.implementation.receive_delivery().await
+    }
+
+    async fn accept_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
+        self.implementation.accept_delivery(delivery).await
+    }
+
+    async fn reject_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
+        self.implementation.reject_delivery(delivery).await
+    }
+
+    async fn release_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
+        self.implementation.release_delivery(delivery).await
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -57,8 +57,8 @@ pub trait AmqpReceiverApis {
     ) -> impl std::future::Future<Output = Result<()>>;
 
     fn detach(self) -> impl std::future::Future<Output = Result<()>>;
-    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode);
-    fn get_credit_mode(&self) -> ReceiverCreditMode;
+    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) -> Result<()>;
+    fn credit_mode(&self) -> Result<ReceiverCreditMode>;
     fn receive_delivery(&self) -> impl std::future::Future<Output = Result<AmqpDelivery>>;
     fn accept_delivery(
         &self,
@@ -92,12 +92,12 @@ impl AmqpReceiverApis for AmqpReceiver {
         self.implementation.detach().await
     }
 
-    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) {
-        self.implementation.set_credit_mode(credit_mode);
+    fn set_credit_mode(&self, credit_mode: ReceiverCreditMode) -> Result<()> {
+        self.implementation.set_credit_mode(credit_mode)
     }
 
-    fn get_credit_mode(&self) -> ReceiverCreditMode {
-        self.implementation.get_credit_mode()
+    fn credit_mode(&self) -> Result<ReceiverCreditMode> {
+        self.implementation.credit_mode()
     }
 
     async fn receive_delivery(&self) -> Result<AmqpDelivery> {

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -60,15 +60,15 @@ pub trait AmqpReceiverApis {
     fn receive_delivery(&self) -> impl std::future::Future<Output = Result<AmqpDelivery>>;
     fn accept_delivery(
         &self,
-        delivery: AmqpDelivery,
+        delivery: &AmqpDelivery,
     ) -> impl std::future::Future<Output = Result<()>>;
     fn reject_delivery(
         &self,
-        delivery: AmqpDelivery,
+        delivery: &AmqpDelivery,
     ) -> impl std::future::Future<Output = Result<()>>;
     fn release_delivery(
         &self,
-        delivery: AmqpDelivery,
+        delivery: &AmqpDelivery,
     ) -> impl std::future::Future<Output = Result<()>>;
 }
 
@@ -98,15 +98,15 @@ impl AmqpReceiverApis for AmqpReceiver {
         self.implementation.receive_delivery().await
     }
 
-    async fn accept_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
+    async fn accept_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         self.implementation.accept_delivery(delivery).await
     }
 
-    async fn reject_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
+    async fn reject_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         self.implementation.reject_delivery(delivery).await
     }
 
-    async fn release_delivery(&self, delivery: AmqpDelivery) -> Result<()> {
+    async fn release_delivery(&self, delivery: &AmqpDelivery) -> Result<()> {
         self.implementation.release_delivery(delivery).await
     }
 }

--- a/sdk/core/azure_core_amqp/src/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/receiver.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 //cspell: words amqp
 
-use super::messaging::{AmqpDelivery, AmqpMessage, AmqpSource, AmqpTarget};
+use super::messaging::{AmqpDelivery, AmqpSource, AmqpTarget};
 use super::session::AmqpSession;
 use super::value::{AmqpOrderedMap, AmqpSymbol, AmqpValue};
 use super::ReceiverSettleMode;
@@ -56,7 +56,7 @@ pub trait AmqpReceiverApis {
         options: Option<AmqpReceiverOptions>,
     ) -> impl std::future::Future<Output = Result<()>>;
     fn detach(self) -> impl std::future::Future<Output = Result<()>>;
-    fn receive(&self) -> impl std::future::Future<Output = Result<AmqpMessage>>;
+    //    fn receive(&self) -> impl std::future::Future<Output = Result<AmqpMessage>>;
     fn receive_delivery(&self) -> impl std::future::Future<Output = Result<AmqpDelivery>>;
     fn accept_delivery(
         &self,
@@ -89,9 +89,10 @@ impl AmqpReceiverApis for AmqpReceiver {
     async fn detach(self) -> Result<()> {
         self.implementation.detach().await
     }
-    async fn receive(&self) -> Result<AmqpMessage> {
-        self.implementation.receive().await
-    }
+
+    // async fn receive(&self) -> Result<AmqpMessage> {
+    //     self.implementation.receive().await
+    // }
 
     async fn receive_delivery(&self) -> Result<AmqpDelivery> {
         self.implementation.receive_delivery().await

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -24,7 +24,7 @@ use azure_core_amqp::{
     cbs::{AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis},
     connection::{AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions},
     management::{AmqpManagement, AmqpManagementApis},
-    messaging::{AmqpSource, AmqpSourceFilter},
+    messaging::{AmqpDeliveryApis, AmqpSource, AmqpSourceFilter},
     receiver::{AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode},
     session::{AmqpSession, AmqpSessionApis},
     value::{AmqpDescribed, AmqpOrderedMap, AmqpSymbol, AmqpValue},
@@ -293,8 +293,11 @@ impl ConsumerClient {
             .await?;
 
             loop{
-                let message = receiver.receive().await?;
-                let event: ReceivedEventData= message.into();
+                let delivery = receiver.receive_delivery().await?;
+
+                receiver.accept_delivery(&delivery).await?;
+                let message = delivery.into_message();
+                let event = ReceivedEventData::from(message);
                 yield event;
             }
         }


### PR DESCRIPTION
Updated the infrastructure for receiving AMQP messages to require that message deliveries be explicitly accepted or rejected - this is not needed for Eventhubs but will be a requirement for ServiceBus.

This PR also includes an enhancement to the AMQP receiver to set and retrieve the link credit mode - this will almost certainly be needed to implement batch receive.

Please note that much of this infrastructure is not currently tested (and almost certainly doesn't work correctly) because we don't have full live test support.

This PR also includes the start of tests for AMQP connection APIs. but this functionality is disabled because we don't have CI pipeline support for starting the test AMQP broker.

Bonus gratuitous changes: I removed the word "test" from a number of test functions because it's redundant.

CoPilot summary:
---
This pull request includes several changes to the `azure_core_amqp` package, focusing on improving the handling of AMQP deliveries and enhancing the test infrastructure. The changes introduce new structs and traits for better abstraction and add new methods to existing traits. Additionally, some tests have been disabled temporarily until the CI environment can support them.

### Improvements to AMQP delivery handling:

* Introduced `Fe2o3AmqpDelivery` struct and implemented `AmqpDeliveryApis` trait for it in `sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs`.
* Added `AmqpDelivery` struct and `AmqpDeliveryApis` trait in `sdk/core/azure_core_amqp/src/messaging.rs` to abstract delivery handling.

### Enhancements to AMQP receiver:

* Added methods for setting and getting credit mode, and handling delivery acceptance, rejection, and release in `sdk/core/azure_core_amqp/src/fe2o3/receiver.rs`. [[1]](diffhunk://#diff-7edae0d79194c90511b829f65add319a4668df84da79b1474f5c0b77b63321b4L97-R138) [[2]](diffhunk://#diff-7edae0d79194c90511b829f65add319a4668df84da79b1474f5c0b77b63321b4R157-R226)
* Updated `AmqpReceiverApis` trait to include new delivery-related methods in `sdk/core/azure_core_amqp/src/receiver.rs`. [[1]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07R58-R74) [[2]](diffhunk://#diff-a634f353791f652d393072a657e893e1f9fac11a464864040da69b6e1951ca07L79-R116)

### Test infrastructure improvements:

* Disabled certain tests in `sdk/core/azure_core_amqp/src/connection.rs` until the AMQP test broker can be started in CI.
* Renamed test functions for consistency in `sdk/core/azure_core_amqp/src/connection.rs`. [[1]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L88-R88) [[2]](diffhunk://#diff-3b1cde9b879b09dbdc03797027041992fe34df702acdf708bed1df18f358c695L200-R200)

### Additional changes:

* Added `tokio` as a dev dependency in `sdk/core/azure_core_amqp/Cargo.toml`.
* Updated imports and logging levels in `sdk/core/azure_core_amqp/src/fe2o3/connection.rs`.

These changes collectively enhance the robustness and maintainability of the `azure_core_amqp` package.