### PR TITLE
Trace stdout from test-proxy

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.0"
+channel = "stable"
 components = [
   "rustc",
   "rustfmt",

--- a/sdk/core/azure_core_test/README.md
+++ b/sdk/core/azure_core_test/README.md
@@ -105,6 +105,26 @@ cargo test
 If you get errors, they could indicate regressions in your tests or perhaps variables or random data wasn't saved correctly.
 Review any data you generate or use not coming from the service.
 
+## Troubleshooting
+
+Like all Azure SDK client libraries, the `azure_core_test` crate writes information with the target rooted in the crate name
+followed by any modules in which the span was created e.g., `azure_core_test::proxy`.
+Because this crate is used to test Azure SDK client libraries and developers will most likely want to see fewer traces from this crate,
+the log levels used are a level lower than typical client libraries:
+
+- `INFO` includes only important information e.g., the version of `test-proxy` and on what port it's listening.
+- `DEBUG` includes when a test recording or playback has started and stopped.
+- `TRACE` includes details like communications with the `test-proxy` itself.
+
+The `azure_core_test` crate also traces useful information that the `test-proxy` process itself writes to `stdout` using the `test-proxy` target and the `TRACE` logging level.
+
+You can configuring using the [`RUST_LOG`](https://docs.rs/env_logger) environment variable.
+For example, if you wanted to see debug information from all sources by default but see `test-proxy` messages written to `stdout` you'd run:
+
+```bash
+RUST_LOG=debug,test-proxy=trace cargo test
+```
+
 [PowerShell]: https://learn.microsoft.com/powershell/scripting/install/installing-powershell
 [Test Proxy]: https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
 [Test Resources]: https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/TestResources/README.md

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -33,27 +33,29 @@ pub use bootstrap::start;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod bootstrap {
-    use super::*;
-    use azure_core::{test::TestMode, Result};
-    use serde_json::json;
-    use std::{env, io, path::Path, process::Stdio, time::Duration};
-    use tokio::{
+    pub(super) use super::*;
+    pub(super) use azure_core::{test::TestMode, Result};
+    pub(super) use serde_json::json;
+    pub(super) use std::{env, io, path::Path, process::Stdio, time::Duration};
+    pub(super) use tokio::{
         fs,
         io::{AsyncBufReadExt, BufReader},
         process::{ChildStdout, Command},
     };
 
     // cspell:ignore aspnetcore devcert teamprojectid testproxy
-    const KESTREL_CERT_PATH_ENV: &str = "ASPNETCORE_Kestrel__Certificates__Default__Path";
-    const KESTREL_CERT_PASSWORD_ENV: &str = "ASPNETCORE_Kestrel__Certificates__Default__Password";
-    const KESTREL_CERT_PASSWORD: &str = "password";
-    const PROXY_MANUAL_START: &str = "PROXY_MANUAL_START";
-    const SYSTEM_TEAMPROJECTID: &str = "SYSTEM_TEAMPROJECTID";
-    const MIN_VERSION: Version = Version {
+    pub(super) const KESTREL_CERT_PATH_ENV: &str =
+        "ASPNETCORE_Kestrel__Certificates__Default__Path";
+    pub(super) const KESTREL_CERT_PASSWORD_ENV: &str =
+        "ASPNETCORE_Kestrel__Certificates__Default__Password";
+    pub(super) const KESTREL_CERT_PASSWORD: &str = "password";
+    pub(super) const MIN_VERSION: Version = Version {
         major: 20241213,
         minor: 1,
         metadata: None,
     };
+    const PROXY_MANUAL_START: &str = "PROXY_MANUAL_START";
+    const SYSTEM_TEAMPROJECTID: &str = "SYSTEM_TEAMPROJECTID";
 
     /// Starts the test-proxy.
     ///
@@ -68,7 +70,7 @@ mod bootstrap {
             tracing::warn!(
                 "environment variable {PROXY_MANUAL_START} is 'true'; not starting test-proxy"
             );
-            return Ok(Proxy::default());
+            return Ok(Proxy::existing());
         }
 
         // Find root of git repo or work tree: a ".git" directory or file will exist either way.
@@ -82,12 +84,44 @@ mod bootstrap {
         );
 
         // Create an assets.json file in the crate_dir if a parent doesn't already exist.
-        #[cfg(not(target_arch = "wasm32"))]
+        ensure_assets_file(test_mode, crate_dir).await?;
+
+        // Construct the command line arguments and start the test-proxy service.
+        let mut args: Vec<String> = Vec::new();
+        args.extend_from_slice(&[
+            "start".into(),
+            "--storage-location".into(),
+            git_dir
+                .to_str()
+                .ok_or_else(|| ErrorKind::Other.into_error())?
+                .into(),
+        ]);
+        options.unwrap_or_default().copy_to(&mut args);
+
+        let mut proxy = Proxy::default();
+        let max_seconds = Duration::from_secs(env::var(SYSTEM_TEAMPROJECTID).map_or(5, |_| 20));
+        tokio::select! {
+            _ = proxy.start(git_dir, args.into_iter()) => {
+                proxy.endpoint()
+            }
+            _ = tokio::time::sleep(max_seconds) => {
+                proxy.stop().await?;
+                return Err(azure_core::Error::message(ErrorKind::Other, "timed out waiting for test-proxy to start"));
+            },
+        };
+
+        Ok(proxy)
+    }
+
+    async fn ensure_assets_file(
+        test_mode: Option<TestMode>,
+        crate_dir: impl AsRef<Path>,
+    ) -> Result<()> {
         if test_mode == Some(TestMode::Record)
             && matches!(crate::find_ancestor_file(crate_dir.as_ref(), "assets.json"), Err(err) if err.kind() == &ErrorKind::Io)
         {
             let assets_file = crate_dir.as_ref().join("assets.json");
-            tracing::trace!("creating {path}", path = assets_file.display());
+            tracing::debug!("creating {path}", path = assets_file.display());
 
             let assets_dir = assets_file
                 .parent()
@@ -107,67 +141,97 @@ mod bootstrap {
                 "Tag": "",
             });
             let file = fs::File::create_new(assets_file).await?;
-            serde_json::to_writer_pretty(file.into_std().await, &assets_content)?;
+            return serde_json::to_writer_pretty(file.into_std().await, &assets_content)
+                .map_err(azure_core::Error::from);
         }
 
-        // Construct the command line arguments and start the test-proxy service.
-        let mut args: Vec<String> = Vec::new();
-        args.extend_from_slice(&[
-            "start".into(),
-            "--storage-location".into(),
-            git_dir
-                .to_str()
-                .ok_or_else(|| ErrorKind::Other.into_error())?
-                .into(),
-        ]);
-        options.unwrap_or_default().copy_to(&mut args);
-        args.extend_from_slice(&["--", "--urls", "http://0.0.0.0:0"].map(Into::into));
+        Ok(())
+    }
 
+    pub(super) fn trace_line(line: &str) {
+        if !line.starts_with('[') {
+            let line = line.trim();
+            tracing::trace!(target: "test-proxy", "{line}");
+        }
+    }
+}
+
+/// Represents the running `test-proxy` service.
+#[derive(Debug, Default)]
+pub struct Proxy {
+    #[cfg(not(target_arch = "wasm32"))]
+    command: Option<Child>,
+    endpoint: Option<Url>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+use bootstrap::*;
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Proxy {
+    async fn start<I: Iterator<Item = String>>(&mut self, git_dir: &Path, args: I) -> Result<()> {
         let mut command = Command::new("test-proxy")
-            .args(args.iter())
+            .args(args)
             .env(
                 KESTREL_CERT_PATH_ENV,
                 git_dir.join("eng/common/testproxy/dotnet-devcert.pfx"),
             )
             .env(KESTREL_CERT_PASSWORD_ENV, KESTREL_CERT_PASSWORD)
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
+            .stderr(Stdio::inherit())
             .spawn()
-            .map_err(|e| azure_core::Error::full(ErrorKind::Io, e, "test-proxy not found"))?;
+            .map_err(|err| azure_core::Error::full(ErrorKind::Io, err, "test-proxy not found"))?;
+
+        let mut stdout = command
+            .stdout
+            .take()
+            .ok_or_else(|| azure_core::Error::message(ErrorKind::Io, "no stdout pipe"))?;
+        self.command = Some(command);
 
         // Wait until the service is listening on a port.
-        let mut stdout = command.stdout.take();
-        let max_seconds = Duration::from_secs(env::var(SYSTEM_TEAMPROJECTID).map_or(5, |_| 20));
-        let url = tokio::select! {
-            v = wait_till_listening(command.id(), &mut stdout) => { v? },
-            _ = tokio::time::sleep(max_seconds) => {
-                command.kill().await?;
-                return Err(azure_core::Error::message(ErrorKind::Other, "timed out waiting for test-proxy to start"));
-            },
-        };
+        self.wait_till_listening(&mut stdout).await?;
 
-        Ok(Proxy {
-            command: Some(command),
-            url,
-        })
+        // Then spawn a thread to keep pumping messages to stdout.
+        // The pipe will be closed when the process is shut down, which will terminate the task.
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(&mut stdout).lines();
+            while let Some(line) = reader.next_line().await.unwrap_or(None) {
+                // Trace useful lines that test-proxy writes to stdout.
+                trace_line(&line);
+            }
+        });
+
+        Ok(())
     }
 
-    async fn wait_till_listening(
-        pid: Option<u32>,
-        stdout: &mut Option<ChildStdout>,
-    ) -> Result<Url> {
-        let Some(stdout) = stdout else {
-            return Err(azure_core::Error::message(
-                ErrorKind::Io,
-                "test-proxy stdout not captured",
-            ));
-        };
+    /// Attempts to stop the service.
+    ///
+    /// Waits until the process is killed.
+    pub async fn stop(&mut self) -> Result<()> {
+        if let Some(command) = &mut self.command {
+            tracing::debug!(pid = ?command.id(), "stopping");
+            return Ok(command.kill().await?);
+        }
+        Ok(())
+    }
 
-        // Wait for the process to respond to requests and check output until pattern: "Now listening on: http://0.0.0.0:60583" (random port).
+    /// Waits for the Test Proxy service to exit, return the process exit code when completed.
+    pub async fn wait(&mut self) -> Result<ExitStatus> {
+        if let Some(command) = &mut self.command {
+            return Ok(command.wait().await?);
+        }
+        Ok(ExitStatus::default())
+    }
+
+    async fn wait_till_listening(&mut self, stdout: &mut ChildStdout) -> Result<()> {
+        let pid = self.command.as_ref().and_then(Child::id);
         let mut reader = BufReader::new(stdout).lines();
         while let Some(line) = reader.next_line().await? {
             const RUNNING_PATTERN: &str = "Running proxy version is Azure.Sdk.Tools.TestProxy ";
             const LISTENING_PATTERN: &str = "Now listening on: ";
+
+            // Trace useful lines that test-proxy writes to stdout.
+            trace_line(&line);
 
             if let Some(idx) = line.find(RUNNING_PATTERN) {
                 let idx = idx + RUNNING_PATTERN.len();
@@ -191,62 +255,31 @@ mod bootstrap {
                 endpoint.set_host(Some("localhost"))?;
                 tracing::info!(?pid, %endpoint, "test-proxy listening on {endpoint}");
 
-                return Ok(endpoint);
+                self.endpoint = Some(endpoint);
+                break;
             }
         }
 
-        Err(azure_core::Error::message(
-            ErrorKind::Io,
-            "timed out waiting for test-proxy to start",
-        ))
-    }
-}
-
-/// Represents the running `test-proxy` service.
-#[derive(Debug)]
-pub struct Proxy {
-    #[cfg(not(target_arch = "wasm32"))]
-    command: Option<Child>,
-    url: Url,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Proxy {
-    /// Waits for the Test Proxy service to exit, return the process exit code when completed.
-    pub async fn wait(&mut self) -> Result<ExitStatus> {
-        if let Some(command) = &mut self.command {
-            return Ok(command.wait().await?);
-        }
-        Ok(ExitStatus::default())
-    }
-
-    /// Attempts to stop the service.
-    ///
-    /// Waits until the process is killed.
-    pub async fn stop(&mut self) -> Result<()> {
-        if let Some(command) = &mut self.command {
-            tracing::debug!(pid = ?command.id(), "stopping");
-            return Ok(command.kill().await?);
-        }
         Ok(())
     }
 }
 
 impl Proxy {
-    /// Gets the [`Url`] to which the test-proxy is listening.
-    pub fn endpoint(&self) -> &Url {
-        &self.url
-    }
-}
-
-impl Default for Proxy {
-    fn default() -> Self {
-        let url = "http://localhost:5000".parse().unwrap();
+    /// Gets a proxy representing an existing test-proxy process.
+    pub fn existing() -> Self {
         Self {
             #[cfg(not(target_arch = "wasm32"))]
             command: None,
-            url,
+            endpoint: Some("http://localhost:5000".parse().unwrap()),
         }
+    }
+
+    /// Gets the [`Url`] to which the test-proxy is listening.
+    pub fn endpoint(&self) -> &Url {
+        self.endpoint
+            .as_ref()
+            // Okay to panic because this is a developer error.
+            .unwrap_or_else(|| panic!("endpoint not set"))
     }
 }
 
@@ -265,6 +298,9 @@ impl Drop for Proxy {
 /// Options for starting the [`Proxy`].
 #[derive(Clone, Debug)]
 pub struct ProxyOptions {
+    /// `true` to bind to any available port; otherwise, bind to only the default port `:5000`.
+    pub auto: bool,
+
     /// Allow insecure upstream SSL certs.
     pub insecure: bool,
 
@@ -283,12 +319,17 @@ impl ProxyOptions {
             "--auto-shutdown-in-seconds".into(),
             self.auto_shutdown_in_seconds.to_string(),
         ]);
+
+        if self.auto {
+            args.extend_from_slice(&["--", "--urls", "http://0.0.0.0:0"].map(Into::into));
+        }
     }
 }
 
 impl Default for ProxyOptions {
     fn default() -> Self {
         Self {
+            auto: true,
             insecure: false,
             auto_shutdown_in_seconds: 300,
         }

--- a/sdk/core/azure_core_test/src/recording.rs
+++ b/sdk/core/azure_core_test/src/recording.rs
@@ -350,7 +350,7 @@ impl Recording {
     // #[cfg(any(test, doctest))] // BUGBUG: https://github.com/rust-lang/rust/issues/67295
     #[doc(hidden)]
     pub fn with_seed() -> Self {
-        let span = tracing::trace_span!("Recording::seeded");
+        let span = tracing::trace_span!("Recording::with_seed");
         Self {
             test_mode: TestMode::Playback,
             span: span.entered(),


### PR DESCRIPTION
This is a big refactor of the test-proxy wrapper that will precede other work. This will help diagnose issues that, in the past,  you could only do if you started the test-proxy separately and remembered to pass `PROXY_MANUAL_START=true` when testing.
