### PR TITLE
Revert #2390

### DIFF
--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -23,8 +23,6 @@
 
 ### Bugs Fixed
 
-- Handle MSI token servers which respond with `expires_on: i64` instead of `expires_on: String`
-
 ### Other Changes
 
 ## 0.22.0 (2025-02-18)


### PR DESCRIPTION
IMDS [returns expires_on as a string](https://github.com/Azure/azure-rest-api-specs/blob/dba6ed1f03bda88ac6884c0a883246446cc72495/specification/imds/data-plane/Microsoft.InstanceMetadataService/stable/2021-02-01/imds.json#L861), so it doesn't make sense for azure_identity to expect another type and it wouldn't be safe for an application to depend on azure_identity doing that.