### PR TITLE
Remove channel declaration from rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,4 @@
 [toolchain]
-channel = "1.80.0"
 components = [
   "rustc",
   "rustfmt",


### PR DESCRIPTION
For a workspace full of lib crates, this probably isn't necessary anyway.
We'll still keep the MSRV of 1.80 currently and test PRs against it,
stable, and nightly, so there really should be no harm in doing this.

Besides, after updating the rust-analyzer VSCode extension, it warned me
that 1.82 or newer was required. Of course, it'd be nice if it warned me
before I spent a couple hours trying to resolve the situation ultimately
resulting in going scorched earth on my rust installation, but 🤷‍♂️.
