### PR TITLE
Remove Unnecessary Proxy Install

### DIFF
--- a/eng/pipelines/templates/jobs/test.yml
+++ b/eng/pipelines/templates/jobs/test.yml
@@ -36,9 +36,6 @@ jobs:
       ServiceDirectory: ${{ parameters.ServiceDirectory }}
       PackageInfoDirectory: $(Build.ArtifactStagingDirectory)/PackageInfo
 
-  - ${{ if eq(parameters.TestProxy, true) }}:
-    - template: /eng/common/testproxy/test-proxy-standalone-tool.yml
-
   - task: Powershell@2
     displayName: "Test Packages"
     condition: and(succeeded(), ne(variables['NoPackagesChanged'],'true'))


### PR DESCRIPTION
fyi @heaths @hallipr 

If `cargo test` takes care of downloading the proxy in all cases, this build yaml is no longer necessary.