### PR TITLE
Fix issue bumping wrong versions

### DIFF
--- a/eng/scripts/Update-PackageVersion.ps1
+++ b/eng/scripts/Update-PackageVersion.ps1
@@ -72,7 +72,7 @@ if ($pkgProperties.ChangeLogPath) {
 
 $tomlPath = Join-Path $pkgProperties.DirectoryPath "Cargo.toml"
 $content = Get-Content -Path $tomlPath -Raw
-$updated = $content -replace '([package](.|\n)+?version\s*=\s*)"(.+?)"', "`$1`"$packageSemVer`""
+$updated = $content -replace '(\[package\](.|\n)+?version\s*=\s*)"(.+?)"', "`$1`"$packageSemVer`""
 
 if ($content -ne $updated) {
   $updated | Set-Content -Path $tomlPath  -Encoding utf8 -NoNewLine


### PR DESCRIPTION
The square brackets matched regex character class syntax and should be escaped.