### PR TITLE
Add ClientAssertionCredential

### DIFF
--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -69,6 +69,59 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+### Authenticate with `ClientAssertionCredential`
+
+This example demonstrates how to use the `ClientAssertionCredential` in conjunction with `VirtualMachineManagedIdentityCredential` in order to retrieve an access token as an app registration
+that a virtual machine identity has been federated for, which can be used in "service to service"
+authentication flows. For more details on this scenario see [Configure an application to trust a managed identity](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center)
+
+```rust no_run
+use azure_core::credentials::{AccessToken, TokenCredential};
+use azure_identity::{ClientAssertionCredential, ImdsId, VirtualMachineManagedIdentityCredential};
+
+#[derive(Debug)]
+struct VmClientAssertion {
+    credential: Arc<dyn TokenCredential>,
+    scope: String,
+}
+
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+impl ClientAssertion for VmClientAssertion {
+    async fn secret(&self) -> azure_core::Result<String> {
+        Ok(self
+            .credential
+            .get_token(&[&self.scope])
+            .await?
+            .token
+            .secret()
+            .to_string())
+    }
+}
+
+async fn get_federated_token() -> azure_core::Result<AccessToken> {
+    let assertion = VmClientAssertion {
+        credential: VirtualMachineManagedIdentityCredential::new(
+            ImdsId::SystemAssigned,
+            TokenCredentialOptions::default(),
+        )?,
+        scope: String::from("api://AzureADTokenExchange/.default"),
+    };
+
+    let client_assertion_credential = ClientAssertionCredential::new(
+        azure_core::new_http_client(),
+        Url::parse("https://login.microsoftonline.com")?,
+        String::from("guid-for-aad-tenant-id"),
+        String::from("guid-for-app-id-of-client-app-registration"),
+        assertion,
+    )?;
+
+    let fic_scope = String::from("your-service-app.com/scope");
+    client_assertion_credential.get_token(&[&fic_scope]).await
+}
+
+```
+
 
 ## Credential classes
 

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -77,7 +77,8 @@ authentication flows. For more details on this scenario see [Configure an applic
 
 ```rust no_run
 use azure_core::credentials::{AccessToken, TokenCredential};
-use azure_identity::{ClientAssertionCredential, ImdsId, VirtualMachineManagedIdentityCredential};
+use azure_identity::{ClientAssertion, ClientAssertionCredential, ImdsId, TokenCredentialOptions, VirtualMachineManagedIdentityCredential};
+use std::sync::Arc;
 
 #[derive(Debug)]
 struct VmClientAssertion {
@@ -111,7 +112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let client_assertion_credential = ClientAssertionCredential::new(
         azure_core::new_http_client(),
-        Url::parse("https://login.microsoftonline.com")?,
+        azure_core::Url::parse("https://login.microsoftonline.com")?,
         String::from("guid-for-aad-tenant-id"),
         String::from("guid-for-app-id-of-client-app-registration"),
         assertion,

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -99,8 +99,9 @@ impl ClientAssertion for VmClientAssertion {
     }
 }
 
-async fn get_federated_token() -> azure_core::Result<AccessToken> {
-    let assertion = VmClientAssertion {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let assertion = VmClientAssertion {
         credential: VirtualMachineManagedIdentityCredential::new(
             ImdsId::SystemAssigned,
             TokenCredentialOptions::default(),
@@ -117,7 +118,8 @@ async fn get_federated_token() -> azure_core::Result<AccessToken> {
     )?;
 
     let fic_scope = String::from("your-service-app.com/scope");
-    client_assertion_credential.get_token(&[&fic_scope]).await
+    let fic_token = client_assertion_credential.get_token(&[&fic_scope]).await?;
+    Ok(())
 }
 
 ```

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -73,7 +73,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 This example demonstrates how to use the `ClientAssertionCredential` in conjunction with `VirtualMachineManagedIdentityCredential` in order to retrieve an access token as an app registration
 that a virtual machine identity has been federated for, which can be used in "service to service"
-authentication flows. For more details on this scenario see [Configure an application to trust a managed identity](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center)
+authentication flows. For more details on this scenario see [Configure an application to trust a managed identity](https://learn.microsoft.com/entra/workload-id/workload-identity-federation-config-app-trust-managed-identity?tabs=microsoft-entra-admin-center)
 
 ```rust no_run
 use azure_core::credentials::{AccessToken, TokenCredential};

--- a/sdk/identity/azure_identity/src/credentials/mod.rs
+++ b/sdk/identity/azure_identity/src/credentials/mod.rs
@@ -12,6 +12,7 @@ mod app_service_managed_identity_credential;
 #[cfg(not(target_arch = "wasm32"))]
 mod azure_cli_credentials;
 mod cache;
+mod client_assertion_credentials;
 #[cfg(feature = "client_certificate")]
 mod client_certificate_credentials;
 mod default_credentials;
@@ -23,6 +24,7 @@ mod workload_identity_credentials;
 pub use app_service_managed_identity_credential::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use azure_cli_credentials::*;
+pub use client_assertion_credentials::*;
 #[cfg(feature = "client_certificate")]
 pub use client_certificate_credentials::*;
 pub use default_credentials::*;


### PR DESCRIPTION
Most azure-identity sdks split out the central logic currently contained in WorkloadIdentityCredential into a ClientAssertionCredential. Doing so allows users to create alternative ways of supplying a client assertion besides those supported by WorkloadIdentityCredential.

This PR moves the central logic of WorkloadIdentityCredential into a ClientAssertionCredential and refactors the WorkloadIdentityCredential to use ClientAssertionCredential. Under the covers, the rust implementation of WorkloadIdentityCredential was already incredibly close to supporting this, and had an internal Token that created the central api that a ClientAssertionCredential would need: an async function to retrieve the secret jwt token string. This moves that internal api into a publicly accessible ClientAssertion trait and changes the internals of WorkloadIdentityCredential to implement that trait for Token instead of having its implementation be a part of implementing Token.