### PR TITLE
Import the right features for HTTP-based crates

### DIFF
--- a/.taplo.toml
+++ b/.taplo.toml
@@ -2,6 +2,7 @@
 align_single_comments = false
 array_auto_collapse = false
 array_trailing_comma = true
+indent_string = "  "
 
 [[rule]]
 include = ["**/Cargo.toml"]

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,15 @@
+[formatting]
+align_single_comments = false
+array_auto_collapse = false
+array_trailing_comma = true
+
+[[rule]]
+include = ["**/Cargo.toml"]
+keys = [
+  "dependencies",
+  "build-dependencies",
+  "dev-dependencies",
+]
+
+[rule.formatting]
+reorder_keys = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ repository = "https://github.com/azure/azure-sdk-for-rust"
 rust-version = "1.80"
 
 [workspace.dependencies.typespec]
+default-features = false
 path = "sdk/typespec"
 version = "0.2.0"
-default-features = false
 
 [workspace.dependencies.typespec_client_core]
+default-features = false
 path = "sdk/typespec/typespec_client_core"
 version = "0.1.0"
-default-features = false
 
 [workspace.dependencies.typespec_macros]
 version = "0.1.0"

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -14,22 +14,22 @@ edition.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-typespec = { workspace = true, features = ["http", "json"] }
-typespec_client_core = { workspace = true, features = ["http", "json"] }
 async-lock = { workspace = true }
 async-trait.workspace = true
 bytes.workspace = true
 futures.workspace = true
-tracing.workspace = true
+hmac = { workspace = true, optional = true }
+once_cell.workspace = true
+openssl = { workspace = true, optional = true }
+paste.workspace = true
+pin-project.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-pin-project.workspace = true
-paste.workspace = true
-tokio = { workspace = true, optional = true }
-hmac = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
-openssl = { workspace = true, optional = true }
-once_cell.workspace = true
+tokio = { workspace = true, optional = true }
+tracing.workspace = true
+typespec = { workspace = true, features = ["http", "json"] }
+typespec_client_core = { workspace = true, features = ["http", "json"] }
 
 [build-dependencies]
 rustc_version.workspace = true
@@ -37,17 +37,24 @@ rustc_version.workspace = true
 [dev-dependencies]
 azure_identity.path = "../../identity/azure_identity"
 azure_security_keyvault_secrets.path = "../../keyvault/azure_security_keyvault_secrets"
-time.workspace = true
-tracing-subscriber.workspace = true
-tokio.workspace = true
 thiserror.workspace = true
+time.workspace = true
+tokio.workspace = true
+tracing-subscriber.workspace = true
 
 [features]
-default = []
+default = [
+  "reqwest",
+  "reqwest_deflate",
+  "reqwest_gzip",
+  "tokio_fs",
+  "tokio_sleep",
+]
 azurite_workaround = []
 hmac_openssl = ["dep:openssl"]
 hmac_rust = ["dep:sha2", "dep:hmac"]
 reqwest = ["typespec_client_core/reqwest"]
+reqwest_deflate = ["typespec_client_core/reqwest_deflate"]
 reqwest_gzip = ["typespec_client_core/reqwest_gzip"]
 reqwest_rustls = ["typespec_client_core/reqwest_rustls"]
 test = ["typespec_client_core/test"]
