### PR TITLE
Work around package/publish cyclic dependency

### DIFF
--- a/sdk/typespec/typespec_macros/Cargo.toml
+++ b/sdk/typespec/typespec_macros/Cargo.toml
@@ -20,7 +20,11 @@ proc-macro2.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true
-typespec_client_core = { workspace = true, features = ["http", "json", "xml"] }
+typespec_client_core = { path = "../typespec_client_core", features = [
+  "http",
+  "json",
+  "xml",
+] }
 serde.workspace = true
 serde_json.workspace = true
 cargo_metadata.workspace = true


### PR DESCRIPTION
Due to https://github.com/rust-lang/cargo/issues/4242, `cargo package`
is considering dev-dependencies when trying to package and there's a
cyclic dependency only when doing that. This works around that cycle
while retaining the ability to doctest.
