### PR TITLE
Replace http-types with http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,23 +91,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
-
-[[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
 name = "async-channel"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,7 +125,7 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite",
  "parking",
  "polling",
  "rustix",
@@ -157,7 +140,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -168,15 +151,15 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-io",
  "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
- "event-listener 5.3.1",
- "futures-lite 2.5.0",
+ "event-listener",
+ "futures-lite",
  "rustix",
  "tracing",
 ]
@@ -308,8 +291,8 @@ dependencies = [
  "azure_security_keyvault_secrets",
  "clap",
  "futures",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand",
+ "rand_chacha",
  "serde",
  "serde_json",
  "tokio",
@@ -400,14 +383,14 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_keys"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "azure_core",
  "azure_core_test",
  "azure_identity",
  "azure_security_keyvault_test",
  "futures",
- "rand 0.8.5",
+ "rand",
  "rustc_version",
  "serde",
  "serde_json",
@@ -419,14 +402,14 @@ dependencies = [
 
 [[package]]
 name = "azure_security_keyvault_secrets"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "azure_core",
  "azure_core_test",
  "azure_identity",
  "azure_security_keyvault_test",
  "futures",
- "rand 0.8.5",
+ "rand",
  "rustc_version",
  "serde",
  "serde_json",
@@ -488,12 +471,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -525,10 +502,10 @@ version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.3.1",
+ "async-channel",
  "async-task",
  "futures-io",
- "futures-lite 2.5.0",
+ "futures-lite",
  "piper",
 ]
 
@@ -839,12 +816,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
@@ -860,17 +831,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
- "event-listener 5.3.1",
+ "event-listener",
  "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -889,7 +851,7 @@ dependencies = [
  "fe2o3-amqp-types",
  "fluvio-wasm-timer",
  "futures-util",
- "getrandom 0.2.15",
+ "getrandom",
  "native-tls",
  "parking_lot 0.12.3",
  "pin-project-lite",
@@ -1058,26 +1020,11 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
- "fastrand 2.2.0",
+ "fastrand",
  "futures-core",
  "futures-io",
  "parking",
@@ -1137,17 +1084,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
@@ -1155,7 +1091,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1224,26 +1160,6 @@ dependencies = [
  "http",
  "http-body",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel 1.9.0",
- "base64 0.13.1",
- "futures-lite 1.13.0",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
 ]
 
 [[package]]
@@ -1504,12 +1420,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
-
-[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.52.0",
 ]
 
@@ -1699,11 +1609,11 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
- "getrandom 0.2.15",
+ "getrandom",
  "http",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -1778,7 +1688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c65ee1f9701bf938026630b455d5315f490640234259037edb259798b3bcf85e"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
  "serde",
 ]
 
@@ -1893,7 +1803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
- "fastrand 2.2.0",
+ "fastrand",
  "futures-io",
 ]
 
@@ -1977,8 +1887,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom 0.2.15",
- "rand 0.8.5",
+ "getrandom",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2015,37 +1925,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
  "serde",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2055,16 +1942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2073,17 +1951,8 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
  "serde",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -2155,7 +2024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "async-compression",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "futures-util",
@@ -2204,7 +2073,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom",
  "libc",
  "spin",
  "untrusted",
@@ -2462,17 +2331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "serde_repr"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,7 +2509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
- "fastrand 2.2.0",
+ "fastrand",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2932,8 +2790,8 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 name = "typespec"
 version = "0.2.0"
 dependencies = [
- "base64 0.22.1",
- "http-types",
+ "base64",
+ "http",
  "serde_json",
  "thiserror 1.0.69",
  "url",
@@ -2944,16 +2802,16 @@ name = "typespec_client_core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "dyn-clone",
  "futures",
- "getrandom 0.2.15",
- "http-types",
+ "getrandom",
+ "http",
  "once_cell",
  "pin-project",
  "quick-xml",
- "rand 0.8.5",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -3044,7 +2902,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom",
 ]
 
 [[package]]
@@ -3066,12 +2924,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,12 +2931,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ fe2o3-amqp-types = { version = "0.12" }
 futures = "0.3"
 getrandom = { version = "0.2", features = ["js"] }
 hmac = { version = "0.12" }
-http-types = { version = "2.12", default-features = false }
+http = { version = "1.2", default-features = false }
 log = "0.4"
 oauth2 = { version = "5.0.0", default-features = false }
 once_cell = "1.18"

--- a/eng/dict/crates.txt
+++ b/eng/dict/crates.txt
@@ -11,7 +11,7 @@ dyn-clone
 futures
 getrandom
 hmac
-http-types
+http
 oauth2
 once_cell
 openssl

