### PR TITLE
Updating openssl to 0.10.70 (CVE-2025-24898)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,9 +1761,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1793,9 +1793,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ http-types = { version = "2.12", default-features = false }
 log = "0.4"
 oauth2 = { version = "5.0.0", default-features = false }
 once_cell = "1.18"
-openssl = { version = "0.10.46" }
+openssl = { version = "0.10.70" }
 paste = "1.0"
 pin-project = "1.0"
 proc-macro2 = "1.0.86"


### PR DESCRIPTION
Resolving this security advisory: https://github.com/sfackler/rust-openssl/security/advisories/GHSA-rpmj-rpgj-qmpm