### PR TITLE
Add impl TryFrom<serde_json::Value> for RequestContent<serde_json::Value>

### DIFF
--- a/sdk/typespec/typespec_client_core/CHANGELOG.md
+++ b/sdk/typespec/typespec_client_core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 0.1.1 (unreleased)
+
+### Features Added
+
+- Added `TryFrom<serde_json::Value>` for `RequestContent<serde_json::Value>` to simplify creating request bodies that are raw JSON.
+
 ## 0.1.0 (2025-02-18)
 
 ### Features Added

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -262,6 +262,16 @@ impl<T> TryFrom<Vec<u8>> for RequestContent<T> {
     }
 }
 
+impl TryFrom<serde_json::Value> for RequestContent<serde_json::Value> {
+    type Error = crate::Error;
+    fn try_from(body: serde_json::Value) -> Result<Self, Self::Error> {
+        Ok(Self {
+            body: Bytes::from(serde_json::to_vec(&body)?).into(),
+            phantom: PhantomData,
+        })
+    }
+}
+
 impl<T> TryFrom<&'static str> for RequestContent<T> {
     type Error = crate::Error;
     fn try_from(body: &'static str) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Simplifies creating request bodies that are raw JSON.

```rust
json!({"name": "name", "desc": "desc"}).try_into().unwrap(),
```