### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@
 /eng/common/             @Azure/azure-sdk-eng
 /.github/workflows/      @Azure/azure-sdk-eng
 /.github/CODEOWNERS      @RickWinter @ronniegeraghty @Azure/azure-sdk-eng
+/.config/1espt/          @benbp @weshaggard
 
 # Add owners for notifications for specific pipelines
 /eng/common/pipelines/codeowners-linter.yml       @rickwinter


### PR DESCRIPTION
Add owner for the 1espt config paths.

FYI @heaths @RickWinter this should take you guys off the auto-baselining PRs.