### PR TITLE
Add version numbers for workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,28 +26,36 @@ rust-version = "1.80"
 
 [workspace.dependencies.typespec]
 path = "sdk/typespec"
+version = "0.2.0"
 default-features = false
 
 [workspace.dependencies.typespec_client_core]
 path = "sdk/typespec/typespec_client_core"
+version = "0.1.0"
 default-features = false
 
 [workspace.dependencies.typespec_macros]
+version = "0.1.0"
 path = "sdk/typespec/typespec_macros"
 
 [workspace.dependencies.azure_core]
+version = "0.22.0"
 path = "sdk/core/azure_core"
 
 [workspace.dependencies.azure_core_amqp]
+version = "0.1.0"
 path = "sdk/core/azure_core_amqp"
 
 [workspace.dependencies.azure_core_test]
+version = "0.1.0"
 path = "sdk/core/azure_core_test"
 
 [workspace.dependencies.azure_core_test_macros]
+version = "0.1.0"
 path = "sdk/core/azure_core_test_macros"
 
 [workspace.dependencies.azure_identity]
+version = "0.22.0"
 path = "sdk/identity/azure_identity"
 
 [workspace.dependencies.azure_storage_common]

--- a/sdk/core/azure_core_test_macros/Cargo.toml
+++ b/sdk/core/azure_core_test_macros/Cargo.toml
@@ -23,5 +23,5 @@ quote.workspace = true
 syn.workspace = true
 
 [dev-dependencies]
-azure_core_test.workspace = true
+azure_core_test.path = "../azure_core_test"
 tokio.workspace = true

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -24,12 +24,12 @@ typespec_client_core = { workspace = true, features = ["derive"] }
 url.workspace = true
 
 [dev-dependencies]
-azure_identity.workspace = true
-azure_core_test.workspace = true
+azure_identity.path = "../../identity/azure_identity"
+azure_core_test.path = "../../core/azure_core_test"
 clap.workspace = true
 reqwest.workspace = true
 time.workspace = true
-tracing-subscriber = { workspace = true, features = [ "env-filter", "fmt" ] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tokio = { workspace = true, default-features = false, features = [
   "rt-multi-thread",
   "macros",
@@ -43,7 +43,8 @@ workspace = true
 default = ["hmac_rust"]
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
-key_auth = [] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
+key_auth = [
+] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
 
 [package.metadata.docs.rs]
 features = ["key_auth"]

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -32,8 +32,8 @@ rustc_version.workspace = true
 
 [dev-dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
-azure_core_test.workspace = true
-azure_identity.workspace = true
+azure_core_test.path = "../../core/azure_core_test"
+azure_identity.path = "../../identity/azure_identity"
 tokio = { workspace = true, default-features = false, features = [
   "rt-multi-thread",
   "macros",

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -25,7 +25,7 @@ time = { workspace = true}
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-azure_identity.workspace = true
+azure_identity.path = "../../identity/azure_identity"
 rand.workspace = true
 tokio.workspace = true
 

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -43,7 +43,7 @@ once_cell.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
-typespec_macros.workspace = true
+typespec_macros.path = "../typespec_macros"
 
 [features]
 default = ["http", "json", "reqwest", "reqwest_gzip", "reqwest_rustls"]


### PR DESCRIPTION
- Workspace dependencies should include `version` to accommodate `cargo package`
- Path based Intra-repo dev-dependencies should use local paths, not `workspace = true`
  - This is because, at package time, dev dependencies don't resolve correctly when the local dependency is unpublished but has a version number referenced in the workspace toml.