### PR TITLE
add custom identity option for app service

### DIFF
--- a/sdk/identity/azure_identity/src/credentials/app_service_managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/credentials/app_service_managed_identity_credential.rs
@@ -20,6 +20,20 @@ pub struct AppServiceManagedIdentityCredential {
 
 impl AppServiceManagedIdentityCredential {
     pub fn new(options: impl Into<TokenCredentialOptions>) -> azure_core::Result<Arc<Self>> {
+        Self::create(options, ImdsId::SystemAssigned)
+    }
+
+    pub fn with_id(
+        options: impl Into<TokenCredentialOptions>,
+        id: ImdsId,
+    ) -> azure_core::Result<Arc<Self>> {
+        Self::create(options, id)
+    }
+
+    fn create(
+        options: impl Into<TokenCredentialOptions>,
+        id: ImdsId,
+    ) -> azure_core::Result<Arc<Self>> {
         let options = options.into();
         let env = options.env();
         let endpoint = &env
@@ -43,7 +57,7 @@ impl AppServiceManagedIdentityCredential {
                 API_VERSION,
                 SECRET_HEADER,
                 SECRET_ENV,
-                ImdsId::SystemAssigned,
+                id,
             ),
         }))
     }


### PR DESCRIPTION
As per #1659, need the ability to specify a managed identity rather than assuming System Assigned.

Followed the model proposed in #1799, though would prefer to transparently check for the CLIENT_ID environment var, as DefaultCredentials does in .net and other implementations.