### PR TITLE
Remove labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report a bug in the Azure SDK for Rust
-labels: ["needs-triage"]
 type: "Bug"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: Suggest an idea for this project
-labels: ["needs-triage"]
 type: "Feature"
 
 body:


### PR DESCRIPTION
Remove labels from issue templates as it interferes with the labeling actions.