--- a/eng/test/mock_transport/src/mock_response.rs
+++ b/eng/test/mock_transport/src/mock_response.rs
@@ -87,7 +87,7 @@ impl Serialize for MockResponse {
         for (h, v) in self.headers.iter() {
             headers.insert(h.as_str().into(), v.as_str().into());
         }
-        let status = self.status as u16;
+        let status = u16::from(self.status);
         let body = base64::encode(&self.body);
         let s = SerializedMockResponse {
             status,

--- a/sdk/core/azure_core/README.md
+++ b/sdk/core/azure_core/README.md
@@ -148,7 +148,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     match client.get_secret("secret-name", "", None).await {
         Ok(secret) => println!("Secret: {:?}", secret.into_body().await?.value),
         Err(e) => match e.kind() {
-            ErrorKind::HttpResponse { status, error_code, .. } if *status == StatusCode::NotFound => {
+            ErrorKind::HttpResponse { status, error_code, .. } if *status == StatusCode::NOT_FOUND => {
                 // handle not found error
                 if let Some(code) = error_code {
                     println!("ErrorCode: {}", code);

--- a/sdk/core/azure_core/src/lro.rs
+++ b/sdk/core/azure_core/src/lro.rs
@@ -90,14 +90,14 @@ pub mod body_content {
         S: Serialize,
     {
         match status_code {
-            StatusCode::Accepted => Ok(LroStatus::InProgress),
-            StatusCode::Created => {
+            StatusCode::ACCEPTED => Ok(LroStatus::InProgress),
+            StatusCode::CREATED => {
                 Ok(get_provisioning_state_from_body(body).unwrap_or(LroStatus::InProgress))
             }
-            StatusCode::Ok => {
+            StatusCode::OK => {
                 Ok(get_provisioning_state_from_body(body).unwrap_or(LroStatus::Succeeded))
             }
-            StatusCode::NoContent => Ok(LroStatus::Succeeded),
+            StatusCode::NO_CONTENT => Ok(LroStatus::Succeeded),
             _ => Err(crate::error::Error::from(
                 crate::error::ErrorKind::HttpResponse {
                     status: status_code,

--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -56,7 +56,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Record/Start")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.set_body(body);
@@ -79,7 +79,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Record/Stop")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.insert_header(RECORDING_ID, recording_id.to_string());
@@ -102,7 +102,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Playback/Start")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.add_optional_header(&options.recording_id);
@@ -127,7 +127,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Playback/Stop")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.insert_header(RECORDING_ID, recording_id.to_string());
@@ -149,7 +149,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/SetMatcher")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.insert_headers(&matcher)?;
@@ -176,7 +176,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/AddSanitizer")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.insert_headers(&sanitizer)?;
@@ -199,7 +199,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/RemoveSanitizers")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.add_optional_header(&options.recording_id);
@@ -221,7 +221,7 @@ impl Client {
         let ctx = Context::with_context(&options.method_options.context);
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/Reset")?;
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header(ACCEPT, "application/json");
         request.insert_header(CONTENT_TYPE, "application/json");
         request.add_optional_header(&options.recording_id);

--- a/sdk/core/azure_core_test/src/proxy/models.rs
+++ b/sdk/core/azure_core_test/src/proxy/models.rs
@@ -16,7 +16,7 @@ pub struct Error {
 
 impl Error {
     fn default_status() -> StatusCode {
-        StatusCode::Ok
+        StatusCode::OK
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/delete.rs
@@ -62,7 +62,7 @@ impl DeleteCommand {
                     .delete_item(partition_key, &item_id, None)
                     .await;
                 match response {
-                    Err(e) if e.http_status() == Some(StatusCode::NotFound) => {
+                    Err(e) if e.http_status() == Some(StatusCode::NOT_FOUND) => {
                         println!("Item not found!")
                     }
                     Ok(_) => println!("Item deleted"),

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/patch.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/patch.rs
@@ -46,7 +46,7 @@ impl PatchCommand {
             .patch_item(pk, &self.item_id, patch, None)
             .await;
         match response {
-            Err(e) if e.http_status() == Some(StatusCode::NotFound) => println!("Item not found!"),
+            Err(e) if e.http_status() == Some(StatusCode::NOT_FOUND) => println!("Item not found!"),
             Ok(r) => {
                 let item: serde_json::Value = r.into_json_body().await?;
                 println!("Patched item:");

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/read.rs
@@ -57,7 +57,7 @@ impl ReadCommand {
                     .read_item(&partition_key, &item_id, None)
                     .await;
                 match response {
-                    Err(e) if e.http_status() == Some(StatusCode::NotFound) => {
+                    Err(e) if e.http_status() == Some(StatusCode::NOT_FOUND) => {
                         println!("Item not found!")
                     }
                     Ok(r) => {

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/replace.rs
@@ -83,7 +83,7 @@ impl ReplaceCommand {
                     .replace_item(pk, &item_id, item, Some(options))
                     .await;
                 match response {
-                    Err(e) if e.http_status() == Some(StatusCode::NotFound) => {
+                    Err(e) if e.http_status() == Some(StatusCode::NOT_FOUND) => {
                         println!("Item not found!")
                     }
                     Ok(r) => {

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -64,7 +64,7 @@ impl ContainerClient {
     ) -> azure_core::Result<Response<ContainerProperties>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.link);
-        let mut req = Request::new(url, Method::Get);
+        let mut req = Request::new(url, Method::GET);
         self.pipeline
             .send(options.method_options.context, &mut req, self.link.clone())
             .await
@@ -108,7 +108,7 @@ impl ContainerClient {
     ) -> azure_core::Result<Response<ContainerProperties>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.link);
-        let mut req = Request::new(url, Method::Put);
+        let mut req = Request::new(url, Method::PUT);
         req.set_json(&properties)?;
         self.pipeline
             .send(options.method_options.context, &mut req, self.link.clone())
@@ -175,7 +175,7 @@ impl ContainerClient {
     ) -> azure_core::Result<Response> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.link);
-        let mut req = Request::new(url, Method::Delete);
+        let mut req = Request::new(url, Method::DELETE);
         self.pipeline
             .send(options.method_options.context, &mut req, self.link.clone())
             .await
@@ -255,7 +255,7 @@ impl ContainerClient {
     ) -> azure_core::Result<Response> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.items_link);
-        let mut req = Request::new(url, Method::Post);
+        let mut req = Request::new(url, Method::POST);
         if !options.enable_content_response_on_write {
             req.insert_header(azure_core::headers::PREFER, constants::PREFER_MINIMAL);
         }
@@ -346,7 +346,7 @@ impl ContainerClient {
         let options = options.unwrap_or_default();
         let link = self.items_link.item(item_id);
         let url = self.pipeline.url(&link);
-        let mut req = Request::new(url, Method::Put);
+        let mut req = Request::new(url, Method::PUT);
         if !options.enable_content_response_on_write {
             req.insert_header(azure_core::headers::PREFER, constants::PREFER_MINIMAL);
         }
@@ -434,7 +434,7 @@ impl ContainerClient {
     ) -> azure_core::Result<Response> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.items_link);
-        let mut req = Request::new(url, Method::Post);
+        let mut req = Request::new(url, Method::POST);
         if !options.enable_content_response_on_write {
             req.insert_header(azure_core::headers::PREFER, constants::PREFER_MINIMAL);
         }
@@ -492,7 +492,7 @@ impl ContainerClient {
         let options = options.unwrap_or_default();
         let link = self.items_link.item(item_id);
         let url = self.pipeline.url(&link);
-        let mut req = Request::new(url, Method::Get);
+        let mut req = Request::new(url, Method::GET);
         req.insert_headers(&partition_key.into())?;
         self.pipeline
             .send(options.method_options.context, &mut req, link)
@@ -528,7 +528,7 @@ impl ContainerClient {
         let options = options.unwrap_or_default();
         let link = self.items_link.item(item_id);
         let url = self.pipeline.url(&link);
-        let mut req = Request::new(url, Method::Delete);
+        let mut req = Request::new(url, Method::DELETE);
         req.insert_headers(&partition_key.into())?;
         self.pipeline
             .send(options.method_options.context, &mut req, link)
@@ -601,7 +601,7 @@ impl ContainerClient {
         let options = options.unwrap_or_default();
         let link = self.items_link.item(item_id);
         let url = self.pipeline.url(&link);
-        let mut req = Request::new(url, Method::Patch);
+        let mut req = Request::new(url, Method::PATCH);
         if !options.enable_content_response_on_write {
             req.insert_header(azure_core::headers::PREFER, constants::PREFER_MINIMAL);
         }
@@ -674,7 +674,7 @@ impl ContainerClient {
     ) -> azure_core::Result<Pager<QueryResults<T>>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.items_link);
-        let mut base_request = Request::new(url, Method::Post);
+        let mut base_request = Request::new(url, Method::POST);
         let QueryPartitionStrategy::SinglePartition(partition_key) = partition_key.into();
         base_request.insert_headers(&partition_key)?;
 

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -132,7 +132,7 @@ impl CosmosClient {
     ) -> azure_core::Result<azure_core::Pager<DatabaseQueryResults>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.databases_link);
-        let base_request = Request::new(url, azure_core::Method::Post);
+        let base_request = Request::new(url, azure_core::Method::POST);
 
         self.pipeline.send_query_request(
             options.method_options.context,
@@ -162,7 +162,7 @@ impl CosmosClient {
         }
 
         let url = self.pipeline.url(&self.databases_link);
-        let mut req = Request::new(url, Method::Post);
+        let mut req = Request::new(url, Method::POST);
         req.insert_headers(&options.throughput)?;
         req.set_json(&RequestBody { id })?;
 

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -76,7 +76,7 @@ impl DatabaseClient {
     ) -> azure_core::Result<Response<DatabaseProperties>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.link);
-        let mut req = Request::new(url, Method::Get);
+        let mut req = Request::new(url, Method::GET);
         self.pipeline
             .send(options.method_options.context, &mut req, self.link.clone())
             .await
@@ -112,7 +112,7 @@ impl DatabaseClient {
     ) -> azure_core::Result<Pager<ContainerQueryResults>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.containers_link);
-        let base_request = Request::new(url, Method::Post);
+        let base_request = Request::new(url, Method::POST);
 
         self.pipeline.send_query_request(
             options.method_options.context,
@@ -136,7 +136,7 @@ impl DatabaseClient {
     ) -> azure_core::Result<Response<ContainerProperties>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.containers_link);
-        let mut req = Request::new(url, Method::Post);
+        let mut req = Request::new(url, Method::POST);
         req.insert_headers(&options.throughput)?;
         req.set_json(&properties)?;
 
@@ -161,7 +161,7 @@ impl DatabaseClient {
     ) -> azure_core::Result<Response> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.link);
-        let mut req = Request::new(url, Method::Delete);
+        let mut req = Request::new(url, Method::DELETE);
         self.pipeline
             .send(options.method_options.context, &mut req, self.link.clone())
             .await

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
@@ -79,7 +79,7 @@ impl Policy for AuthorizationPolicy {
         let auth = generate_authorization(
             &self.credential,
             request.url(),
-            SignatureTarget::new(*request.method(), resource_link, &date_string),
+            SignatureTarget::new(request.method().clone(), resource_link, &date_string),
         )
         .await?;
 
@@ -190,7 +190,7 @@ mod tests {
             &auth_token,
             &url,
             SignatureTarget::new(
-                azure_core::Method::Get,
+                azure_core::Method::GET,
                 &ResourceLink::root(ResourceType::Databases).item("ToDoList"),
                 &date_string,
             ),
@@ -222,7 +222,7 @@ mod tests {
             &auth_token,
             &url,
             SignatureTarget::new(
-                azure_core::Method::Get,
+                azure_core::Method::GET,
                 &ResourceLink::root(ResourceType::Databases)
                     .item("MyDatabase")
                     .feed(ResourceType::Containers)
@@ -256,7 +256,7 @@ mod tests {
             &auth_token,
             &url,
             SignatureTarget::new(
-                azure_core::Method::Get,
+                azure_core::Method::GET,
                 &ResourceLink::root(ResourceType::Databases).item("ToDoList"),
                 &date_string,
             ),

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -129,7 +129,7 @@ impl CosmosPipeline {
         let mut results: Pager<OfferResults> = self.send_query_request(
             context.clone(),
             query,
-            Request::new(self.url(&offers_link), Method::Post),
+            Request::new(self.url(&offers_link), Method::POST),
             offers_link.clone(),
         )?;
         let offers = results
@@ -149,7 +149,7 @@ impl CosmosPipeline {
         let offer_url = self.url(&offer_link);
 
         // Now we can read the offer itself
-        let mut req = Request::new(offer_url, Method::Get);
+        let mut req = Request::new(offer_url, Method::GET);
         self.send(context, &mut req, offer_link).await.map(Some)
     }
 
@@ -177,7 +177,7 @@ impl CosmosPipeline {
         // NOTE: Offers API doesn't allow Enable Content Response On Write to be false, so once we support that option, we'll need to ignore it here.
         let offer_link =
             ResourceLink::root(ResourceType::Offers).item(&current_throughput.offer_id);
-        let mut req = Request::new(self.url(&offer_link), Method::Put);
+        let mut req = Request::new(self.url(&offer_link), Method::PUT);
         req.set_json(&current_throughput)?;
 
         self.send(context, &mut req, offer_link).await

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/signature_target.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/signature_target.rs
@@ -49,15 +49,15 @@ impl<'a> SignatureTarget<'a> {
             "{}\n{}\n{}\n{}\n\n",
             // Cosmos' signature algorithm requires lower-case methods, so we use our own match instead of the impl of AsRef<str>, which is uppercase.
             match self.http_method {
-                azure_core::Method::Get => "get",
-                azure_core::Method::Put => "put",
-                azure_core::Method::Post => "post",
-                azure_core::Method::Delete => "delete",
-                azure_core::Method::Head => "head",
-                azure_core::Method::Trace => "trace",
-                azure_core::Method::Options => "options",
-                azure_core::Method::Connect => "connect",
-                azure_core::Method::Patch => "patch",
+                azure_core::Method::GET => "get",
+                azure_core::Method::PUT => "put",
+                azure_core::Method::POST => "post",
+                azure_core::Method::DELETE => "delete",
+                azure_core::Method::HEAD => "head",
+                azure_core::Method::TRACE => "trace",
+                azure_core::Method::OPTIONS => "options",
+                azure_core::Method::CONNECT => "connect",
+                azure_core::Method::PATCH => "patch",
                 _ => "extension",
             },
             self.link.resource_type().path_segment(),
@@ -85,7 +85,7 @@ mod tests {
         let date_string = date::to_rfc7231(&time_nonce).to_lowercase();
 
         let ret = SignatureTarget::new(
-            azure_core::Method::Get,
+            azure_core::Method::GET,
             &ResourceLink::root(ResourceType::Databases)
                 .item("MyDatabase")
                 .feed(ResourceType::Containers)

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_items.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_items.rs
@@ -123,7 +123,7 @@ pub async fn item_create_read_replace_delete(context: TestContext) -> Result<(),
     match result {
         Ok(_) => return Err("expected a 404 error when reading the deleted item".into()),
         Err(err) => {
-            assert_eq!(Some(azure_core::StatusCode::NotFound), err.http_status());
+            assert_eq!(Some(azure_core::StatusCode::NOT_FOUND), err.http_status());
         }
     }
 
@@ -383,7 +383,7 @@ pub async fn item_null_partition_key(context: TestContext) -> Result<(), Box<dyn
     match result {
         Ok(_) => return Err("expected a 404 error when reading the deleted item".into()),
         Err(err) => {
-            assert_eq!(Some(azure_core::StatusCode::NotFound), err.http_status());
+            assert_eq!(Some(azure_core::StatusCode::NOT_FOUND), err.http_status());
         }
     }
 

--- a/sdk/identity/azure_identity/src/credentials/client_certificate_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/client_certificate_credentials.rs
@@ -240,7 +240,7 @@ impl ClientCertificateCredential {
             encoded.finish()
         };
 
-        let mut req = Request::new(url, Method::Post);
+        let mut req = Request::new(url, Method::POST);
         req.insert_header(
             headers::CONTENT_TYPE,
             content_type::APPLICATION_X_WWW_FORM_URLENCODED,

--- a/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
@@ -87,7 +87,7 @@ impl ImdsManagedIdentityCredential {
         let mut url = self.endpoint.clone();
         url.query_pairs_mut().extend_pairs(query_items);
 
-        let mut req = Request::new(url, Method::Get);
+        let mut req = Request::new(url, Method::GET);
 
         req.insert_header("metadata", "true");
 
@@ -103,13 +103,13 @@ impl ImdsManagedIdentityCredential {
 
         if !rsp_status.is_success() {
             match rsp_status {
-                StatusCode::BadRequest => {
+                StatusCode::BAD_REQUEST => {
                     return Err(Error::message(
                         ErrorKind::Credential,
                         "the requested identity has not been assigned to this resource",
                     ))
                 }
-                StatusCode::BadGateway | StatusCode::GatewayTimeout => {
+                StatusCode::BAD_GATEWAY | StatusCode::GATEWAY_TIMEOUT => {
                     return Err(Error::message(
                         ErrorKind::Credential,
                         "the request failed due to a gateway error",

--- a/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
+++ b/sdk/identity/azure_identity/src/federated_credentials_flow/mod.rs
@@ -39,7 +39,7 @@ pub async fn authorize(
             format!("The supplied tenant id could not be url encoded: {tenant_id}")
         })?;
 
-    let mut req = Request::new(url, Method::Post);
+    let mut req = Request::new(url, Method::POST);
     req.insert_header(
         headers::CONTENT_TYPE,
         content_type::APPLICATION_X_WWW_FORM_URLENCODED,

--- a/sdk/identity/azure_identity/src/refresh_token.rs
+++ b/sdk/identity/azure_identity/src/refresh_token.rs
@@ -42,7 +42,7 @@ pub async fn exchange(
         "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
     ))?;
 
-    let mut req = Request::new(url, Method::Post);
+    let mut req = Request::new(url, Method::POST);
     req.insert_header(
         headers::CONTENT_TYPE,
         content_type::APPLICATION_X_WWW_FORM_URLENCODED,

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -102,7 +102,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -133,7 +133,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -172,7 +172,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -202,7 +202,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Delete);
+        let mut request = Request::new(url, Method::DELETE);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -238,7 +238,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -267,7 +267,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -315,7 +315,7 @@ impl KeyClient {
                 }
                 None => first_url.clone(),
             };
-            let mut request = Request::new(url, Method::Get);
+            let mut request = Request::new(url, Method::GET);
             request.insert_header("accept", "application/json");
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
@@ -362,7 +362,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -393,7 +393,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -420,7 +420,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -469,7 +469,7 @@ impl KeyClient {
                 }
                 None => first_url.clone(),
             };
-            let mut request = Request::new(url, Method::Get);
+            let mut request = Request::new(url, Method::GET);
             request.insert_header("accept", "application/json");
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
@@ -532,7 +532,7 @@ impl KeyClient {
                 }
                 None => first_url.clone(),
             };
-            let mut request = Request::new(url, Method::Get);
+            let mut request = Request::new(url, Method::GET);
             request.insert_header("accept", "application/json");
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
@@ -572,7 +572,7 @@ impl KeyClient {
         url = url.join("rng")?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -604,7 +604,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -633,7 +633,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Delete);
+        let mut request = Request::new(url, Method::DELETE);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -661,7 +661,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -693,7 +693,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -726,7 +726,7 @@ impl KeyClient {
         url = url.join("keys/restore")?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -754,7 +754,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -786,7 +786,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -821,7 +821,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -856,7 +856,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Patch);
+        let mut request = Request::new(url, Method::PATCH);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -886,7 +886,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(key_rotation_policy);
@@ -922,7 +922,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -959,7 +959,7 @@ impl KeyClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);

--- a/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
@@ -211,7 +211,7 @@ async fn purge_key(ctx: TestContext) -> Result<()> {
                 println!("{name} has been purged");
                 break;
             }
-            Err(err) if matches!(err.http_status(), Some(StatusCode::Conflict)) => {
+            Err(err) if matches!(err.http_status(), Some(StatusCode::CONFLICT)) => {
                 println!(
                     "Retrying in {} seconds",
                     retry.duration().unwrap_or_default().as_secs_f32()

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
@@ -93,7 +93,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -120,7 +120,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Delete);
+        let mut request = Request::new(url, Method::DELETE);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -147,7 +147,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -193,7 +193,7 @@ impl SecretClient {
                 }
                 None => first_url.clone(),
             };
-            let mut request = Request::new(url, Method::Get);
+            let mut request = Request::new(url, Method::GET);
             request.insert_header("accept", "application/json");
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
@@ -240,7 +240,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -290,7 +290,7 @@ impl SecretClient {
                 }
                 None => first_url.clone(),
             };
-            let mut request = Request::new(url, Method::Get);
+            let mut request = Request::new(url, Method::GET);
             request.insert_header("accept", "application/json");
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
@@ -353,7 +353,7 @@ impl SecretClient {
                 }
                 None => first_url.clone(),
             };
-            let mut request = Request::new(url, Method::Get);
+            let mut request = Request::new(url, Method::GET);
             request.insert_header("accept", "application/json");
             let ctx = options.method_options.context.clone();
             let pipeline = pipeline.clone();
@@ -396,7 +396,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Delete);
+        let mut request = Request::new(url, Method::DELETE);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -423,7 +423,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         self.pipeline.send(&ctx, &mut request).await
     }
@@ -447,7 +447,7 @@ impl SecretClient {
         url = url.join("secrets/restore")?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -479,7 +479,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);
@@ -513,7 +513,7 @@ impl SecretClient {
         url = url.join(&path)?;
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
-        let mut request = Request::new(url, Method::Patch);
+        let mut request = Request::new(url, Method::PATCH);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/json");
         request.set_body(parameters);

--- a/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
@@ -200,7 +200,7 @@ async fn purge_secret(ctx: TestContext) -> Result<()> {
                 println!("{name} has been purged");
                 break;
             }
-            Err(err) if matches!(err.http_status(), Some(StatusCode::Conflict)) => {
+            Err(err) if matches!(err.http_status(), Some(StatusCode::CONFLICT)) => {
                 println!(
                     "Retrying in {} seconds",
                     retry.duration().unwrap_or_default().as_secs_f32()

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_append_blob_client.rs
@@ -44,7 +44,7 @@ impl BlobAppendBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
@@ -135,7 +135,7 @@ impl BlobAppendBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
@@ -240,7 +240,7 @@ impl BlobAppendBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "application/octet-stream");
@@ -346,7 +346,7 @@ impl BlobAppendBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_blob_client.rs
@@ -50,7 +50,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -83,7 +83,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -137,7 +137,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -188,7 +188,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -241,7 +241,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -343,7 +343,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -428,7 +428,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Delete);
+        let mut request = Request::new(url, Method::DELETE);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -486,7 +486,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Delete);
+        let mut request = Request::new(url, Method::DELETE);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -519,7 +519,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/octet-stream");
         if let Some(if_match) = options.if_match {
             request.insert_header("if-match", if_match);
@@ -599,7 +599,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -632,7 +632,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Head);
+        let mut request = Request::new(url, Method::HEAD);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/octet-stream");
         if let Some(if_match) = options.if_match {
@@ -698,7 +698,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -735,7 +735,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -800,7 +800,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -849,7 +849,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -896,7 +896,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -929,7 +929,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -1002,7 +1002,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_unmodified_since) = options.if_unmodified_since {
@@ -1051,7 +1051,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -1079,7 +1079,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -1151,7 +1151,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", transactional_content_md5);
@@ -1200,7 +1200,7 @@ impl BlobBlobClient {
         if let Some(version_id) = options.version_id {
             url.query_pairs_mut().append_pair("versionid", &version_id);
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         request.insert_header("x-ms-access-tier", tier.to_string());
@@ -1238,7 +1238,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -1337,7 +1337,7 @@ impl BlobBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_block_blob_client.rs
@@ -50,7 +50,7 @@ impl BlobBlockBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
             request.insert_header("content-md5", transactional_content_md5);
@@ -170,7 +170,7 @@ impl BlobBlockBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -210,7 +210,7 @@ impl BlobBlockBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
@@ -344,7 +344,7 @@ impl BlobBlockBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
@@ -413,7 +413,7 @@ impl BlobBlockBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "application/xml");
@@ -495,7 +495,7 @@ impl BlobBlockBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -43,7 +43,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -83,7 +83,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -121,7 +121,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -154,7 +154,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(access) = options.access {
@@ -196,7 +196,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Delete);
+        let mut request = Request::new(url, Method::DELETE);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -252,7 +252,7 @@ impl BlobContainerClient {
         if let Some(where_param) = options.where_param {
             url.query_pairs_mut().append_pair("where", &where_param);
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -278,7 +278,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -307,7 +307,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -332,7 +332,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -364,7 +364,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -398,7 +398,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -430,7 +430,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -463,7 +463,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -497,7 +497,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -536,7 +536,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_modified_since) = options.if_modified_since {
@@ -575,7 +575,7 @@ impl BlobContainerClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "multipart/mixed");
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "multipart/mixed");

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_page_blob_client.rs
@@ -48,7 +48,7 @@ impl BlobPageBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "application/octet-stream");
@@ -139,7 +139,7 @@ impl BlobPageBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -187,7 +187,7 @@ impl BlobPageBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "application/octet-stream");
@@ -305,7 +305,7 @@ impl BlobPageBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -373,7 +373,7 @@ impl BlobPageBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(if_match) = options.if_match {
@@ -435,7 +435,7 @@ impl BlobPageBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         if let Some(transactional_content_md5) = options.transactional_content_md5 {
@@ -545,7 +545,7 @@ impl BlobPageBlobClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "application/octet-stream");

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -59,7 +59,7 @@ impl BlobServiceClient {
         if let Some(where_param) = options.where_param {
             url.query_pairs_mut().append_pair("where", &where_param);
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -85,7 +85,7 @@ impl BlobServiceClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -112,7 +112,7 @@ impl BlobServiceClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -139,7 +139,7 @@ impl BlobServiceClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Get);
+        let mut request = Request::new(url, Method::GET);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -167,7 +167,7 @@ impl BlobServiceClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "application/xml");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -197,7 +197,7 @@ impl BlobServiceClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Put);
+        let mut request = Request::new(url, Method::PUT);
         request.insert_header("accept", "application/json");
         request.insert_header("content-type", "application/xml");
         if let Some(client_request_id) = options.client_request_id {
@@ -234,7 +234,7 @@ impl BlobServiceClient {
             url.query_pairs_mut()
                 .append_pair("timeout", &timeout.to_string());
         }
-        let mut request = Request::new(url, Method::Post);
+        let mut request = Request::new(url, Method::POST);
         request.insert_header("accept", "multipart/mixed");
         request.insert_header("content-length", content_length.to_string());
         request.insert_header("content-type", "multipart/mixed");

--- a/sdk/typespec/Cargo.toml
+++ b/sdk/typespec/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["typespec"]
 
 [dependencies]
 base64.workspace = true
-http-types = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 url.workspace = true
 
@@ -22,5 +22,5 @@ thiserror.workspace = true
 
 [features]
 default = ["http", "json"]
-http = ["dep:http-types"]
+http = ["dep:http"]
 json = ["dep:serde_json"]

--- a/sdk/typespec/src/error/mod.rs
+++ b/sdk/typespec/src/error/mod.rs
@@ -4,7 +4,7 @@
 //! Interfaces for working with errors.
 
 #[cfg(feature = "http")]
-use http_types::StatusCode;
+use http::StatusCode;
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Display};

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -16,7 +16,7 @@ base64.workspace = true
 bytes.workspace = true
 dyn-clone.workspace = true
 futures.workspace = true
-http-types = { workspace = true, optional = true }
+http = { workspace = true, optional = true }
 pin-project.workspace = true
 quick-xml = { workspace = true, optional = true }
 rand.workspace = true
@@ -48,7 +48,7 @@ typespec_macros.path = "../typespec_macros"
 [features]
 default = ["http", "json", "reqwest", "reqwest_deflate", "reqwest_gzip"]
 derive = ["dep:typespec_macros"]
-http = ["dep:http-types", "typespec/http"]
+http = ["dep:http", "typespec/http"]
 json = ["typespec/json"]
 reqwest = ["reqwest/native-tls"]
 reqwest_deflate = ["reqwest/deflate"]

--- a/sdk/typespec/typespec_client_core/examples/binary_data_request.rs
+++ b/sdk/typespec/typespec_client_core/examples/binary_data_request.rs
@@ -71,7 +71,7 @@ mod client {
         println!("{content}");
 
         Ok(Response::new(
-            StatusCode::NoContent,
+            StatusCode::NO_CONTENT,
             Headers::new(),
             Box::pin(BytesStream::new_empty()),
         ))

--- a/sdk/typespec/typespec_client_core/examples/stream_response.rs
+++ b/sdk/typespec/typespec_client_core/examples/stream_response.rs
@@ -67,7 +67,7 @@ mod client {
         };
 
         Ok(Response::new(
-            StatusCode::Ok,
+            StatusCode::OK,
             Headers::new(),
             Box::pin(response),
         ))
@@ -95,7 +95,7 @@ mod client {
         };
 
         Ok(Response::new(
-            StatusCode::Ok,
+            StatusCode::OK,
             Headers::new(),
             Box::pin(response),
         ))

--- a/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
@@ -42,7 +42,7 @@ impl HttpClient for ::reqwest::Client {
     async fn execute_request(&self, request: &Request) -> Result<Response> {
         let url = request.url().clone();
         let method = request.method();
-        let mut req = self.request(try_from_method(*method)?, url.clone());
+        let mut req = self.request(try_from_method(method.clone())?, url.clone());
         for (name, value) in request.headers().iter() {
             req = req.header(name.as_str(), value.as_str());
         }
@@ -102,15 +102,15 @@ fn to_headers(map: &::reqwest::header::HeaderMap) -> Headers {
 
 fn try_from_method(method: Method) -> Result<::reqwest::Method> {
     match method {
-        Method::Connect => Ok(::reqwest::Method::CONNECT),
-        Method::Delete => Ok(::reqwest::Method::DELETE),
-        Method::Get => Ok(::reqwest::Method::GET),
-        Method::Head => Ok(::reqwest::Method::HEAD),
-        Method::Options => Ok(::reqwest::Method::OPTIONS),
-        Method::Patch => Ok(::reqwest::Method::PATCH),
-        Method::Post => Ok(::reqwest::Method::POST),
-        Method::Put => Ok(::reqwest::Method::PUT),
-        Method::Trace => Ok(::reqwest::Method::TRACE),
+        Method::CONNECT => Ok(::reqwest::Method::CONNECT),
+        Method::DELETE => Ok(::reqwest::Method::DELETE),
+        Method::GET => Ok(::reqwest::Method::GET),
+        Method::HEAD => Ok(::reqwest::Method::HEAD),
+        Method::OPTIONS => Ok(::reqwest::Method::OPTIONS),
+        Method::PATCH => Ok(::reqwest::Method::PATCH),
+        Method::POST => Ok(::reqwest::Method::POST),
+        Method::PUT => Ok(::reqwest::Method::PUT),
+        Method::TRACE => Ok(::reqwest::Method::TRACE),
         _ => ::reqwest::Method::from_str(method.as_ref()).map_kind(ErrorKind::DataConversion),
     }
 }

--- a/sdk/typespec/typespec_client_core/src/http/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/mod.rs
@@ -25,7 +25,7 @@ pub use request::{Body, Request, RequestContent};
 pub use response::{Model, Response};
 
 // Re-export important types.
-pub use http_types::{Method, StatusCode};
+pub use http::{Method, StatusCode};
 pub use url::Url;
 
 /// Add a new query pair into the target [`Url`]'s query string.

--- a/sdk/typespec/typespec_client_core/src/http/pager.rs
+++ b/sdk/typespec/typespec_client_core/src/http/pager.rs
@@ -67,7 +67,7 @@ impl<T> Pager<T> {
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// # struct MyModel;
     /// let url = "https://example.com/my_paginated_api".parse().unwrap();
-    /// let mut base_req = Request::new(url, Method::Get);
+    /// let mut base_req = Request::new(url, Method::GET);
     /// let pager = Pager::from_callback(move |continuation| {
     ///     // The callback must be 'static, so you have to clone and move any values you want to use.
     ///     let pipeline = pipeline.clone();
@@ -171,7 +171,7 @@ mod tests {
             match continuation {
                 None => Ok(PagerResult::Continue {
                     response: Response::from_bytes(
-                        StatusCode::Ok,
+                        StatusCode::OK,
                         HashMap::from([(
                             HeaderName::from_static("x-test-header"),
                             HeaderValue::from_static("page-1"),
@@ -183,7 +183,7 @@ mod tests {
                 }),
                 Some("1") => Ok(PagerResult::Continue {
                     response: Response::from_bytes(
-                        StatusCode::Ok,
+                        StatusCode::OK,
                         HashMap::from([(
                             HeaderName::from_static("x-test-header"),
                             HeaderValue::from_static("page-2"),
@@ -195,7 +195,7 @@ mod tests {
                 }),
                 Some("2") => Ok(PagerResult::Complete {
                     response: Response::from_bytes(
-                        StatusCode::Ok,
+                        StatusCode::OK,
                         HashMap::from([(
                             HeaderName::from_static("x-test-header"),
                             HeaderValue::from_static("page-3"),
@@ -243,7 +243,7 @@ mod tests {
             match continuation {
                 None => Ok(PagerResult::Continue {
                     response: Response::from_bytes(
-                        StatusCode::Ok,
+                        StatusCode::OK,
                         HashMap::from([(
                             HeaderName::from_static("x-test-header"),
                             HeaderValue::from_static("page-1"),

--- a/sdk/typespec/typespec_client_core/src/http/pipeline.rs
+++ b/sdk/typespec/typespec_client_core/src/http/pipeline.rs
@@ -117,7 +117,7 @@ mod tests {
             ) -> PolicyResult {
                 let buffer = Bytes::from_static(br#"{"foo":1,"bar":"baz"}"#);
                 let stream: BytesStream = buffer.into();
-                let response = Response::new(StatusCode::Ok, Headers::new(), Box::pin(stream));
+                let response = Response::new(StatusCode::OK, Headers::new(), Box::pin(stream));
                 Ok(std::future::ready(response).await)
             }
         }
@@ -135,7 +135,7 @@ mod tests {
         };
         let pipeline = Pipeline::new(options, Vec::new(), Vec::new());
 
-        let mut request = Request::new("http://localhost".parse().unwrap(), Method::Get);
+        let mut request = Request::new("http://localhost".parse().unwrap(), Method::GET);
         let model: Model = pipeline
             .send(&Context::default(), &mut request)
             .await

--- a/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
@@ -101,12 +101,12 @@ pub trait RetryPolicy: std::fmt::Debug + Send + Sync {
 ///
 /// On all other 4xx and 5xx status codes no retry is attempted.
 const RETRY_STATUSES: &[StatusCode] = &[
-    StatusCode::RequestTimeout,
-    StatusCode::TooManyRequests,
-    StatusCode::InternalServerError,
-    StatusCode::BadGateway,
-    StatusCode::ServiceUnavailable,
-    StatusCode::GatewayTimeout,
+    StatusCode::REQUEST_TIMEOUT,
+    StatusCode::TOO_MANY_REQUESTS,
+    StatusCode::INTERNAL_SERVER_ERROR,
+    StatusCode::BAD_GATEWAY,
+    StatusCode::SERVICE_UNAVAILABLE,
+    StatusCode::GATEWAY_TIMEOUT,
 ];
 
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
@@ -148,11 +148,11 @@ where
                     // Error status code
                     let status = response.status();
 
-                    // For a 429 response (TooManyRequests) or 503 (ServiceUnavailable),
+                    // For a 429 response (TOO_MANY_REQUESTS) or 503 (SERVICE_UNAVAILABLE),
                     // use any "retry-after" headers returned by the server to determine how long to wait before retrying.
                     // https://learn.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#retry-usage-guidance
                     let retry_after = match status {
-                        StatusCode::TooManyRequests | StatusCode::ServiceUnavailable => {
+                        StatusCode::TOO_MANY_REQUESTS | StatusCode::SERVICE_UNAVAILABLE => {
                             get_retry_after(response.headers(), OffsetDateTime::now_utc)
                         }
                         _ => None,

--- a/sdk/typespec/typespec_client_core/src/http/policies/transport.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/transport.rs
@@ -8,7 +8,7 @@ use crate::http::{
     Context, Header, Request,
 };
 use async_trait::async_trait;
-use http_types::Method;
+use http::Method;
 use std::sync::Arc;
 use tracing::debug;
 
@@ -38,7 +38,7 @@ impl Policy for TransportPolicy {
         if request.body().is_empty()
             && matches!(
                 *request.method(),
-                Method::Patch | Method::Post | Method::Put
+                Method::PATCH | Method::POST | Method::PUT
             )
         {
             request.add_mandatory_header(EMPTY_CONTENT_LENGTH);
@@ -68,7 +68,7 @@ impl Header for EmptyContentLength {
 mod tests {
     use super::*;
     use crate::http::{headers::Headers, Response};
-    use http_types::StatusCode;
+    use http::StatusCode;
 
     #[derive(Debug)]
     struct MockTransport;
@@ -82,7 +82,7 @@ mod tests {
             _next: &[Arc<dyn Policy>],
         ) -> PolicyResult {
             PolicyResult::Ok(Response::from_bytes(
-                StatusCode::Ok,
+                StatusCode::OK,
                 Headers::new(),
                 Vec::new(),
             ))
@@ -94,12 +94,12 @@ mod tests {
         let transport =
             TransportPolicy::new(TransportOptions::new_custom_policy(Arc::new(MockTransport)));
 
-        let mut request = Request::new("http://localhost".parse()?, Method::Get);
+        let mut request = Request::new("http://localhost".parse()?, Method::GET);
         transport.send(&Context::new(), &mut request, &[]).await?;
         assert!(!request.headers().iter().any(|h| CONTENT_LENGTH.eq(h.0)));
 
         request.headers = Headers::new();
-        request.method = Method::Patch;
+        request.method = Method::PATCH;
         transport.send(&Context::new(), &mut request, &[]).await?;
         assert_eq!(
             request
@@ -110,7 +110,7 @@ mod tests {
         );
 
         request.headers = Headers::new();
-        request.method = Method::Post;
+        request.method = Method::POST;
         transport.send(&Context::new(), &mut request, &[]).await?;
         assert_eq!(
             request
@@ -121,7 +121,7 @@ mod tests {
         );
 
         request.headers = Headers::new();
-        request.method = Method::Put;
+        request.method = Method::PUT;
         transport.send(&Context::new(), &mut request, &[]).await?;
         assert_eq!(
             request

--- a/sdk/typespec/typespec_client_core/src/http/response.rs
+++ b/sdk/typespec/typespec_client_core/src/http/response.rs
@@ -143,7 +143,7 @@ impl<T> Response<T> {
     /// # #[tokio::main]
     /// # async fn main() {
     /// #    let r: Response<GetSecretResponse> = typespec_client_core::http::Response::from_bytes(
-    /// #      http_types::StatusCode::Ok,
+    /// #      http_types::StatusCode::OK,
     /// #      typespec_client_core::http::headers::Headers::new(),
     /// #      "{\"name\":\"database_password\",\"value\":\"hunter2\"}",
     /// #    );
@@ -185,7 +185,7 @@ impl<T> Response<T> {
     /// # #[tokio::main]
     /// # async fn main() {
     /// #    let r: Response<GetSecretResponse> = typespec_client_core::http::Response::from_bytes(
-    /// #      http_types::StatusCode::Ok,
+    /// #      http_types::StatusCode::OK,
     /// #      typespec_client_core::http::headers::Headers::new(),
     /// #      "<Response><name>database_password</name><value>hunter2</value></Response>",
     /// #    );
@@ -233,7 +233,7 @@ impl<T: Model> Response<T> {
     /// # impl SecretClient {
     /// #   pub async fn get_secret(&self) -> typespec_client_core::http::Response<GetSecretResponse> {
     /// #    typespec_client_core::http::Response::from_bytes(
-    /// #      http_types::StatusCode::Ok,
+    /// #      http_types::StatusCode::OK,
     /// #      typespec_client_core::http::headers::Headers::new(),
     /// #      "{\"name\":\"database_password\",\"value\":\"hunter2\"}",
     /// #    )
@@ -247,7 +247,7 @@ impl<T: Model> Response<T> {
     /// # async fn main() {
     /// let secret_client = create_secret_client();
     /// let response = secret_client.get_secret().await;
-    /// assert_eq!(response.status(), http_types::StatusCode::Ok);
+    /// assert_eq!(response.status(), http_types::StatusCode::OK);
     /// let model = response.into_body().await.unwrap();
     /// assert_eq!(model.name, "database_password");
     /// assert_eq!(model.value, "hunter2");
@@ -348,7 +348,7 @@ impl fmt::Debug for ResponseBody {
 mod tests {
     use crate::http::headers::Headers;
     use crate::http::{response::ResponseBody, Model, Response};
-    use http_types::StatusCode;
+    use http::StatusCode;
 
     #[tokio::test]
     pub async fn can_extract_raw_body_regardless_of_t() -> Result<(), Box<dyn std::error::Error>> {
@@ -361,14 +361,14 @@ mod tests {
 
         {
             let response_raw: Response =
-                Response::from_bytes(StatusCode::Ok, Headers::new(), b"Hello".as_slice());
+                Response::from_bytes(StatusCode::OK, Headers::new(), b"Hello".as_slice());
             let body = response_raw.into_raw_body();
             assert_eq!(b"Hello", &*body.collect().await?);
         }
 
         {
             let response_t: Response<MyModel> =
-                Response::from_bytes(StatusCode::Ok, Headers::new(), b"Hello".as_slice())
+                Response::from_bytes(StatusCode::OK, Headers::new(), b"Hello".as_slice())
                     .with_default_deserialize_type();
             let body = response_t.into_raw_body();
             assert_eq!(b"Hello", &*body.collect().await?);
@@ -380,7 +380,7 @@ mod tests {
     mod json {
         use crate::http::headers::Headers;
         use crate::http::Response;
-        use http_types::StatusCode;
+        use http::StatusCode;
         use serde::Deserialize;
         use typespec_macros::Model;
 
@@ -404,7 +404,7 @@ mod tests {
         /// A sample service client function.
         fn get_secret() -> Response<GetSecretResponse> {
             Response::from_bytes(
-                StatusCode::Ok,
+                StatusCode::OK,
                 Headers::new(),
                 r#"{"name":"my_secret","value":"my_value"}"#,
             )
@@ -413,7 +413,7 @@ mod tests {
         /// A sample service client function to return a list of secrets.
         fn list_secrets() -> Response<GetSecretListResponse> {
             Response::from_bytes(
-                StatusCode::Ok,
+                StatusCode::OK,
                 Headers::new(),
                 r#"{"value":[{"name":"my_secret","value":"my_value"}],"nextLink":"?page=2"}"#,
             )
@@ -451,13 +451,13 @@ mod tests {
             let bytes = body.collect().await.expect("collect response");
             let model: GetSecretListResponse =
                 crate::json::from_json(bytes.clone()).expect("deserialize GetSecretListResponse");
-            assert_eq!(status, StatusCode::Ok);
+            assert_eq!(status, StatusCode::OK);
             assert_eq!(model.value.len(), 1);
             assert_eq!(model.next_link, Some("?page=2".to_string()));
 
             let response: Response<GetSecretListResponse> =
                 Response::from_bytes(status, headers, bytes);
-            assert_eq!(response.status(), StatusCode::Ok);
+            assert_eq!(response.status(), StatusCode::OK);
             let model = response
                 .into_body()
                 .await
@@ -470,7 +470,7 @@ mod tests {
     mod xml {
         use crate::http::headers::Headers;
         use crate::http::Response;
-        use http_types::StatusCode;
+        use http::StatusCode;
         use serde::Deserialize;
         use typespec_macros::Model;
 
@@ -486,7 +486,7 @@ mod tests {
         /// A sample service client function.
         fn get_secret() -> Response<GetSecretResponse> {
             Response::from_bytes(
-                StatusCode::Ok,
+                StatusCode::OK,
                 Headers::new(),
                 "<GetSecretResponse><name>my_secret</name><value>my_value</value></GetSecretResponse>",
             )


### PR DESCRIPTION
As mentioned in https://github.com/Azure/azure-sdk-for-rust/pull/1937, `http-types` is not being maintained (and neither are some its dependencies).

This replaces it with the `http` crate which seems to be the ecosystem standard (10x more recent downloads).