### PR TITLE
Add more SecretClient tests

### DIFF
--- a/sdk/core/azure_core_test/src/proxy/models.rs
+++ b/sdk/core/azure_core_test/src/proxy/models.rs
@@ -98,3 +98,23 @@ pub struct PlaybackStartResult {
     #[serde(flatten)]
     pub variables: HashMap<String, String>,
 }
+
+#[derive(Debug, Default, Serialize)]
+pub struct SanitizerList {
+    #[serde(rename = "Sanitizers")]
+    pub sanitizers: Vec<String>,
+}
+
+impl TryFrom<SanitizerList> for RequestContent<SanitizerList> {
+    type Error = azure_core::Error;
+    fn try_from(value: SanitizerList) -> Result<Self, Self::Error> {
+        RequestContent::try_from(to_json(&value)?)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RemovedSanitizers {
+    #[allow(dead_code)]
+    #[serde(rename = "Removed")]
+    pub removed: Vec<String>,
+}

--- a/sdk/keyvault/assets.json
+++ b/sdk/keyvault/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
   "TagPrefix": "rust/keyvault",
-  "Tag": "rust/keyvault_0b4c5acf34"
+  "Tag": "rust/keyvault_efd801460c"
 }

--- a/sdk/keyvault/assets.json
+++ b/sdk/keyvault/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
   "TagPrefix": "rust/keyvault",
-  "Tag": "rust/keyvault_efd801460c"
+  "Tag": "rust/keyvault_9528e38b39"
 }

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/models.rs
@@ -302,7 +302,6 @@ pub struct SecretSetParameters {
 
 /// The secret update parameters.
 #[derive(Clone, Debug, Default, Deserialize, Serialize, azure_core::Model)]
-#[non_exhaustive]
 pub struct SecretUpdateParameters {
     /// Type of the secret value such as a password.
     #[serde(rename = "contentType", skip_serializing_if = "Option::is_none")]

--- a/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
@@ -3,11 +3,14 @@
 
 #![cfg_attr(target_arch = "wasm32", allow(unused_imports))]
 
-use azure_core::Result;
+use azure_core::{Result, Url};
 use azure_core_test::{recorded, TestContext};
 use azure_security_keyvault_secrets::{
-    models::SecretSetParameters, SecretClient, SecretClientOptions,
+    models::{SecretSetParameters, SecretUpdateParameters},
+    SecretClient, SecretClientOptions,
 };
+use futures::TryStreamExt;
+use std::collections::HashMap;
 
 #[recorded::test]
 async fn secret_roundtrip(ctx: TestContext) -> Result<()> {
@@ -22,23 +25,158 @@ async fn secret_roundtrip(ctx: TestContext) -> Result<()> {
         Some(options),
     )?;
 
+    // Set a secret.
     let body = SecretSetParameters {
         value: Some("secret-value".into()),
         ..Default::default()
     };
-    client
-        // TODO: https://github.com/Azure/typespec-rust/issues/223
-        .set_secret("secret-name".into(), body.try_into()?, None)
-        .await?;
-
     let secret = client
         // TODO: https://github.com/Azure/typespec-rust/issues/223
-        .get_secret("secret-name".into(), "".into(), None)
+        .set_secret("secret-roundtrip".into(), body.try_into()?, None)
         .await?
         .into_body()
         .await?;
+    assert_eq!(secret.value, Some("secret-value".into()));
 
-    assert_eq!("secret-value", secret.value.unwrap());
+    // Get the secret version from the ID.
+    let version = secret
+        .id
+        .and_then(|id| Url::parse(id.as_ref()).ok())
+        .and_then(|url| {
+            url.path_segments()
+                .and_then(|mut segments| segments.nth(2))
+                .map(Into::into)
+        })
+        .unwrap_or_default();
+
+    // Get a specific version of a secret.
+    let secret = client
+        // TODO: https://github.com/Azure/typespec-rust/issues/223
+        .get_secret("secret-roundtrip".into(), version, None)
+        .await?
+        .into_body()
+        .await?;
+    assert_eq!(secret.value, Some("secret-value".into()));
+
+    Ok(())
+}
+
+#[recorded::test]
+async fn update_secret_properties(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+
+    let mut options = SecretClientOptions::default();
+    recording.instrument(&mut options.client_options);
+
+    let client = SecretClient::new(
+        recording.var("AZURE_KEYVAULT_URL", None).as_str(),
+        recording.credential(),
+        Some(options),
+    )?;
+
+    // Set a secret.
+    let body = SecretSetParameters {
+        value: Some("secret-value".into()),
+        ..Default::default()
+    };
+    let secret = client
+        // TODO: https://github.com/Azure/typespec-rust/issues/223
+        .set_secret("update-secret".into(), body.try_into()?, None)
+        .await?
+        .into_body()
+        .await?;
+    assert_eq!(secret.value, Some("secret-value".into()));
+
+    // Update secret properties.
+    let properties = SecretUpdateParameters {
+        content_type: Some("text/plain".into()),
+        secret_attributes: secret.attributes,
+        tags: Some(HashMap::from_iter(vec![(
+            "test-name".into(),
+            "update_secret_properties".into(),
+        )])),
+    };
+    let secret = client
+        .update_secret(
+            // TODO: https://github.com/Azure/typespec-rust/issues/223
+            "update-secret".into(),
+            "".into(),
+            properties.try_into()?,
+            None,
+        )
+        .await?
+        .into_body()
+        .await?;
+    assert_eq!(secret.content_type, Some("text/plain".into()));
+    assert_eq!(
+        secret.tags.as_ref().and_then(|tags| tags.get("test-name")),
+        Some(&String::from("update_secret_properties"))
+    );
+
+    Ok(())
+}
+
+#[recorded::test]
+async fn list_secrets(ctx: TestContext) -> Result<()> {
+    let recording = ctx.recording();
+
+    let mut options = SecretClientOptions::default();
+    recording.instrument(&mut options.client_options);
+
+    let client = SecretClient::new(
+        recording.var("AZURE_KEYVAULT_URL", None).as_str(),
+        recording.credential(),
+        Some(options),
+    )?;
+
+    // Create several secrets.
+    let mut names = vec!["list-secrets-1", "list-secrets-2"];
+    let (secret1, secret2) = tokio::try_join!(
+        client
+            .set_secret(
+                names[0].into(),
+                r#"{"value":"secret-value-1"}"#.try_into()?,
+                None
+            )
+            .await?
+            .into_body(),
+        client
+            .set_secret(
+                names[1].into(),
+                r#"{"value":"secret-value-2"}"#.try_into()?,
+                None
+            )
+            .await?
+            .into_body(),
+    )?;
+    assert_eq!(secret1.value, Some("secret-value-1".into()));
+    assert_eq!(secret2.value, Some("secret-value-2".into()));
+
+    // List secrets.
+    let mut pager = client.get_secrets(None)?.into_stream();
+    while let Some(secrets) = pager.try_next().await? {
+        let Some(secrets) = secrets.into_body().await?.value else {
+            continue;
+        };
+
+        for secret in secrets {
+            // Get the secret name from the ID.
+            let name: String = secret
+                .id
+                .and_then(|id| Url::parse(id.as_ref()).ok())
+                .and_then(|url| {
+                    url.path_segments()
+                        .and_then(|mut segments| segments.nth(1))
+                        .map(Into::into)
+                })
+                .unwrap_or_default();
+
+            if let Some(idx) = names.iter().position(|n| name.eq(*n)) {
+                names.remove(idx);
+            }
+        }
+    }
+    assert!(names.is_empty());
 
     Ok(())
 }


### PR DESCRIPTION
Also removes the `$..id` body sanitizer that breaks Key Vault resource ID assertions and name/version harvesting.
