### PR TITLE
[Cosmos] reduce azure_data_cosmos to 5 keywords

### DIFF
--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 rust-version.workspace = true
 homepage = "https://github.com/azure/azure-sdk-for-rust"
 documentation = "https://docs.rs/azure_data_cosmos"
-keywords = ["sdk", "azure", "rest", "cloud", "cosmos", "database"]
+keywords = ["sdk", "azure", "rest", "cloud", "cosmos"]
 categories = ["api-bindings"]
 
 [dependencies]


### PR DESCRIPTION
>Note: [crates.io](https://crates.io/) allows a **maximum of 5 keywords**. Each keyword must be ASCII text, have at most 20 characters, start with an alphanumeric character, and only contain letters, numbers, _, - or +.
> 
> https://doc.rust-lang.org/cargo/reference/manifest.html#the-keywords-field

🤦🏻‍♀️ 

I guess I didn't think to check that, and the `--dry-run` we do doesn't seem to verify it.

For now, I'm just removing the `database` keyword. We can always revise these later if we decide to swap out one of the existing keywords for something else. Most of the other keywords we have are shared among other `azure_` crates.