### PR TITLE
Always ignore certain headers and sanitizers

### DIFF
--- a/sdk/core/azure_core_test/src/proxy/bootstrap.rs
+++ b/sdk/core/azure_core_test/src/proxy/bootstrap.rs
@@ -46,7 +46,7 @@ pub async fn start(
         tracing::warn!(
             "environment variable {PROXY_MANUAL_START} is 'true'; not starting test-proxy"
         );
-        return Ok(Proxy::existing());
+        return Proxy::existing();
     }
 
     // Find root of git repo or work tree: a ".git" directory or file will exist either way.

--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -16,7 +16,7 @@ use azure_core::{
         request::{Request, RequestContent},
         ClientMethodOptions, ClientOptions, Context, Method, Pipeline, Url,
     },
-    Result,
+    Bytes, Result,
 };
 use tracing::Span;
 
@@ -157,6 +157,8 @@ impl Client {
         request.insert_header(CONTENT_TYPE, "application/json");
         request.insert_headers(&matcher)?;
         request.add_optional_header(&options.recording_id);
+        let body: Bytes = matcher.try_into()?;
+        request.set_body(body);
         self.pipeline.send::<()>(&ctx, &mut request).await?;
         Ok(())
     }

--- a/sdk/core/azure_core_test/src/proxy/matchers.rs
+++ b/sdk/core/azure_core_test/src/proxy/matchers.rs
@@ -11,7 +11,7 @@ use std::{convert::Infallible, iter};
 
 // cspell:ignore headerless
 
