### PR TITLE
Make ChainedTokenCredential private

### DIFF
--- a/sdk/identity/azure_identity/src/chained_token_credential.rs
+++ b/sdk/identity/azure_identity/src/chained_token_credential.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#![allow(dead_code)]
+
 use crate::credentials::cache::TokenCache;
 use crate::TokenCredentialOptions;
 use async_lock::RwLock;

--- a/sdk/identity/azure_identity/src/lib.rs
+++ b/sdk/identity/azure_identity/src/lib.rs
@@ -17,7 +17,6 @@ mod timeout;
 
 use azure_core::{error::ErrorKind, Error, Result};
 pub use azure_pipelines_credential::*;
-pub use chained_token_credential::*;
 pub use credentials::*;
 pub use managed_identity_credential::*;
 use std::borrow::Cow;


### PR DESCRIPTION
This type hasn't shipped in the public API yet. I want to postpone doing that for a couple reasons:
1. falling back from one credential (identity) to another is a dangerous anti-pattern, especially in production, because it complicates determining an application's runtime privileges and makes it easy to turn a configuration mistake into a security incident
1. the current implementation is incomplete in that chained credentials have no way to signal to ChainedTokenCredential whether it should stop iterating after they return an error. This distinction helps to prevent some configuration errors from becoming security incidents