### PR TITLE
Remove write! calls for Error Display impl

### DIFF
--- a/sdk/core/azure_core_amqp/src/error.rs
+++ b/sdk/core/azure_core_amqp/src/error.rs
@@ -32,7 +32,7 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
             ErrorKind::AmqpReceiverAlreadyAttached => {
-                write!(f, "AMQP Receiver is already attached")
+                f.write_str("AMQP Receiver is already attached")
             }
             ErrorKind::TransportImplementationError { source } => {
                 write!(f, "Transport Implementation Error: {:?}", source)

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -64,25 +64,23 @@ impl std::error::Error for EventhubsError {
 impl std::fmt::Display for EventhubsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.kind {
-            ErrorKind::MissingMessageSender => write!(f, "Missing message sender."),
-            ErrorKind::ArithmeticError => write!(f, "Arithmetic overflow has occurred."),
-            ErrorKind::InvalidManagementResponse => write!(f, "Invalid management response"),
+            ErrorKind::MissingMessageSender => f.write_str("Missing message sender."),
+            ErrorKind::ArithmeticError => f.write_str("Arithmetic overflow has occurred."),
+            ErrorKind::InvalidManagementResponse => f.write_str("Invalid management response"),
             ErrorKind::UnableToAddAuthenticationToken => {
-                write!(f, "Unable to add authentication token")
+                f.write_str("Unable to add authentication token")
             }
             ErrorKind::MissingSession => {
-                write!(f, "The session for the specified partition is missing.")
+                f.write_str("The session for the specified partition is missing.")
             }
             ErrorKind::AmqpError(source) => write!(f, "AmqpError: {:?}", source),
-            ErrorKind::MissingConnection => write!(f, "Connection is not yet open."),
-            ErrorKind::MissingManagementClient => write!(f, "Missing management client."),
+            ErrorKind::MissingConnection => f.write_str("Connection is not yet open."),
+            ErrorKind::MissingManagementClient => f.write_str("Missing management client."),
             ErrorKind::InvalidParameter(s) => write!(f, "Invalid parameter: {}", s),
-            ErrorKind::MissingConnectionString => write!(f, "Missing connection string"),
-            ErrorKind::MissingSharedAccessKeyName => {
-                write!(f, "Missing shared access key name")
-            }
-            ErrorKind::MissingEndpoint => write!(f, "Missing endpoint"),
-            ErrorKind::MissingHostInEndpoint => write!(f, "Missing host in endpoint"),
+            ErrorKind::MissingConnectionString => f.write_str("Missing connection string"),
+            ErrorKind::MissingSharedAccessKeyName => f.write_str("Missing shared access key name"),
+            ErrorKind::MissingEndpoint => f.write_str("Missing endpoint"),
+            ErrorKind::MissingHostInEndpoint => f.write_str("Missing host in endpoint"),
         }
     }
 }

--- a/sdk/typespec/src/error/mod.rs
+++ b/sdk/typespec/src/error/mod.rs
@@ -293,12 +293,10 @@ impl From<core::convert::Infallible> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.context {
-            ErrorContext::Simple(kind) => write!(f, "{kind}"),
-            ErrorContext::Message { message, .. } => write!(f, "{message}"),
-            ErrorContext::Custom(Custom { error, .. }) => write!(f, "{error}"),
-            ErrorContext::Full(_, message) => {
-                write!(f, "{message}")
-            }
+            ErrorContext::Simple(kind) => std::fmt::Display::fmt(&kind, f),
+            ErrorContext::Message { message, .. } => f.write_str(message),
+            ErrorContext::Custom(Custom { error, .. }) => std::fmt::Display::fmt(&error, f),
+            ErrorContext::Full(_, message) => f.write_str(message),
         }
     }
 }

--- a/sdk/typespec/typespec_client_core/src/http/models/etag.rs
+++ b/sdk/typespec/typespec_client_core/src/http/models/etag.rs
@@ -31,6 +31,6 @@ impl FromStr for Etag {
 
 impl fmt::Display for Etag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        fmt::Display::fmt(&self.0, f)
     }
 }

--- a/sdk/typespec/typespec_client_core/src/http/options/retry.rs
+++ b/sdk/typespec/typespec_client_core/src/http/options/retry.rs
@@ -32,8 +32,8 @@ impl Debug for RetryMode {
         match self {
             RetryMode::Exponential(o) => write!(f, "Exponential({o:?})"),
             RetryMode::Fixed(o) => write!(f, "Fixed({o:?})"),
-            RetryMode::Custom(_) => write!(f, "Custom"),
-            RetryMode::None => write!(f, "None"),
+            RetryMode::Custom(_) => f.write_str("Custom"),
+            RetryMode::None => f.write_str("None"),
         }
     }
 }

--- a/sdk/typespec/typespec_client_core/src/macros.rs
+++ b/sdk/typespec/typespec_client_core/src/macros.rs
@@ -75,7 +75,7 @@ macro_rules! create_enum {
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 match self {
                     $(
-                        $name::$variant => write!(f, "{}", $value),
+                        $name::$variant => ::std::fmt::Display::fmt(&$value, f),
                     )*
                 }
             }


### PR DESCRIPTION
This simply replaces calls to `write!(f, "{variable}")` in the `Display` implementation of `typespec::error::Error` and other crates with direct calls to `f.write_str(variable)` when they are `str`-like, or `Display::fmt` when they are complex types.