### PR TITLE
Remove azure_identity's old_azure_cli feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,7 +291,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "typespec_client_core",
- "tz-rs",
  "url",
 ]
 
@@ -590,12 +589,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
 
 [[package]]
 name = "convert_case"
@@ -1546,15 +1539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,9 +2486,7 @@ dependencies = [
  "deranged",
  "itoa",
  "js-sys",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -2763,15 +2745,6 @@ dependencies = [
  "syn",
  "tokio",
  "typespec_client_core",
-]
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,6 @@ tokio = { version = "1.0", default-features = false, features = [
 ] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3"
-tz-rs = { version = "0.6" }
 url = "2.2"
 uuid = { version = "1.0", features = ["v4"] }
 zerofrom = "0.1.5"

--- a/eng/dict/crates.txt
+++ b/eng/dict/crates.txt
@@ -65,7 +65,6 @@ typespec_client_core
 typespec_client_core
 typespec_macros
 typespec_macros
-tz-rs
 url
 uuid
 zerofrom

--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed `get_subscription()` and `get_tenant()` from `AzureCliCredential`.
 - `WorkloadIdentityCredential` constructors moved some parameters to an `Option<ClientAssertionCredentialOptions>` parameter.
 - Removed `clear_cache()` from all credential types
+- Removed `old_azure_cli` feature. `AzureCliCredential` now requires a recent version of the Azure CLI (2.54.0 or later).
 - Replaced `AppServiceManagedIdentityCredential`, `VirtualMachineManagedIdentityCredential`, and `ImdsId` with `ManagedIdentityCredential` and `UserAssignedId`
 
 ### Bugs Fixed

--- a/sdk/identity/azure_identity/Cargo.toml
+++ b/sdk/identity/azure_identity/Cargo.toml
@@ -26,9 +26,6 @@ tracing.workspace = true
 typespec_client_core = { workspace = true, features = ["derive"] }
 url.workspace = true
 
-[target.'cfg(unix)'.dependencies]
-tz-rs = { workspace = true, optional = true }
-
 [dev-dependencies]
 azure_core_test.workspace = true
 azure_security_keyvault_secrets = { path = "../../keyvault/azure_security_keyvault_secrets" }
@@ -40,18 +37,11 @@ tokio.workspace = true
 tracing-subscriber.workspace = true
 
 [features]
-default = ["reqwest", "old_azure_cli"]
+default = ["reqwest"]
 reqwest = ["azure_core/reqwest"]
 reqwest_rustls = ["azure_core/reqwest_rustls"]
 tokio = ["azure_core/tokio"]
 client_certificate = ["openssl"]
-
-# If you are using and Azure CLI version older than 2.54.0 from November 2023,
-# upgrade your Azure CLI version or enable this feature.
-# Azure CLI 2.54.0 and above has an "expires_on" timestamp that we can use.
-# https://github.com/Azure/azure-cli/releases/tag/azure-cli-2.54.0
-# https://github.com/Azure/azure-cli/issues/19700
-old_azure_cli = ["time/local-offset", "tz-rs"]
 
 [lints]
 workspace = true

--- a/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/azure_cli_credentials.rs
@@ -16,105 +16,11 @@ use std::{ffi::OsStr, fmt::Debug, str, sync::Arc};
 use time::OffsetDateTime;
 use tracing::trace;
 
-#[cfg(feature = "old_azure_cli")]
-mod az_cli_date_format {
-    use azure_core::error::{ErrorKind, ResultExt};
-    use serde::{Deserialize, Deserializer};
-    use time::format_description::FormatItem;
-    use time::macros::format_description;
-    #[cfg(not(unix))]
-    use time::UtcOffset;
-    use time::{OffsetDateTime, PrimitiveDateTime};
-
-    // cspell:ignore subsecond
-    const FORMAT: &[FormatItem] =
-        format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:6]");
-
-    pub fn parse(s: &str) -> azure_core::Result<OffsetDateTime> {
-        // expiresOn from azure cli uses the local timezone and needs to be converted to UTC
-        let dt = PrimitiveDateTime::parse(s, FORMAT)
-            .with_context(ErrorKind::DataConversion, || {
-                format!("unable to parse expiresOn '{s}")
-            })?;
-        Ok(assume_local(&dt))
-    }
-
-    #[cfg(unix)]
-    /// attempt to convert `PrimitiveDateTime` to `OffsetDate` using
-    /// `tz::TimeZone`.  If any part of the conversion fails, such as if no
-    /// timezone can be found, then use use the value as UTC.
-    pub(crate) fn assume_local(date: &PrimitiveDateTime) -> OffsetDateTime {
-        let as_utc = date.assume_utc();
-
-        // try parsing the timezone from `TZ` environment variable.  If that
-        // fails, or the environment variable doesn't exist, try using
-        // `TimeZone::local`.  If that fails, then just return the UTC date.
-        let Some(tz) = std::env::var("TZ")
-            .ok()
-            .and_then(|x| tz::TimeZone::from_posix_tz(&x).ok())
-            .or_else(|| tz::TimeZone::local().ok())
-        else {
-            return as_utc;
-        };
-
-        let as_unix = as_utc.unix_timestamp();
-
-        // if we can't find the local time type, just return the UTC date
-        let Ok(local_time_type) = tz.find_local_time_type(as_unix) else {
-            return as_utc;
-        };
-
-        // if we can't convert the unix timestamp to a DateTime, just return the UTC date
-        let date = as_utc.date();
-        let time = as_utc.time();
-        let Ok(date) = tz::DateTime::new(
-            date.year(),
-            u8::from(date.month()),
-            date.day(),
-            time.hour(),
-            time.minute(),
-            time.second(),
-            time.nanosecond(),
-            *local_time_type,
-        ) else {
-            return as_utc;
-        };
-
-        // if we can't then convert to unix time (with the timezone) and then
-        // back into an OffsetDateTime, then return the UTC date
-        let Ok(date) = OffsetDateTime::from_unix_timestamp(date.unix_time()) else {
-            return as_utc;
-        };
-
-        date
-    }
-
-    /// Assumes the local offset. Default to UTC if unable to get local offset.
-    #[cfg(not(unix))]
-    pub(crate) fn assume_local(date: &PrimitiveDateTime) -> OffsetDateTime {
-        date.assume_offset(UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC))
-    }
-
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<OffsetDateTime, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        parse(&s).map_err(serde::de::Error::custom)
-    }
-}
-
 /// The response from `az account get-access-token --output json`.
 #[derive(Debug, Clone, Deserialize)]
 struct CliTokenResponse {
     #[serde(rename = "accessToken")]
     pub access_token: Secret,
-    #[cfg(feature = "old_azure_cli")]
-    #[serde(rename = "expiresOn", with = "az_cli_date_format")]
-    /// The token's expiry time formatted in the local timezone.
-    /// Unfortunately, this requires additional timezone dependencies.
-    /// See https://github.com/Azure/azure-cli/issues/19700 for details.
-    pub local_expires_on: OffsetDateTime,
     #[serde(rename = "expires_on")]
     /// The token's expiry time in seconds since the epoch, a unix timestamp.
     /// Available in Azure CLI 2.54.0 or newer.
@@ -131,19 +37,10 @@ impl CliTokenResponse {
                 .with_context(ErrorKind::DataConversion, || {
                     format!("unable to parse expires_on '{timestamp}'")
                 })?),
-            None => {
-                #[cfg(feature = "old_azure_cli")]
-                {
-                    Ok(self.local_expires_on)
-                }
-                #[cfg(not(feature = "old_azure_cli"))]
-                {
-                    Err(Error::message(
-                        ErrorKind::DataConversion,
-                        "expires_on field not found. Please use Azure CLI 2.54.0 or newer.",
-                    ))
-                }
-            }
+            None => Err(Error::message(
+                ErrorKind::DataConversion,
+                "expires_on field not found. Please use Azure CLI 2.54.0 or newer.",
+            )),
         }
     }
 }
