### PR TITLE
Add LarryOsterman to catch-all CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,10 +19,10 @@
 
 # Catch all for loose files in the root, which are mostly global configuration and
 # should not be changed without team discussion.
-/*                       @heaths @RickWinter @ronniegeraghty
+/*                       @heaths @RickWinter @ronniegeraghty @LarryOsterman
 
 # Catch all for non-code project files and unowned files | folders
-/**                      @heaths @RickWinter @ronniegeraghty
+/**                      @heaths @RickWinter @ronniegeraghty @LarryOsterman
 
 ##################
 # Automation


### PR DESCRIPTION
Given new org-level branch policies, it would be helpful to add
@LarryOsterman to the catch-all CODEOWNERS for timely reviews.
