### PR TITLE
Remove default dependencies on ring, webpki-roots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,6 +734,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,26 +1329,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1703,7 +1697,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2213,18 +2207,17 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -2232,7 +2225,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -2241,7 +2233,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
  "windows-registry",
 ]
 
@@ -2306,6 +2297,18 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.0.1",
 ]
 
 [[package]]
@@ -2380,7 +2383,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1415a607e92bec364ea2cf9264646dcce0f91e6d65281bd6f2819cca3bf39c8"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3232,15 +3248,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -57,10 +57,11 @@ xml = ["typespec_client_core/xml"]
 features = [
   "hmac_openssl",
   "hmac_rust",
+  "reqwest",
   "reqwest_gzip",
   "reqwest_rustls",
-  "reqwest",
   "test",
   "tokio_fs",
+  "tokio_sleep",
   "xml",
 ]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -46,13 +46,13 @@ tracing-subscriber.workspace = true
 typespec_macros.path = "../typespec_macros"
 
 [features]
-default = ["http", "json", "reqwest", "reqwest_gzip", "reqwest_rustls"]
+default = ["http", "json", "reqwest", "reqwest_gzip"]
 derive = ["dep:typespec_macros"]
 http = ["dep:http-types", "typespec/http"]
 json = ["typespec/json"]
-reqwest = ["dep:reqwest", "reqwest/default-tls"]
+reqwest = ["dep:reqwest"]
 reqwest_gzip = ["reqwest/gzip"]
-reqwest_rustls = ["reqwest/rustls-tls"]
+reqwest_rustls = ["reqwest/rustls-tls-native-roots"]
 tokio_fs = ["tokio/fs", "tokio/sync", "tokio/io-util"]
 tokio_sleep = ["tokio/time"]
 xml = ["dep:quick-xml"]


### PR DESCRIPTION
Since `reqwest` 0.12.9 (based on our current Cargo.lock) uses `native-tls` by default, with these changes we no longer have a dependency on `ring` or `webpki-roots`.

See <https://github.com/seanmonstar/reqwest/blob/v0.12.9/README.md#requirements>.
