### PR TITLE
[Storage] `azure_storage_blob` release prep (+ `delete()` for `BlobClient`)

### DIFF
--- a/sdk/storage/.dict.txt
+++ b/sdk/storage/.dict.txt
@@ -19,3 +19,4 @@ immutabilitypolicy
 uncommittedblobs
 policyid
 ruleid
+westus

--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_d3c80a557c",
+  "Tag": "rust/azure_storage_blob_7d1988e753",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_7d1988e753",
+  "Tag": "rust/azure_storage_blob_c02de844b6",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0 (2024-07)
+# Release History
 
-- initial TODO
+## 0.1.0 (2025-04-08)
+
+### Features Added
+
+* Initial supported release.

--- a/sdk/storage/azure_storage_blob/README.md
+++ b/sdk/storage/azure_storage_blob/README.md
@@ -34,12 +34,12 @@ az storage account create -n my-storage-account-name -g my-resource-group
 
 #### Authenticate the client
 
-In order to interact with the Azure Blobs Storage service, you'll need to create an instance of a client, `BlobClient`, `BlobContainerClient`, or `BlobServiceClient`. The [Azure Identity] library makes it easy to add Azure Active Directory support for authenticating Azure SDK clients with their corresponding Azure services:
+In order to interact with the Azure Blobs Storage service, you'll need to create an instance of a client, `BlobClient`, `BlobContainerClient`, or `BlobServiceClient`. The [Azure Identity] library makes it easy to add Microsoft Entra ID support for authenticating Azure SDK clients with their corresponding Azure services:
 ```rust
 use azure_storage_blob::BlobClient;
 use azure_identity::DefaultAzureCredential;
 
-// Create a BlobClient that will authenticate through Active Directory
+// Create a BlobClient that will authenticate through Microsoft Entra ID
 let credential = DefaultAzureCredential::new()?;
 let blob_client = BlobClient::new(
     "https://<storage_account_name>.blob.core.windows.net/", // endpoint
@@ -57,7 +57,7 @@ let blob_client = BlobClient::new(
 use azure_storage_blob::BlobClient;
 use azure_identity::DefaultAzureCredential;
 
-// Create a BlobClient that will authenticate through Active Directory
+// Create a BlobClient that will authenticate through Microsoft Entra ID
 let credential = DefaultAzureCredential::new()?;
 let blob_client = BlobClient::new(
     "https://<storage_account_name>.blob.core.windows.net/", // endpoint

--- a/sdk/storage/azure_storage_blob/README.md
+++ b/sdk/storage/azure_storage_blob/README.md
@@ -1,3 +1,140 @@
-# sdk/storage/azure_storage_blob
+# Azure Storage Blobs client library for Rust
 
-TODO TODO TODO
+Azure Blob storage is Microsoft's object storage solution for the cloud. Blob storage is optimized for storing massive amounts of unstructured data, such as text or binary data.
+
+[Source code] | [Package (crates.io)] | [API reference documentation] | [REST API documentation] | [Product documentation]
+
+## Getting started
+
+### Install the package
+
+Install the Azure Storage Blobs client library for Rust with [cargo]:
+
+```sh
+cargo add azure_storage_blob
+```
+
+### Prerequisites
+
+* You must have an [Azure subscription] and an [Azure storage account] to use this package.
+
+
+
+### Create a storage account
+If you wish to create a new storage account, you can use the
+[Azure Portal], [Azure PowerShell], or [Azure CLI]:
+```bash
+# Create a new resource group to hold the storage account -
+# if using an existing resource group, skip this step
+az group create --name my-resource-group --location westus2
+
+# Create the storage account
+az storage account create -n my-storage-account-name -g my-resource-group
+```
+
+#### Authenticate the client
+
+In order to interact with the Azure Blobs Storage service, you'll need to create an instance of a client, `BlobClient`, `BlobContainerClient`, or `BlobServiceClient`. The [Azure Identity] library makes it easy to add Azure Active Directory support for authenticating Azure SDK clients with their corresponding Azure services:
+```rust
+use azure_storage_blob::BlobClient;
+use azure_identity::DefaultAzureCredential;
+
+// Create a BlobClient that will authenticate through Active Directory
+let credential = DefaultAzureCredential::new()?;
+let blob_client = BlobClient::new(
+    "https://<storage_account_name>.blob.core.windows.net/", // endpoint
+    "container_name".to_string(),                            // container name
+    "blob_name".to_string(),                                 // blob name
+    credential,                                              // credential
+    Some(BlobClientOptions::default()),                      // BlobClient options
+)?;
+```
+
+## Examples
+
+### Create `BlobClient`
+```rust
+use azure_storage_blob::BlobClient;
+use azure_identity::DefaultAzureCredential;
+
+// Create a BlobClient that will authenticate through Active Directory
+let credential = DefaultAzureCredential::new()?;
+let blob_client = BlobClient::new(
+    "https://<storage_account_name>.blob.core.windows.net/", // endpoint
+    "container_name".to_string(),                            // container name
+    "blob_name".to_string(),                                 // blob name
+    credential,                                              // credential
+    Some(BlobClientOptions::default()),                      // BlobClient options
+)?;
+```
+### Upload Blob
+```rust
+use azure_storage_blob::BlobClient;
+use azure_identity::DefaultAzureCredential;
+
+let credential = DefaultAzureCredential::new()?;
+let blob_client = BlobClient::new(
+    "https://<storage_account_name>.blob.core.windows.net/",
+    "container_name".to_string(),
+    "blob_name".to_string(),
+    credential,
+    Some(BlobClientOptions::default()),
+)?;
+
+blob_client
+    .upload(
+        RequestContent::from(data.to_vec()), // data
+        false,                               // overwrite
+        u64::try_from(data.len())?,          // content length
+        None,                                // upload options
+    )
+    .await?;
+```
+
+### Get Blob Properties
+```rust
+use azure_storage_blob::BlobClient;
+use azure_identity::DefaultAzureCredential;
+
+let credential = DefaultAzureCredential::new()?;
+let blob_client = BlobClient::new(
+    "https://<storage_account_name>.blob.core.windows.net/",
+    "container_name".to_string(),
+    "blob_name".to_string(),
+    credential,
+    Some(BlobClientOptions::default()),
+)?;
+let blob_properties = blob_client.get_properties(
+    None // get properties options
+    )
+    .await?;
+```
+
+
+## Next steps
+
+### Provide feedback
+
+If you encounter bugs or have suggestions, [open an issue](https://github.com/Azure/azure-sdk-for-rust/issues).
+
+## Contributing
+
+This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit [https://cla.microsoft.com](https://cla.microsoft.com).
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You'll only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information, see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+<!-- LINKS -->
+[Azure subscription]: https://azure.microsoft.com/free/
+[Azure storage account]: https://learn.microsoft.com/azure/storage/common/storage-account-overview
+[Azure Portal]: https://learn.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal
+[Azure PowerShell]: https://learn.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-powershell
+[Azure CLI]: https://learn.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-cli
+[cargo]: https://dev-doc.rust-lang.org/stable/cargo/commands/cargo.html
+[Azure Identity]: https://github.com/Azure/azure-sdk-for-rust/tree/main/sdk/identity/azure_identity
+[API reference documentation]: https://docs.rs/crate/azure_storage_blob/latest
+[Package (crates.io)]: https://crates.io/crates/azure_storage_blob
+[Source code]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob
+[REST API documentation]: https://learn.microsoft.com/rest/api/storageservices/blob-service-rest-api
+[Product documentation]: https://learn.microsoft.com/azure/storage/blobs/storage-blobs-overview

--- a/sdk/storage/azure_storage_blob/README.md
+++ b/sdk/storage/azure_storage_blob/README.md
@@ -51,7 +51,7 @@ let blob_client = BlobClient::new(
 ```
 
 #### Permissions
