### PR TITLE
[APIView] Adding "paths" back in the JSON to show re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ name = "azure_messaging_eventhubs"
 version = "0.2.0"
 dependencies = [
  "async-stream",
+ "async-trait",
  "azure_core",
  "azure_core_amqp",
  "azure_core_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,6 @@ name = "azure_messaging_eventhubs"
 version = "0.2.0"
 dependencies = [
  "async-stream",
- "async-trait",
  "azure_core",
  "azure_core_amqp",
  "azure_core_test",

--- a/eng/tools/generate_api_report/src/main.rs
+++ b/eng/tools/generate_api_report/src/main.rs
@@ -62,10 +62,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     });
 
     // Clear unnecessary fields in the Crate structure
-    // 1. paths
-    // 2. external_crates
-    // 3. span in all items
-    root.paths.clear();
+    // 1. external_crates
+    // 2. span in all items
     root.external_crates.clear();
     for (_id, item) in root.index.iter_mut() {
         // Reset span to default empty value


### PR DESCRIPTION
Addresses the handling of the `paths` property in the JSON configuration, which contains information relevant to re-exports.

#2019 added logic to clear the paths property from the `Crate` object. This PR removes the same.