### PR TITLE
[cosmos] use version-only references to avoid broken publish rewriting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ version = "0.22.0"
 dependencies = [
  "async-lock",
  "async-trait",
- "azure_identity",
+ "azure_identity 0.22.0",
  "azure_security_keyvault_secrets",
  "bytes",
  "futures",
@@ -274,15 +274,39 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_client_core",
+ "typespec 0.2.0",
+ "typespec_client_core 0.1.0",
+]
+
+[[package]]
+name = "azure_core"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c749d6035e8835014fa4897173792d772f0a65fac32e57c3cd9d676c8114e8a"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "bytes",
+ "futures",
+ "hmac",
+ "once_cell",
+ "openssl",
+ "paste",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tracing",
+ "typespec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typespec_client_core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "azure_core_amqp"
 version = "0.1.0"
 dependencies = [
- "azure_core",
+ "azure_core 0.22.0",
  "fe2o3-amqp",
  "fe2o3-amqp-cbs",
  "fe2o3-amqp-ext",
@@ -294,7 +318,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
+ "typespec 0.2.0",
 ]
 
 [[package]]
@@ -302,9 +326,9 @@ name = "azure_core_test"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.22.0",
  "azure_core_test_macros",
- "azure_identity",
+ "azure_identity 0.22.0",
  "azure_security_keyvault_secrets",
  "clap",
  "futures",
@@ -315,7 +339,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec_client_core",
+ "typespec_client_core 0.1.0",
  "url",
  "uuid",
 ]