-You may need to specify RBAC roles to access Blob Storage via Microsoft Entra ID. [Please see Assign an Azure role for access to blob data] for more details.
+You may need to specify RBAC roles to access Blob Storage via Microsoft Entra ID. Please see [Assign an Azure role for access to blob data] for more details.
 
 ## Examples
 
@@ -141,4 +141,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [Source code]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob
 [REST API documentation]: https://learn.microsoft.com/rest/api/storageservices/blob-service-rest-api
 [Product documentation]: https://learn.microsoft.com/azure/storage/blobs/storage-blobs-overview
-[Please see Assign an Azure role for access to blob data]: https://learn.microsoft.com/azure/storage/blobs/assign-azure-role-data-access?tabs=portal
+[Assign an Azure role for access to blob data]: https://learn.microsoft.com/azure/storage/blobs/assign-azure-role-data-access?tabs=portal

--- a/sdk/storage/azure_storage_blob/README.md
+++ b/sdk/storage/azure_storage_blob/README.md
@@ -1,4 +1,4 @@
-# Azure Storage Blobs client library for Rust
+# Azure Storage Blob client library for Rust
 
 Azure Blob storage is Microsoft's object storage solution for the cloud. Blob storage is optimized for storing massive amounts of unstructured data, such as text or binary data.
 
@@ -8,7 +8,7 @@ Azure Blob storage is Microsoft's object storage solution for the cloud. Blob st
 
 ### Install the package
 
