### PR TITLE
Event Hubs: make it possible to set a custom endpoint for use with TCP proxies

### DIFF
--- a/sdk/core/azure_core_amqp/src/connection.rs
+++ b/sdk/core/azure_core_amqp/src/connection.rs
@@ -24,6 +24,7 @@ pub struct AmqpConnectionOptions {
     pub desired_capabilities: Option<Vec<AmqpSymbol>>,
     pub properties: Option<AmqpOrderedMap<AmqpSymbol, AmqpValue>>,
     pub buffer_size: Option<usize>,
+    pub custom_endpoint: Option<Url>,
 }
 
 impl AmqpConnectionOptions {}
@@ -206,6 +207,7 @@ mod tests {
             incoming_locales: Some(vec!["en-US".to_string()]),
             offered_capabilities: Some(vec!["capability".into()]),
             desired_capabilities: Some(vec!["capability".into()]),
+            custom_endpoint: None,
             properties: Some(
                 vec![("key", "value")]
                     .into_iter()

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -51,7 +51,14 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
                 .container_id(id)
                 .max_frame_size(65536);
 
+            let mut endpoint = url.clone();
+
             if let Some(options) = options {
+                if let Some(custom_endpoint) = options.custom_endpoint {
+                    endpoint = custom_endpoint.clone();
+                    builder = builder.hostname(url.host_str().unwrap());
+                }
+
                 if let Some(frame_size) = options.max_frame_size {
                     builder = builder.max_frame_size(frame_size);
                 }
@@ -101,7 +108,12 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
                 }
             }
             self.connection
-                .set(Mutex::new(builder.open(url).await.map_err(AmqpOpen::from)?))
+                .set(Mutex::new(
+                    builder
+                        .open(endpoint.clone())
+                        .await
+                        .map_err(AmqpOpen::from)?,
+                ))
                 .map_err(|_| {
                     azure_core::Error::new(
                         azure_core::error::ErrorKind::Other,

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/producer/mod.rs
@@ -47,6 +47,9 @@ pub struct ProducerClientOptions {
 
     /// The maximum size of a message that can be sent to the Event Hub.
     pub max_message_size: Option<u64>,
+
+    /// A custom endpoint to connect to. Use this to connect through a TCP proxy.
+    pub custom_endpoint: Option<String>,
 }
 
 impl ProducerClientOptions {}
@@ -367,6 +370,7 @@ impl ProducerClient {
     async fn ensure_connection(&self, url: &str) -> Result<()> {
         if self.connection.get().is_none() {
             let connection = AmqpConnection::new();
+
             connection
                 .open(
                     self.options
@@ -386,6 +390,10 @@ impl ProducerClient {
                             .map(|(k, v)| (AmqpSymbol::from(k), AmqpValue::from(v)))
                             .collect(),
                         ),
+                        custom_endpoint: Some(Url::parse(
+                            // TODO: yeah...probably not right.
+                            self.options.custom_endpoint.as_ref().unwrap().as_str(),
+                        )?),
                         ..Default::default()
                     }),
                 )


### PR DESCRIPTION
AMQP clients can choose to connect _through_ another host, like a TCP proxy. When you do that you need to set the Host attribute in the AMQP connection.

This draft just shows how to do that, and plumbs it through the Producer.

This is how I configure the client to use it:

```rust
    let client = ProducerClient::new(
        host,
        eventhub.clone(),
        credential,
        Some(ProducerClientOptions {
            application_id: Some("test_get_properties".to_string()),
            custom_endpoint: Some("amqp://localhost:5671".to_string()),
            ..Default::default()
        }),
    );
```

NOTE, since it's the amqpproxy, and I don't have a proper signed cert (yet) I used plain `amqp`. It's only unencrypted between the code and the proxy - all outbound traffic from the proxy to the actual Event Hubs service is still TLS.