@@ -324,7 +348,7 @@ dependencies = [
 name = "azure_core_test_macros"
 version = "0.1.0"
 dependencies = [
- "azure_core",
+ "azure_core 0.22.0",
  "azure_core_test",
  "proc-macro2",
  "quote",
@@ -334,12 +358,12 @@ dependencies = [
 
 [[package]]
 name = "azure_data_cosmos"
-version = "0.23.0"
+version = "0.22.1"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap",
  "futures",
  "reqwest",
@@ -349,7 +373,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec_client_core",
+ "typespec_client_core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
 ]
 
@@ -360,7 +384,7 @@ dependencies = [
  "async-lock",
  "async-process",
  "async-trait",
- "azure_core",
+ "azure_core 0.22.0",
  "azure_security_keyvault_secrets",
  "clap",
  "futures",
@@ -375,7 +399,28 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec_client_core",
+ "typespec_client_core 0.1.0",
+ "tz-rs",
+ "url",
+]
+
+[[package]]
+name = "azure_identity"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc50602247671f7c7e59520b6d6ee78cc8c409cfd796d28fd4a084db9c9791b"
+dependencies = [
+ "async-lock",
+ "async-process",
+ "async-trait",
+ "azure_core 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "oauth2",
+ "pin-project",
+ "serde",
+ "time",
+ "tracing",
+ "typespec_client_core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tz-rs",
  "url",
 ]
@@ -385,11 +430,10 @@ name = "azure_messaging_eventhubs"
 version = "0.2.0"
 dependencies = [
  "async-stream",
- "async-trait",
- "azure_core",
+ "azure_core 0.22.0",
  "azure_core_amqp",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.22.0",
  "futures",
  "rustc_version",
  "time",
@@ -402,9 +446,9 @@ dependencies = [
 name = "azure_security_keyvault_keys"
 version = "0.2.0"
 dependencies = [
- "azure_core",
+ "azure_core 0.22.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.22.0",
  "azure_security_keyvault_test",
  "futures",
  "rand 0.8.5",
@@ -414,16 +458,16 @@ dependencies = [
  "sha2",
  "time",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 0.1.0",
 ]
 
 [[package]]
 name = "azure_security_keyvault_secrets"
 version = "0.2.0"
 dependencies = [
- "azure_core",
+ "azure_core 0.22.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.22.0",
  "azure_security_keyvault_test",
  "futures",
  "rand 0.8.5",
@@ -432,7 +476,7 @@ dependencies = [
  "serde_json",
  "time",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 0.1.0",
 ]
 
 [[package]]
@@ -447,14 +491,14 @@ name = "azure_storage_blob"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "azure_core",
+ "azure_core 0.22.0",
  "azure_core_test",
- "azure_identity",
+ "azure_identity 0.22.0",
  "azure_storage_common",
  "serde",
  "time",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 0.1.0",
  "url",
  "uuid",
 ]
@@ -2936,6 +2980,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "typespec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f39c392e9cb463e8f1f9b86d2d5934ef391ee83724095e7f813aa0202e4e8d3b"
+dependencies = [
+ "base64 0.22.1",
+ "http-types",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "typespec_client_core"
 version = "0.1.0"
 dependencies = [
@@ -2957,8 +3013,35 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typespec",
- "typespec_macros",
+ "typespec 0.2.0",
+ "typespec_macros 0.1.0",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0839582d301a1ba457905b6940f10879ff16b43b98ff66477cb4a44cbea81a92"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "getrandom 0.2.15",
+ "http-types",
+ "pin-project",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typespec_macros 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url",
  "uuid",
 ]
@@ -2974,7 +3057,18 @@ dependencies = [
  "serde_json",
  "syn",
  "tokio",
- "typespec_client_core",
+ "typespec_client_core 0.1.0",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c71455f35c6aa14e033a4dcf79fc5798d97acb8ce583d21ca29e0faaf929411"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/eng/scripts/Language-Settings.ps1
+++ b/eng/scripts/Language-Settings.ps1
@@ -132,7 +132,7 @@ function Get-rust-AdditionalValidationPackagesFromPackageSet ($packagesWithChang
   [array]$additionalPackages = $affectedPackages | Where-Object { $packagesWithChanges -notcontains $_ }
 
   # if the change affected no packages, e.g. eng/common change, we use core and template for validation
-  if ($additionalPackages.Length -eq 0) {
+  if ($packagesWithChanges.Length -eq 0) {
     $additionalPackages += $allPackageProperties | Where-Object { $_.Name -eq "azure_core" -or $_.Name -eq "azure_template" }
   }
 

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -7,7 +7,8 @@
 ### Breaking Changes
 
 ### Bugs Fixed
-* Fixed a publishing issue that caused the `key_auth` feature to be omitted. [#2241](https://github.com/Azure/azure-sdk-for-rust/issues/2241)
+
+* Fixed a publishing issue that caused the `key_auth` feature to be omitted. ([#2241](https://github.com/Azure/azure-sdk-for-rust/issues/2241))
 
 ### Other Changes
 
@@ -15,4 +16,4 @@
 
 ### Features Added
 
-- Initial supported release.
+* Initial supported release.

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Release History
 
-## 0.23.0 (Unreleased)
+## 0.22.1 (Unreleased)
 
 ### Features Added
 
 ### Breaking Changes
 
 ### Bugs Fixed
+* Fixed a publishing issue that caused the `key_auth` feature to be omitted. [#2241](https://github.com/Azure/azure-sdk-for-rust/issues/2241)
 
 ### Other Changes
 

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -1,16 +1,10 @@
 # Release History
 
-## 0.22.1 (Unreleased)
-
-### Features Added
-
-### Breaking Changes
+## 0.22.1 (2025-03-05)
 
 ### Bugs Fixed
 
 * Fixed a publishing issue that caused the `key_auth` feature to be omitted. ([#2241](https://github.com/Azure/azure-sdk-for-rust/issues/2241))
-
-### Other Changes
 
 ## 0.22.0 (2025-02-25)
 

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -25,7 +25,7 @@ url.workspace = true
 
 [dev-dependencies]
 azure_identity = "0.22.0"
-azure_core_test = "0.1.0"
+azure_core_test.workspace = true
 clap.workspace = true
 reqwest.workspace = true
 time.workspace = true

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azure_data_cosmos"
-version = "0.23.0"
+version = "0.22.1"
 description = "Rust wrappers around Microsoft Azure REST APIs - Azure Cosmos DB"
 readme = "README.md"
 authors.workspace = true
@@ -15,17 +15,17 @@ categories = ["api-bindings"]
 
 [dependencies]
 async-trait.workspace = true
-azure_core.workspace = true
+azure_core = "0.22.0"
 futures.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 tracing.workspace = true
-typespec_client_core = { workspace = true, features = ["derive"] }
+typespec_client_core = { version = "0.1.0", features = ["derive"] }
 url.workspace = true
 
 [dev-dependencies]
-azure_identity.path = "../../identity/azure_identity"
-azure_core_test.path = "../../core/azure_core_test"
+azure_identity = "0.22.0"
+azure_core_test = "0.1.0"
 clap.workspace = true
 reqwest.workspace = true
 time.workspace = true

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -25,7 +25,7 @@ url.workspace = true
 
 [dev-dependencies]
 azure_identity = "0.22.0"
-azure_core_test.workspace = true
+azure_core_test.path = "../../core/azure_core_test"
 clap.workspace = true
 reqwest.workspace = true
 time.workspace = true

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -36,11 +36,10 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 workspace = true
 
 [features]
+default = ["hmac_rust"]
+key_auth = [] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
-key_auth = [
-] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
-default = ["hmac_rust"]
 
 [package.metadata.docs.rs]
 features = ["key_auth"]


### PR DESCRIPTION
This is a somewhat-temporary workaround to fix #2241 so we can publish a version of the package with the `key_auth` feature.

The current publishing code rewrites any dependency with a `path` key (i.e. referencing a crate in the repository, like `azure_core`) so that it instead references the latest released (or to-be-released) version. This rewriting code is written in PowerShell and deserializes/reserializes Cargo.toml. Due to a bug in Tomlyn (https://github.com/xoofx/Tomlyn/issues/98), empty TOML arrays can be lost during this serialization process, which is what caused us to lose the `key_auth` feature.

The quick-fix here is to remove the `path` references and depend _solely_ on released versions of `azure_`/`typespec_` crates. As we continue, this may cause issues if we want to depend on features that are still being developed in-repo, but for now, this is just fine and matches user expectations.

My plan is to release this as a patch release (0.22.1) ASAP, if it works properly. I should be able to tell from the output of the Pack Crates step (which currently reports warnings due to the missing `key_auth` feature, which I'm looking at turning to errors in a separate PR).