### PR TITLE
Optimize rebuild when AZURE_TEST_MODE changes

### DIFF
--- a/sdk/core/azure_core_test/build.rs
+++ b/sdk/core/azure_core_test/build.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 pub fn main() {
     // Force a rebuild of this package, and thus anything dependent upon it, if AZURE_TEST_MODE changes.
     println!("cargo::rerun-if-env-changed=AZURE_TEST_MODE");


### PR DESCRIPTION
Doesn't need to be as far down as rebuilding the macros crate.
