### PR TITLE
Use `cargo read-manifest` to get rust_version from core

### DIFF
--- a/eng/pipelines/templates/steps/use-rust.yml
+++ b/eng/pipelines/templates/steps/use-rust.yml
@@ -11,7 +11,7 @@ steps:
       $toolchain = '${{ parameters.Toolchain }}'
       if ($toolchain -eq 'msrv') {
           Write-Host "Reading MSRV from azure_core"
-          $toolchain = cargo metadata --manifest-path ./sdk/core/azure_core/Cargo.toml --format-version 1 | convertfrom-json | select -expand packages | where { $_.name -eq 'azure_core' } | select -expand rust_version
+          $toolchain = cargo read-manifest --manifest-path ./sdk/core/azure_core/Cargo.toml | ConvertFrom-Json | Select-Object -ExpandProperty rust_version
       }
 
       Write-Host "Setting Toolchain variable to $toolchain"
@@ -24,10 +24,10 @@ steps:
         $attempts++
         Write-Host "> rustup toolchain install --no-self-update $toolchain"
         rustup toolchain install --no-self-update $toolchain
-        
+
         if ($?) { exit 0 }
 
-        if ($attempts -lt $maxAttempts) { 
+        if ($attempts -lt $maxAttempts) {
           Write-Host "Failed to install $toolchain, attempt $attempts, retrying..."
         } else {
           Write-Host "Failed to install $toolchain after $attempts attempts."


### PR DESCRIPTION
Because we have workspace path dependencies and direct version dependencies on azure_core in the repo, cargo metadata returns multiple packages named azure_core. We could use `--no-deps` to stop returning dependency packages, but then we still have to filter the results to `azure_core`.   `cargo read-manifest` is already filtered to the target package and seems like a more direct way to get at specific package properties.