### PR TITLE
Support .env files for testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ dependencies = [
  "azure_identity",
  "azure_security_keyvault_secrets",
  "clap",
+ "dotenvy",
  "flate2",
  "futures",
  "rand",
@@ -755,6 +756,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dyn-clone"

--- a/eng/dict/crates.txt
+++ b/eng/dict/crates.txt
@@ -22,6 +22,7 @@ base64
 bytes
 cargo_metadata
 clap
+dotenvy
 dyn-clone
 fe2o3-amqp
 fe2o3-amqp-cbs

--- a/eng/scripts/verify-dependencies.rs
+++ b/eng/scripts/verify-dependencies.rs
@@ -17,7 +17,10 @@ use std::{
     process::Command,
 };
 
-static EXEMPTIONS: &[(&str, &str)] = &[("azure_template", "serde")];
+static EXEMPTIONS: &[(&str, &str)] = &[
+    ("azure_core_test", "dotenvy"),
+    ("azure_template", "serde"),
+];
 
 fn main() {
     let manifest_path = std::env::args()

--- a/sdk/core/azure_core_test/Cargo.toml
+++ b/sdk/core/azure_core_test/Cargo.toml
@@ -23,6 +23,7 @@ async-trait.workspace = true
 azure_core = { workspace = true, features = ["test"] }
 azure_core_test_macros.workspace = true
 azure_identity.workspace = true
+dotenvy = "0.15.7"
 futures.workspace = true
 rand.workspace = true
 rand_chacha.workspace = true

--- a/sdk/core/azure_core_test/src/recorded.rs
+++ b/sdk/core/azure_core_test/src/recorded.rs
@@ -68,6 +68,21 @@ pub async fn start(
         ctx.test_recording_file(),
         ctx.test_recording_assets_file(mode),
     );
+
+    // Attempt to read any .env file up to the repo root.
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Ok(path) = crate::find_ancestor_file(ctx.crate_dir, ".env") {
+        tracing::debug!("loading environment variables from {}", path.display());
+
+        use azure_core::error::ResultExt as _;
+        dotenvy::from_filename(&path).with_context(azure_core::error::ErrorKind::Io, || {
+            format!(
+                "failed to load environment variables from {}",
+                path.display()
+            )
+        })?;
+    };
+
     recording.start().await?;
 
     ctx.recording = Some(recording);


### PR DESCRIPTION
Requires changes to the TestResources scripts, which will need to be merged into Azure/azure-sdk-tools. Client libraries need to opt in.

Resolves #2038