-/// The headers ignored by default for [`CustomDefaultMatcherBody`];
+/// The headers ignored by default for [`CustomDefaultMatcher`];
 pub const DEFAULT_IGNORED_HEADERS: &[&str; 6] = &[
     "date",
     "request-id",

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -113,7 +113,7 @@ impl Proxy {
     }
 
     /// Gets the [`Client`] for this proxy.
-    pub fn client(&self) -> Option<&Client> {
+    pub(crate) fn client(&self) -> Option<&Client> {
         self.client.as_ref()
     }
 
@@ -179,13 +179,14 @@ impl Proxy {
 
 impl Proxy {
     /// Gets a proxy representing an existing test-proxy process.
-    pub fn existing() -> Self {
-        Self {
+    pub fn existing() -> Result<Self> {
+        let endpoint: Url = "http://localhost:5000".parse()?;
+        Ok(Self {
             #[cfg(not(target_arch = "wasm32"))]
             command: None,
-            endpoint: Some("http://localhost:5000".parse().unwrap()),
-            client: None,
-        }
+            endpoint: Some(endpoint.clone()),
+            client: Some(Client::new(endpoint)?),
+        })
     }
 
     /// Gets the [`Url`] to which the test-proxy is listening.

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -23,9 +23,9 @@ use azure_core::{
 use bootstrap::*;
 use client::Client;
 use serde::Serializer;
-use std::{fmt, str::FromStr};
 #[cfg(not(target_arch = "wasm32"))]
-use std::{process::ExitStatus, sync::Arc};
+use std::process::ExitStatus;
+use std::{fmt, str::FromStr, sync::Arc};
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::process::Child;
 
@@ -44,7 +44,6 @@ pub struct Proxy {
     #[cfg(not(target_arch = "wasm32"))]
     command: Option<Child>,
     endpoint: Option<Url>,
-    #[cfg(not(target_arch = "wasm32"))]
     client: Option<Client>,
 }
 
@@ -185,7 +184,6 @@ impl Proxy {
             #[cfg(not(target_arch = "wasm32"))]
             command: None,
             endpoint: Some("http://localhost:5000".parse().unwrap()),
-            #[cfg(not(target_arch = "wasm32"))]
             client: None,
         }
     }

--- a/sdk/core/azure_core_test/src/proxy/sanitizers.rs
+++ b/sdk/core/azure_core_test/src/proxy/sanitizers.rs
@@ -64,7 +64,7 @@ pub struct BodyKeySanitizer {
     /// The JSONPath that will be checked for replacements.
     pub json_path: String,
 
-    /// The substitution value. The default is [`SANITIZED_VALUE`].
+    /// The substitution value. The default is [`DEFAULT_SANITIZED_VALUE`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 
@@ -106,7 +106,7 @@ fn test_body_key_sanitizer_as_headers() {
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BodyRegexSanitizer {
-    /// The substitution value. The default is [`SANITIZED_VALUE`].
+    /// The substitution value. The default is [`DEFAULT_SANITIZED_VALUE`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 
@@ -155,7 +155,7 @@ impl_sanitizer!(GeneralRegexSanitizer, GeneralStringSanitizer);
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GeneralRegexSanitizer {
-    /// The substitution value. The default is [`SANITIZED_VALUE`].
+    /// The substitution value. The default is [`DEFAULT_SANITIZED_VALUE`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 
@@ -195,7 +195,7 @@ impl_sanitizer!(HeaderRegexSanitizer, HeaderStringSanitizer);
 pub struct HeaderRegexSanitizer {
     pub key: String,
 
-    /// The substitution value. The default is [`SANITIZED_VALUE`].
+    /// The substitution value. The default is [`DEFAULT_SANITIZED_VALUE`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 
@@ -268,7 +268,7 @@ impl_sanitizer!(
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UriRegexSanitizer {
-    /// The substitution value. The default is [`SANITIZED_VALUE`].
+    /// The substitution value. The default is [`DEFAULT_SANITIZED_VALUE`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
 

--- a/sdk/core/azure_core_test/src/proxy/sanitizers.rs
+++ b/sdk/core/azure_core_test/src/proxy/sanitizers.rs
@@ -13,8 +13,15 @@ use std::{
     iter::{once, Once},
 };
 
+/// Default sanitizers to remove.
+// See <https://github.com/Azure/azure-sdk-for-net/blob/eedbc408d565fbc5cbca96222807c737ae53605e/sdk/core/Azure.Core.TestFramework/src/RecordedTestBase.cs#L123>.
+pub const DEFAULT_SANITIZERS_TO_REMOVE: &[&str; 2] = &[
+    "AZSDK3430", // $..id
+    "AZSDK3490", // $..etag
+];
+
 /// Default sanitization replacement value, "Sanitized";
-pub const SANITIZED_VALUE: &str = "Sanitized";
+pub const DEFAULT_SANITIZED_VALUE: &str = "Sanitized";
 
 /// Represents a sanitizer.
 pub trait Sanitizer: AsHeaders + fmt::Debug + Serialize {}

--- a/sdk/core/azure_core_test/src/recorded.rs
+++ b/sdk/core/azure_core_test/src/recorded.rs
@@ -3,7 +3,7 @@
 
 //! Live recording and playing back of client library tests.
 use crate::{
-    proxy::{client::Client, Proxy, ProxyOptions},
+    proxy::{Proxy, ProxyOptions},
     recording::Recording,
     TestContext,
 };
@@ -59,18 +59,11 @@ pub async fn start(
         }
     };
 
-    // TODO: Could we cache the client? Hypothetically, this function should only run once per `tests/*` file so it should be practical.
-    let mut client = None;
-    if let Some(proxy) = proxy.as_ref() {
-        client = Some(Client::new(proxy.endpoint().clone())?);
-    }
-
     let span = tracing::debug_span!("recording", ?mode, name);
     let mut recording = Recording::new(
         mode,
         span.entered(),
         proxy.clone(),
-        client,
         ctx.service_dir(),
         ctx.test_recording_file(),
         ctx.test_recording_assets_file(mode),

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_account.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_account.rs
@@ -103,14 +103,6 @@ impl TestAccount {
         // We need the context_id to be constant, so that record/replay work.
         let context_id = context.name().to_string();
 
-        // Disable some sanitizers that affect our tests
-        context
-            .recording()
-            .remove_sanitizers(&[
-                "AZSDK3430", // Sanitizes "id" properties. The tests need the id to be preserved.
-            ])
-            .await?;
-
         Ok(TestAccount {
             context,
             context_id,

--- a/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/tests/key_client.rs
@@ -17,16 +17,9 @@ use azure_security_keyvault_test::Retry;
 use futures::TryStreamExt;
 use std::collections::HashMap;
 
-#[cfg(not(target_arch = "wasm32"))]
-const REMOVE_SANITIZERS: &[&str] = &[
-    // BodyKeySanitizer("$..id"): the resource ID contains the required name and version.
-    "AZSDK3430",
-];
-
 #[recorded::test]
 async fn key_roundtrip(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = KeyClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -65,7 +58,6 @@ async fn key_roundtrip(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn update_key_properties(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = KeyClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -111,7 +103,6 @@ async fn update_key_properties(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn list_keys(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = KeyClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -166,7 +157,6 @@ async fn list_keys(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn purge_key(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = KeyClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -225,7 +215,6 @@ async fn purge_key(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn encrypt_decrypt(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = KeyClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -283,7 +272,6 @@ async fn sign_verify(ctx: TestContext) -> Result<()> {
     use sha2::{Digest as _, Sha256};
 
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = KeyClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -345,7 +333,6 @@ async fn sign_verify(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn wrap_key_unwrap_key(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = KeyClientOptions::default();
     recording.instrument(&mut options.client_options);

--- a/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/tests/secret_client.rs
@@ -13,16 +13,9 @@ use azure_security_keyvault_test::Retry;
 use futures::TryStreamExt;
 use std::collections::HashMap;
 
-#[cfg(not(target_arch = "wasm32"))]
-const REMOVE_SANITIZERS: &[&str] = &[
-    // BodyKeySanitizer("$..id"): the resource ID contains the required name and version.
-    "AZSDK3430",
-];
-
 #[recorded::test]
 async fn secret_roundtrip(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = SecretClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -60,7 +53,6 @@ async fn secret_roundtrip(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn update_secret_properties(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = SecretClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -109,7 +101,6 @@ async fn update_secret_properties(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn list_secrets(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = SecretClientOptions::default();
     recording.instrument(&mut options.client_options);
@@ -156,7 +147,6 @@ async fn list_secrets(ctx: TestContext) -> Result<()> {
 #[recorded::test]
 async fn purge_secret(ctx: TestContext) -> Result<()> {
     let recording = ctx.recording();
-    recording.remove_sanitizers(REMOVE_SANITIZERS).await?;
 
     let mut options = SecretClientOptions::default();
     recording.instrument(&mut options.client_options);


### PR DESCRIPTION
With #2406 adding `x-ms-client-request-id`, I updated the default matcher and set that invariably like other languages. While looking into other languages, I see they also remove several default sanitizers after starting the test-proxy, which Key Vault and Cosmos were already doing so I made that default. To do so, I did some refactoring which, I think, cleans up the `azure_core_test` code a bit.

Opened tracking issue #2411 to remove `x-ms-client-request-id` from the `excludedHeaders` after recordings are updated. It should only be in `ignoredHeaders` long-term.
