### PR TITLE
Minor fixes for test proxy on Windows

### DIFF
--- a/sdk/core/azure_core_test/src/lib.rs
+++ b/sdk/core/azure_core_test/src/lib.rs
@@ -127,27 +127,25 @@ impl TestContext {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            match mode {
-                TestMode::Live => None,
-                _ => {
-                    let path = match find_ancestor_file(self.crate_dir, ASSETS_FILE) {
-                        Ok(path) => path,
-                        Err(_) if mode == TestMode::Record => {
-                            return Path::new("sdk")
-                                .join(self.service_dir)
-                                .join(ASSETS_FILE)
-                                .as_path()
-                                .to_str()
-                                .map(String::from);
-                        }
-                        Err(err) => panic!("{err}"),
-                    };
-                    path.strip_prefix(self.repo_dir)
-                        .expect("not rooted within repo")
-                        .to_str()
-                        .map(String::from)
-                }
+            if mode == TestMode::Live {
+                return None;
             }
+            let path = match find_ancestor_file(self.crate_dir, ASSETS_FILE) {
+                Ok(path) => path,
+                Err(_) if mode == TestMode::Record => {
+                    return Path::new("sdk")
+                        .join(self.service_dir)
+                        .join(ASSETS_FILE)
+                        .as_path()
+                        .to_str()
+                        .map(String::from);
+                }
+                Err(err) => panic!("{err}"),
+            };
+            path.strip_prefix(self.repo_dir)
+                .expect("not rooted within repo")
+                .to_str()
+                .map(String::from)
         }
     }
 

--- a/sdk/core/azure_core_test/src/lib.rs
+++ b/sdk/core/azure_core_test/src/lib.rs
@@ -127,22 +127,27 @@ impl TestContext {
 
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let path = match find_ancestor_file(self.crate_dir, ASSETS_FILE) {
-                Ok(path) => path,
-                Err(_) if mode == TestMode::Record => {
-                    return Path::new("sdk")
-                        .join(self.service_dir)
-                        .join(ASSETS_FILE)
-                        .as_path()
+            match mode {
+                TestMode::Live => None,
+                _ => {
+                    let path = match find_ancestor_file(self.crate_dir, ASSETS_FILE) {
+                        Ok(path) => path,
+                        Err(_) if mode == TestMode::Record => {
+                            return Path::new("sdk")
+                                .join(self.service_dir)
+                                .join(ASSETS_FILE)
+                                .as_path()
+                                .to_str()
+                                .map(String::from);
+                        }
+                        Err(err) => panic!("{err}"),
+                    };
+                    path.strip_prefix(self.repo_dir)
+                        .expect("not rooted within repo")
                         .to_str()
-                        .map(String::from);
+                        .map(String::from)
                 }
-                Err(err) => panic!("{err}"),
-            };
-            path.strip_prefix(self.repo_dir)
-                .expect("not rooted within repo")
-                .to_str()
-                .map(String::from)
+            }
         }
     }
 

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -146,7 +146,8 @@ mod bootstrap {
 
             if let Some(idx) = line.find(LISTENING_PATTERN) {
                 let idx = idx + LISTENING_PATTERN.len();
-                let url = line[idx..].parse()?;
+                let mut url: Url = line[idx..].parse()?;
+                url.set_host(Some("localhost"))?;
                 tracing::event!(target: crate::SPAN_TARGET, Level::INFO, "listening on {url}");
 
                 return Ok(url);


### PR DESCRIPTION
Two fixes for test proxy:
1. To get the proxy working on Windows, replace the 0.0.0.0 IP address reported by the test-proxy tool with localhost
2. If `AZURE_TEST_MODE` is live, then return None for the `assets.json` file.

