### PR TITLE
Move managed identity credentials behind ManagedIdentityCredential

### DIFF
--- a/sdk/identity/.dict.txt
+++ b/sdk/identity/.dict.txt
@@ -3,6 +3,9 @@ appservice
 azureauth
 clientcertificate
 clientsecret
+cloudshell
 imds
+managedidentity
 msal
+replacen
 workloadidentity

--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Removed `get_subscription()` and `get_tenant()` from `AzureCliCredential`.
 - `WorkloadIdentityCredential` constructors moved some parameters to an `Option<ClientAssertionCredentialOptions>` parameter.
 - Removed `clear_cache()` from all credential types
+- Replaced `AppServiceManagedIdentityCredential`, `VirtualMachineManagedIdentityCredential`, and `ImdsId`
+  with `ManagedIdentityCredential` and `UserAssignedId`
 
 ### Bugs Fixed
 

--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -17,8 +17,7 @@
 - Removed `get_subscription()` and `get_tenant()` from `AzureCliCredential`.
 - `WorkloadIdentityCredential` constructors moved some parameters to an `Option<ClientAssertionCredentialOptions>` parameter.
 - Removed `clear_cache()` from all credential types
-- Replaced `AppServiceManagedIdentityCredential`, `VirtualMachineManagedIdentityCredential`, and `ImdsId`
-  with `ManagedIdentityCredential` and `UserAssignedId`
+- Replaced `AppServiceManagedIdentityCredential`, `VirtualMachineManagedIdentityCredential`, and `ImdsId` with `ManagedIdentityCredential` and `UserAssignedId`
 
 ### Bugs Fixed
 