@@ -307,68 +204,7 @@ impl From<TokenCredentialOptions> for AzureCliCredentialOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(feature = "old_azure_cli")]
-    use serial_test::serial;
-    #[cfg(feature = "old_azure_cli")]
-    use time::macros::datetime;
 
-    #[cfg(feature = "old_azure_cli")]
-    #[test]
-    #[serial]
-    fn can_parse_expires_on() -> azure_core::Result<()> {
-        let expires_on = "2022-07-30 12:12:53.919110";
-        assert_eq!(
-            az_cli_date_format::parse(expires_on)?,
-            az_cli_date_format::assume_local(&datetime!(2022-07-30 12:12:53.919110))
-        );
-
-        Ok(())
-    }
-
-    #[cfg(all(feature = "old_azure_cli", unix))]
-    #[test]
-    #[serial]
-    /// test the timezone conversion works as expected on unix platforms
-    ///
-    /// To validate the timezone conversion works as expected, this test
-    /// temporarily sets the timezone to PST, performs the check, then resets
-    /// the TZ environment variable.
-    fn check_timezone() -> azure_core::Result<()> {
-        let before = std::env::var("TZ").ok();
-        std::env::set_var("TZ", "US/Pacific");
-        let expires_on = "2022-11-30 12:12:53.919110";
-        let result = az_cli_date_format::parse(expires_on);
-
-        if let Some(before) = before {
-            std::env::set_var("TZ", before);
-        } else {
-            std::env::remove_var("TZ");
-        }
-
-        let expected = datetime!(2022-11-30 20:12:53.0).assume_utc();
-        assert_eq!(expected, result?);
-
-        Ok(())
-    }
-
-    /// Test `from_json` for `CliTokenResponse` for old Azure CLI
-    #[test]
-    fn read_old_cli_token_response() -> azure_core::Result<()> {
-        let json = br#"
-        {
-            "accessToken": "MuchLonger_NotTheRealOne_Sv8Orn0Wq0OaXuQEg",
-            "expiresOn": "2024-01-01 19:23:16.000000",
-            "subscription": "33b83be5-faf7-42ea-a712-320a5f9dd111",
-            "tenant": "065e9f5e-870d-4ed1-af2b-1b58092353f3",
-            "tokenType": "Bearer"
-          }
-        "#;
-        let token_response: CliTokenResponse = from_json(json)?;
-        assert_eq!(token_response.expires_on, None);
-        Ok(())
-    }
-
-    /// Test `from_json` for `CliTokenResponse` for current Azure CLI
     #[test]
     fn read_cli_token_response() -> azure_core::Result<()> {
         let json = br#"


### PR DESCRIPTION
This feature enables parsing token expiration times from old Azure CLI versions. The newest "old" version is 2.53.0. Assuming that was an LTS release, the Azure CLI team stopped supporting it in 11-2024 with the release of version 2.66.0. #2327 proposes removing the crate feature while keeping the "old format" parsing code, however I think it's reasonable to remove both because we haven't shipped a stable azure_identity with this feature and no supported Azure CLI version now requires it.