### PR TITLE
Periodically read workload identity token from file

### DIFF
--- a/eng/dict/rust-custom.txt
+++ b/eng/dict/rust-custom.txt
@@ -2,6 +2,7 @@ bindgen
 cfg
 cfgs
 newtype
+oneshot
 repr
 rustc
 rustflags


### PR DESCRIPTION
Fixes #1739 similar to other languages by reading the file every 10 minutes pointed to by AZURE_FEDERATED_TOKEN_FILE.
