### PR TITLE
Handle MsiTokenResponse::expires_on being an int or string.

### DIFF
--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Bugs Fixed
 
+- Handle MSI token servers which respond with `expires_on: i64` instead of `expires_on: String`
+
 ### Other Changes
 
 ## 0.22.0 (2025-02-18)

--- a/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
@@ -148,7 +148,7 @@ where
 {
     struct ExpiresOnVisitor;
 
-    impl<'de> de::Visitor<'de> for ExpiresOnVisitor {
+    impl de::Visitor<'_> for ExpiresOnVisitor {
         type Value = OffsetDateTime;
 
         fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
@@ -140,13 +140,45 @@ impl TokenCredential for ImdsManagedIdentityCredential {
     }
 }
 
+// `expires_on` varies between a number and a date string depending on token server implementation
+// https://github.com/Azure/azure-sdk-for-go/blob/66eca06a3fb1a931ddd3c7e61462967f6e5b9c2e/sdk/azidentity/managed_identity_client.go#L310
 fn expires_on_string<'de, D>(deserializer: D) -> std::result::Result<OffsetDateTime, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let v = String::deserialize(deserializer)?;
-    let as_i64 = v.parse::<i64>().map_err(de::Error::custom)?;
-    OffsetDateTime::from_unix_timestamp(as_i64).map_err(de::Error::custom)
+    struct ExpiresOnVisitor;
+
+    impl<'de> de::Visitor<'de> for ExpiresOnVisitor {
+        type Value = OffsetDateTime;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or integer representing a Unix timestamp")
+        }
+
+        fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            let as_i64 = value.parse::<i64>().map_err(de::Error::custom)?;
+            OffsetDateTime::from_unix_timestamp(as_i64).map_err(de::Error::custom)
+        }
+
+        fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            OffsetDateTime::from_unix_timestamp(value).map_err(de::Error::custom)
+        }
+
+        fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            OffsetDateTime::from_unix_timestamp(value as i64).map_err(de::Error::custom)
+        }
+    }
+
+    deserializer.deserialize_any(ExpiresOnVisitor)
 }
 
 /// Convert a `AADv2` scope to an `AADv1` resource
@@ -171,7 +203,7 @@ fn scopes_to_resource<'a>(scopes: &'a [&'a str]) -> azure_core::Result<&'a str> 
     Ok(scope.strip_suffix("/.default").unwrap_or(*scope))
 }
 
-// NOTE: expires_on is a String version of unix epoch time, not an integer.
+// NOTE: expires_on is _meant_ to be a String version of unix epoch time, not an integer, though it varies between implementations.
 // https://learn.microsoft.com/azure/app-service/overview-managed-identity?tabs=dotnet#rest-protocol-examples
 #[derive(Debug, Clone, Deserialize)]
 #[allow(unused)]
@@ -201,5 +233,21 @@ mod tests {
         let parsed: TestExpires = from_json(as_string)?;
         assert_eq!(expected, parsed.date);
         Ok(())
+    }
+
+    #[test]
+    fn check_expires_on_int() -> azure_core::Result<()> {
+        let as_string = r#"{"date": 1586984735}"#;
+        let expected = datetime!(2020-4-15 21:5:35 UTC);
+        let parsed: TestExpires = from_json(as_string)?;
+        assert_eq!(expected, parsed.date);
+        Ok(())
+    }
+
+    #[test]
+    fn check_expires_on_invalid() {
+        let as_string = r#"{"date": "invalid"}"#;
+        let parsed: Result<TestExpires, Error> = from_json(as_string);
+        assert!(parsed.is_err());
     }
 }


### PR DESCRIPTION
Some MSI token servers don't follow the spec and return `expires_on` as an int unix timestamp, rather than the expected string of an int unix timestamp, so to be broadly compatible it's nice to handle both.