### PR TITLE
API Review feedback; fixed a bunch of type documentation; reduced type visibility in public API surface.

### DIFF
--- a/sdk/core/azure_core_amqp/examples/connection.rs
+++ b/sdk/core/azure_core_amqp/examples/connection.rs
@@ -13,10 +13,7 @@
 //      cargo run --example connection --package azure_core_amqp
 
 use azure_core::Url;
-use azure_core_amqp::{
-    connection::{AmqpConnection, AmqpConnectionApis},
-    value::AmqpSymbol,
-};
+use azure_core_amqp::{AmqpConnection, AmqpConnectionApis, AmqpSymbol};
 
 async fn amqp_connection_open() {
     let connection = AmqpConnection::new();

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 
-pub mod message_fields;
-pub mod message_source;
-pub mod message_target;
-pub mod messaging_types;
+pub(crate) mod message_fields;
+pub(crate) mod message_source;
+pub(crate) mod message_target;
+pub(crate) mod messaging_types;
 
 use crate::{
     messaging::{AmqpMessage, AmqpMessageBody},

--- a/sdk/core/azure_core_amqp/src/fe2o3/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/mod.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
-pub mod cbs;
-pub mod connection;
-pub mod error;
-pub mod management;
-pub mod messaging;
-pub mod receiver;
-pub mod sender;
-pub mod session;
-pub mod value;
+pub(crate) mod cbs;
+pub(crate) mod connection;
+pub(crate) mod error;
+pub(crate) mod management;
+pub(crate) mod messaging;
+pub(crate) mod receiver;
+pub(crate) mod sender;
+pub(crate) mod session;
+pub(crate) mod value;

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -545,20 +545,6 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "cplusplus")]
-    #[test]
-    fn amqp_composite() {
-        use crate::value::AmqpComposite;
-
-        let composite =
-            AmqpComposite::new(0x270, AmqpList::from(vec![AmqpValue::from("String value")]));
-        assert_eq!(composite.descriptor(), &AmqpDescriptor::Code(0x270));
-        assert_eq!(
-            composite.value(),
-            &AmqpList::from(vec![AmqpValue::from("String value")])
-        );
-    }
-
     #[test]
     fn test_from_amqp_value_to_fe2o3_amqp_types_primitives_value() {
         let value = AmqpValue::String("test".to_string());

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -203,14 +203,14 @@ impl From<AmqpValue> for fe2o3_amqp_types::primitives::Value {
             #[cfg(feature = "cplusplus")]
             AmqpValue::Composite(d) => fe2o3_amqp_types::primitives::Value::Described(Box::new(
                 serde_amqp::described::Described {
-                    descriptor: d.descriptor.clone().into(),
-                    value: d.value.clone().into(),
+                    descriptor: d.descriptor().clone().into(),
+                    value: d.value().clone().into(),
                 },
             )),
             AmqpValue::Described(d) => fe2o3_amqp_types::primitives::Value::Described(Box::new(
                 serde_amqp::described::Described {
-                    descriptor: d.descriptor.clone().into(),
-                    value: d.value.clone().into(),
+                    descriptor: d.descriptor().clone().into(),
+                    value: d.value().clone().into(),
                 },
             )),
             AmqpValue::Unknown => todo!(),
@@ -268,7 +268,7 @@ impl From<fe2o3_amqp_types::primitives::Value> for AmqpValue {
                         AmqpDescriptor::Name(symbol.into())
                     }
                 };
-                AmqpValue::Described(Box::new(AmqpDescribed { descriptor, value }))
+                AmqpValue::Described(Box::new(AmqpDescribed::new(descriptor, value)))
             }
             fe2o3_amqp_types::primitives::Value::Decimal128(_) => todo!(),
             fe2o3_amqp_types::primitives::Value::Decimal32(_) => todo!(),
@@ -281,7 +281,7 @@ impl PartialEq<AmqpDescribed>
     for serde_amqp::described::Described<fe2o3_amqp_types::primitives::Value>
 {
     fn eq(&self, other: &AmqpDescribed) -> bool {
-        self.descriptor == other.descriptor && self.value == other.value
+        self.descriptor == *other.descriptor() && self.value == *other.value()
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -545,6 +545,20 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "cplusplus")]
+    #[test]
+    fn amqp_composite() {
+        use crate::value::AmqpComposite;
+
+        let composite =
+            AmqpComposite::new(0x270, AmqpList::from(vec![AmqpValue::from("String value")]));
+        assert_eq!(composite.descriptor(), &AmqpDescriptor::Code(0x270));
+        assert_eq!(
+            composite.value(),
+            &AmqpList::from(vec![AmqpValue::from("String value")])
+        );
+    }
+
     #[test]
     fn test_from_amqp_value_to_fe2o3_amqp_types_primitives_value() {
         let value = AmqpValue::String("test".to_string());

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -5,19 +5,31 @@ mod fe2o3;
 #[cfg(any(not(feature = "fe2o3-amqp"), target_arch = "wasm32"))]
 mod noop;
 
-pub mod cbs;
-pub mod connection;
-pub mod error;
-pub mod management;
-pub mod messaging;
-pub mod receiver;
-pub mod sender;
-pub mod session;
-pub mod value;
+pub(crate) mod cbs;
+pub(crate) mod connection;
+pub(crate) mod error;
+pub(crate) mod management;
+pub(crate) mod messaging;
+pub(crate) mod receiver;
+pub(crate) mod sender;
+pub(crate) mod session;
+pub(crate) mod value;
 
-pub use uuid::Uuid;
-
+pub use cbs::{AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis};
+pub use connection::{AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions};
+pub use error::Error;
+pub use management::{AmqpManagement, AmqpManagementApis};
+pub use messaging::{
+    AmqpAnnotationKey, AmqpAnnotations, AmqpDelivery, AmqpDeliveryApis, AmqpMessage,
+    AmqpMessageBody, AmqpMessageHeader, AmqpMessageId, AmqpMessageProperties, AmqpSource,
+    AmqpSourceFilter, AmqpTarget,
+};
+pub use receiver::{AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode};
+pub use sender::{AmqpSendOptions, AmqpSender, AmqpSenderApis, AmqpSenderOptions};
+pub use session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions};
 use std::fmt::Debug;
