### PR TITLE
dev-dependencies of workspace packages should still use path

### DIFF
--- a/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_keys/Cargo.toml
@@ -22,7 +22,9 @@ time = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = ["tracing"] }
+azure_core_test = { path = "../../core/azure_core_test", features = [
+    "tracing",
+] }
 azure_identity.path = "../../identity/azure_identity"
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 rand.workspace = true

--- a/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
+++ b/sdk/keyvault/azure_security_keyvault_secrets/Cargo.toml
@@ -25,7 +25,9 @@ time = { workspace = true }
 typespec_client_core = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
-azure_core_test = { workspace = true, features = ["tracing"] }
+azure_core_test = { path = "../../core/azure_core_test", features = [
+    "tracing",
+] }
 azure_identity.path = "../../identity/azure_identity"
 azure_security_keyvault_test = { path = "../azure_security_keyvault_test" }
 rand.workspace = true


### PR DESCRIPTION
1. `cargo package` requires that all dependencies have versions declared
2. `workspace = true` on dependencies and dev-dependencies use `workspace.dependencies` for resolution
3. `path` based packages in `workspace.dependencies` get version numbers added during packaging to satisfy `1.`
4. `cargo package` expects dependencies with versions to be available in the feed or the local vendor directory
5. packages with `publish = false` aren't packaged or placed in the vendor directory
6. workspace based dev-dependencies on unpublished crates fails because of `3.` + `4.` + `5.`
    - consider  A depends on B, B dev depends on A
    - when A and B both publish, B must package before A.  B will not have `version` A available to satisfy the dev-dependency, but it will have `path` A available. Because of `.3. + `4.`, `cargo package` on B will fail because it can't find A@version even though `path` is also specified
  
We can:
- stop using workspace dependencies for dev-dependencies
    - will ensure that no version is added to a path dev-dependency through workspace.dependencies
- start skipping `publish = false` packages when placing version numbers beside path dependencies in toml
    - will prevent cargo from expecting "local only" packages to come from the feed
    - will mean that some packages in dev-dependencies can use workspace = true (ones that publish) while others can't (ones that don't)