### PR TITLE
Do not convert dates

### DIFF
--- a/sdk/core/azure_core/src/request_options/if_source_modified_since_condition.rs
+++ b/sdk/core/azure_core/src/request_options/if_source_modified_since_condition.rs
@@ -24,7 +24,7 @@ impl Header for IfSourceModifiedSinceCondition {
     fn value(&self) -> headers::HeaderValue {
         match self {
             IfSourceModifiedSinceCondition::Modified(date)
-            | IfSourceModifiedSinceCondition::Unmodified(date) => date::to_rfc1123(date).into(),
+            | IfSourceModifiedSinceCondition::Unmodified(date) => date::to_rfc7231(date).into(),
         }
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
@@ -70,7 +70,7 @@ impl Policy for AuthorizationPolicy {
         );
 
         // x-ms-date and the string used in the signature must be exactly the same, so just generate it here once.
-        let date_string = date::to_rfc1123(&OffsetDateTime::now_utc()).to_lowercase();
+        let date_string = date::to_rfc7231(&OffsetDateTime::now_utc()).to_lowercase();
 
         let resource_link: &ResourceLink = ctx
             .value()
@@ -179,7 +179,7 @@ mod tests {
     #[tokio::test]
     async fn generate_authorization_for_token_credential() {
         let time_nonce = date::parse_rfc3339("1900-01-01T01:00:00.000000000+00:00").unwrap();
-        let date_string = date::to_rfc1123(&time_nonce).to_lowercase();
+        let date_string = date::to_rfc7231(&time_nonce).to_lowercase();
         let cred = Arc::new(TestTokenCredential("test_token".to_string()));
         let auth_token = Credential::Token(cred);
 
@@ -209,7 +209,7 @@ mod tests {
     #[cfg(feature = "key_auth")]
     async fn generate_authorization_for_primary_key_0() {
         let time_nonce = date::parse_rfc3339("1900-01-01T01:00:00.000000000+00:00").unwrap();
-        let date_string = date::to_rfc1123(&time_nonce).to_lowercase();
+        let date_string = date::to_rfc7231(&time_nonce).to_lowercase();
 
         let auth_token = Credential::PrimaryKey(
             "8F8xXXOptJxkblM1DBXW7a6NMI5oE8NnwPGYBmwxLCKfejOK7B7yhcCHMGvN3PBrlMLIOeol1Hv9RCdzAZR5sg==".into(),
@@ -243,7 +243,7 @@ mod tests {
     #[cfg(feature = "key_auth")]
     async fn generate_authorization_for_primary_key_1() {
         let time_nonce = date::parse_rfc3339("2017-04-27T00:51:12.000000000+00:00").unwrap();
-        let date_string = date::to_rfc1123(&time_nonce).to_lowercase();
+        let date_string = date::to_rfc7231(&time_nonce).to_lowercase();
 
         let auth_token = Credential::PrimaryKey(
             "dsZQi3KtZmCv1ljt3VNWNm7sQUF1y5rJfC6kv5JiwvW0EndXdDku/dkKBp8/ufDToSxL".into(),

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/signature_target.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/signature_target.rs
@@ -82,7 +82,7 @@ mod tests {
     #[test]
     fn into_signable_string_generates_correct_value() {
         let time_nonce = date::parse_rfc3339("1900-01-01T01:00:00.000000000+00:00").unwrap();
-        let date_string = date::to_rfc1123(&time_nonce).to_lowercase();
+        let date_string = date::to_rfc7231(&time_nonce).to_lowercase();
 
         let ret = SignatureTarget::new(
             azure_core::Method::Get,

--- a/sdk/typespec/typespec_client_core/src/date/iso8601.rs
+++ b/sdk/typespec/typespec_client_core/src/date/iso8601.rs
@@ -8,7 +8,7 @@ use time::{
         iso8601::{Config, EncodedConfig, TimePrecision},
         Iso8601,
     },
-    OffsetDateTime, UtcOffset,
+    OffsetDateTime,
 };
 use typespec::error::{ErrorKind, ResultExt};
 
@@ -49,7 +49,6 @@ pub fn serialize<S>(date: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Er
 where
     S: Serializer,
 {
-    date.to_offset(UtcOffset::UTC);
     let as_str = to_iso8601(date).map_err(serde::ser::Error::custom)?;
     serializer.serialize_str(&as_str)
 }

--- a/sdk/typespec/typespec_client_core/src/date/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/date/mod.rs
@@ -24,7 +24,7 @@ pub mod rfc7231;
 ///
 /// <https://www.rfc-editor.org/rfc/rfc3339>
 ///
-/// In (TypeSpec)[https://aka.ms/typespec] properties are specified as `utcDateTime` or `offsetDateTime`.
+/// In [TypeSpec](https://aka.ms/typespec) properties are specified as `utcDateTime` or `offsetDateTime`.
 /// In OpenAPI 2.0 specifications properties are specified as `"format": "date-time"`.
 ///
 /// Example string: `1985-04-12T23:20:50.52Z`.
@@ -38,7 +38,7 @@ pub fn parse_rfc3339(s: &str) -> crate::Result<OffsetDateTime> {
 ///
 /// <https://www.rfc-editor.org/rfc/rfc3339>
 ///
-/// In (TypeSpec)[https://aka.ms/typespec] properties are specified as `utcDateTime` or `offsetDateTime`.
+/// In [TypeSpec](https://aka.ms/typespec) properties are specified as `utcDateTime` or `offsetDateTime`.
 /// In OpenAPI 2.0 specifications properties are specified as `"format": "date-time"`.
 ///
 /// Example string: `1985-04-12T23:20:50.52Z`.
@@ -51,7 +51,7 @@ pub fn to_rfc3339(date: &OffsetDateTime) -> String {
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1>
 ///
-/// In (TypeSpec)[https://aka.ms/typespec] headers are specified as `utcDateTime`.
+/// In [TypeSpec](https://aka.ms/typespec) headers are specified as `utcDateTime`.
 /// In REST API specifications headers are specified as `"format": "date-time-rfc1123"`.
 ///
 /// This format is also the preferred HTTP date-based header format.
@@ -75,7 +75,7 @@ const RFC7231_FORMAT: &[FormatItem] = format_description!(
 ///
 /// <https://datatracker.ietf.org/doc/html/rfc7231#section-7.1.1.1>
 ///
-/// In (TypeSpec)[https://aka.ms/typespec] headers are specified as `utcDateTime`.
+/// In [TypeSpec](https://aka.ms/typespec) headers are specified as `utcDateTime`.
 /// In REST API specifications headers are specified as `"format": "date-time-rfc1123"`.
 ///
 /// This format is also the preferred HTTP date-based header format.

--- a/sdk/typespec/typespec_client_core/src/date/rfc7231.rs
+++ b/sdk/typespec/typespec_client_core/src/date/rfc7231.rs
@@ -1,50 +1,50 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-//! RFC 1123 date and time parsing and formatting functions.
-use crate::date::{parse_rfc1123, to_rfc1123};
+//! RFC 7231 date and time parsing and formatting functions.
+use crate::date::{parse_rfc7231, to_rfc7231};
 use serde::{de, Deserialize, Deserializer, Serializer};
 use time::OffsetDateTime;
 
-/// Deserialize an RFC 1123 date and time string into an [`OffsetDateTime`].
+/// Deserialize an RFC 7231 date and time string into an [`OffsetDateTime`].
 pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    parse_rfc1123(&s).map_err(de::Error::custom)
+    parse_rfc7231(&s).map_err(de::Error::custom)
 }
 
-/// Serialize an [`OffsetDateTime`] to an RFC 1123 date and time string.
+/// Serialize an [`OffsetDateTime`] to an RFC 7231 date and time string.
 pub fn serialize<S>(date: &OffsetDateTime, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    serializer.serialize_str(&to_rfc1123(date))
+    serializer.serialize_str(&to_rfc7231(date))
 }
 
 pub mod option {
-    use crate::date::{parse_rfc1123, to_rfc1123};
+    use crate::date::{parse_rfc7231, to_rfc7231};
     use serde::{Deserialize, Deserializer, Serializer};
     use time::OffsetDateTime;
 
-    /// Deserialize an RFC 1123 date and time string into an optional [`OffsetDateTime`].
+    /// Deserialize an RFC 7231 date and time string into an optional [`OffsetDateTime`].
     pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<OffsetDateTime>, D::Error>
     where
         D: Deserializer<'de>,
     {
         let s: Option<String> = Option::deserialize(deserializer)?;
-        s.map(|s| parse_rfc1123(&s).map_err(serde::de::Error::custom))
+        s.map(|s| parse_rfc7231(&s).map_err(serde::de::Error::custom))
             .transpose()
     }
 
-    /// Serialize an optional [`OffsetDateTime`] to an RFC 1123 date and time string.
+    /// Serialize an optional [`OffsetDateTime`] to an RFC 7231 date and time string.
     pub fn serialize<S>(date: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         if let Some(date) = date {
-            serializer.serialize_str(&to_rfc1123(date))
+            serializer.serialize_str(&to_rfc7231(date))
         } else {
             serializer.serialize_none()
         }

--- a/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
@@ -24,10 +24,10 @@ use std::{sync::Arc, time::Duration};
 use tracing::{debug, trace};
 use typespec::error::{Error, ErrorKind, ResultExt};
 
-/// Attempts to parse the supplied string as an HTTP date, of the form defined by RFC 1123 (e.g. `Fri, 01 Jan 2021 00:00:00 GMT`).
+/// Attempts to parse the supplied string as an HTTP date, of the form defined by RFC 7231 (e.g. `Fri, 01 Jan 2021 00:00:00 GMT`).
 /// Returns `None` if the string is not a valid HTTP date.
 fn try_parse_retry_after_http_date(http_date: &str) -> Option<OffsetDateTime> {
-    crate::date::parse_rfc1123(http_date).ok()
+    crate::date::parse_rfc7231(http_date).ok()
 }
 
 /// A function that returns an `OffsetDateTime`.

--- a/sdk/typespec/typespec_client_core/src/http/request/options/if_modified_since.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/options/if_modified_since.rs
@@ -24,7 +24,7 @@ impl Header for IfModifiedSince {
     }
 
     fn value(&self) -> headers::HeaderValue {
-        date::to_rfc1123(&self.0).into()
+        date::to_rfc7231(&self.0).into()
     }
 }
 

--- a/sdk/typespec/typespec_client_core/src/http/request/options/if_modified_since_condition.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/options/if_modified_since_condition.rs
@@ -26,7 +26,7 @@ impl Header for IfModifiedSinceCondition {
     fn value(&self) -> headers::HeaderValue {
         match self {
             IfModifiedSinceCondition::Modified(date)
-            | IfModifiedSinceCondition::Unmodified(date) => date::to_rfc1123(date),
+            | IfModifiedSinceCondition::Unmodified(date) => date::to_rfc7231(date),
         }
         .into()
     }

--- a/sdk/typespec/typespec_client_core/src/parsing.rs
+++ b/sdk/typespec/typespec_client_core/src/parsing.rs
@@ -36,7 +36,7 @@ impl FromStringOptional<bool> for bool {
 
 impl FromStringOptional<date::OffsetDateTime> for date::OffsetDateTime {
     fn from_str_optional(s: &str) -> crate::Result<date::OffsetDateTime> {
-        date::parse_rfc1123(s).with_context(ErrorKind::DataConversion, || {
+        date::parse_rfc7231(s).with_context(ErrorKind::DataConversion, || {
             format!("error parsing date time '{s}'")
         })
     }


### PR DESCRIPTION
Technically, we weren't because we weren't capturing the return of `to_offset()`, but this cleans up the code and adds some tests that caused us to miss this.

Resolves #1982

This also renames RFC 1123 functions to 7231, which obsolesces 1123 effectively; though, is itself obsolesced by 9110. We do refer to 7231 in both [TypeSpec](https://typespec.io/docs/libraries/http/encoding/#utcdatetime-and-offsetdatetime) and [REST API Guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#http-header-date-values) already, though.