### PR TITLE
[Storage] [BlobClient] `set_tier` (standard tiers only)

### DIFF
--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_1a0956f648",
+  "Tag": "rust/azure_storage_blob_9f4842ba91",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -257,7 +257,6 @@ impl BlobClient {
         tier: AccessTier,
         options: Option<BlobClientSetTierOptions<'_>>,
     ) -> Result<Response<()>> {
-        let response = self.client.set_tier(tier, options).await?;
-        Ok(response)
+        self.client.set_tier(tier, options).await
     }
 }

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -8,12 +8,13 @@ use crate::{
         BlockBlobClientCommitBlockListResult, BlockBlobClientStageBlockResult,
         BlockBlobClientUploadResult,
     },
-    models::{BlockList, BlockListType, BlockLookupList},
+    models::{AccessTier, BlockList, BlockListType, BlockLookupList},
     pipeline::StorageHeadersPolicy,
     BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
     BlobClientOptions, BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions,
-    BlockBlobClientCommitBlockListOptions, BlockBlobClientGetBlockListOptions,
-    BlockBlobClientStageBlockOptions, BlockBlobClientUploadOptions,
+    BlobClientSetTierOptions, BlockBlobClientCommitBlockListOptions,
+    BlockBlobClientGetBlockListOptions, BlockBlobClientStageBlockOptions,
+    BlockBlobClientUploadOptions,
 };
 use azure_core::{
     credentials::TokenCredential,
@@ -241,6 +242,22 @@ impl BlobClient {
     ) -> Result<Response<BlockList>> {
         let block_blob_client = self.client.get_block_blob_client();
         let response = block_blob_client.get_block_list(list_type, options).await?;
+        Ok(response)
+    }
+
+    /// Sets the tier on a blob. Standard tiers are only applicable for Block blobs, while Premium tiers are only applicable
+    /// for Page blobs.
+    ///
+    /// # Arguments
+    ///
+    /// * `tier` - The tier to be set on the blob.
+    /// * `options` - Optional configuration for the request.
+    pub async fn set_tier(
+        &self,
+        tier: AccessTier,
+        options: Option<BlobClientSetTierOptions<'_>>,
+    ) -> Result<Response<()>> {
+        let response = self.client.set_tier(tier, options).await?;
         Ok(response)
     }
 }

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -17,11 +17,12 @@ pub use crate::generated::clients::{
 };
 pub use crate::generated::models::{
     BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
-    BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions, BlobContainerClientCreateOptions,
-    BlobContainerClientDeleteOptions, BlobContainerClientGetPropertiesOptions,
-    BlobContainerClientSetMetadataOptions, BlobServiceClientGetPropertiesOptions,
-    BlockBlobClientCommitBlockListOptions, BlockBlobClientGetBlockListOptions,
-    BlockBlobClientStageBlockOptions, BlockBlobClientUploadOptions,
+    BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions, BlobClientSetTierOptions,
+    BlobContainerClientCreateOptions, BlobContainerClientDeleteOptions,
+    BlobContainerClientGetPropertiesOptions, BlobContainerClientSetMetadataOptions,
+    BlobServiceClientGetPropertiesOptions, BlockBlobClientCommitBlockListOptions,
+    BlockBlobClientGetBlockListOptions, BlockBlobClientStageBlockOptions,
+    BlockBlobClientUploadOptions,
 };
 
 pub mod models {

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -8,8 +8,8 @@ use azure_core::{
 use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::{
     models::{
-        BlobClientDownloadResultHeaders, BlobClientGetPropertiesResultHeaders, BlockListType,
-        BlockLookupList, LeaseState,
+        AccessTier, BlobClientDownloadResultHeaders, BlobClientGetPropertiesResultHeaders,
+        BlockListType, BlockLookupList, LeaseState,
     },
     BlobClient, BlobClientOptions, BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions,
     BlobContainerClient, BlobContainerClientOptions, BlockBlobClientUploadOptions,
@@ -666,6 +666,69 @@ async fn test_get_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Assert
     assert_eq!(3, block_list.committed_blocks.len());
     assert_eq!(0, block_list.uncommitted_blocks.len());
+
+    container_client.delete_container(None).await?;
+    Ok(())
+}
+
+#[recorded::test]
+async fn test_set_access_tier(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    // Recording Setup
+    let recording = ctx.recording();
+    let (options, endpoint) = recorded_test_setup(recording);
+    let container_name = recording
+        .random_string::<17>(Some("container"))
+        .to_ascii_lowercase();
+    let blob_name = recording
+        .random_string::<12>(Some("blob"))
+        .to_ascii_lowercase();
+
+    let container_client_options = BlobContainerClientOptions {
+        client_options: options.clone(),
+        ..Default::default()
+    };
+    // Act
+    let container_client = BlobContainerClient::new(
+        &endpoint,
+        container_name.clone(),
+        recording.credential(),
+        Some(container_client_options),
+    )?;
+
+    let blob_client_options = BlobClientOptions {
+        client_options: options.clone(),
+        ..Default::default()
+    };
+    let blob_client = BlobClient::new(
+        &endpoint,
+        container_name,
+        blob_name,
+        recording.credential(),
+        Some(blob_client_options),
+    )?;
+    container_client.create_container(None).await?;
+
+    let data = b"hello rusty world";
+    blob_client
+        .upload(
+            RequestContent::from(data.to_vec()),
+            true,
+            u64::try_from(data.len())?,
+            None,
+        )
+        .await?;
+
+    let original_response = blob_client.get_properties(None).await?;
+    let og_access_tier = original_response.tier()?;
+    assert_eq!(AccessTier::Hot, og_access_tier.unwrap());
+
+    // Set Standard Blob Tier (Cold)
+    blob_client.set_tier(AccessTier::Cold, None).await?;
+    let response = blob_client.get_properties(None).await?;
+
+    // Assert
+    let access_tier = response.tier()?;
+    assert_eq!(AccessTier::Cold, access_tier.unwrap());
 
     container_client.delete_container(None).await?;
     Ok(())


### PR DESCRIPTION
Premium tiers will be covered in a follow-up PR as those are only applicable to Page blobs (which cannot be spun up currently)