@@ -60,9 +67,9 @@ features = [
   "hmac_openssl",
   "hmac_rust",
   "reqwest",
+  "reqwest_deflate",
   "reqwest_gzip",
   "reqwest_rustls",
-  "test",
   "tokio_fs",
   "tokio_sleep",
   "xml",

--- a/sdk/core/azure_core/Cargo.toml
+++ b/sdk/core/azure_core/Cargo.toml
@@ -47,8 +47,6 @@ default = [
   "reqwest",
   "reqwest_deflate",
   "reqwest_gzip",
-  "tokio_fs",
-  "tokio_sleep",
 ]
 azurite_workaround = []
 hmac_openssl = ["dep:openssl"]

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -18,17 +18,17 @@ categories = ["api-bindings"]
 edition = "2021"
 
 [dependencies]
-tokio.workspace = true
-azure_core.workspace = true
-time.workspace = true
-tracing.workspace = true
+azure_core = { path = "../azure_core", default-features = false }
 fe2o3-amqp = { workspace = true, optional = true }
+fe2o3-amqp-cbs = { workspace = true, optional = true }
 fe2o3-amqp-ext = { workspace = true, optional = true }
 fe2o3-amqp-management = { workspace = true, optional = true }
-fe2o3-amqp-cbs = { workspace = true, optional = true }
 fe2o3-amqp-types = { workspace = true, optional = true }
 serde_amqp = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
+time.workspace = true
+tokio.workspace = true
+tracing.workspace = true
 uuid = { workspace = true }
 
 [dev-dependencies]

--- a/sdk/core/azure_core_test/src/lib.rs
+++ b/sdk/core/azure_core_test/src/lib.rs
@@ -17,7 +17,6 @@ use std::path::{Path, PathBuf};
 
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 const ASSETS_FILE: &str = "assets.json";
-const SPAN_TARGET: &str = "test-proxy";
 
 /// Context information required by recorded client library tests.
 ///
@@ -28,20 +27,20 @@ pub struct TestContext {
     repo_dir: &'static Path,
     crate_dir: &'static Path,
     service_dir: &'static str,
-    test_module: &'static str,
-    test_name: &'static str,
+    module_name: &'static str,
+    name: &'static str,
     recording: Option<Recording>,
 }
 
 impl TestContext {
     pub(crate) fn new(
         crate_dir: &'static str,
-        test_module: &'static str,
-        test_name: &'static str,
+        module_dir: &'static str,
+        name: &'static str,
     ) -> azure_core::Result<Self> {
         let service_dir = parent_of(crate_dir, "sdk")
             .ok_or_else(|| Error::message(ErrorKind::Other, "not under 'sdk' folder in repo"))?;
-        let test_module = Path::new(test_module)
+        let test_module = Path::new(module_dir)
             .file_stem()
             .ok_or_else(|| Error::message(ErrorKind::Other, "invalid test module"))?
             .to_str()
@@ -50,8 +49,8 @@ impl TestContext {
             repo_dir: find_ancestor_of(crate_dir, ".git")?,
             crate_dir: Path::new(crate_dir),
             service_dir,
-            test_module,
-            test_name,
+            module_name: test_module,
+            name,
             recording: None,
         })
     }
@@ -100,13 +99,13 @@ impl TestContext {
     }
 
     /// Gets the module name containing the current test.
-    pub fn test_module(&self) -> &'static str {
-        self.test_module
+    pub fn module_name(&self) -> &'static str {
+        self.module_name
     }
 
     /// Gets the current test function name.
-    pub fn test_name(&self) -> &'static str {
-        self.test_name
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
     /// Gets the recording assets file under the crate directory.
