### PR TITLE
Add run_command abstraction to azure_identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,43 +202,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel 2.3.1",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.3.1",
- "futures-lite 2.5.0",
- "rustix",
- "tracing",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "async-std"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,7 +385,6 @@ name = "azure_identity"
 version = "0.22.0"
 dependencies = [
  "async-lock",
- "async-process",
  "async-trait",
  "azure_core",
  "azure_security_keyvault_secrets",

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -25,9 +25,7 @@ async-trait.workspace = true
 openssl = { workspace = true, optional = true }
 pin-project.workspace = true
 typespec_client_core = { workspace = true, features = ["derive"] }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-process.workspace = true
+tokio = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 tz-rs = { workspace = true, optional = true }
@@ -46,6 +44,7 @@ default = ["reqwest", "old_azure_cli"]
 reqwest = ["azure_core/reqwest"]
 reqwest_rustls = ["azure_core/reqwest_rustls"]
 client_certificate = ["openssl"]
+tokio_process = ["tokio"]
 
 # If you are using and Azure CLI version older than 2.54.0 from November 2023,
 # upgrade your Azure CLI version or enable this feature.

--- a/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::credentials::cache::TokenCache;
-use async_process::Command;
+use crate::{credentials::cache::TokenCache, run_command::run_command};
 use azure_core::{
     credentials::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
@@ -193,7 +192,7 @@ impl AzureCliCredential {
             args.join(" "),
         );
 
-        match Command::new(program).args(args).output().await {
+        match run_command(program, args).await {
             Ok(az_output) if az_output.status.success() => {
                 let output = str::from_utf8(&az_output.stdout)?;
 

--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![doc = include_str!("../README.md")]
 
+mod run_command;
+
 mod authorization_code_flow;
 mod credentials;
 mod env;

--- a/sdk/identity/azure_identity/src/run_command/mod.rs
+++ b/sdk/identity/azure_identity/src/run_command/mod.rs
@@ -1,0 +1,38 @@
+use std::io::Error;
+use std::{ffi::OsStr, process::Output};
+
+#[cfg(feature = "tokio_process")]
+pub(crate) async fn run_command<S, I, A>(program: S, args: I) -> Result<Output, Error>
+where
+    S: AsRef<OsStr>,
+    I: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+{
+    tokio::process::Command::new(program)
+        .args(args)
+        .output()
+        .await
+}
+
+#[cfg(not(feature = "tokio_process"))]
+pub(crate) async fn run_command<S, I, A>(program: S, args: I) -> Result<Output, Error>
+where
+    S: AsRef<OsStr>,
+    I: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+{
+    use futures::channel::oneshot;
+    use std::io::ErrorKind;
+
+    let (tx, rx) = oneshot::channel();
+    let mut cmd = std::process::Command::new(program);
+    cmd.args(args);
+    std::thread::spawn(move || {
+        let output = cmd.output();
+        tx.send(output)
+    });
+    let output = rx
+        .await
+        .map_err(|err| Error::new(ErrorKind::Other, err))??;
+    Ok(output)
+}


### PR DESCRIPTION
Adds a `run_command` function to `azure_identity` and uses it in the one place where we used `async-process` before. We provide two implementations:

* one based on tokio, behind an optional feature
* the other (used by default) is a manual implementation with a oneshot channel and a dedicated thread

successor of #1654
fixes #1652
