### PR TITLE
Create assets.json in crate directory if needed

### DIFF
--- a/sdk/core/azure_core_test/examples/test_proxy.rs
+++ b/sdk/core/azure_core_test/examples/test_proxy.rs
@@ -19,7 +19,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .from_env_lossy();
     tracing_subscriber::fmt().with_env_filter(filter).init();
 
-    let mut proxy = proxy::start(env!("CARGO_MANIFEST_DIR"), Some(args.into())).await?;
+    let mut proxy = proxy::start(None, env!("CARGO_MANIFEST_DIR"), Some(args.into())).await?;
 
     let code = tokio::select! {
         _ = tokio::signal::ctrl_c() => {

--- a/sdk/core/azure_core_test/src/lib.rs
+++ b/sdk/core/azure_core_test/src/lib.rs
@@ -195,7 +195,7 @@ fn find_ancestor_file(dir: impl AsRef<Path>, name: &str) -> azure_core::Result<P
         let path = dir.join(".git");
         if path.exists() {
             return Err(azure_core::Error::message(
-                ErrorKind::Other,
+                ErrorKind::Io,
                 format!("{name} not found under repo {}", dir.display()),
             ));
         }

--- a/sdk/core/azure_core_test/src/recorded.rs
+++ b/sdk/core/azure_core_test/src/recorded.rs
@@ -49,7 +49,9 @@ pub async fn start(
                                 .init();
                         }
 
-                        crate::proxy::start(crate_dir, options).await.map(Arc::new)
+                        crate::proxy::start(Some(test_mode), crate_dir, options)
+                            .await
+                            .map(Arc::new)
                     })
                     .await
                     .as_ref()


### PR DESCRIPTION
Resolves #2041 by creating an empty assets.json file in the crate directory if one doesn't already exist in the crate or ancestor directories (up until the repo root).