@@ -153,8 +152,8 @@ impl TestContext {
     pub(crate) fn test_recording_file(&self) -> String {
         let path = self
             .test_data_dir()
-            .join(self.test_module)
-            .join(self.test_name)
+            .join(self.module_name)
+            .join(self.name)
             .as_path()
             .with_extension("json");
         path.to_str()
@@ -238,8 +237,8 @@ mod tests {
             .unwrap()
             .replace("\\", "/")
             .ends_with("sdk/core/azure_core_test"));
-        assert_eq!(ctx.test_module(), "lib");
-        assert_eq!(ctx.test_name(), "test_context_new");
+        assert_eq!(ctx.module_name(), "lib");
+        assert_eq!(ctx.name(), "test_context_new");
         assert_eq!(
             ctx.test_recording_file().replace("\\", "/"),
             "sdk/core/azure_core_test/tests/data/lib/test_context_new.json"

--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -15,6 +15,7 @@ use azure_core::{
     ClientMethodOptions, ClientOptions, Context, Method, Pipeline, Request, RequestContent, Result,
     Url,
 };
+use tracing::Span;
 
 /// The test-proxy client.
 ///
@@ -45,6 +46,7 @@ impl Client {
         &self.endpoint
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint), err)]
     pub async fn record_start(
         &self,
         body: RequestContent<StartPayload>,
@@ -66,6 +68,7 @@ impl Client {
         Ok(RecordStartResult { recording_id })
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint, recording_id), err)]
     pub async fn record_stop(
         &self,
         recording_id: &str,
@@ -85,12 +88,17 @@ impl Client {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint, recording_id), err)]
     pub async fn playback_start(
         &self,
         body: RequestContent<StartPayload>,
         options: Option<ClientPlaybackStartOptions<'_>>,
     ) -> Result<PlaybackStartResult> {
         let options = options.unwrap_or_default();
+        Span::current().record(
+            stringify!(recording_id),
+            options.recording_id.map(AsRef::as_ref),
+        );
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Playback/Start")?;
@@ -109,6 +117,7 @@ impl Client {
         Ok(result)
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint, recording_id), err)]
     pub async fn playback_stop(
         &self,
         recording_id: &str,
@@ -126,12 +135,17 @@ impl Client {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint, recording_id), err)]
     pub async fn set_matcher(
         &self,
         matcher: Matcher,
         options: Option<ClientSetMatcherOptions<'_>>,
     ) -> Result<()> {
         let options = options.unwrap_or_default();
+        Span::current().record(
+            stringify!(recording_id),
+            options.recording_id.map(AsRef::as_ref),
+        );
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/SetMatcher")?;
@@ -144,6 +158,7 @@ impl Client {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint, recording_id), err)]
     pub async fn add_sanitizer<S>(
         &self,
         sanitizer: S,
@@ -154,6 +169,10 @@ impl Client {
         azure_core::Error: From<<S as AsHeaders>::Error>,
     {
         let options = options.unwrap_or_default();
+        Span::current().record(
+            stringify!(recording_id),
+            options.recording_id.map(AsRef::as_ref),
+        );
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/AddSanitizer")?;
@@ -166,12 +185,17 @@ impl Client {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint, recording_id), err)]
     pub async fn remove_sanitizers(
         &self,
         body: RequestContent<SanitizerList>,
         options: Option<ClientRemoveSanitizersOptions<'_>>,
     ) -> Result<RemovedSanitizers> {
         let options = options.unwrap_or_default();
+        Span::current().record(
+            stringify!(recording_id),
+            options.recording_id.map(AsRef::as_ref),
+        );
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/RemoveSanitizers")?;
@@ -187,8 +211,13 @@ impl Client {
             .await
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(endpoint = %self.endpoint, recording_id), err)]
     pub async fn reset(&self, options: Option<ClientResetOptions<'_>>) -> Result<()> {
         let options = options.unwrap_or_default();
+        Span::current().record(
+            stringify!(recording_id),
+            options.recording_id.map(AsRef::as_ref),
+        );
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/Reset")?;

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -21,8 +21,6 @@ use std::process::ExitStatus;
 use std::{fmt, str::FromStr};
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::process::Child;
-#[cfg(not(target_arch = "wasm32"))]
-use tracing::Level;
 
 const ABSTRACTION_IDENTIFIER: HeaderName = HeaderName::from_static("x-abstraction-identifier");
 const RECORDING_ID: HeaderName = HeaderName::from_static("x-recording-id");
@@ -58,12 +56,15 @@ mod bootstrap {
     /// Starts the test-proxy.
     ///
     /// This is intended for internal use only and should not be called directly in tests.
+    #[tracing::instrument(level = "debug", fields(crate_dir = ?crate_dir.as_ref(), ?options), err)]
     pub async fn start(
         crate_dir: impl AsRef<Path>,
         options: Option<ProxyOptions>,
     ) -> Result<Proxy> {
         if env::var(PROXY_MANUAL_START).is_ok_and(|v| v.eq_ignore_ascii_case("true")) {
-            tracing::event!(target: crate::SPAN_TARGET, Level::WARN, "environment variable {PROXY_MANUAL_START} is 'true'; not starting test proxy");
+            tracing::warn!(
+                "environment variable {PROXY_MANUAL_START} is 'true'; not starting test-proxy"
+            );
             return Ok(Proxy::default());
         }
 
@@ -72,6 +73,10 @@ mod bootstrap {
         let git_dir = git_dir.parent().ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, "parent git repository not found")
         })?;
+        tracing::debug!(
+            "starting test-proxy with storage location {git_dir}",
+            git_dir = git_dir.display()
+        );
 
         let mut args: Vec<String> = Vec::new();
         args.extend_from_slice(&[
@@ -101,7 +106,7 @@ mod bootstrap {
         let mut stdout = command.stdout.take();
         let max_seconds = Duration::from_secs(env::var(SYSTEM_TEAMPROJECTID).map_or(5, |_| 20));
         let url = tokio::select! {
-            v = wait_till_listening(&mut stdout) => { v? },
+            v = wait_till_listening(command.id(), &mut stdout) => { v? },
             _ = tokio::time::sleep(max_seconds) => {
                 command.kill().await?;
                 return Err(azure_core::Error::message(ErrorKind::Other, "timed out waiting for test-proxy to start"));
@@ -114,7 +119,10 @@ mod bootstrap {
         })
     }
 
-    async fn wait_till_listening(stdout: &mut Option<ChildStdout>) -> Result<Url> {
+    async fn wait_till_listening(
+        pid: Option<u32>,
+        stdout: &mut Option<ChildStdout>,
+    ) -> Result<Url> {
         let Some(stdout) = stdout else {
             return Err(azure_core::Error::message(
                 ErrorKind::Io,
@@ -131,7 +139,7 @@ mod bootstrap {
             if let Some(idx) = line.find(RUNNING_PATTERN) {
                 let idx = idx + RUNNING_PATTERN.len();
                 let version: Version = line[idx..].parse()?;
-                tracing::event!(target: crate::SPAN_TARGET, Level::INFO, "starting test-proxy version {version}");
+                tracing::info!(?pid, %version, "started test-proxy version {version}");
 
                 // Need to check version since `test-proxy start` does not fail with unknown parameters.
                 if version < MIN_VERSION {
@@ -146,11 +154,11 @@ mod bootstrap {
 
             if let Some(idx) = line.find(LISTENING_PATTERN) {
                 let idx = idx + LISTENING_PATTERN.len();
-                let mut url: Url = line[idx..].parse()?;
-                url.set_host(Some("localhost"))?;
-                tracing::event!(target: crate::SPAN_TARGET, Level::INFO, "listening on {url}");
+                let mut endpoint: Url = line[idx..].parse()?;
+                endpoint.set_host(Some("localhost"))?;
+                tracing::info!(?pid, %endpoint, "test-proxy listening on {endpoint}");
 
-                return Ok(url);
+                return Ok(endpoint);
             }
         }
 
@@ -184,7 +192,7 @@ impl Proxy {
     /// Waits until the process is killed.
     pub async fn stop(&mut self) -> Result<()> {
         if let Some(command) = &mut self.command {
-            tracing::event!(target: crate::SPAN_TARGET, Level::DEBUG, "stopping");
+            tracing::debug!(pid = ?command.id(), "stopping");
             return Ok(command.kill().await?);
         }
         Ok(())
@@ -192,7 +200,7 @@ impl Proxy {
 }
 
 impl Proxy {
-    /// Gets the [`Url`] to which the test proxy is listening.
+    /// Gets the [`Url`] to which the test-proxy is listening.
     pub fn endpoint(&self) -> &Url {
         &self.url
     }
@@ -200,10 +208,11 @@ impl Proxy {
 
 impl Default for Proxy {
     fn default() -> Self {
+        let url = "http://localhost:5000".parse().unwrap();
         Self {
             #[cfg(not(target_arch = "wasm32"))]
             command: None,
-            url: "http://localhost:5000".parse().unwrap(),
+            url,
         }
     }
 }

--- a/sdk/core/azure_core_test/src/proxy/policy.rs
+++ b/sdk/core/azure_core_test/src/proxy/policy.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::{
-    proxy::{RecordingId, RECORDING_UPSTREAM_BASE_URI},
+    proxy::{RecordingId, RECORDING_MODE, RECORDING_UPSTREAM_BASE_URI},
     Skip,
 };
 use async_trait::async_trait;
@@ -16,10 +16,8 @@ use std::{
     convert::Infallible,
     sync::{Arc, RwLock},
 };
-use tracing::{debug_span, Instrument};
+use tracing::Instrument;
 use url::Origin;
-
-use super::RECORDING_MODE;
 
 #[derive(Debug, Default)]
 pub struct RecordingPolicy {
@@ -38,7 +36,7 @@ impl Policy for RecordingPolicy {
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult {
-        let span = debug_span!(target: crate::SPAN_TARGET, "request", mode = ?self.test_mode);
+        let span = tracing::trace_span!("request", mode = ?self.test_mode);
 
         // Replace the upstream host with the test-proxy host, which will make and record the upstream call.
         let mut origin = None;

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -30,11 +30,7 @@ clap.workspace = true
 reqwest.workspace = true
 time.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
-tokio = { workspace = true, default-features = false, features = [
-  "rt-multi-thread",
-  "macros",
-  "time",
-] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
 [lints]
 workspace = true

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -1,6 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 //! Provides a framework for integration tests for the Azure Cosmos DB service.
 //!
-//! The framework allows tests to easily run against real Cosmos DB instances, the local emulator, or a mock server using test proxy.
+//! The framework allows tests to easily run against real Cosmos DB instances, the local emulator, or a mock server using test-proxy.
 
 mod test_account;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_account.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_account.rs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 #![cfg_attr(not(feature = "key_auth"), allow(dead_code))]
 
 use std::sync::{Arc, Once};
@@ -90,7 +93,7 @@ impl TestAccount {
 
         let context_id = format!(
             "{}_{}_{}",
-            context.test_name(),
+            context.name(),
             OffsetDateTime::now_utc().format(format_description!(
                 "[year]_[month]_[day]T[hour]_[minute]_[second]"
             ))?,

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -18,12 +18,12 @@ categories = ["api-bindings"]
 edition = "2021"
 
 [dependencies]
-tokio.workspace = true
 async-stream.workspace = true
-azure_core.workspace = true
+azure_core = { path = "../../core/azure_core", default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 time.workspace = true
+tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 uuid.workspace = true
@@ -32,11 +32,7 @@ uuid.workspace = true
 rustc_version.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 azure_core_test.path = "../../core/azure_core_test"
 azure_identity.path = "../../identity/azure_identity"
-tokio = { workspace = true, default-features = false, features = [
-  "rt-multi-thread",
-  "macros",
-  "time",
-] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/sdk/keyvault/assets.json
+++ b/sdk/keyvault/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
   "TagPrefix": "rust/keyvault",
-  "Tag": "rust/keyvault_108fb9e37c"
+  "Tag": "rust/keyvault_5166c190c1"
 }

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -28,8 +28,8 @@ tokio = { workspace = true, optional = true }
 tracing.workspace = true
 typespec = { workspace = true, default-features = false }
 typespec_macros = { workspace = true, optional = true }
-uuid.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
@@ -46,15 +46,15 @@ tracing-subscriber.workspace = true
 typespec_macros.path = "../typespec_macros"
 
 [features]
-default = ["http", "json", "reqwest", "reqwest_gzip"]
+default = ["http", "json", "reqwest", "reqwest_deflate", "reqwest_gzip"]
 derive = ["dep:typespec_macros"]
 http = ["dep:http-types", "typespec/http"]
 json = ["typespec/json"]
 reqwest = ["reqwest/native-tls"]
+reqwest_deflate = ["reqwest/deflate"]
 reqwest_gzip = ["reqwest/gzip"]
 reqwest_rustls = ["reqwest/rustls-tls-native-roots"]
-# Enables extra tracing including error bodies that may contain PII.
-test = []
+test = [] # Enables extra tracing including error bodies that may contain PII.
 tokio_fs = ["tokio/fs", "tokio/sync", "tokio/io-util"]
 tokio_sleep = ["tokio/time"]
 xml = ["dep:quick-xml"]
@@ -68,4 +68,15 @@ name = "stream_response"
 required-features = ["derive"]
 
 [package.metadata.docs.rs]
-all-features = true
+features = [
+  "derive",
+  "http",
+  "json",
+  "reqwest",
+  "reqwest_deflate",
+  "reqwest_gzip",
+  "reqwest_rustls",
+  "tokio_fs",
+  "tokio_sleep",
+  "xml",
+]


### PR DESCRIPTION
Resolves #2056 by making sure we import the right features for the vast majority of crates, which are HTTP-based on azure_core. Those not using HTTP-based azure_core will need to use a path dependency until after GA and will then probably need to use a version dependency...which should be the norm by then anyway.
