### PR TITLE
Don't replace existing change log entry

### DIFF
--- a/eng/scripts/Update-PackageVersion.ps1
+++ b/eng/scripts/Update-PackageVersion.ps1
@@ -49,13 +49,13 @@ Write-Host "  ChangeLogPath: $($pkgProperties.ChangeLogPath)"
 
 #If we're just bumping the version with no release date, we want to set the changelog entry to unreleased
 $setChangeLogEntryToUnreleased = !$ReleaseDate -and !$NewVersionString
+$packageSemVer = [AzureEngSemanticVersion]::new($pkgProperties.Version)
 
-if ($NewVersionString) {
-  $packageSemVer = [AzureEngSemanticVersion]::new($NewVersionString)
+if (!$NewVersionString) {
+  $packageSemVer.IncrementAndSetToPrerelease();
 }
 else {
-  $packageSemVer = [AzureEngSemanticVersion]::new($pkgProperties.Version)
-  $packageSemVer.IncrementAndSetToPrerelease();
+  $packageSemVer = [AzureEngSemanticVersion]::new($NewVersionString)
 }
 
 if ($packageSemVer.HasValidPrereleaseLabel() -ne $true) {

--- a/eng/scripts/Update-PackageVersion.ps1
+++ b/eng/scripts/Update-PackageVersion.ps1
@@ -33,7 +33,7 @@ Param (
   [string] $PackageName,
   [string] $NewVersionString,
   [string] $ReleaseDate,
-  [boolean] $ReplaceLatestEntryTitle = $false
+  [boolean] $ReplaceLatestEntryTitle
 )
 
 . (Join-Path $PSScriptRoot '../common/scripts/common.ps1')

--- a/eng/scripts/Update-PackageVersion.ps1
+++ b/eng/scripts/Update-PackageVersion.ps1
@@ -49,13 +49,13 @@ Write-Host "  ChangeLogPath: $($pkgProperties.ChangeLogPath)"
 
 #If we're just bumping the version with no release date, we want to set the changelog entry to unreleased
 $setChangeLogEntryToUnreleased = !$ReleaseDate -and !$NewVersionString
-$packageSemVer = [AzureEngSemanticVersion]::new($pkgProperties.Version)
 
-if (!$NewVersionString) {
-  $packageSemVer.IncrementAndSetToPrerelease();
+if ($NewVersionString) {
+  $packageSemVer = [AzureEngSemanticVersion]::new($NewVersionString)
 }
 else {
-  $packageSemVer = [AzureEngSemanticVersion]::new($NewVersionString)
+  $packageSemVer = [AzureEngSemanticVersion]::new($pkgProperties.Version)
+  $packageSemVer.IncrementAndSetToPrerelease();
 }
 
 if ($packageSemVer.HasValidPrereleaseLabel() -ne $true) {


### PR DESCRIPTION
- Default `$ReplaceLatestEntryTitle` to `$false`
- Clean up the naming and handling of the variable passed to `Update-ChangeLog.ps1 -Unreleased` parameter.