+pub use uuid::Uuid;
+pub use value::{AmqpDescribed, AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
 
 // AMQP Settle mode:
 // https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-sender-settle-mode

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -1081,7 +1081,7 @@ impl AmqpMessage {
     /// # Examples
     ///
     /// ```
-    /// use azure_core_amqp::messaging::AmqpMessage;
+    /// use azure_core_amqp::AmqpMessage;
     ///
     /// let mut message = AmqpMessage::default();
     /// message.set_message_id(uuid::Uuid::new_v4());
@@ -1110,8 +1110,8 @@ impl AmqpMessage {
     ///
     /// # Examples
     /// ```
-    /// use azure_core_amqp::messaging::AmqpMessage;
-    /// use azure_core_amqp::value::AmqpSymbol;
+    /// use azure_core_amqp::AmqpMessage;
+    /// use azure_core_amqp::AmqpSymbol;
     /// let mut message = AmqpMessage::default();
     /// message.add_message_annotation(AmqpSymbol::from("key"), "value");
     /// ```
@@ -1138,8 +1138,8 @@ impl AmqpMessage {
     /// # Examples
     ///
     /// ```
-    /// use azure_core_amqp::messaging::AmqpMessage;
-    /// use azure_core_amqp::messaging::AmqpMessageBody;
+    /// use azure_core_amqp::AmqpMessage;
+    /// use azure_core_amqp::AmqpMessageBody;
     ///
     /// let mut message = AmqpMessage::default();
     /// message.set_message_body(AmqpMessageBody::Value("Hello, world!".into()));

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -1229,7 +1229,7 @@ impl Deserializable<AmqpMessage> for AmqpMessage {
     }
 }
 
-pub mod builders {
+mod builders {
     use super::*;
 
     pub struct AmqpSourceBuilder {

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -916,4 +916,15 @@ mod tests {
         assert_eq!(unknown_value, AmqpValue::Unknown);
         assert_eq!(AmqpValue::Unknown, unknown_value);
     }
+
+    #[test]
+    fn amqp_composite() {
+        let composite =
+            AmqpComposite::new(0x270, AmqpList::from(vec![AmqpValue::from("String value")]));
+        assert_eq!(composite.descriptor(), &AmqpDescriptor::Code(0x270));
+        assert_eq!(
+            composite.value(),
+            &AmqpList::from(vec![AmqpValue::from("String value")])
+        );
+    }
 }

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -16,14 +16,11 @@ use crate::{Deserializable, Serializable};
 #[cfg(feature = "cplusplus")]
 use azure_core::Result;
 
+/// An AMQP symbol.
+///
+/// Symbols are used to identify a type of data. They are similar to strings, and represent symbolic values from a constrained domain.
 #[derive(Debug, PartialEq, Clone, Default, Eq)]
 pub struct AmqpSymbol(pub String);
-
-// impl PartialEq<str> for AmqpSymbol {
-//     fn eq(&self, other: &str) -> bool {
-//         self.0.as_str() == other
-//     }
-// }
 
 impl PartialEq<AmqpSymbol> for str {
     fn eq(&self, other: &AmqpSymbol) -> bool {
@@ -77,6 +74,7 @@ impl Borrow<str> for AmqpSymbol {
     }
 }
 
+/// A sequence of AMQP values
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct AmqpList(pub Vec<AmqpValue>);
 
@@ -132,6 +130,10 @@ impl From<std::time::SystemTime> for AmqpTimestamp {
     }
 }
 
+/// An ordered mapping from distinct keys to values.
+///
+/// This is a simple implementation of a map that is backed by a vector.
+/// It is not intended to be used for large maps, but rather for small maps where the order of the keys is important.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct AmqpOrderedMap<K, V>
 where
@@ -212,26 +214,48 @@ impl AmqpComposite {
 pub enum AmqpValue {
     #[default]
     Null,
+    /// A boolean (true/false) value.
     Boolean(bool),
+    /// An unsigned byte value.
     UByte(u8),
+    /// An unsigned short value.
     UShort(u16),
+    /// An unsigned integer value.
     UInt(u32),
+    /// An unsigned long value.
     ULong(u64),
+    /// A signed byte value.
     Byte(i8),
+    /// A signed short value.
     Short(i16),
+    /// A signed integer value.
     Int(i32),
+    /// A signed long value.
     Long(i64),
+    /// A 32-bit floating point value.
     Float(f32),
+    /// A 64-bit floating point value.
     Double(f64),
+    /// A single Unicode character.
     Char(char),
+    /// A point in time.
     TimeStamp(AmqpTimestamp),
+    /// A universally unique identifier.
     Uuid(Uuid),
+    /// A sequence of octets.
     Binary(Vec<u8>),
+    /// A sequence of Unicode characters.
     String(String),
+    /// An AMQP Symbol.
     Symbol(AmqpSymbol),
+
+    /// An ordered list of AMQP values.
     List(AmqpList),
+    /// An ordered map of AMQP values.
     Map(AmqpOrderedMap<AmqpValue, AmqpValue>),
+    /// An array of AMQP values.
     Array(Vec<AmqpValue>),
+    /// A described value.
     Described(Box<AmqpDescribed>),
     #[cfg(feature = "cplusplus")]
     Composite(Box<AmqpComposite>),
@@ -509,7 +533,6 @@ where
 mod tests {
     use super::*;
     use std::vec;
-    use Uuid;
 
     #[test]
     fn test_value_create_specific() {

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -166,8 +166,8 @@ where
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct AmqpDescribed {
-    pub descriptor: AmqpDescriptor,
-    pub value: AmqpValue,
+    descriptor: AmqpDescriptor,
+    value: AmqpValue,
 }
 
 impl AmqpDescribed {
@@ -187,10 +187,14 @@ impl AmqpDescribed {
     }
 }
 
+/// An AMQP Composite type.
+/// This is a complex type that is composed of a descriptor and a value.
+/// The descriptor is used to identify the type of the value.
+/// The value is the actual value.
 #[derive(Debug, PartialEq, Clone)]
 pub struct AmqpComposite {
-    pub descriptor: AmqpDescriptor,
-    pub value: AmqpList,
+    descriptor: AmqpDescriptor,
+    value: AmqpList,
 }
 
 impl AmqpComposite {

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -192,11 +192,13 @@ impl AmqpDescribed {
 /// The descriptor is used to identify the type of the value.
 /// The value is the actual value.
 #[derive(Debug, PartialEq, Clone)]
+#[cfg(feature = "cplusplus")]
 pub struct AmqpComposite {
     descriptor: AmqpDescriptor,
     value: AmqpList,
 }
 
+#[cfg(feature = "cplusplus")]
 impl AmqpComposite {
     pub fn new(descriptor: impl Into<AmqpDescriptor>, value: impl Into<AmqpList>) -> Self {
         Self {
@@ -918,6 +920,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cplusplus")]
     fn amqp_composite() {
         let composite =
             AmqpComposite::new(0x270, AmqpList::from(vec![AmqpValue::from("String value")]));

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -215,6 +215,7 @@ use azure_messaging_eventhubs::ProducerClient;
 
 async fn send_events(producer: &ProducerClient) -> Result<(), Box<dyn std::error::Error>> {
     producer.send_event(vec![1, 2, 3, 4], None).await?;
+    Ok(())
 }
 ```
 
@@ -224,12 +225,13 @@ async fn send_events(producer: &ProducerClient) -> Result<(), Box<dyn std::error
 use azure_messaging_eventhubs::ProducerClient;
 
 async fn send_events(producer: &ProducerClient) -> Result<(), Box<dyn std::error::Error>> {
-    let mut batch = producer.create_batch(None).await;
+    let mut batch = producer.create_batch(None).await?;
     assert_eq!(batch.len(), 0);
     assert!(batch.try_add_event_data(vec![1, 2, 3, 4], None)?);
 
     let res = producer.send_batch(&batch, None).await;
     assert!(res.is_ok());
+    Ok(())
 }
 ```
 
@@ -277,6 +279,7 @@ async fn receive_events(client: &ConsumerClient) -> Result<(), Box<dyn std::erro
             }
         }
     }
+    Ok(())
 }
 ```
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -162,7 +162,7 @@ Examples for various scenarios can be found on in the samples directory in our G
 ## Open an Event Hubs message producer on an Event Hubs instance.
 
 ```rust no_run
-use azure_messaging_eventhubs::{ProducerClient, ProducerClientOptions};
+use azure_messaging_eventhubs::ProducerClient;
 
 async fn open_producer_client() -> Result<ProducerClient,azure_core::Error>
 {
@@ -171,13 +171,11 @@ async fn open_producer_client() -> Result<ProducerClient,azure_core::Error>
 
     let credential = azure_identity::DefaultAzureCredential::new()?;
 
-    let producer = azure_messaging_eventhubs::ProducerClient::new(
+    let producer = azure_messaging_eventhubs::ProducerClient::builder(
         host.to_string(),
         eventhub.to_string(),
-        credential.clone(),
-        None,
-        );
-    producer.open().await?;
+        credential.clone())
+        .open().await?;
 
     Ok(producer)
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -184,7 +184,7 @@ async fn open_producer_client() -> Result<ProducerClient,azure_core::Error>
 ## Open an Event Hubs message consumer on an Event Hubs instance.
 
 ```rust no_run
-use azure_messaging_eventhubs::{ConsumerClient, ConsumerClientOptions};
+use azure_messaging_eventhubs::ConsumerClient;
 
 async fn open_consumer_client() -> Result<ConsumerClient, azure_core::Error>
 {
@@ -193,14 +193,12 @@ async fn open_consumer_client() -> Result<ConsumerClient, azure_core::Error>
 
     let credential = azure_identity::DefaultAzureCredential::new()?;
 
-    let consumer = azure_messaging_eventhubs::ConsumerClient::new(
+    let consumer = azure_messaging_eventhubs::ConsumerClient::builder(
         host.to_string(),
         eventhub.to_string(),
         None,
-        credential.clone(),
-        None
-        );
-    consumer.open().await?;
+        credential.clone())
+        .open().await?;
     Ok(consumer)
 }
 ```

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -172,10 +172,7 @@ async fn open_producer_client() -> Result<ProducerClient,azure_core::Error>
     let credential = azure_identity::DefaultAzureCredential::new()?;
 
     let producer = azure_messaging_eventhubs::ProducerClient::builder(
-        host.to_string(),
-        eventhub.to_string(),
-        credential.clone())
-        .open().await?;
+        host, eventhub, credential.clone()).open().await?;
 
     Ok(producer)
     }
@@ -194,8 +191,8 @@ async fn open_consumer_client() -> Result<ConsumerClient, azure_core::Error>
     let credential = azure_identity::DefaultAzureCredential::new()?;
 
     let consumer = azure_messaging_eventhubs::ConsumerClient::builder(
-        host.to_string(),
-        eventhub.to_string(),
+        host,
+        eventhub,
         None,
         credential.clone())
         .open().await?;
@@ -229,7 +226,7 @@ async fn send_events(producer: &ProducerClient) {
     assert_eq!(batch.len(), 0);
     assert!(batch.try_add_event_data(vec![1, 2, 3, 4], None).unwrap());
 
-    let res = producer.submit_batch(&batch, None).await;
+    let res = producer.send_batch(&batch, None).await;
     assert!(res.is_ok());
 }
 ```
@@ -252,7 +249,7 @@ use async_std::stream::StreamExt;
 async fn receive_events(client : &ConsumerClient) {
     let message_receiver = client
         .open_receiver_on_partition(
-            "0".to_string(),
+            "0",
             Some(
                 azure_messaging_eventhubs::OpenReceiverOptions{
                     start_position: Some(azure_messaging_eventhubs::StartPosition{

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -171,8 +171,8 @@ async fn open_producer_client() -> Result<ProducerClient, azure_core::Error> {
     let credential = azure_identity::DefaultAzureCredential::new()?;
 
     let producer =
-        azure_messaging_eventhubs::ProducerClient::builder(host, eventhub, credential.clone())
-            .open()
+        azure_messaging_eventhubs::ProducerClient::builder()
+            .open(host, eventhub, credential.clone())
             .await?;
 
     Ok(producer)
@@ -190,14 +190,11 @@ async fn open_consumer_client() -> Result<ConsumerClient, azure_core::Error> {
 
     let credential = azure_identity::DefaultAzureCredential::new()?;
 
-    let consumer = azure_messaging_eventhubs::ConsumerClient::builder(
-        host,
-        eventhub,
-        None,
-        credential.clone(),
-    )
-    .open()
-    .await?;
+    let consumer = azure_messaging_eventhubs::ConsumerClient::builder()
+        .open(host,
+              eventhub,
+              credential.clone()
+        ).await?;
     Ok(consumer)
 }
 ```

--- a/sdk/eventhubs/azure_messaging_eventhubs/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/README.md
@@ -164,18 +164,19 @@ Examples for various scenarios can be found on in the samples directory in our G
 ```rust no_run
 use azure_messaging_eventhubs::ProducerClient;
 
-async fn open_producer_client() -> Result<ProducerClient,azure_core::Error>
-{
+async fn open_producer_client() -> Result<ProducerClient, azure_core::Error> {
     let host = "<EVENTHUBS_HOST>";
     let eventhub = "<EVENTHUB_NAME>";
 
     let credential = azure_identity::DefaultAzureCredential::new()?;
 
-    let producer = azure_messaging_eventhubs::ProducerClient::builder(
-        host, eventhub, credential.clone()).open().await?;
+    let producer =
+        azure_messaging_eventhubs::ProducerClient::builder(host, eventhub, credential.clone())
+            .open()
+            .await?;
 
     Ok(producer)
-    }
+}
 ```
 
 ## Open an Event Hubs message consumer on an Event Hubs instance.
@@ -183,8 +184,7 @@ async fn open_producer_client() -> Result<ProducerClient,azure_core::Error>
 ```rust no_run
 use azure_messaging_eventhubs::ConsumerClient;
 
-async fn open_consumer_client() -> Result<ConsumerClient, azure_core::Error>
-{
+async fn open_consumer_client() -> Result<ConsumerClient, azure_core::Error> {
     let host = "<EVENTHUBS_HOST>";
     let eventhub = "<EVENTHUB_NAME>";
 
@@ -194,8 +194,10 @@ async fn open_consumer_client() -> Result<ConsumerClient, azure_core::Error>
         host,
         eventhub,
         None,
-        credential.clone())
-        .open().await?;
+        credential.clone(),
+    )
+    .open()
+    .await?;
     Ok(consumer)
 }
 ```
@@ -211,8 +213,8 @@ send multiple messages in a single network request to the service.
 ```rust no_run
 use azure_messaging_eventhubs::ProducerClient;
 
-async fn send_events(producer: &ProducerClient) {
-    let res = producer.send_event(vec![1,2,3,4], None).await;
+async fn send_events(producer: &ProducerClient) -> Result<(), Box<dyn std::error::Error>> {
+    producer.send_event(vec![1, 2, 3, 4], None).await?;
 }
 ```
 
@@ -221,10 +223,10 @@ async fn send_events(producer: &ProducerClient) {
 ```rust no_run
 use azure_messaging_eventhubs::ProducerClient;
 
-async fn send_events(producer: &ProducerClient) {
-    let mut batch = producer.create_batch(None).await.unwrap();
+async fn send_events(producer: &ProducerClient) -> Result<(), Box<dyn std::error::Error>> {
+    let mut batch = producer.create_batch(None).await;
     assert_eq!(batch.len(), 0);
-    assert!(batch.try_add_event_data(vec![1, 2, 3, 4], None).unwrap());
+    assert!(batch.try_add_event_data(vec![1, 2, 3, 4], None)?);
 
     let res = producer.send_batch(&batch, None).await;
     assert!(res.is_ok());
@@ -241,25 +243,23 @@ events.
 Each message receiver can only receive messages from a single Event Hubs partition
 
 ```rust no_run
-
+use async_std::stream::StreamExt;
 use azure_messaging_eventhubs::ConsumerClient;
 use futures::pin_mut;
-use async_std::stream::StreamExt;
 
-async fn receive_events(client : &ConsumerClient) {
+async fn receive_events(client: &ConsumerClient) -> Result<(), Box<dyn std::error::Error>> {
     let message_receiver = client
         .open_receiver_on_partition(
             "0",
-            Some(
-                azure_messaging_eventhubs::OpenReceiverOptions{
-                    start_position: Some(azure_messaging_eventhubs::StartPosition{
-                        location: azure_messaging_eventhubs::StartLocation::Earliest,
-                        ..Default::default()
-                    }),
+            Some(azure_messaging_eventhubs::OpenReceiverOptions {
+                start_position: Some(azure_messaging_eventhubs::StartPosition {
+                    location: azure_messaging_eventhubs::StartLocation::Earliest,
                     ..Default::default()
-                },
-            ))
-        .await.unwrap();
+                }),
+                ..Default::default()
+            }),
+        )
+        .await?;
 
     let event_stream = message_receiver.stream_events();
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("EventData message sent to partition: {}", partition_id);
         }
 
-        client.submit_batch(&batch, None).await?;
+        client.send_batch(&batch, None).await?;
     }
 
     Ok(())

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
@@ -11,13 +11,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(
-        eventhub_namespace.as_str(),
-        eventhub_name.as_str(),
-        credential.clone(),
-    )
-    .open()
-    .await?;
+    let client = ProducerClient::builder()
+        .open(
+            eventhub_namespace.as_str(),
+            eventhub_name.as_str(),
+            credential.clone(),
+        )
+        .await?;
 
     // Get the partition IDs
     let properties = client.get_eventhub_properties().await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
@@ -11,10 +11,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::new(eventhub_namespace, eventhub_name, credential.clone(), None);
-
-    // Open the client
-    client.open().await?;
+    let client = ProducerClient::builder(eventhub_namespace, eventhub_name, credential.clone())
+        .open()
+        .await?;
 
     // Get the partition IDs
     let properties = client.get_eventhub_properties().await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
@@ -11,9 +11,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(eventhub_namespace, eventhub_name, credential.clone())
-        .open()
-        .await?;
+    let client = ProducerClient::builder(
+        eventhub_namespace.as_str(),
+        eventhub_name.as_str(),
+        credential.clone(),
+    )
+    .open()
+    .await?;
 
     // Get the partition IDs
     let properties = client.get_eventhub_properties().await?;
@@ -41,12 +45,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Send an event built using the `EventData` builder which allows for more control over the event.
         if batch.try_add_event_data(
             EventData::builder()
-                .with_content_type("text/plain".to_string())
+                .with_content_type("text/plain")
                 .with_correlation_id(Uuid::new_v4())
                 .with_body("This is some text")
-                .add_property("Event Property".to_string(), "Property Value")
-                .add_property("Pi".to_string(), std::f32::consts::PI)
-                .add_property("Binary".to_string(), vec![0x08, 0x09, 0x0A])
+                .add_property("Event Property", "Property Value")
+                .add_property("Pi", std::f32::consts::PI)
+                .add_property("Binary", vec![0x08, 0x09, 0x0A])
                 .build(),
             None,
         )? {

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_batch_produce_events.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Send the message to each partition using a batch sender.
     for partition_id in properties.partition_ids {
-        let mut batch = client
+        let batch = client
             .create_batch(Some(EventDataBatchOptions {
                 partition_id: Some(partition_id.clone()),
                 ..Default::default()

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
@@ -13,17 +13,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let consumer = ConsumerClient::new(
-        eventhub_namespace,
-        eventhub_name,
-        None,
-        credential.clone(),
-        None,
-    );
+    let consumer =
+        ConsumerClient::builder(eventhub_namespace, eventhub_name, None, credential.clone())
+            .open()
+            .await?;
 
-    println!("Created consumer client");
-    // Open the client
-    consumer.open().await?;
+    println!("Opened consumer client");
 
     // Get the partition IDs
     let properties = consumer.get_eventhub_properties().await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
@@ -56,7 +56,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Receive events until the receive_timeout has been reached.
     while let Some(event) = receive_stream.next().await {
-        println!("Received: {:?}", event?);
+        let event = event?;
+        println!("Received: {:?}", event);
+
+        println!("Partition ID: {:?}", event.partition_key());
+        println!("Event offset: {:?}", event.offset());
     }
 
     consumer.close().await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
@@ -13,10 +13,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let consumer =
-        ConsumerClient::builder(eventhub_namespace, eventhub_name, None, credential.clone())
-            .open()
-            .await?;
+    let consumer = ConsumerClient::builder(
+        eventhub_namespace.as_str(),
+        eventhub_name.as_str(),
+        None,
+        credential.clone(),
+    )
+    .open()
+    .await?;
 
     println!("Opened consumer client");
 
@@ -27,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The default is to receive messages from the end of the partition, so specify a start position at the start of the partition.
     let receiver = consumer
         .open_receiver_on_partition(
-            properties.partition_ids[0].clone(),
+            properties.partition_ids[0].as_str(),
             Some(OpenReceiverOptions {
                 start_position: Some(StartPosition {
                     location: StartLocation::Earliest,

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
@@ -16,7 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let consumer = ConsumerClient::builder(
         eventhub_namespace.as_str(),
         eventhub_name.as_str(),
-        None,
         credential.clone(),
     )
     .open()

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_events.rs
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let consumer = ConsumerClient::builder(
-        eventhub_namespace.as_str(),
-        eventhub_name.as_str(),
-        credential.clone(),
-    )
-    .open()
-    .await?;
+    let consumer = ConsumerClient::builder()
+        .open(
+            eventhub_namespace.as_str(),
+            eventhub_name.as_str(),
+            credential.clone(),
+        )
+        .await?;
 
     println!("Opened consumer client");
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
@@ -13,17 +13,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let consumer = ConsumerClient::new(
-        eventhub_namespace,
-        eventhub_name,
-        None,
-        credential.clone(),
-        None,
-    );
+    let consumer =
+        ConsumerClient::builder(eventhub_namespace, eventhub_name, None, credential.clone())
+            .open()
+            .await?;
 
-    println!("Created consumer client");
-    // Open the client
-    consumer.open().await?;
+    println!("Opened consumer client");
 
     // Get the partition IDs
     let properties = consumer.get_eventhub_properties().await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
@@ -13,10 +13,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let consumer =
-        ConsumerClient::builder(eventhub_namespace, eventhub_name, None, credential.clone())
-            .open()
-            .await?;
+    let consumer = ConsumerClient::builder(
+        eventhub_namespace.as_str(),
+        eventhub_name.as_str(),
+        None,
+        credential.clone(),
+    )
+    .open()
+    .await?;
 
     println!("Opened consumer client");
 
@@ -27,7 +31,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The default is to receive messages from the end of the partition, so specify a start position at the start of the partition.
     let receiver = consumer
         .open_receiver_on_partition(
-            properties.partition_ids[0].clone(),
+            properties.partition_ids[0].as_str(),
             Some(OpenReceiverOptions {
                 start_position: Some(StartPosition {
                     location: StartLocation::Earliest,

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
@@ -16,7 +16,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let consumer = ConsumerClient::builder(
         eventhub_namespace.as_str(),
         eventhub_name.as_str(),
-        None,
         credential.clone(),
     )
     .open()

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_consume_messages.rs
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let consumer = ConsumerClient::builder(
-        eventhub_namespace.as_str(),
-        eventhub_name.as_str(),
-        credential.clone(),
-    )
-    .open()
-    .await?;
+    let consumer = ConsumerClient::builder()
+        .open(
+            eventhub_namespace.as_str(),
+            eventhub_name.as_str(),
+            credential.clone(),
+        )
+        .await?;
 
     println!("Opened consumer client");
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license.
 use azure_core::error::Result;
 use azure_identity::DefaultAzureCredential;
-use azure_messaging_eventhubs::{ProducerClient, ProducerClientOptions};
+use azure_messaging_eventhubs::ProducerClient;
 
 use std::env;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -17,21 +16,17 @@ async fn main() -> Result<()> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::new(
-        host,
-        eventhub.clone(),
-        credential.clone(),
-        Some(ProducerClientOptions {
-            application_id: Some("test_get_properties".to_string()),
-            ..Default::default()
-        }),
-    );
-    let result = client.open().await;
-    info!("Open result: {:?}", result);
-    if result.is_err() {
-        println!("Error opening client: {:?}", result.err());
+    let result = ProducerClient::builder(host, eventhub.clone(), credential.clone())
+        .with_application_id("test_get_properties".to_string())
+        .open()
+        .await;
+
+    if let Err(err) = result {
+        println!("Error opening client: {:?}", err);
         return Ok(());
     }
+    let client = result?;
+
     let properties = client.get_eventhub_properties().await.unwrap();
     println!("Eventhub Properties for: {eventhub} {:?}", properties);
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
@@ -16,8 +16,8 @@ async fn main() -> Result<()> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let result = ProducerClient::builder(host, eventhub.clone(), credential.clone())
-        .with_application_id("test_get_properties".to_string())
+    let result = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_get_properties")
         .open()
         .await;
 
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
 
     for partition in properties.partition_ids.iter() {
         let partition_properties = client
-            .get_partition_properties(partition.clone())
+            .get_partition_properties(partition.as_str())
             .await
             .unwrap();
         println!(

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_partition_properties.rs
@@ -16,9 +16,9 @@ async fn main() -> Result<()> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let result = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let result = ProducerClient::builder()
         .with_application_id("test_get_properties")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await;
 
     if let Err(err) = result {

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(
-        eventhub_namespace.as_str(),
-        eventhub_name.as_str(),
-        credential.clone(),
-    )
-    .open()
-    .await?;
+    let client = ProducerClient::builder()
+        .open(
+            eventhub_namespace.as_str(),
+            eventhub_name.as_str(),
+            credential.clone(),
+        )
+        .await?;
 
     println!("Created producer client.");
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
@@ -13,9 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(eventhub_namespace, eventhub_name, credential.clone())
-        .open()
-        .await?;
+    let client = ProducerClient::builder(
+        eventhub_namespace.as_str(),
+        eventhub_name.as_str(),
+        credential.clone(),
+    )
+    .open()
+    .await?;
 
     println!("Created producer client.");
 
@@ -39,12 +43,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     client
         .send_event(
             EventData::builder()
-                .with_content_type("text/plain".to_string())
+                .with_content_type("text/plain")
                 .with_correlation_id(Uuid::new_v4())
                 .with_body("This is some text")
-                .add_property("Event Property".to_string(), "Property Value")
-                .add_property("Pi".to_string(), f32::consts::PI)
-                .add_property("Binary".to_string(), vec![0x08, 0x09, 0x0A])
+                .add_property("Event Property", "Property Value")
+                .add_property("Pi", f32::consts::PI)
+                .add_property("Binary", vec![0x08, 0x09, 0x0A])
                 .build(),
             None,
         )

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_events.rs
@@ -13,12 +13,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::new(eventhub_namespace, eventhub_name, credential.clone(), None);
+    let client = ProducerClient::builder(eventhub_namespace, eventhub_name, credential.clone())
+        .open()
+        .await?;
 
     println!("Created producer client.");
-
-    // Open the client
-    client.open().await?;
 
     // Send an event to an eventhub instance directly. The message will be sent to a random partition.
     // Note that this uses an implicit builder to create the EventData being sent to the service.

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_messages.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_messages.rs
@@ -13,13 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(
-        eventhub_namespace.as_str(),
-        eventhub_name.as_str(),
-        credential.clone(),
-    )
-    .open()
-    .await?;
+    let client = ProducerClient::builder()
+        .open(
+            eventhub_namespace.as_str(),
+            eventhub_name.as_str(),
+            credential.clone(),
+        )
+        .await?;
 
     println!("Created producer client.");
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_messages.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_messages.rs
@@ -13,12 +13,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::new(eventhub_namespace, eventhub_name, credential.clone(), None);
+    let client = ProducerClient::builder(eventhub_namespace, eventhub_name, credential.clone())
+        .open()
+        .await?;
 
     println!("Created producer client.");
-
-    // Open the client
-    client.open().await?;
 
     // Send a message to an eventhub instance directly. The message will be sent to a random partition.
     client

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_messages.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_produce_messages.rs
@@ -13,9 +13,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let eventhub_name = std::env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(eventhub_namespace, eventhub_name, credential.clone())
-        .open()
-        .await?;
+    let client = ProducerClient::builder(
+        eventhub_namespace.as_str(),
+        eventhub_name.as_str(),
+        credential.clone(),
+    )
+    .open()
+    .await?;
 
     println!("Created producer client.");
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
@@ -3,10 +3,9 @@
 
 use azure_core::error::Result;
 use azure_identity::DefaultAzureCredential;
-use azure_messaging_eventhubs::{ProducerClient, ProducerClientOptions};
+use azure_messaging_eventhubs::ProducerClient;
 
 use std::env;
-use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -18,21 +17,15 @@ async fn main() -> Result<()> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::new(
-        host,
-        eventhub.clone(),
-        credential.clone(),
-        Some(ProducerClientOptions {
-            application_id: Some("test_get_properties".to_string()),
-            ..Default::default()
-        }),
-    );
-    let result = client.open().await;
-    info!("Open result: {:?}", result);
-    if result.is_err() {
-        println!("Error opening client: {:?}", result.err());
+    let result = ProducerClient::builder(host, eventhub.clone(), credential.clone())
+        .with_application_id("test_get_properties".to_string())
+        .open()
+        .await;
+    if let Err(err) = result {
+        println!("Error opening client: {:?}", err);
         return Ok(());
     }
+    let client = result?;
     let properties = client.get_eventhub_properties().await.unwrap();
     println!("Eventhub Properties for: {eventhub} {:?}", properties);
     Ok(())

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
@@ -28,5 +28,6 @@ async fn main() -> Result<()> {
     let client = result?;
     let properties = client.get_eventhub_properties().await.unwrap();
     println!("Eventhub Properties for: {eventhub} {:?}", properties);
+
     Ok(())
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
@@ -17,9 +17,9 @@ async fn main() -> Result<()> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let result = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let result = ProducerClient::builder()
         .with_application_id("test_get_properties")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await;
     if let Err(err) = result {
         eprintln!("Error opening client: {err}");

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
@@ -17,8 +17,8 @@ async fn main() -> Result<()> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let result = ProducerClient::builder(host, eventhub.clone(), credential.clone())
-        .with_application_id("test_get_properties".to_string())
+    let result = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_get_properties")
         .open()
         .await;
     if let Err(err) = result {

--- a/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/examples/eventhubs_properties.rs
@@ -22,12 +22,12 @@ async fn main() -> Result<()> {
         .open()
         .await;
     if let Err(err) = result {
-        println!("Error opening client: {:?}", err);
-        return Ok(());
+        eprintln!("Error opening client: {err}");
+        return Err(err);
     }
     let client = result?;
     let properties = client.get_eventhub_properties().await.unwrap();
-    println!("Eventhub Properties for: {eventhub} {:?}", properties);
+    println!("Eventhub Properties for: {eventhub} {properties:?}");
 
     Ok(())
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/mod.rs
@@ -41,7 +41,7 @@ impl ManagementInstance {
         Self { management }
     }
 
-    pub async fn get_eventhub_properties(&self, eventhub: String) -> Result<EventHubProperties> {
+    pub async fn get_eventhub_properties(&self, eventhub: &str) -> Result<EventHubProperties> {
         let mut application_properties: AmqpOrderedMap<String, AmqpValue> = AmqpOrderedMap::new();
         application_properties.insert(EVENTHUB_PROPERTY_NAME.to_string(), eventhub.into());
 
@@ -91,8 +91,8 @@ impl ManagementInstance {
 
     pub async fn get_eventhub_partition_properties(
         &self,
-        eventhub: String,
-        partition_id: String,
+        eventhub: &str,
+        partition_id: &str,
     ) -> Result<EventHubPartitionProperties> {
         let mut application_properties: AmqpOrderedMap<String, AmqpValue> = AmqpOrderedMap::new();
         application_properties.insert(EVENTHUB_PROPERTY_NAME.to_string(), eventhub.into());

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/mod.rs
@@ -7,8 +7,7 @@ use crate::{
 };
 use azure_core::error::Result;
 use azure_core_amqp::{
-    management::{AmqpManagement, AmqpManagementApis},
-    value::{AmqpOrderedMap, AmqpTimestamp, AmqpValue},
+    AmqpManagement, AmqpManagementApis, AmqpOrderedMap, AmqpTimestamp, AmqpValue,
 };
 use std::time::SystemTime;
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
@@ -31,7 +31,7 @@ use azure_messaging_eventhubs::ConsumerClient;
 
 #[tokio::main]
 async fn main() -> Result<(), azure_core::Error> {
-    let my_credential = DefaultAzureCredential::new().unwrap();
+    let my_credential = DefaultAzureCredential::new()?;
     let result = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
         .open()
         .await;
@@ -46,6 +46,7 @@ async fn main() -> Result<(), azure_core::Error> {
             eprintln!("Error opening connection: {:?}", err);
         }
     }
+    Ok(())
 }
 ```
 
@@ -74,6 +75,7 @@ async fn main() -> Result<(), azure_core::Error> {
             eprintln!("Error closing connection: {:?}", err);
         }
     }
+    Ok(())
 }
 ```
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
@@ -32,8 +32,8 @@ use azure_messaging_eventhubs::ConsumerClient;
 #[tokio::main]
 async fn main() -> Result<(), azure_core::Error> {
     let my_credential = DefaultAzureCredential::new()?;
-    let result = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-        .open()
+    let result = ConsumerClient::builder()
+        .open("my_namespace", "my_eventhub", my_credential)
         .await;
 
     match result {
@@ -59,8 +59,8 @@ use azure_messaging_eventhubs::ConsumerClient;
 #[tokio::main]
 async fn main() -> Result<(), azure_core::Error> {
     let my_credential = DefaultAzureCredential::new()?;
-    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-        .open()
+    let consumer = ConsumerClient::builder()
+        .open("my_namespace", "my_eventhub", my_credential)
         .await?;
 
     let result = consumer.close().await;
@@ -90,8 +90,8 @@ use futures::pin_mut;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-        .open()
+    let consumer = ConsumerClient::builder()
+        .open("my_namespace", "my_eventhub", my_credential)
         .await?;
     let partition_id = "0";
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
@@ -10,31 +10,33 @@ and manage the lifecycle of the consumer client.
 ### Creating a new [`ConsumerClient`] instance
 
 ```rust no_run
-# #[tokio::main]
-# async fn main() -> Result<(), azure_core::Error>{
-use azure_messaging_eventhubs::ConsumerClient;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
+use azure_messaging_eventhubs::ConsumerClient;
 
-let my_credential = DefaultAzureCredential::new()?;
-let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-    .open().await?;
-# Ok(())
-# }
+#[tokio::main]
+async fn main() -> Result<(), azure_core::Error> {
+    let my_credential = DefaultAzureCredential::new()?;
+    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
+        .open()
+        .await?;
+    Ok(())
+}
 ```
 
 ### Opening a connection to the Event Hub
 
 ```rust no_run
-use azure_messaging_eventhubs::ConsumerClient;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
+use azure_messaging_eventhubs::ConsumerClient;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), azure_core::Error> {
     let my_credential = DefaultAzureCredential::new().unwrap();
     let result = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-        .open().await;
+        .open()
+        .await;
 
-     match result {
+    match result {
         Ok(consumer) => {
             // Connection opened successfully
             println!("Connection opened successfully");
@@ -50,14 +52,15 @@ async fn main() {
 ### Closing the connection to the Event Hub
 
 ```rust no_run
-use azure_messaging_eventhubs::ConsumerClient;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
+use azure_messaging_eventhubs::ConsumerClient;
 
 #[tokio::main]
-async fn main() {
-    let my_credential = DefaultAzureCredential::new().unwrap();
+async fn main() -> Result<(), azure_core::Error> {
+    let my_credential = DefaultAzureCredential::new()?;
     let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-        .open().await.unwrap();
+        .open()
+        .await?;
 
     let result = consumer.close().await;
 
@@ -77,18 +80,17 @@ async fn main() {
 ### Receiving events from a specific partition of the Event Hub
 
 ```rust no_run
-use azure_messaging_eventhubs::ConsumerClient;
-use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 use async_std::stream::StreamExt;
+use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
+use azure_messaging_eventhubs::ConsumerClient;
 use futures::pin_mut;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>>  {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let consumer = ConsumerClient::builder("my_namespace",
-        "my_eventhub",
-        None,
-        my_credential).open().await?;
+    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
+        .open()
+        .await?;
     let partition_id = "0";
 
     let message_receiver = consumer

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
@@ -16,7 +16,7 @@ use azure_messaging_eventhubs::ConsumerClient;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 
 let my_credential = DefaultAzureCredential::new()?;
-let consumer = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
     .open().await?;
 # Ok(())
 # }
@@ -31,7 +31,7 @@ use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 #[tokio::main]
 async fn main() {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let result = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+    let result = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
         .open().await;
 
      match result {
@@ -56,7 +56,7 @@ use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 #[tokio::main]
 async fn main() {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let consumer = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
         .open().await.unwrap();
 
     let result = consumer.close().await;
@@ -85,16 +85,14 @@ use futures::pin_mut;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>>  {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let consumer = ConsumerClient::builder("my_namespace".to_string(),
-        "my_eventhub".to_string(),
+    let consumer = ConsumerClient::builder("my_namespace",
+        "my_eventhub",
         None,
         my_credential).open().await?;
     let partition_id = "0";
 
     let message_receiver = consumer
-        .open_receiver_on_partition(
-            partition_id.to_string(),
-            None)
+        .open_receiver_on_partition(partition_id, None)
         .await?;
 
     let event_stream = message_receiver.stream_events();

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
@@ -10,11 +10,16 @@ and manage the lifecycle of the consumer client.
 ### Creating a new [`ConsumerClient`] instance
 
 ```rust no_run
+# #[tokio::main]
+# async fn main() -> Result<(), azure_core::Error>{
 use azure_messaging_eventhubs::ConsumerClient;
 use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 
-let my_credential = DefaultAzureCredential::new().unwrap();
-let consumer = ConsumerClient::new("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential, None);
+let my_credential = DefaultAzureCredential::new()?;
+let consumer = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+    .open().await?;
+# Ok(())
+# }
 ```
 
 ### Opening a connection to the Event Hub
@@ -26,12 +31,11 @@ use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 #[tokio::main]
 async fn main() {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let consumer = ConsumerClient::new("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential, None);
-
-    let result = consumer.open().await;
+    let result = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+        .open().await;
 
      match result {
-        Ok(()) => {
+        Ok(consumer) => {
             // Connection opened successfully
             println!("Connection opened successfully");
         }
@@ -52,9 +56,8 @@ use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
 #[tokio::main]
 async fn main() {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let consumer = ConsumerClient::new("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential, None);
-
-    consumer.open().await.unwrap();
+    let consumer = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+        .open().await.unwrap();
 
     let result = consumer.close().await;
 
@@ -82,10 +85,11 @@ use futures::pin_mut;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>>  {
     let my_credential = DefaultAzureCredential::new().unwrap();
-    let consumer = ConsumerClient::new("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential, None);
+    let consumer = ConsumerClient::builder("my_namespace".to_string(),
+        "my_eventhub".to_string(),
+        None,
+        my_credential).open().await?;
     let partition_id = "0";
-
-    consumer.open().await?;
 
     let message_receiver = consumer
         .open_receiver_on_partition(

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/README.md
@@ -16,8 +16,8 @@ use azure_messaging_eventhubs::ConsumerClient;
 #[tokio::main]
 async fn main() -> Result<(), azure_core::Error> {
     let my_credential = DefaultAzureCredential::new()?;
-    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-        .open()
+    let consumer = ConsumerClient::builder()
+        .open("my_namespace", "my_eventhub", my_credential)
         .await?;
     Ok(())
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -5,10 +5,7 @@ use crate::models::ReceivedEventData;
 use async_std::future::timeout;
 use async_stream::try_stream;
 use azure_core::error::Result;
-use azure_core_amqp::{
-    messaging::AmqpDeliveryApis,
-    receiver::{AmqpReceiver, AmqpReceiverApis},
-};
+use azure_core_amqp::{AmqpDeliveryApis, AmqpReceiver, AmqpReceiverApis};
 use futures::stream::Stream;
 use tracing::trace;
 
@@ -76,7 +73,7 @@ impl EventReceiver {
     /// # Examples
     ///
     /// ```no_run
-    /// use azure_messaging_eventhubs::consumer::EventReceiver;
+    /// use azure_messaging_eventhubs::EventReceiver;
     /// use async_std::stream::StreamExt;
     /// use futures::pin_mut;
     ///

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -24,8 +24,8 @@ use tracing::trace;
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let my_credential = DefaultAzureCredential::new()?;
-///     let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-///        .open().await?;
+///     let consumer = ConsumerClient::builder()
+///        .open("my_namespace", "my_eventhub", my_credential).await?;
 ///     let partition_id = "0";
 ///
 ///     let receiver  = consumer.open_receiver_on_partition(partition_id, None).await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -24,10 +24,9 @@ use tracing::trace;
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let my_credential = DefaultAzureCredential::new()?;
-///     let consumer = ConsumerClient::new("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential, None);
+///     let consumer = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+///        .open().await?;
 ///     let partition_id = "0";
-///
-///     consumer.open().await?;
 ///
 ///     let receiver  = consumer.open_receiver_on_partition(partition_id.to_string(), None).await?;
 ///

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/event_receiver.rs
@@ -24,11 +24,11 @@ use tracing::trace;
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let my_credential = DefaultAzureCredential::new()?;
-///     let consumer = ConsumerClient::builder("my_namespace".to_string(), "my_eventhub".to_string(), None, my_credential)
+///     let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
 ///        .open().await?;
 ///     let partition_id = "0";
 ///
-///     let receiver  = consumer.open_receiver_on_partition(partition_id.to_string(), None).await?;
+///     let receiver  = consumer.open_receiver_on_partition(partition_id, None).await?;
 ///
 ///     let event_stream = receiver.stream_events();
 ///

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -61,12 +61,6 @@ impl ConsumerClient {
     /// This function returns a builder which enables creation of a new [`ConsumerClient`]
     /// instance with the specified parameters.
     ///
-    /// # Arguments
-    ///
-    /// * `fully_qualified_namespace` - The fully qualified namespace of the Event Hubs instance.
-    /// * `eventhub_name` - The name of the Event Hub.
-    /// * `consumer_group` - Optional consumer group name. If not provided, the default consumer group will be used.
-    /// * `credential` - The token credential used to authenticate with the Event Hubs service.
     ///
     /// # Returns
     ///
@@ -81,17 +75,13 @@ impl ConsumerClient {
     /// use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
     ///
     ///     let my_credential = DefaultAzureCredential::new()?;
-    /// let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential.clone())
-    ///    .open().await?;
+    /// let consumer = ConsumerClient::builder()
+    ///    .open("my_namespace", "my_eventhub", my_credential.clone()).await?;
     /// # Ok(())}
     /// ```
     ///
-    pub fn builder(
-        fully_qualified_namespace: &str,
-        eventhub_name: &str,
-        credential: Arc<dyn TokenCredential>,
-    ) -> builders::ConsumerClientBuilder {
-        builders::ConsumerClientBuilder::new(fully_qualified_namespace, eventhub_name, credential)
+    pub fn builder() -> builders::ConsumerClientBuilder {
+        builders::ConsumerClientBuilder::new()
     }
 
     fn new(
@@ -142,8 +132,8 @@ impl ConsumerClient {
     /// #[tokio::main]
     /// async fn main() {
     ///     let my_credential = DefaultAzureCredential::new().unwrap();
-    ///     let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-    ///         .open().await.unwrap();
+    ///     let consumer = ConsumerClient::builder()
+    ///         .open("my_namespace", "my_eventhub", my_credential).await.unwrap();
     ///
     ///     let result = consumer.close().await;
     ///
@@ -196,8 +186,8 @@ impl ConsumerClient {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let my_credential = DefaultAzureCredential::new()?;
-    ///     let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-    ///        .open().await?;
+    ///     let consumer = ConsumerClient::builder()
+    ///        .open("my_namespace", "my_eventhub", my_credential).await?;
     ///     let partition_id = "0";
     ///
     ///     let receiver  = consumer.open_receiver_on_partition(partition_id, None).await?;
@@ -291,8 +281,8 @@ impl ConsumerClient {
     /// #[tokio::main]
     /// async fn main(){
     ///     let my_credential = DefaultAzureCredential::new().unwrap();
-    ///     let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-    ///         .open().await.unwrap();
+    ///     let consumer = ConsumerClient::builder()
+    ///         .open("my_namespace", "my_eventhub", my_credential).await.unwrap();
     ///
     ///     let eventhub_properties = consumer.get_eventhub_properties().await;
     ///
@@ -342,8 +332,8 @@ impl ConsumerClient {
     /// #[tokio::main]
     /// async fn main() {
     ///     let my_credential = DefaultAzureCredential::new().unwrap();
-    ///     let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-    ///         .open().await.unwrap();
+    ///     let consumer = ConsumerClient::builder()
+    ///         .open("my_namespace", "my_eventhub", my_credential).await.unwrap();
     ///     let partition_id = "0";
     ///
     ///     let partition_properties = consumer.get_partition_properties(partition_id).await;
@@ -681,31 +671,21 @@ pub mod builders {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///    let my_credential = DefaultAzureCredential::new().unwrap();
-    ///   let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-    ///      .open().await?;
+    ///   let consumer = ConsumerClient::builder()
+    ///      .open("my_namespace", "my_eventhub", my_credential).await?;
     ///   Ok(())
     /// }
     /// ```
     pub struct ConsumerClientBuilder {
-        fully_qualified_namespace: String,
-        eventhub_name: String,
         consumer_group: Option<String>,
-        credential: Arc<dyn azure_core::credentials::TokenCredential>,
         application_id: Option<String>,
         instance_id: Option<String>,
         retry_options: Option<RetryOptions>,
     }
 
     impl ConsumerClientBuilder {
-        pub(super) fn new(
-            fully_qualified_namespace: &str,
-            eventhub_name: &str,
-            credential: Arc<dyn azure_core::credentials::TokenCredential>,
-        ) -> Self {
+        pub(super) fn new() -> Self {
             Self {
-                fully_qualified_namespace: fully_qualified_namespace.to_string(),
-                eventhub_name: eventhub_name.to_string(),
-                credential,
                 consumer_group: None,
                 application_id: None,
                 instance_id: None,
@@ -735,9 +715,9 @@ pub mod builders {
         /// #[tokio::main]
         /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ///    let my_credential = DefaultAzureCredential::new()?;
-        ///    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
+        ///    let consumer = ConsumerClient::builder()
         ///      .with_consumer_group("my_consumer_group")
-        ///      .open().await?;
+        ///      .open("my_namespace", "my_eventhub", my_credential).await?;
         ///   Ok(())
         /// }
         ///
@@ -779,8 +759,8 @@ pub mod builders {
         /// #[tokio::main]
         /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ///     let my_credential = DefaultAzureCredential::new().unwrap();
-        ///     let result = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-        ///         .open().await;
+        ///     let result = ConsumerClient::builder()
+        ///         .open("my_namespace", "my_eventhub", my_credential).await;
         ///
         ///     match result {
         ///         Ok(_connection) => {
@@ -795,12 +775,17 @@ pub mod builders {
         ///     Ok(())
         /// }
         /// ```
-        pub async fn open(self) -> Result<super::ConsumerClient> {
+        pub async fn open(
+            self,
+            fully_qualified_namespace: &str,
+            eventhub_name: &str,
+            credential: Arc<dyn azure_core::credentials::TokenCredential>,
+        ) -> Result<super::ConsumerClient> {
             let consumer = super::ConsumerClient::new(
-                self.fully_qualified_namespace,
-                self.eventhub_name,
+                fully_qualified_namespace.to_string(),
+                eventhub_name.to_string(),
                 self.consumer_group,
-                self.credential,
+                credential,
                 self.application_id,
                 self.instance_id,
                 self.retry_options,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -685,10 +685,11 @@ pub mod builders {
     /// use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
     ///
     /// #[tokio::main]
-    /// async fn main() {
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///    let my_credential = DefaultAzureCredential::new().unwrap();
     ///   let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
-    ///      .open().await.unwrap();
+    ///      .open().await?;
+    ///   Ok(())
     /// }
     /// ```
     pub struct ConsumerClientBuilder {
@@ -754,7 +755,7 @@ pub mod builders {
         /// use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
         ///
         /// #[tokio::main]
-        /// async fn main() {
+        /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ///     let my_credential = DefaultAzureCredential::new().unwrap();
         ///     let result = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
         ///         .open().await;
@@ -769,6 +770,7 @@ pub mod builders {
         ///             eprintln!("Error opening connection: {:?}", err);
         ///         }
         ///     }
+        ///     Ok(())
         /// }
         /// ```
         pub async fn open(self) -> Result<super::ConsumerClient> {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -89,15 +89,9 @@ impl ConsumerClient {
     pub fn builder(
         fully_qualified_namespace: &str,
         eventhub_name: &str,
-        consumer_group: Option<String>,
         credential: Arc<dyn TokenCredential>,
     ) -> builders::ConsumerClientBuilder {
-        builders::ConsumerClientBuilder::new(
-            fully_qualified_namespace,
-            eventhub_name,
-            consumer_group,
-            credential,
-        )
+        builders::ConsumerClientBuilder::new(fully_qualified_namespace, eventhub_name, credential)
     }
 
     fn new(
@@ -706,14 +700,13 @@ pub mod builders {
         pub(super) fn new(
             fully_qualified_namespace: &str,
             eventhub_name: &str,
-            consumer_group: Option<String>,
             credential: Arc<dyn azure_core::credentials::TokenCredential>,
         ) -> Self {
             Self {
                 fully_qualified_namespace: fully_qualified_namespace.to_string(),
                 eventhub_name: eventhub_name.to_string(),
-                consumer_group,
                 credential,
+                consumer_group: None,
                 application_id: None,
                 instance_id: None,
                 retry_options: None,
@@ -723,6 +716,35 @@ pub mod builders {
         /// Specifies the name of the application creating the [`ConsumerClient`].
         pub fn with_application_id(mut self, application_id: &str) -> Self {
             self.application_id = Some(application_id.to_string());
+            self
+        }
+
+        /// Specifies the consumer group for the [`ConsumerClient`].
+        ///
+        /// If not specified, the default consumer group will be used.
+        ///
+        /// For more information on Event Hubs consumer groups, see
+        /// [Consumer groups](https://learn.microsoft.com/azure/event-hubs/event-hubs-features#consumer-groups).
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use azure_messaging_eventhubs::ConsumerClient;
+        /// use azure_identity::{DefaultAzureCredential, TokenCredentialOptions};
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        ///    let my_credential = DefaultAzureCredential::new()?;
+        ///    let consumer = ConsumerClient::builder("my_namespace", "my_eventhub", None, my_credential)
+        ///      .with_consumer_group("my_consumer_group")
+        ///      .open().await?;
+        ///   Ok(())
+        /// }
+        ///
+        /// ```
+        ///
+        pub fn with_consumer_group(mut self, consumer_group: &str) -> Self {
+            self.consumer_group = Some(consumer_group.to_string());
             self
         }
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -2,6 +2,11 @@
 // Licensed under the MIT license.
 
 #![doc = include_str!("README.md")]
+/// Receive messages from a partition.
+pub(crate) mod event_receiver;
+
+pub use event_receiver::EventReceiver;
+
 use super::{
     common::{
         user_agent::{get_package_name, get_package_version, get_platform_info, get_user_agent},
@@ -18,15 +23,11 @@ use azure_core::{
     RetryOptions,
 };
 use azure_core_amqp::{
-    cbs::{AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis},
-    connection::{AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions},
-    management::{AmqpManagement, AmqpManagementApis},
-    messaging::{AmqpSource, AmqpSourceFilter},
-    receiver::{AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode},
-    session::{AmqpSession, AmqpSessionApis},
-    value::{AmqpDescribed, AmqpOrderedMap, AmqpSymbol, AmqpValue},
+    AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis, AmqpConnection, AmqpConnectionApis,
+    AmqpConnectionOptions, AmqpDescribed, AmqpManagement, AmqpManagementApis, AmqpOrderedMap,
+    AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, AmqpSession, AmqpSessionApis, AmqpSource,
+    AmqpSourceFilter, AmqpSymbol, AmqpValue, ReceiverCreditMode,
 };
-pub use event_receiver::EventReceiver;
 use std::{
     collections::HashMap,
     default::Default,
@@ -36,9 +37,6 @@ use std::{
 };
 use tracing::{debug, trace};
 use url::Url;
-
-/// Receive messages from a partition.
-mod event_receiver;
 
 /// A client that can be used to receive events from an Event Hub.
 pub struct ConsumerClient {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All Rights Reserved.
 // Licensed under the MIT License.
 
-use azure_core_amqp::error::Error;
+use azure_core_amqp::Error;
 
 /// Represents the different kinds of errors that can occur in the Eventhubs module.
 pub enum ErrorKind {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
@@ -25,6 +25,11 @@ pub use producer::{
 };
 
 pub use consumer::{
-    ConsumerClient, ConsumerClientOptions, EventReceiver, OpenReceiverOptions, StartLocation,
-    StartPosition,
+    ConsumerClient, EventReceiver, OpenReceiverOptions, StartLocation, StartPosition,
 };
+
+/// Builders for producer client and consumer client.
+pub mod builders {
+    pub use crate::consumer::builders::ConsumerClientBuilder;
+    pub use crate::producer::builders::ProducerClientBuilder;
+}

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
@@ -8,26 +8,24 @@
 pub(crate) mod common;
 
 /// Types related to consuming events from an Event Hubs instance.
-pub mod consumer;
+pub(crate) mod consumer;
 
 /// Types related to errors processing events.
-pub mod error;
+mod error;
 
 /// Types to create and send events to an Event Hubs instance.
-pub mod producer;
+pub(crate) mod producer;
 
 /// Types sent to and received from the Event Hubs service.
 pub mod models;
 
-pub use producer::batch::*;
-pub use producer::ProducerClient;
-pub use producer::ProducerClientOptions;
-pub use producer::SendEventOptions;
-pub use producer::SendMessageOptions;
-pub use producer::SubmitBatchOptions;
+pub use producer::{
+    batch::{EventDataBatch, EventDataBatchOptions},
+    ProducerClient, ProducerClientOptions, SendEventOptions, SendMessageOptions,
+    SubmitBatchOptions,
+};
 
-pub use consumer::ConsumerClient;
-pub use consumer::ConsumerClientOptions;
-pub use consumer::OpenReceiverOptions;
-pub use consumer::StartLocation;
-pub use consumer::StartPosition;
+pub use consumer::{
+    ConsumerClient, ConsumerClientOptions, EventReceiver, OpenReceiverOptions, StartLocation,
+    StartPosition,
+};

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
@@ -21,8 +21,7 @@ pub mod models;
 
 pub use producer::{
     batch::{EventDataBatch, EventDataBatchOptions},
-    ProducerClient, ProducerClientOptions, SendEventOptions, SendMessageOptions,
-    SubmitBatchOptions,
+    ProducerClient, SendEventOptions, SendMessageOptions, SubmitBatchOptions,
 };
 
 pub use consumer::{

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/lib.rs
@@ -21,7 +21,7 @@ pub mod models;
 
 pub use producer::{
     batch::{EventDataBatch, EventDataBatchOptions},
-    ProducerClient, SendEventOptions, SendMessageOptions, SubmitBatchOptions,
+    ProducerClient, SendBatchOptions, SendEventOptions, SendMessageOptions,
 };
 
 pub use consumer::{

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
@@ -1,5 +1,5 @@
 use crate::models::{AmqpMessage, AmqpValue, MessageId};
-use azure_core_amqp::messaging::{AmqpAnnotationKey, AmqpMessageBody, AmqpMessageProperties};
+use azure_core_amqp::{AmqpAnnotationKey, AmqpMessageBody, AmqpMessageProperties};
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
@@ -19,10 +19,10 @@ use std::{
 ///
 /// let event_data = EventData::builder()
 ///    .with_body(b"Hello, world!")
-///    .with_content_type("text/plain".to_string())
+///    .with_content_type("text/plain")
 ///    .with_correlation_id("correlation_id")
 ///    .with_message_id("message_id")
-///    .add_property("key".to_string(), "value")
+///    .add_property("key", "value")
 ///    .build();
 ///
 /// println!("{:?}", event_data);
@@ -84,7 +84,7 @@ impl EventData {
         if let Some(properties) = message.properties() {
             if let Some(content_type) = &properties.content_type {
                 event_data_builder = event_data_builder
-                    .with_content_type(Into::<String>::into(content_type.clone()));
+                    .with_content_type(Into::<String>::into(content_type.clone()).as_str());
             }
             if let Some(correlation_id) = &properties.correlation_id {
                 event_data_builder = event_data_builder.with_correlation_id(correlation_id.clone());
@@ -95,7 +95,7 @@ impl EventData {
         }
         if let Some(application_properties) = message.application_properties() {
             for (key, value) in application_properties.0.clone() {
-                event_data_builder = event_data_builder.add_property(key, value);
+                event_data_builder = event_data_builder.add_property(key.as_str(), value);
             }
         }
         event_data_builder.build()
@@ -345,8 +345,8 @@ pub mod builders {
         ///
         /// A reference to the updated builder.
         ///
-        pub fn with_content_type(mut self, content_type: String) -> Self {
-            self.event_data.content_type = Some(content_type);
+        pub fn with_content_type(mut self, content_type: &str) -> Self {
+            self.event_data.content_type = Some(content_type.to_string());
             self
         }
 
@@ -391,13 +391,13 @@ pub mod builders {
         ///
         /// A reference to the updated builder.
         ///
-        pub fn add_property(mut self, key: String, value: impl Into<AmqpValue>) -> Self {
+        pub fn add_property(mut self, key: &str, value: impl Into<AmqpValue>) -> Self {
             if let Some(mut properties) = self.event_data.properties {
-                properties.insert(key, value.into());
+                properties.insert(key.to_string(), value.into());
                 self.event_data.properties = Some(properties);
             } else {
                 let mut properties = HashMap::new();
-                properties.insert(key, value.into());
+                properties.insert(key.to_string(), value.into());
                 self.event_data.properties = Some(properties);
             }
             self
@@ -430,9 +430,7 @@ mod tests {
     #[test]
     fn test_event_data_builder_with_content_type() {
         let content_type = "application/json";
-        let event_data = EventData::builder()
-            .with_content_type(content_type.to_string())
-            .build();
+        let event_data = EventData::builder().with_content_type(content_type).build();
 
         assert_eq!(event_data.content_type(), Some(content_type));
     }
@@ -459,13 +457,13 @@ mod tests {
 
     #[test]
     fn test_event_data_builder_add_property() {
-        let key = "key".to_string();
+        let key = "key";
         let value: AmqpValue = "value".into();
         let event_data = EventData::builder()
-            .add_property(key.clone(), value.clone())
+            .add_property(key, value.clone())
             .build();
 
-        assert_eq!(event_data.properties().unwrap().get(&key), Some(&value));
+        assert_eq!(event_data.properties().unwrap().get(key), Some(&value));
     }
 
     #[test]
@@ -474,21 +472,21 @@ mod tests {
         let content_type = "application/json";
         let correlation_id = MessageId::String("correlation-id".to_string());
         let message_id = MessageId::String("message-id".to_string());
-        let key = "key".to_string();
+        let key = "key";
         let value: AmqpValue = "value".into();
 
         let event_data = EventData::builder()
             .with_body(body.clone())
-            .with_content_type(content_type.to_string())
+            .with_content_type(content_type)
             .with_correlation_id(correlation_id.clone())
             .with_message_id(message_id.clone())
-            .add_property(key.clone(), value.clone())
+            .add_property(key, value.clone())
             .build();
 
         assert_eq!(event_data.body().unwrap(), &body);
         assert_eq!(event_data.content_type(), Some(content_type));
         assert_eq!(event_data.correlation_id(), Some(&correlation_id));
         assert_eq!(event_data.message_id(), Some(&message_id));
-        assert_eq!(event_data.properties().unwrap().get(&key), Some(&value));
+        assert_eq!(event_data.properties().unwrap().get(key), Some(&value));
     }
 }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
@@ -42,7 +42,7 @@ use std::fmt::Debug;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone())
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain", "eventhub_name", None, my_credentials.clone())
 ///    .open().await?;
 ///
 /// let eventhub_properties = consumer_client.get_eventhub_properties().await?;
@@ -88,10 +88,10 @@ pub struct EventHubProperties {
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone())
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain", "eventhub_name", None, my_credentials.clone())
 ///   .open().await?;
 ///
-/// let partition_properties = consumer_client.get_partition_properties("0".to_string()).await?;
+/// let partition_properties = consumer_client.get_partition_properties("0").await?;
 /// # Ok(()) }
 /// ```
 ///

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
@@ -42,7 +42,8 @@ use std::fmt::Debug;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::new("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone(), None);
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone())
+///    .open().await?;
 ///
 /// let eventhub_properties = consumer_client.get_eventhub_properties().await?;
 ///
@@ -87,7 +88,8 @@ pub struct EventHubProperties {
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::new("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone(), None);
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone())
+///   .open().await?;
 ///
 /// let partition_properties = consumer_client.get_partition_properties("0".to_string()).await?;
 /// # Ok(()) }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
@@ -1,21 +1,26 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 
+/// [`EventData`] and [`ReceivedEventData`] types.
 mod event_data;
 
 /// An AMQP Message sent to the eventhubs service.
-pub type AmqpMessage = azure_core_amqp::messaging::AmqpMessage;
+pub use azure_core_amqp::AmqpMessage;
 
 /// An AMQP Value.
-pub type AmqpValue = azure_core_amqp::value::AmqpValue;
+pub use azure_core_amqp::AmqpValue;
 
 /// An event received from an Event Hub.
-pub type ReceivedEventData = event_data::ReceivedEventData;
+pub use event_data::ReceivedEventData;
 
+/// Event data builders.
+pub mod builders {
+    pub use crate::models::event_data::builders::EventDataBuilder;
+}
 /// Event sent to an Event Hub.
-pub type EventData = event_data::EventData;
+pub use event_data::EventData;
 
-use azure_core_amqp::messaging::AmqpMessageId;
+use azure_core_amqp::AmqpMessageId;
 use std::fmt::Debug;
 
 /// Represents the properties of an Event Hubs instance.
@@ -37,7 +42,7 @@ use std::fmt::Debug;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::consumer::ConsumerClient::new("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone(), None);
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::new("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone(), None);
 ///
 /// let eventhub_properties = consumer_client.get_eventhub_properties().await?;
 ///
@@ -82,7 +87,7 @@ pub struct EventHubProperties {
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::consumer::ConsumerClient::new("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone(), None);
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::new("fully_qualified_domain".to_string(), "eventhub_name".to_string(), None, my_credentials.clone(), None);
 ///
 /// let partition_properties = consumer_client.get_partition_properties("0".to_string()).await?;
 /// # Ok(()) }
@@ -225,7 +230,7 @@ impl From<MessageId> for AmqpMessageId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use azure_core_amqp::messaging::AmqpMessageId;
+    use azure_core_amqp::AmqpMessageId;
 
     #[test]
     fn test_message_id_from_u64() {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
@@ -42,8 +42,8 @@ use std::fmt::Debug;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain", "eventhub_name", None, my_credentials.clone())
-///    .open().await?;
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder()
+///    .open("fully_qualified_domain", "eventhub_name", my_credentials.clone()).await?;
 ///
 /// let eventhub_properties = consumer_client.get_eventhub_properties().await?;
 ///
@@ -88,8 +88,8 @@ pub struct EventHubProperties {
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// # let my_credentials = DefaultAzureCredential::new()?;
-/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder("fully_qualified_domain", "eventhub_name", None, my_credentials.clone())
-///   .open().await?;
+/// let consumer_client = azure_messaging_eventhubs::ConsumerClient::builder()
+///   .open("fully_qualified_domain", "eventhub_name", my_credentials.clone()).await?;
 ///
 /// let partition_properties = consumer_client.get_partition_properties("0").await?;
 /// # Ok(()) }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -35,7 +35,7 @@ struct EventDataBatchState {
 ///
 /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credentials = azure_identity::DefaultAzureCredential::new()?;
-/// # let producer_client = ProducerClient::builder("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), credentials.clone())
+/// # let producer_client = ProducerClient::builder("fully_qualified_domain_name", "event_hub_name", credentials.clone())
 /// #     .open().await?;
 /// #
 ///
@@ -44,7 +44,7 @@ struct EventDataBatchState {
 /// batch.try_add_event_data("Hello, Event Hub!", None)?;
 /// batch.try_add_event_data("This is another event.", None)?;
 ///
-/// producer_client.submit_batch(&batch, None).await?;
+/// producer_client.send_batch(&batch, None).await?;
 ///
 /// # Ok(())
 /// # }
@@ -160,7 +160,7 @@ impl<'a> EventDataBatch<'a> {
     ///
     /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
     /// # let my_credential = azure_identity::DefaultAzureCredential::new()?;
-    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), my_credential.clone()).open().await?;
+    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name", "event_hub_name", my_credential.clone()).open().await?;
     /// let mut batch = producer_client.create_batch(None).await?;
     ///
     /// let event_data = EventData::builder().build();
@@ -204,7 +204,7 @@ impl<'a> EventDataBatch<'a> {
     ///
     /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
     /// # let my_credential = azure_identity::DefaultAzureCredential::new()?;
-    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), my_credential.clone()).open().await?;
+    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name", "event_hub_name", my_credential.clone()).open().await?;
     /// let mut batch = producer_client.create_batch(None).await?;
     ///
     /// let amqp_message = AmqpMessage::builder().build();

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -31,12 +31,13 @@ struct EventDataBatchState {
 ///
 /// ``` no_run
 /// # use azure_messaging_eventhubs::ProducerClient;
-/// # use azure_messaging_eventhubs::ProducerClientOptions;
 /// # use azure_identity::TokenCredentialOptions;
 ///
 /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credentials = azure_identity::DefaultAzureCredential::new()?;
-/// # let producer_client = ProducerClient::new("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), credentials.clone(), None);
+/// # let producer_client = ProducerClient::builder("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), credentials.clone())
+/// #     .open().await?;
+/// #
 ///
 /// let mut batch = producer_client.create_batch(None).await?;
 ///
@@ -154,12 +155,12 @@ impl<'a> EventDataBatch<'a> {
     ///
     /// ```no_run
     ///
-    /// # use azure_messaging_eventhubs::{ProducerClient, ProducerClientOptions};
+    /// # use azure_messaging_eventhubs::ProducerClient;
     /// # use azure_messaging_eventhubs::models::EventData;
     ///
     /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
     /// # let my_credential = azure_identity::DefaultAzureCredential::new()?;
-    /// # let producer_client = ProducerClient::new("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), my_credential.clone(), None);
+    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), my_credential.clone()).open().await?;
     /// let mut batch = producer_client.create_batch(None).await?;
     ///
     /// let event_data = EventData::builder().build();
@@ -197,13 +198,13 @@ impl<'a> EventDataBatch<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use azure_messaging_eventhubs::{ProducerClient, ProducerClientOptions};
+    /// # use azure_messaging_eventhubs::ProducerClient;
     /// # use azure_messaging_eventhubs::models::EventData;
     /// # use azure_messaging_eventhubs::models::AmqpMessage;
     ///
     /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
     /// # let my_credential = azure_identity::DefaultAzureCredential::new()?;
-    /// # let producer_client = ProducerClient::new("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), my_credential.clone(), None);
+    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name".to_string(), "event_hub_name".to_string(), my_credential.clone()).open().await?;
     /// let mut batch = producer_client.create_batch(None).await?;
     ///
     /// let amqp_message = AmqpMessage::builder().build();

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -172,7 +172,7 @@ impl<'a> EventDataBatch<'a> {
     /// # use azure_messaging_eventhubs::EventDataBatch;
     ///
     pub fn try_add_event_data(
-        &mut self,
+        &self,
         event_data: impl Into<EventData>,
         options: Option<AddEventDataOptions>,
     ) -> Result<bool> {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -35,8 +35,8 @@ struct EventDataBatchState {
 ///
 /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
 /// # let credentials = azure_identity::DefaultAzureCredential::new()?;
-/// # let producer_client = ProducerClient::builder("fully_qualified_domain_name", "event_hub_name", credentials.clone())
-/// #     .open().await?;
+/// # let producer_client = ProducerClient::builder()
+/// #     .open("fully_qualified_domain_name", "event_hub_name", credentials.clone()).await?;
 /// #
 ///
 /// let mut batch = producer_client.create_batch(None).await?;
@@ -160,7 +160,7 @@ impl<'a> EventDataBatch<'a> {
     ///
     /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
     /// # let my_credential = azure_identity::DefaultAzureCredential::new()?;
-    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name", "event_hub_name", my_credential.clone()).open().await?;
+    /// # let producer_client = ProducerClient::builder().open("fully_qualified_domain_name", "event_hub_name", my_credential.clone()).await?;
     /// let mut batch = producer_client.create_batch(None).await?;
     ///
     /// let event_data = EventData::builder().build();
@@ -204,7 +204,7 @@ impl<'a> EventDataBatch<'a> {
     ///
     /// # async fn send_event_batch() -> Result<(), Box<dyn std::error::Error>> {
     /// # let my_credential = azure_identity::DefaultAzureCredential::new()?;
-    /// # let producer_client = ProducerClient::builder("fully_qualified_domain_name", "event_hub_name", my_credential.clone()).open().await?;
+    /// # let producer_client = ProducerClient::builder().open("fully_qualified_domain_name", "event_hub_name", my_credential.clone()).await?;
     /// let mut batch = producer_client.create_batch(None).await?;
     ///
     /// let amqp_message = AmqpMessage::builder().build();

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/batch.rs
@@ -7,11 +7,7 @@ use super::ProducerClient;
 
 use crate::{error::ErrorKind, models::EventData};
 use azure_core::{error::Result, Error};
-use azure_core_amqp::{
-    messaging::{AmqpMessage, AmqpMessageBody},
-    sender::AmqpSenderApis,
-    value::AmqpSymbol,
-};
+use azure_core_amqp::{AmqpMessage, AmqpSenderApis, AmqpSymbol};
 use tracing::debug;
 use uuid::Uuid;
 
@@ -281,7 +277,7 @@ impl<'a> EventDataBatch<'a> {
         let mut serialized_messages = Vec::<Vec<u8>>::new();
         serialized_messages.append(&mut batch_state.serialized_messages);
 
-        batch_envelope.set_message_body(AmqpMessageBody::Binary(serialized_messages));
+        batch_envelope.set_message_body(serialized_messages);
 
         // Reset the batch state for the next batch
         batch_state.batch_envelope = None;

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -16,12 +16,10 @@ use azure_core::{
     RetryOptions, Uuid,
 };
 use azure_core_amqp::{
-    cbs::{AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis},
-    connection::{AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions},
-    management::{AmqpManagement, AmqpManagementApis},
-    sender::{AmqpSendOptions, AmqpSender, AmqpSenderApis, AmqpSenderOptions},
-    session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions},
-    value::{AmqpSymbol, AmqpValue},
+    AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis, AmqpConnection, AmqpConnectionApis,
+    AmqpConnectionOptions, AmqpManagement, AmqpManagementApis, AmqpSendOptions, AmqpSender,
+    AmqpSenderApis, AmqpSenderOptions, AmqpSession, AmqpSessionApis, AmqpSessionOptions,
+    AmqpSymbol, AmqpValue,
 };
 use batch::{EventDataBatch, EventDataBatchOptions};
 use std::sync::{Arc, OnceLock};
@@ -30,7 +28,7 @@ use tracing::{debug, trace};
 use url::Url;
 
 /// Types used to collect messages into a "batch" before submitting them to an Event Hub.
-pub mod batch;
+pub(crate) mod batch;
 
 const DEFAULT_EVENTHUBS_APPLICATION: &str = "DefaultApplicationName";
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/consumer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/consumer.rs
@@ -19,7 +19,6 @@ async fn test_new() -> Result<(), Box<dyn Error>> {
     let _client = ConsumerClient::builder(
         host.as_str(),
         eventhub.as_str(),
-        None,
         DefaultAzureCredential::new()?,
     )
     .with_application_id("test_new")
@@ -37,7 +36,6 @@ async fn test_new_with_error() -> Result<(), Box<dyn Error>> {
     let result = ConsumerClient::builder(
         "invalid_host",
         eventhub.as_str(),
-        None,
         DefaultAzureCredential::new()?,
     )
     .with_application_id("test_new")
@@ -57,7 +55,6 @@ async fn test_open() -> Result<(), Box<dyn Error>> {
     let _client = ConsumerClient::builder(
         host.as_str(),
         eventhub.as_str(),
-        None,
         azure_identity::DefaultAzureCredential::new()?,
     )
     .with_application_id("test_open")
@@ -74,7 +71,6 @@ async fn test_close() -> Result<(), Box<dyn Error>> {
     let client = ConsumerClient::builder(
         host.as_str(),
         eventhub.as_str(),
-        None,
         azure_identity::DefaultAzureCredential::new()?,
     )
     .with_application_id("test_open")
@@ -93,11 +89,10 @@ async fn test_get_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client =
-        ConsumerClient::builder(host.as_str(), eventhub.as_str(), None, credential.clone())
-            .with_application_id("test_open")
-            .open()
-            .await?;
+    let client = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_open")
+        .open()
+        .await?;
     let properties = client.get_eventhub_properties().await?;
     info!("Properties: {:?}", properties);
     assert_eq!(properties.name, eventhub);
@@ -113,11 +108,10 @@ async fn test_get_partition_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client =
-        ConsumerClient::builder(host.as_str(), eventhub.as_str(), None, credential.clone())
-            .with_application_id("test_open")
-            .open()
-            .await?;
+    let client = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_open")
+        .open()
+        .await?;
     let properties = client.get_eventhub_properties().await?;
 
     for partition_id in properties.partition_ids {
@@ -143,11 +137,10 @@ async fn receive_lots_of_events() -> Result<(), Box<dyn Error>> {
     let credential = DefaultAzureCredential::new()?;
 
     info!("Creating client.");
-    let client =
-        ConsumerClient::builder(host.as_str(), eventhub.as_str(), None, credential.clone())
-            .with_application_id("test_open")
-            .open()
-            .await?;
+    let client = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_open")
+        .open()
+        .await?;
 
     let receiver = client
         .open_receiver_on_partition(

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/consumer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/consumer.rs
@@ -16,10 +16,15 @@ async fn test_new() -> Result<(), Box<dyn Error>> {
     common::setup();
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
-    let _client = ConsumerClient::builder(host, eventhub, None, DefaultAzureCredential::new()?)
-        .with_application_id("test_new".to_string())
-        .open()
-        .await?;
+    let _client = ConsumerClient::builder(
+        host.as_str(),
+        eventhub.as_str(),
+        None,
+        DefaultAzureCredential::new()?,
+    )
+    .with_application_id("test_new")
+    .open()
+    .await?;
 
     Ok(())
 }
@@ -30,12 +35,12 @@ async fn test_new_with_error() -> Result<(), Box<dyn Error>> {
     trace!("test_new_with_error");
     let eventhub = env::var("EVENTHUB_NAME")?;
     let result = ConsumerClient::builder(
-        "invalid_host".into(),
-        eventhub,
+        "invalid_host",
+        eventhub.as_str(),
         None,
         DefaultAzureCredential::new()?,
     )
-    .with_application_id("test_new".to_string())
+    .with_application_id("test_new")
     .open()
     .await;
     assert!(result.is_err());
@@ -50,12 +55,12 @@ async fn test_open() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let _client = ConsumerClient::builder(
-        host,
-        eventhub,
+        host.as_str(),
+        eventhub.as_str(),
         None,
         azure_identity::DefaultAzureCredential::new()?,
     )
-    .with_application_id("test_open".to_string())
+    .with_application_id("test_open")
     .open()
     .await?;
 
@@ -67,12 +72,12 @@ async fn test_close() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let client = ConsumerClient::builder(
-        host,
-        eventhub,
+        host.as_str(),
+        eventhub.as_str(),
         None,
         azure_identity::DefaultAzureCredential::new()?,
     )
-    .with_application_id("test_open".to_string())
+    .with_application_id("test_open")
     .open()
     .await?;
     client.close().await?;
@@ -88,10 +93,11 @@ async fn test_get_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ConsumerClient::builder(host, eventhub.clone(), None, credential.clone())
-        .with_application_id("test_open".to_string())
-        .open()
-        .await?;
+    let client =
+        ConsumerClient::builder(host.as_str(), eventhub.as_str(), None, credential.clone())
+            .with_application_id("test_open")
+            .open()
+            .await?;
     let properties = client.get_eventhub_properties().await?;
     info!("Properties: {:?}", properties);
     assert_eq!(properties.name, eventhub);
@@ -107,15 +113,16 @@ async fn test_get_partition_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ConsumerClient::builder(host, eventhub, None, credential.clone())
-        .with_application_id("test_open".to_string())
-        .open()
-        .await?;
+    let client =
+        ConsumerClient::builder(host.as_str(), eventhub.as_str(), None, credential.clone())
+            .with_application_id("test_open")
+            .open()
+            .await?;
     let properties = client.get_eventhub_properties().await?;
 
     for partition_id in properties.partition_ids {
         let partition_properties = client
-            .get_partition_properties(partition_id.clone())
+            .get_partition_properties(partition_id.as_str())
             .await?;
         info!("Partition properties: {:?}", partition_properties);
         assert_eq!(partition_properties.id, partition_id);
@@ -136,14 +143,15 @@ async fn receive_lots_of_events() -> Result<(), Box<dyn Error>> {
     let credential = DefaultAzureCredential::new()?;
 
     info!("Creating client.");
-    let client = ConsumerClient::builder(host, eventhub, None, credential.clone())
-        .with_application_id("test_open".to_string())
-        .open()
-        .await?;
+    let client =
+        ConsumerClient::builder(host.as_str(), eventhub.as_str(), None, credential.clone())
+            .with_application_id("test_open")
+            .open()
+            .await?;
 
     let receiver = client
         .open_receiver_on_partition(
-            "0".to_string(),
+            "0",
             Some(OpenReceiverOptions {
                 start_position: Some(StartPosition {
                     location: azure_messaging_eventhubs::StartLocation::Earliest,

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/consumer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/consumer.rs
@@ -16,14 +16,14 @@ async fn test_new() -> Result<(), Box<dyn Error>> {
     common::setup();
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
-    let _client = ConsumerClient::builder(
-        host.as_str(),
-        eventhub.as_str(),
-        DefaultAzureCredential::new()?,
-    )
-    .with_application_id("test_new")
-    .open()
-    .await?;
+    let _client = ConsumerClient::builder()
+        .with_application_id("test_new")
+        .open(
+            host.as_str(),
+            eventhub.as_str(),
+            DefaultAzureCredential::new()?,
+        )
+        .await?;
 
     Ok(())
 }
@@ -33,14 +33,14 @@ async fn test_new_with_error() -> Result<(), Box<dyn Error>> {
     common::setup();
     trace!("test_new_with_error");
     let eventhub = env::var("EVENTHUB_NAME")?;
-    let result = ConsumerClient::builder(
-        "invalid_host",
-        eventhub.as_str(),
-        DefaultAzureCredential::new()?,
-    )
-    .with_application_id("test_new")
-    .open()
-    .await;
+    let result = ConsumerClient::builder()
+        .with_application_id("test_new")
+        .open(
+            "invalid_host",
+            eventhub.as_str(),
+            DefaultAzureCredential::new()?,
+        )
+        .await;
     assert!(result.is_err());
     info!("Error: {:?}", result.err());
 
@@ -52,14 +52,14 @@ async fn test_open() -> Result<(), Box<dyn Error>> {
     common::setup();
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
-    let _client = ConsumerClient::builder(
-        host.as_str(),
-        eventhub.as_str(),
-        azure_identity::DefaultAzureCredential::new()?,
-    )
-    .with_application_id("test_open")
-    .open()
-    .await?;
+    let _client = ConsumerClient::builder()
+        .with_application_id("test_open")
+        .open(
+            host.as_str(),
+            eventhub.as_str(),
+            azure_identity::DefaultAzureCredential::new()?,
+        )
+        .await?;
 
     Ok(())
 }
@@ -68,14 +68,14 @@ async fn test_close() -> Result<(), Box<dyn Error>> {
     common::setup();
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
-    let client = ConsumerClient::builder(
-        host.as_str(),
-        eventhub.as_str(),
-        azure_identity::DefaultAzureCredential::new()?,
-    )
-    .with_application_id("test_open")
-    .open()
-    .await?;
+    let client = ConsumerClient::builder()
+        .with_application_id("test_open")
+        .open(
+            host.as_str(),
+            eventhub.as_str(),
+            azure_identity::DefaultAzureCredential::new()?,
+        )
+        .await?;
     client.close().await?;
 
     Ok(())
@@ -89,9 +89,9 @@ async fn test_get_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ConsumerClient::builder()
         .with_application_id("test_open")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     let properties = client.get_eventhub_properties().await?;
     info!("Properties: {:?}", properties);
@@ -108,9 +108,9 @@ async fn test_get_partition_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ConsumerClient::builder()
         .with_application_id("test_open")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     let properties = client.get_eventhub_properties().await?;
 
@@ -137,9 +137,9 @@ async fn receive_lots_of_events() -> Result<(), Box<dyn Error>> {
     let credential = DefaultAzureCredential::new()?;
 
     info!("Creating client.");
-    let client = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ConsumerClient::builder()
         .with_application_id("test_open")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
 
     let receiver = client

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
@@ -264,7 +264,7 @@ async fn test_create_and_send_batch() -> Result<(), Box<dyn Error>> {
         assert_eq!(batch.len(), 0);
         assert!(batch.try_add_event_data(vec![1, 2, 3, 4], None)?);
 
-        let res = client.submit_batch(&batch, None).await;
+        let res = client.send_batch(&batch, None).await;
         assert!(res.is_ok());
     }
     {
@@ -287,7 +287,7 @@ async fn test_create_and_send_batch() -> Result<(), Box<dyn Error>> {
         assert!(batch.try_add_event_data("&data", None)?);
         assert!(batch.try_add_event_data("&data", None)?);
 
-        let res = client.submit_batch(&batch, None).await;
+        let res = client.send_batch(&batch, None).await;
         assert!(res.is_ok());
     }
 
@@ -358,7 +358,7 @@ async fn test_add_amqp_messages_to_batch() -> Result<(), Box<dyn std::error::Err
         None
     )?);
 
-    client.submit_batch(&batch, None).await?;
+    client.send_batch(&batch, None).await?;
 
     Ok(())
 }
@@ -398,14 +398,14 @@ async fn test_overload_batch() -> Result<(), Box<dyn Error>> {
                     "Batch is full at {i} ({} bytes), sending batch",
                     batch.size()
                 );
-                let result = client.submit_batch(&batch, None).await;
+                let result = client.send_batch(&batch, None).await;
                 if result.is_err() {
                     info!("Batch submit failed. {:?}", result);
                 }
                 assert!(result.is_ok());
             }
         }
-        let result = client.submit_batch(&batch, None).await;
+        let result = client.send_batch(&batch, None).await;
         if result.is_err() {
             info!("Batch submit failed. {:?}", result);
         }

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
@@ -16,8 +16,8 @@ async fn test_new() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
-    let _client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_new".to_string())
+    let _client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_new")
         .open()
         .await?;
 
@@ -29,11 +29,11 @@ async fn test_new_with_error() -> Result<(), Box<dyn Error>> {
     common::setup();
     let eventhub = env::var("EVENTHUB_NAME")?;
     let result = ProducerClient::builder(
-        "invalid_host".to_string(),
-        eventhub,
+        "invalid_host",
+        eventhub.as_str(),
         azure_identity::DefaultAzureCredential::new()?,
     )
-    .with_application_id("test_new_with_error".to_string())
+    .with_application_id("test_new_with_error")
     .open()
     .await;
     assert!(result.is_err());
@@ -48,8 +48,8 @@ async fn test_open() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
-    let _client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_open".to_string())
+    let _client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_open")
         .open()
         .await?;
 
@@ -61,8 +61,8 @@ async fn test_close() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_close".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_close")
         .open()
         .await?;
     client.close().await?;
@@ -78,8 +78,8 @@ async fn test_get_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host, eventhub.clone(), credential.clone())
-        .with_application_id("test_get_properties".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_get_properties")
         .open()
         .await?;
     let properties = client.get_eventhub_properties().await?;
@@ -97,15 +97,15 @@ async fn test_get_partition_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_get_partition_properties".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_get_partition_properties")
         .open()
         .await?;
     let properties = client.get_eventhub_properties().await?;
 
     for partition_id in properties.partition_ids {
         let partition_properties = client
-            .get_partition_properties(partition_id.clone())
+            .get_partition_properties(partition_id.as_str())
             .await?;
         info!("Partition properties: {:?}", partition_properties);
         assert_eq!(partition_properties.id, partition_id);
@@ -131,10 +131,10 @@ async fn test_create_eventdata() -> Result<(), Box<dyn Error>> {
     let data = b"hello world";
     let _ = azure_messaging_eventhubs::models::EventData::builder()
         .with_body(data.to_vec())
-        .with_content_type("text/plain".to_string())
+        .with_content_type("text/plain")
         .with_correlation_id("correlation_id")
         .with_message_id(35u64)
-        .add_property("key".to_string(), "value")
+        .add_property("key", "value")
         .build();
 
     Ok(())
@@ -148,8 +148,8 @@ async fn send_eventdata() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("send_eventdata".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("send_eventdata")
         .open()
         .await?;
     {
@@ -165,10 +165,10 @@ async fn send_eventdata() -> Result<(), Box<dyn Error>> {
         let data = b"hello world";
         let ed1 = azure_messaging_eventhubs::models::EventData::builder()
             .with_body(data.to_vec())
-            .with_content_type("text/plain".to_string())
+            .with_content_type("text/plain")
             .with_correlation_id("correlation_id")
             .with_message_id(35u64)
-            .add_property("key".to_string(), "value")
+            .add_property("key", "value")
             .build();
 
         let res = client.send_event(ed1, None).await;
@@ -190,8 +190,8 @@ async fn send_message() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("send_eventdata".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("send_eventdata")
         .open()
         .await?;
     {
@@ -234,8 +234,8 @@ async fn test_create_batch() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_create_batch".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_create_batch")
         .open()
         .await?;
     {
@@ -254,8 +254,8 @@ async fn test_create_and_send_batch() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_create_and_send_batch".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_create_and_send_batch")
         .open()
         .await?;
 
@@ -304,8 +304,8 @@ async fn test_add_amqp_messages_to_batch() -> Result<(), Box<dyn std::error::Err
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_add_amqp_messages_to_batch".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_add_amqp_messages_to_batch")
         .open()
         .await?;
 
@@ -374,8 +374,8 @@ async fn test_overload_batch() -> Result<(), Box<dyn Error>> {
 
     info!("Create producer client...");
 
-    let client = ProducerClient::builder(host, eventhub, credential.clone())
-        .with_application_id("test_overload_batch".to_string())
+    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+        .with_application_id("test_overload_batch")
         .open()
         .await?;
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
@@ -260,7 +260,7 @@ async fn test_create_and_send_batch() -> Result<(), Box<dyn Error>> {
         .await?;
 
     {
-        let mut batch = client.create_batch(None).await?;
+        let batch = client.create_batch(None).await?;
         assert_eq!(batch.len(), 0);
         assert!(batch.try_add_event_data(vec![1, 2, 3, 4], None)?);
 
@@ -268,7 +268,7 @@ async fn test_create_and_send_batch() -> Result<(), Box<dyn Error>> {
         assert!(res.is_ok());
     }
     {
-        let mut batch = client
+        let batch = client
             .create_batch(Some(EventDataBatchOptions {
                 partition_id: Some("0".to_string()),
                 ..Default::default()
@@ -381,7 +381,7 @@ async fn test_overload_batch() -> Result<(), Box<dyn Error>> {
 
     info!("Client is open.");
     {
-        let mut batch = client
+        let batch = client
             .create_batch(Some(EventDataBatchOptions {
                 partition_id: Some("0".to_string()),
                 ..Default::default()

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
@@ -16,9 +16,9 @@ async fn test_new() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
-    let _client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let _client = ProducerClient::builder()
         .with_application_id("test_new")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
 
     Ok(())
@@ -28,14 +28,14 @@ async fn test_new() -> Result<(), Box<dyn Error>> {
 async fn test_new_with_error() -> Result<(), Box<dyn Error>> {
     common::setup();
     let eventhub = env::var("EVENTHUB_NAME")?;
-    let result = ProducerClient::builder(
-        "invalid_host",
-        eventhub.as_str(),
-        azure_identity::DefaultAzureCredential::new()?,
-    )
-    .with_application_id("test_new_with_error")
-    .open()
-    .await;
+    let result = ProducerClient::builder()
+        .with_application_id("test_new_with_error")
+        .open(
+            "invalid_host",
+            eventhub.as_str(),
+            azure_identity::DefaultAzureCredential::new()?,
+        )
+        .await;
     assert!(result.is_err());
     info!("Error: {:?}", result.err());
 
@@ -48,9 +48,9 @@ async fn test_open() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
-    let _client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let _client = ProducerClient::builder()
         .with_application_id("test_open")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
 
     Ok(())
@@ -61,9 +61,9 @@ async fn test_close() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("test_close")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     client.close().await?;
 
@@ -78,9 +78,9 @@ async fn test_get_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("test_get_properties")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     let properties = client.get_eventhub_properties().await?;
     info!("Properties: {:?}", properties);
@@ -97,9 +97,9 @@ async fn test_get_partition_properties() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("test_get_partition_properties")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     let properties = client.get_eventhub_properties().await?;
 
@@ -148,9 +148,9 @@ async fn send_eventdata() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("send_eventdata")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     {
         let data = b"hello world";
@@ -190,9 +190,9 @@ async fn send_message() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("send_eventdata")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     {
         let data = b"hello world";
@@ -234,9 +234,9 @@ async fn test_create_batch() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("test_create_batch")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
     {
         let batch = client.create_batch(None).await?;
@@ -254,9 +254,9 @@ async fn test_create_and_send_batch() -> Result<(), Box<dyn Error>> {
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("test_create_and_send_batch")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
 
     {
@@ -304,9 +304,9 @@ async fn test_add_amqp_messages_to_batch() -> Result<(), Box<dyn std::error::Err
 
     let credential = DefaultAzureCredential::new()?;
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("test_add_amqp_messages_to_batch")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
 
     let batch = client.create_batch(None).await?;
@@ -374,9 +374,9 @@ async fn test_overload_batch() -> Result<(), Box<dyn Error>> {
 
     info!("Create producer client...");
 
-    let client = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let client = ProducerClient::builder()
         .with_application_id("test_overload_batch")
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
 
     info!("Client is open.");

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/producer.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 
-use azure_core_amqp::{messaging::AmqpMessageProperties, value::AmqpList};
+use azure_core_amqp::{AmqpList, AmqpMessageProperties};
 use azure_core_test::recorded;
 use azure_identity::DefaultAzureCredential;
 use azure_messaging_eventhubs::{EventDataBatchOptions, ProducerClient, ProducerClientOptions};

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
@@ -100,7 +100,7 @@ async fn test_round_trip_batch() -> Result<(), Box<dyn Error>> {
     assert!(producer.send_batch(&batch, None).await.is_ok());
 
     let credential = DefaultAzureCredential::new()?;
-    let consumer = ConsumerClient::builder(host.as_str(), eventhub.as_str(), None, credential)
+    let consumer = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential)
         .with_application_id(TEST_NAME)
         .open()
         .await?;

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
@@ -26,9 +26,9 @@ async fn test_round_trip_batch() -> Result<(), Box<dyn Error>> {
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
     let credential = DefaultAzureCredential::new()?;
-    let producer = ProducerClient::builder(host.as_str(), eventhub.as_str(), credential.clone())
+    let producer = ProducerClient::builder()
         .with_application_id(TEST_NAME)
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential.clone())
         .await?;
 
     let partition_properties = producer
@@ -100,9 +100,9 @@ async fn test_round_trip_batch() -> Result<(), Box<dyn Error>> {
     assert!(producer.send_batch(&batch, None).await.is_ok());
 
     let credential = DefaultAzureCredential::new()?;
-    let consumer = ConsumerClient::builder(host.as_str(), eventhub.as_str(), credential)
+    let consumer = ConsumerClient::builder()
         .with_application_id(TEST_NAME)
-        .open()
+        .open(host.as_str(), eventhub.as_str(), credential)
         .await?;
     let receiver = consumer
         .open_receiver_on_partition(

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
@@ -44,7 +44,7 @@ async fn test_round_trip_batch() -> Result<(), Box<dyn Error>> {
     );
 
     let start_sequence = partition_properties.last_enqueued_sequence_number;
-    let mut batch = producer
+    let batch = producer
         .create_batch(Some(EventDataBatchOptions {
             partition_id: Some(EVENTHUB_PARTITION.to_string()),
             partition_key: Some("My Partition Key.".to_string()),

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license.
 
 use async_std::stream::StreamExt;
-use azure_core_amqp::{
-    messaging::{AmqpMessage, AmqpMessageProperties},
-    value::{AmqpList, AmqpValue},
-};
+use azure_core_amqp::{AmqpList, AmqpMessage, AmqpMessageProperties, AmqpValue};
 use azure_core_test::recorded;
 use azure_identity::DefaultAzureCredential;
 use azure_messaging_eventhubs::{

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
@@ -2,11 +2,11 @@
 // Licensed under the MIT license.
 
 use async_std::stream::StreamExt;
-use azure_core_amqp::{AmqpList, AmqpMessage, AmqpMessageProperties, AmqpValue};
+use azure_core_amqp::{AmqpList, AmqpMessageProperties};
 use azure_core_test::recorded;
 use azure_identity::DefaultAzureCredential;
 use azure_messaging_eventhubs::{
-    models::{EventData, MessageId},
+    models::{AmqpMessage, AmqpValue, EventData, MessageId},
     {
         ConsumerClient, ConsumerClientOptions, EventDataBatchOptions, OpenReceiverOptions,
         ProducerClient, ProducerClientOptions, StartLocation, StartPosition,

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/round_trip.rs
@@ -9,7 +9,7 @@ use azure_messaging_eventhubs::{
     models::{AmqpMessage, AmqpValue, EventData, MessageId},
     {
         ConsumerClient, ConsumerClientOptions, EventDataBatchOptions, OpenReceiverOptions,
-        ProducerClient, ProducerClientOptions, StartLocation, StartPosition,
+        ProducerClient, StartLocation, StartPosition,
     },
 };
 use futures::pin_mut;
@@ -25,17 +25,14 @@ async fn test_round_trip_batch() -> Result<(), Box<dyn Error>> {
     common::setup();
     let host = env::var("EVENTHUBS_HOST")?;
     let eventhub = env::var("EVENTHUB_NAME")?;
-    let producer = ProducerClient::new(
+    let producer = ProducerClient::builder(
         host.clone(),
         eventhub.clone(),
         DefaultAzureCredential::new()?,
-        Some(ProducerClientOptions {
-            application_id: Some(TEST_NAME.to_string()),
-            ..Default::default()
-        }),
-    );
-
-    assert!(producer.open().await.is_ok());
+    )
+    .with_application_id(TEST_NAME.to_string())
+    .open()
+    .await?;
 
     let partition_properties = producer
         .get_partition_properties(EVENTHUB_PARTITION.to_string())


### PR DESCRIPTION
# Cleanup of AMQP and EventHubs for beta
- Removed `ProducerClient::open()` and `ConsumerClient::open()`, replacing them with builders that terminate in an "open()" verb.
- Renamed `ProducerClient::submit_batch()` to `ProducerClient::send_batch()`
- Renamed `EventDataBatch::size()` to `EventDataBatch::size_in_bytes()`
- Changed input `String` parameters to `&str` parameters to simplify certain authoring scenarios.
- Reduced visibility of AMQP modules and expose types from the root.
- Improved EventHubs documentation including models types.

Fixes #2129 