--- a/sdk/identity/azure_identity/README.md
+++ b/sdk/identity/azure_identity/README.md
@@ -78,7 +78,7 @@ authentication flows. For more details on this scenario see [Configure an applic
 
 ```rust no_run
 use azure_core::credentials::{AccessToken, TokenCredential};
-use azure_identity::{ClientAssertion, ClientAssertionCredential, ImdsId, TokenCredentialOptions, VirtualMachineManagedIdentityCredential};
+use azure_identity::{ClientAssertion, ClientAssertionCredential, TokenCredentialOptions, ManagedIdentityCredential};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -104,10 +104,7 @@ impl ClientAssertion for VmClientAssertion {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let assertion = VmClientAssertion {
-        credential: VirtualMachineManagedIdentityCredential::new(
-            ImdsId::SystemAssigned,
-            TokenCredentialOptions::default(),
-        )?,
+        credential: ManagedIdentityCredential::new(None)?,
         scope: String::from("api://AzureADTokenExchange/.default"),
     };
 

--- a/sdk/identity/azure_identity/src/credentials/app_service_managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/credentials/app_service_managed_identity_credential.rs
@@ -19,7 +19,10 @@ pub struct AppServiceManagedIdentityCredential {
 }
 
 impl AppServiceManagedIdentityCredential {
-    pub fn new(options: impl Into<TokenCredentialOptions>) -> azure_core::Result<Arc<Self>> {
+    pub fn new(
+        id: ImdsId,
+        options: impl Into<TokenCredentialOptions>,
+    ) -> azure_core::Result<Arc<Self>> {
         let options = options.into();
         let env = options.env();
         let endpoint = &env
@@ -43,7 +46,7 @@ impl AppServiceManagedIdentityCredential {
                 API_VERSION,
                 SECRET_HEADER,
                 SECRET_ENV,
-                ImdsId::SystemAssigned,
+                id,
             ),
         }))
     }

--- a/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::{credentials::cache::TokenCache, TokenCredentialOptions};
+use crate::{credentials::cache::TokenCache, TokenCredentialOptions, UserAssignedId};
 use azure_core::{
     credentials::{AccessToken, Secret, TokenCredential},
     error::{http_response_from_body, Error, ErrorKind},
@@ -29,6 +29,16 @@ pub enum ImdsId {
     ObjectId(String),
     /// The Azure resource ID of the user-assigned identity to be used.
     MsiResId(String),
+}
+
+impl From<UserAssignedId> for ImdsId {
+    fn from(user_assigned_id: UserAssignedId) -> Self {
+        match user_assigned_id {
+            UserAssignedId::ClientId(client_id) => ImdsId::ClientId(client_id),
+            UserAssignedId::ObjectId(object_id) => ImdsId::ObjectId(object_id),
+            UserAssignedId::ResourceId(resource_id) => ImdsId::MsiResId(resource_id),
+        }
+    }
 }
 
 /// Attempts authentication using a managed identity that has been assigned to the deployment environment.

--- a/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/imds_managed_identity_credentials.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use crate::{credentials::cache::TokenCache, TokenCredentialOptions, UserAssignedId};
+use crate::{credentials::cache::TokenCache, env::Env, TokenCredentialOptions, UserAssignedId};
 use azure_core::{
     credentials::{AccessToken, Secret, TokenCredential},
     error::{http_response_from_body, Error, ErrorKind},
@@ -55,6 +55,7 @@ pub(crate) struct ImdsManagedIdentityCredential {
     secret_env: String,
     id: ImdsId,
     cache: TokenCache,
+    env: Env,
 }
 
 impl ImdsManagedIdentityCredential {
@@ -75,6 +76,7 @@ impl ImdsManagedIdentityCredential {
             secret_env: secret_env.to_owned(),
             id,
             cache: TokenCache::new(),
+            env: options.env().clone(),
         }
     }
 
@@ -100,7 +102,7 @@ impl ImdsManagedIdentityCredential {
 
         req.insert_header("metadata", "true");
 
-        let msi_secret = std::env::var(&self.secret_env);
+        let msi_secret = self.env.var(&self.secret_env);
         if let Ok(val) = msi_secret {
             req.insert_header(self.secret_header.clone(), val);
         };

--- a/sdk/identity/azure_identity/src/credentials/mod.rs
+++ b/sdk/identity/azure_identity/src/credentials/mod.rs
@@ -21,15 +21,15 @@ mod options;
 mod virtual_machine_managed_identity_credential;
 mod workload_identity_credentials;
 
-pub use app_service_managed_identity_credential::*;
+pub(crate) use app_service_managed_identity_credential::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use azure_cli_credentials::*;
 pub use client_assertion_credentials::*;
 #[cfg(feature = "client_certificate")]
 pub use client_certificate_credentials::*;
 pub use default_azure_credentials::*;
-pub use imds_managed_identity_credentials::ImdsId;
+pub(crate) use imds_managed_identity_credentials::ImdsId;
 pub(crate) use imds_managed_identity_credentials::*;
 pub use options::*;
-pub use virtual_machine_managed_identity_credential::*;
+pub(crate) use virtual_machine_managed_identity_credential::*;
 pub use workload_identity_credentials::*;

--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -22,11 +22,6 @@ pub use credentials::*;
 pub use managed_identity_credential::*;
 use std::borrow::Cow;
 
-#[cfg(test)]
-pub(crate) const LIVE_TEST_RESOURCE: &str = "https://management.azure.com";
-#[cfg(test)]
-pub(crate) const LIVE_TEST_SCOPES: &[&str] = &["https://management.azure.com/.default"];
-
 fn validate_not_empty<C>(value: &str, message: C) -> Result<()>
 where
     C: Into<Cow<'static, str>>,
@@ -114,4 +109,10 @@ fn test_validate_tenant_id() {
     assert!(validate_tenant_id("invalid_tenant@id").is_err());
     assert!(validate_tenant_id("A-1.z").is_ok());
     assert!(validate_tenant_id("7b795fb9-09d3-42f4-a494-38864f99ba3c").is_ok());
+}
+
+#[cfg(test)]
+mod tests {
+    pub const LIVE_TEST_RESOURCE: &str = "https://management.azure.com";
+    pub const LIVE_TEST_SCOPES: &[&str] = &["https://management.azure.com/.default"];
 }

--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -10,6 +10,7 @@ mod chained_token_credential;
 mod credentials;
 mod env;
 mod federated_credentials_flow;
+mod managed_identity_credential;
 mod oauth2_http_client;
 mod refresh_token;
 mod timeout;
@@ -18,7 +19,13 @@ use azure_core::{error::ErrorKind, Error, Result};
 pub use azure_pipelines_credential::*;
 pub use chained_token_credential::*;
 pub use credentials::*;
+pub use managed_identity_credential::*;
 use std::borrow::Cow;
+
+#[cfg(test)]
+pub(crate) const LIVE_TEST_RESOURCE: &str = "https://management.azure.com";
+#[cfg(test)]
+pub(crate) const LIVE_TEST_SCOPES: &[&str] = &["https://management.azure.com/.default"];
 
 fn validate_not_empty<C>(value: &str, message: C) -> Result<()>
 where

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -37,7 +37,7 @@ pub struct ManagedIdentityCredential {
 }
 
 /// Options for constructing a new [`ManagedIdentityCredential`].
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ManagedIdentityCredentialOptions {
     /// The [`TokenCredentialOptions`] to use for the credential.
     pub credential_options: TokenCredentialOptions,

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -45,7 +45,7 @@ impl ManagedIdentityCredential {
         let id = options
             .user_assigned_id
             .clone()
-            .map(|id| id.into())
+            .map(Into::into)
             .unwrap_or(ImdsId::SystemAssigned);
 
         let credential: Arc<dyn TokenCredential> = match source {

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -203,11 +203,9 @@ mod tests {
     ) {
         let _guard = EnvVarGuard::new(&env_vars);
         let actual_source = get_source();
-        assert!(
-            std::mem::discriminant(&actual_source) == std::mem::discriminant(&expected_source),
-            "Expected {:?}, got {:?}",
-            expected_source,
-            actual_source
+        assert_eq!(
+            std::mem::discriminant(&actual_source),
+            std::mem::discriminant(&expected_source)
         );
         let expires_on = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -271,12 +269,14 @@ mod tests {
     ) {
         let _guard = EnvVarGuard::new(&env_vars);
         let actual_source = get_source();
-        assert_eq!(std::mem::discriminant(&actual_source), std::mem::discriminant(&expected_source));
+        assert_eq!(
+            std::mem::discriminant(&actual_source),
+            std::mem::discriminant(&expected_source)
+        );
         let result = ManagedIdentityCredential::new(None);
         assert!(
             matches!(result, Err(ref e) if *e.kind() == azure_core::error::ErrorKind::Credential),
-            "Expected constructor error, got: {:?}",
-            result
+            "Expected constructor error"
         );
     }
 
@@ -366,8 +366,7 @@ mod tests {
         }));
         assert!(
             matches!(result, Err(ref e) if *e.kind() == azure_core::error::ErrorKind::Credential),
-            "Expected constructor error, got: {:?}",
-            result
+            "Expected constructor error"
         );
     }
 

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -114,7 +114,7 @@ enum ManagedIdentitySource {
 }
 
 impl ManagedIdentitySource {
-    pub fn as_str(&self) -> &str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             ManagedIdentitySource::AzureArc => "Azure Arc",
             ManagedIdentitySource::AzureML => "Azure ML",
@@ -271,12 +271,7 @@ mod tests {
     ) {
         let _guard = EnvVarGuard::new(&env_vars);
         let actual_source = get_source();
-        assert!(
-            std::mem::discriminant(&actual_source) == std::mem::discriminant(&expected_source),
-            "Expected {:?}, got {:?}",
-            expected_source,
-            actual_source
-        );
+        assert_eq!(std::mem::discriminant(&actual_source), std::mem::discriminant(&expected_source));
         let result = ManagedIdentityCredential::new(None);
         assert!(
             matches!(result, Err(ref e) if *e.kind() == azure_core::error::ErrorKind::Credential),

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -241,7 +241,7 @@ mod tests {
                         assert_eq!(actual.headers().get_str(k).unwrap(), v.as_str())
                     });
 
-                    return Ok(Response::from_bytes(
+                    Ok(Response::from_bytes(
                         StatusCode::Ok,
                         Headers::default(),
                         Bytes::from(response_format.replacen(
@@ -249,7 +249,7 @@ mod tests {
                             &expires_on.to_string(),
                             1,
                         )),
-                    ));
+                    ))
                 }
             }
             .boxed()

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -156,7 +156,7 @@ fn get_source() -> ManagedIdentitySource {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{LIVE_TEST_RESOURCE, LIVE_TEST_SCOPES};
+    use crate::tests::{LIVE_TEST_RESOURCE, LIVE_TEST_SCOPES};
     use azure_core::http::headers::Headers;
     use azure_core::http::{Method, Request, Response, StatusCode};
     use azure_core::Bytes;

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -6,7 +6,7 @@ use crate::{
     VirtualMachineManagedIdentityCredential,
 };
 use azure_core::credentials::{AccessToken, TokenCredential};
-use std::{fmt::Display, fmt::Formatter, sync::Arc};
+use std::sync::Arc;
 use tracing::trace;
 
 /// Identifies a specific user-assigned identity for [`ManagedIdentityCredential`] to authenticate.
@@ -18,16 +18,6 @@ pub enum UserAssignedId {
     ObjectId(String),
     /// The Azure resource ID of a user-assigned identity
     ResourceId(String),
-}
-
-impl Display for UserAssignedId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UserAssignedId::ClientId(id) => write!(f, r#"client ID "{}""#, id),
-            UserAssignedId::ObjectId(id) => write!(f, r#"object ID "{}""#, id),
-            UserAssignedId::ResourceId(id) => write!(f, r#"resource ID "{}""#, id),
-        }
-    }
 }
 
 /// Authenticates a managed identity from Azure App Service or an Azure Virtual Machine.
@@ -88,7 +78,7 @@ impl ManagedIdentityCredential {
             source.as_str()
         );
         if let Some(user_assigned_id) = options.user_assigned_id {
-            message.push_str(&format!(" with {}", user_assigned_id));
+            message.push_str(&format!(" with {:?}", user_assigned_id));
         }
         trace!(message);
 

--- a/sdk/identity/azure_identity/src/managed_identity_credential.rs
+++ b/sdk/identity/azure_identity/src/managed_identity_credential.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use azure_core::credentials::{AccessToken, TokenCredential};
 use std::sync::Arc;
-use tracing::trace;
+use tracing::info;
 
 /// Identifies a specific user-assigned identity for [`ManagedIdentityCredential`] to authenticate.
 #[derive(Debug, Clone)]
@@ -73,14 +73,7 @@ impl ManagedIdentityCredential {
             }
         };
 
-        let mut message = format!(
-            "ManagedIdentityCredential will use {} managed identity",
-            source.as_str()
-        );
-        if let Some(user_assigned_id) = options.user_assigned_id {
-            message.push_str(&format!(" with {:?}", user_assigned_id));
-        }
-        trace!(message);
+        info!(user_assigned_id = ?options.user_assigned_id, "ManagedIdentityCredential will use {} managed identity", source.as_str());
 
         Ok(Arc::new(Self { credential }))
     }


### PR DESCRIPTION
Adding `ManagedIdentityCredential` as a wrapper around `AppServiceManagedIdentityCredential` and `VirtualMachineManagedIdentityCredential`, and removing those and supporting types from the public API