### PR TITLE
Add ProcessRunner trait to azure_core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,18 +108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,25 +121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.5.0",
- "parking",
- "polling",
- "rustix",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "async-lock"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,43 +129,6 @@ dependencies = [
  "event-listener 5.3.1",
  "event-listener-strategy",
  "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
-dependencies = [
- "async-channel 2.3.1",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener 5.3.1",
- "futures-lite 2.5.0",
- "rustix",
- "tracing",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -222,12 +154,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,12 +163,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -358,7 +278,6 @@ name = "azure_identity"
 version = "0.22.0"
 dependencies = [
  "async-lock",
- "async-process",
  "async-trait",
  "azure_core",
  "azure_security_keyvault_secrets",
@@ -385,7 +304,6 @@ name = "azure_messaging_eventhubs"
 version = "0.2.0"
 dependencies = [
  "async-stream",
- "async-trait",
  "azure_core",
  "azure_core_amqp",
  "azure_core_test",
@@ -524,19 +442,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel 2.3.1",
- "async-task",
- "futures-io",
- "futures-lite 2.5.0",
- "piper",
 ]
 
 [[package]]
@@ -1080,19 +985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-lite"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
-dependencies = [
- "fastrand 2.2.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,12 +1078,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,9 +1127,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
 dependencies = [
  "anyhow",
- "async-channel 1.9.0",
+ "async-channel",
  "base64 0.13.1",
- "futures-lite 1.13.0",
+ "futures-lite",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -1883,36 +1769,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.2.0",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
-
-[[package]]
-name = "polling"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "powerfmt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,6 @@ path = "sdk/storage"
 
 [workspace.dependencies]
 async-lock = "3.0"
-async-process = "2.0"
 async-stream = { version = "0.3.5" }
 async-trait = "0.1"
 base64 = "0.22"

--- a/eng/dict/crates.txt
+++ b/eng/dict/crates.txt
@@ -1,5 +1,4 @@
 async-lock
-async-process
 async-stream
 async-trait
 azure_core

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -57,6 +57,7 @@ reqwest_gzip = ["typespec_client_core/reqwest_gzip"]
 reqwest_rustls = ["typespec_client_core/reqwest_rustls"]
 test = ["typespec_client_core/test"]
 tokio_fs = ["typespec_client_core/tokio_fs"]
+tokio_process = ["dep:tokio"]
 tokio_sleep = ["typespec_client_core/tokio_sleep"]
 xml = ["typespec_client_core/xml"]
 

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -57,7 +57,7 @@ reqwest_gzip = ["typespec_client_core/reqwest_gzip"]
 reqwest_rustls = ["typespec_client_core/reqwest_rustls"]
 test = ["typespec_client_core/test"]
 tokio_fs = ["typespec_client_core/tokio_fs"]
-tokio_process = ["dep:tokio"]
+tokio_process = ["dep:tokio", "tokio/process"]
 tokio_sleep = ["typespec_client_core/tokio_sleep"]
 xml = ["typespec_client_core/xml"]
 

--- a/sdk/core/azure_core/src/lib.rs
+++ b/sdk/core/azure_core/src/lib.rs
@@ -19,6 +19,7 @@ mod policies;
 pub mod credentials;
 pub mod headers;
 pub mod lro;
+pub mod process;
 pub mod request_options;
 
 #[cfg(feature = "test")]

--- a/sdk/core/azure_core/src/process/mod.rs
+++ b/sdk/core/azure_core/src/process/mod.rs
@@ -1,27 +1,51 @@
+use async_trait::async_trait;
+use std::io::Error;
+use std::{ffi::OsStr, process::Output};
+
 #[cfg(not(feature = "tokio_process"))]
 mod thread;
 
 #[cfg(not(feature = "tokio_process"))]
-pub use thread::run_command;
+pub use thread::ThreadRunner;
 
 #[cfg(feature = "tokio_process")]
-pub use self::tokio::run_command;
+pub use tokio::TokioRunner;
 
 #[cfg(feature = "tokio_process")]
 mod tokio {
-    use std::io::Error;
-    use std::{ffi::OsStr, process::Output};
+    use super::*;
 
-    /// Run a command with the given arguments until it terminates, returning the output
-    pub async fn run_command<S, I, A>(program: S, args: I) -> Result<Output, Error>
-    where
-        S: AsRef<OsStr>,
-        I: IntoIterator<Item = A>,
-        A: AsRef<OsStr>,
-    {
-        tokio::process::Command::new(program)
-            .args(args)
-            .output()
-            .await
+    /// Implement [`ProcessRunner`] via [`::tokio::process`]
+    #[derive(Debug)]
+    pub struct TokioRunner;
+
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    impl ProcessRunner for TokioRunner {
+        async fn run_command(&self, program: &OsStr, args: &[&OsStr]) -> Result<Output, Error> {
+            let mut cmd = ::tokio::process::Command::new(program);
+            cmd.args(args);
+            cmd.output().await
+        }
     }
+}
+
+/// Obtains a new process runner
+pub fn new_process_runner() -> Box<dyn ProcessRunner> {
+    #[cfg(feature = "tokio_process")]
+    {
+        Box::new(TokioRunner)
+    }
+    #[cfg(not(feature = "tokio_process"))]
+    {
+        Box::new(ThreadRunner)
+    }
+}
+
+/// An abstraction to run processes
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+pub trait ProcessRunner: Send + Sync + std::fmt::Debug {
+    /// Run a command with the given arguments until it terminates, returning the output
+    async fn run_command(&self, program: &OsStr, args: &[&OsStr]) -> Result<Output, Error>;
 }

--- a/sdk/core/azure_core/src/process/mod.rs
+++ b/sdk/core/azure_core/src/process/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use async_trait::async_trait;
 use std::io::Error;
 use std::{ffi::OsStr, process::Output};
@@ -12,23 +15,7 @@ pub use thread::ThreadRunner;
 pub use tokio::TokioRunner;
 
 #[cfg(feature = "tokio_process")]
-mod tokio {
-    use super::*;
-
-    /// Implement [`ProcessRunner`] via [`::tokio::process`]
-    #[derive(Debug)]
-    pub struct TokioRunner;
-
-    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
-    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
-    impl ProcessRunner for TokioRunner {
-        async fn run_command(&self, program: &OsStr, args: &[&OsStr]) -> Result<Output, Error> {
-            let mut cmd = ::tokio::process::Command::new(program);
-            cmd.args(args);
-            cmd.output().await
-        }
-    }
-}
+mod tokio;
 
 /// Obtains a new process runner
 pub fn new_process_runner() -> Box<dyn ProcessRunner> {

--- a/sdk/core/azure_core/src/process/mod.rs
+++ b/sdk/core/azure_core/src/process/mod.rs
@@ -1,0 +1,27 @@
+#[cfg(not(feature = "tokio_process"))]
+mod thread;
+
+#[cfg(not(feature = "tokio_process"))]
+pub use thread::run_command;
+
+#[cfg(feature = "tokio_process")]
+pub use self::tokio::run_command;
+
+#[cfg(feature = "tokio_process")]
+mod tokio {
+    use std::io::Error;
+    use std::{ffi::OsStr, process::Output};
+
+    /// Run a command with the given arguments until it terminates, returning the output
+    pub async fn run_command<S, I, A>(program: S, args: I) -> Result<Output, Error>
+    where
+        S: AsRef<OsStr>,
+        I: IntoIterator<Item = A>,
+        A: AsRef<OsStr>,
+    {
+        tokio::process::Command::new(program)
+            .args(args)
+            .output()
+            .await
+    }
+}

--- a/sdk/core/azure_core/src/process/thread.rs
+++ b/sdk/core/azure_core/src/process/thread.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 use super::ProcessRunner;
 use async_trait::async_trait;
 use futures::channel::oneshot;

--- a/sdk/core/azure_core/src/process/thread.rs
+++ b/sdk/core/azure_core/src/process/thread.rs
@@ -1,25 +1,28 @@
+use super::ProcessRunner;
+use async_trait::async_trait;
+use futures::channel::oneshot;
 use std::io::Error;
+use std::io::ErrorKind;
 use std::{ffi::OsStr, process::Output};
 
-/// Run a command with the given arguments until it terminates, returning the output
-pub async fn run_command<S, I, A>(program: S, args: I) -> Result<Output, Error>
-where
-    S: AsRef<OsStr>,
-    I: IntoIterator<Item = A>,
-    A: AsRef<OsStr>,
-{
-    use futures::channel::oneshot;
-    use std::io::ErrorKind;
+/// Implement [`ProcessRunner`] via a thread and [`std::process`]
+#[derive(Debug)]
+pub struct ThreadRunner;
 
-    let (tx, rx) = oneshot::channel();
-    let mut cmd = std::process::Command::new(program);
-    cmd.args(args);
-    std::thread::spawn(move || {
-        let output = cmd.output();
-        tx.send(output)
-    });
-    let output = rx
-        .await
-        .map_err(|err| Error::new(ErrorKind::Other, err))??;
-    Ok(output)
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl ProcessRunner for ThreadRunner {
+    async fn run_command(&self, program: &OsStr, args: &[&OsStr]) -> Result<Output, Error> {
+        let (tx, rx) = oneshot::channel();
+        let mut cmd = std::process::Command::new(program);
+        cmd.args(args);
+        std::thread::spawn(move || {
+            let output = cmd.output();
+            tx.send(output)
+        });
+        let output = rx
+            .await
+            .map_err(|err| Error::new(ErrorKind::Other, err))??;
+        Ok(output)
+    }
 }

--- a/sdk/core/azure_core/src/process/tokio.rs
+++ b/sdk/core/azure_core/src/process/tokio.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use super::ProcessRunner;
+use async_trait::async_trait;
+use std::io::Error;
+use std::{ffi::OsStr, process::Output};
+
+/// Implement [`ProcessRunner`] via [`::tokio::process`]
+#[derive(Debug)]
+pub struct TokioRunner;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl ProcessRunner for TokioRunner {
+    async fn run_command(&self, program: &OsStr, args: &[&OsStr]) -> Result<Output, Error> {
+        let mut cmd = ::tokio::process::Command::new(program);
+        cmd.args(args);
+        cmd.output().await
+    }
+}

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -26,9 +26,6 @@ openssl = { workspace = true, optional = true }
 pin-project.workspace = true
 typespec_client_core = { workspace = true, features = ["derive"] }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-async-process.workspace = true
-
 [target.'cfg(unix)'.dependencies]
 tz-rs = { workspace = true, optional = true }
 

--- a/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 use crate::credentials::cache::TokenCache;
-use async_process::Command;
 use azure_core::{
     credentials::{AccessToken, Secret, TokenCredential},
     error::{Error, ErrorKind, ResultExt},
     json::from_json,
+    process::run_command,
 };
 use serde::Deserialize;
 use std::{str, sync::Arc};
@@ -193,7 +193,7 @@ impl AzureCliCredential {
             args.join(" "),
         );
 
-        match Command::new(program).args(args).output().await {
+        match run_command(program, args).await {
             Ok(az_output) if az_output.status.success() => {
                 let output = str::from_utf8(&az_output.stdout)?;
 


### PR DESCRIPTION
Adds a `ProcessRunner` trait to `azure_core`, similar to `HttpClient`, and uses it in the one place in `azure_identity` where we used `async-process` before. We provide two implementations:

* one based on tokio, behind an optional feature
* the other (used by default) is a manual implementation with a oneshot channel and a dedicated thread

successor of #1654, #2175
fixes #1652