-Install the Azure Storage Blobs client library for Rust with [cargo]:
+Install the Azure Storage Blob client library for Rust with [cargo]:
 
 ```sh
 cargo add azure_storage_blob
@@ -34,7 +34,7 @@ az storage account create -n my-storage-account-name -g my-resource-group
 
 #### Authenticate the client
 
-In order to interact with the Azure Blobs Storage service, you'll need to create an instance of a client, `BlobClient`, `BlobContainerClient`, or `BlobServiceClient`. The [Azure Identity] library makes it easy to add Microsoft Entra ID support for authenticating Azure SDK clients with their corresponding Azure services:
+In order to interact with the Azure Blob Storage service, you'll need to create an instance of a client, `BlobClient`, `BlobContainerClient`, or `BlobServiceClient`. The [Azure Identity] library makes it easy to add Microsoft Entra ID support for authenticating Azure SDK clients with their corresponding Azure services:
 ```rust
 use azure_storage_blob::BlobClient;
 use azure_identity::DefaultAzureCredential;
@@ -49,6 +49,9 @@ let blob_client = BlobClient::new(
     Some(BlobClientOptions::default()),                      // BlobClient options
 )?;
 ```
+
+#### Permissions
+You may need to specify RBAC roles to access Blob Storage via Microsoft Entra ID. [Please see Assign an Azure role for access to blob data] for more details.
 
 ## Examples
 
@@ -138,3 +141,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [Source code]: https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/storage/azure-storage-blob
 [REST API documentation]: https://learn.microsoft.com/rest/api/storageservices/blob-service-rest-api
 [Product documentation]: https://learn.microsoft.com/azure/storage/blobs/storage-blobs-overview
+[Please see Assign an Azure role for access to blob data]: https://learn.microsoft.com/azure/storage/blobs/assign-azure-role-data-access?tabs=portal

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -149,7 +149,7 @@ impl BlobClient {
         Ok(response)
     }
 
-    /// Marks the specified blob for deletion. The blob is later deleted during garbage collection.
+    /// Deletes the blob.
     ///
     /// # Arguments
     ///

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -10,8 +10,8 @@ use crate::{
     },
     models::{BlockList, BlockListType, BlockLookupList},
     pipeline::StorageHeadersPolicy,
-    BlobClientDownloadOptions, BlobClientGetPropertiesOptions, BlobClientOptions,
-    BlockBlobClientCommitBlockListOptions, BlockBlobClientGetBlockListOptions,
+    BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
+    BlobClientOptions, BlockBlobClientCommitBlockListOptions, BlockBlobClientGetBlockListOptions,
     BlockBlobClientStageBlockOptions, BlockBlobClientUploadOptions,
 };
 use azure_core::{
@@ -146,6 +146,19 @@ impl BlobClient {
         let response = block_blob_client
             .upload(data, content_length, Some(options))
             .await?;
+        Ok(response)
+    }
+
+    /// Marks the specified blob for deletion. The blob is later deleted during garbage collection.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional configuration for the request.
+    pub async fn delete(
+        &self,
+        options: Option<BlobClientDeleteOptions<'_>>,
+    ) -> Result<Response<()>> {
+        let response = self.client.delete(options).await?;
         Ok(response)
     }
 

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -14,11 +14,11 @@ pub use crate::generated::clients::{
     BlobClientOptions, BlobContainerClientOptions, BlobServiceClientOptions,
 };
 pub use crate::generated::models::{
-    BlobClientDownloadOptions, BlobClientGetPropertiesOptions, BlobContainerClientCreateOptions,
-    BlobContainerClientDeleteOptions, BlobContainerClientGetPropertiesOptions,
-    BlobServiceClientGetPropertiesOptions, BlockBlobClientCommitBlockListOptions,
-    BlockBlobClientGetBlockListOptions, BlockBlobClientStageBlockOptions,
-    BlockBlobClientUploadOptions,
+    BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
+    BlobContainerClientCreateOptions, BlobContainerClientDeleteOptions,
+    BlobContainerClientGetPropertiesOptions, BlobServiceClientGetPropertiesOptions,
+    BlockBlobClientCommitBlockListOptions, BlockBlobClientGetBlockListOptions,
+    BlockBlobClientStageBlockOptions, BlockBlobClientUploadOptions,
 };
 
 pub mod models {

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -238,13 +238,8 @@ async fn test_delete_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         )
         .await?;
 
-    // Assert
-    let response = blob_client.download(None).await?;
-    let content_length = response.content_length()?;
-    let (status_code, _, response_body) = response.deconstruct();
-    assert!(status_code.is_success());
-    assert_eq!(17, content_length.unwrap());
-    assert_eq!(Bytes::from_static(data), response_body.collect().await?);
+    // Existence Check
+    blob_client.get_properties(None).await?;
 
     blob_client.delete(None).await?;
 


### PR DESCRIPTION
This PR contains the following changes:

- Authoring of the initial `README.md` and `CHANGELOG.md` files
- Addition of the `delete()` API for `BlobClient`
    - I thought this was introduced in the initial API surface PR, but must have been overlooked. Either way I think this is important enough to make one more late addition to the MVP.