### PR TITLE
Refactor WorkloadIdentityCredential construction

### DIFF
--- a/sdk/identity/.dict.txt
+++ b/sdk/identity/.dict.txt
@@ -8,7 +8,5 @@ cloudshell
 imds
 managedidentity
 msal
-nanos
 replacen
-subsec
 workloadidentity

--- a/sdk/identity/.dict.txt
+++ b/sdk/identity/.dict.txt
@@ -8,5 +8,7 @@ cloudshell
 imds
 managedidentity
 msal
+nanos
 replacen
+subsec
 workloadidentity

--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Breaking Changes
 
+- Moved `WorkloadIdentityCredential::new` arguments into `WorkloadIdentityCredentialOptions` except `token`, which has been removed (the credential now reads service account tokens only from a file).
+- Removed `WorkloadIdentityCredential::from_env`. `::new` now reads the same environment variables except for `AZURE_FEDERATED_TOKEN` (the Workload Identity webhook doesn't set that variable). `WorkloadIdentityCredentialOptions` overrides environment variable values.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/identity/azure_identity/examples/specific_credential.rs
+++ b/sdk/identity/azure_identity/examples/specific_credential.rs
@@ -111,7 +111,7 @@ impl SpecificAzureCredential {
                         )
                     })?,
                 azure_credential_kinds::WORKLOAD_IDENTITY => {
-                    WorkloadIdentityCredential::from_env(Some(options.into()))
+                    WorkloadIdentityCredential::new(Some(options.into()))
                         .map(SpecificAzureCredentialKind::WorkloadIdentity)
                         .with_context(ErrorKind::Credential, || {
                             format!(

--- a/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
@@ -183,25 +183,21 @@ impl ClientAssertion for Token {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{env::Env, tests::*};
+    use crate::{
+        credentials::client_assertion_credentials::tests::{is_valid_request, FAKE_ASSERTION},
+        env::Env,
+        tests::*,
+    };
     use azure_core::{
-        authority_hosts::AZURE_PUBLIC_CLOUD,
-        http::{
-            headers::{self, content_type, Headers},
-            Body, Method, Request, Response, StatusCode,
-        },
+        http::{headers::Headers, Response, StatusCode},
         Bytes,
     };
     use std::{
-        collections::HashMap,
         env,
         fs::File,
         io::Write,
         time::{SystemTime, UNIX_EPOCH},
     };
-    use url::form_urlencoded;
-
-    const FAKE_ASSERTION: &str = "fake assertion";
 
     pub struct TempFile {
         pub path: PathBuf,
@@ -227,48 +223,6 @@ mod tests {
     impl Drop for TempFile {
         fn drop(&mut self) {
             let _ = fs::remove_file(&self.path);
-        }
-    }
-
-    fn is_valid_request() -> impl Fn(&Request) -> azure_core::Result<()> {
-        let expected_url = format!(
-            "{}{}/oauth2/v2.0/token",
-            AZURE_PUBLIC_CLOUD.as_str(),
-            FAKE_TENANT_ID
-        );
-        move |req: &Request| {
-            assert_eq!(&Method::Post, req.method());
-            assert_eq!(expected_url, req.url().to_string());
-            assert_eq!(
-                req.headers().get_str(&headers::CONTENT_TYPE).unwrap(),
-                content_type::APPLICATION_X_WWW_FORM_URLENCODED.as_str()
-            );
-            let expected_params = [
-                ("client_assertion", FAKE_ASSERTION),
-                (
-                    "client_assertion_type",
-                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-                ),
-                ("client_id", FAKE_CLIENT_ID),
-                ("grant_type", "client_credentials"),
-                ("scope", &LIVE_TEST_SCOPES.join(" ")),
-            ];
-            let body = match req.body() {
-                Body::Bytes(bytes) => str::from_utf8(bytes).unwrap(),
-                _ => panic!("unexpected body type"),
-            };
-            let actual_params: HashMap<String, String> = form_urlencoded::parse(body.as_bytes())
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect();
-            for (key, value) in expected_params.iter() {
-                assert_eq!(
-                    *value,
-                    actual_params
-                        .get(*key)
-                        .unwrap_or_else(|| panic!("no {} in request body", key))
-                );
-            }
-            Ok(())
         }
     }
 

--- a/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
@@ -41,11 +41,11 @@ pub struct WorkloadIdentityCredentialOptions {
     /// Client ID of the Entra identity. Defaults to the value of the environment variable AZURE_CLIENT_ID.
     pub client_id: Option<String>,
 
-    /// Tenant ID of the Entra identity. Defaults to the value of the environment variable AZURE_TENANT_ID.
+    /// Tenant ID of the Entra identity. Defaults to the value of the environment variable `AZURE_TENANT_ID`.
     pub tenant_id: Option<String>,
 
     /// Path of a file containing a Kubernetes service account token. Defaults to the value of the environment
-    /// variable AZURE_FEDERATED_TOKEN_FILE.
+    /// variable `AZURE_FEDERATED_TOKEN_FILE`.
     pub token_file_path: Option<PathBuf>,
 }
 

--- a/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
@@ -203,9 +203,8 @@ mod tests {
             let n = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
-                .subsec_nanos()
-                % 1000;
-            let path = env::temp_dir().join(format!("azure_identity_test_{:03}", n));
+                .subsec_nanos();
+            let path = env::temp_dir().join(format!("azure_identity_test_{}", n));
             File::create(&path)
                 .expect("create temp file")
                 .write_all(content.as_bytes())

--- a/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
@@ -211,6 +211,7 @@ mod tests {
             let n = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
+                // cspell:disable-next-line
                 .subsec_nanos();
             let path = env::temp_dir().join(format!("azure_identity_test_{}", n));
             File::create(&path)

--- a/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
@@ -20,13 +20,13 @@ use super::{
     ClientAssertionCredentialOptions, TokenCredentialOptions,
 };
 
+const AZURE_CLIENT_ID: &str = "AZURE_CLIENT_ID";
 const AZURE_FEDERATED_TOKEN_FILE: &str = "AZURE_FEDERATED_TOKEN_FILE";
-const AZURE_FEDERATED_TOKEN: &str = "AZURE_FEDERATED_TOKEN";
+const AZURE_TENANT_ID: &str = "AZURE_TENANT_ID";
 
-/// Enables authentication to Azure Active Directory using a client secret that was generated for an App Registration.
-///
-/// More information on how to configure a client secret can be found here:
-/// <https://learn.microsoft.com/azure/active-directory/develop/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application>
+/// WorkloadIdentityCredential supports Azure workload identity on Kubernetes. See
+/// [Azure Kubernetes Service documentation](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+/// for more information.
 #[derive(Debug)]
 pub struct WorkloadIdentityCredential(ClientAssertionCredential<Token>);
 
@@ -35,69 +35,52 @@ pub struct WorkloadIdentityCredential(ClientAssertionCredential<Token>);
 pub struct WorkloadIdentityCredentialOptions {
     /// Options for the [`ClientAssertionCredential`] used by the [`WorkloadIdentityCredential`].
     pub credential_options: ClientAssertionCredentialOptions,
+
+    /// Client ID of the Entra identity. Defaults to the value of the environment variable AZURE_CLIENT_ID.
+    pub client_id: Option<String>,
+
+    /// Tenant ID of the Entra identity. Defaults to the value of the environment variable AZURE_TENANT_ID.
+    pub tenant_id: Option<String>,
+
+    /// Path of a file containing a Kubernetes service account token. Defaults to the value of the environment
+    /// variable AZURE_FEDERATED_TOKEN_FILE.
+    pub token_file_path: Option<String>,
 }
 
 impl WorkloadIdentityCredential {
     /// Create a new `WorkloadIdentityCredential`.
-    pub fn new<T>(
-        tenant_id: String,
-        client_id: String,
-        token: T,
+    pub fn new(
         options: Option<WorkloadIdentityCredentialOptions>,
-    ) -> azure_core::Result<Arc<Self>>
-    where
-        T: Into<Secret>,
-    {
+    ) -> azure_core::Result<Arc<Self>> {
         let options = options.unwrap_or_default();
+        let env = options.credential_options.credential_options.env();
+        let tenant_id = match options.tenant_id {
+            Some(id) => id,
+            None => env.var(AZURE_TENANT_ID).with_context(ErrorKind::Credential, || {
+                "no tenant ID specified. Check pod configuration or set tenant_id in the options"
+            })?
+        };
+        crate::validate_tenant_id(&tenant_id)?;
+        let path = match options.token_file_path {
+            Some(path) => path,
+            None => env.var(AZURE_FEDERATED_TOKEN_FILE).with_context(ErrorKind::Credential, || {
+                "no token file specified. Check pod configuration or set token_file_path in the options"
+            })?
+        };
+        let client_id = match options.client_id {
+            Some(id) => id,
+            None => env.var(AZURE_CLIENT_ID).with_context(ErrorKind::Credential, || {
+                "no client id specified. Check pod configuration or set client_id in the options"
+            })?
+        };
         Ok(Arc::new(Self(
             ClientAssertionCredential::<Token>::new_exclusive(
                 tenant_id,
                 client_id,
-                Token::Value(token.into()),
+                Token::new(&path)?,
                 Some(options.credential_options),
             )?,
         )))
-    }
-
-    /// Create a new `WorkloadIdentityCredential` from environment variables.
-    ///
-    /// # Variables
-    ///
-    /// * `AZURE_TENANT_ID`
-    /// * `AZURE_CLIENT_ID`
-    /// * `AZURE_FEDERATED_TOKEN` or `AZURE_FEDERATED_TOKEN_FILE`
-    pub fn from_env(
-        options: Option<WorkloadIdentityCredentialOptions>,
-    ) -> azure_core::Result<Arc<WorkloadIdentityCredential>> {
-        let options = options.unwrap_or_default();
-        let env = options.credential_options.credential_options.env();
-        if let Ok(token) = env
-            .var(AZURE_FEDERATED_TOKEN)
-            .map_kind(ErrorKind::Credential)
-        {
-            return Ok(Arc::new(Self(
-                ClientAssertionCredential::from_env_exclusive(
-                    Token::Value(token.into()),
-                    Some(options.credential_options),
-                )?,
-            )));
-        }
-
-        if let Ok(token_file) = env
-            .var(AZURE_FEDERATED_TOKEN_FILE)
-            .map_kind(ErrorKind::Credential)
-        {
-            return Ok(Arc::new(Self(
-                ClientAssertionCredential::from_env_exclusive(
-                    Token::with_file(token_file.as_ref())?,
-                    Some(options.credential_options),
-                )?,
-            )));
-        }
-
-        Err(Error::with_message(ErrorKind::Credential, || {
-            format!("working identity credential requires {AZURE_FEDERATED_TOKEN} or {AZURE_FEDERATED_TOKEN_FILE} environment variables")
-        }))
     }
 }
 
@@ -105,6 +88,9 @@ impl WorkloadIdentityCredential {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for WorkloadIdentityCredential {
     async fn get_token(&self, scopes: &[&str]) -> azure_core::Result<AccessToken> {
+        if scopes.is_empty() {
+            return Err(Error::message(ErrorKind::Credential, "no scopes specified"));
+        }
         self.0.get_token(scopes).await
     }
 }
@@ -117,17 +103,15 @@ impl From<TokenCredentialOptions> for WorkloadIdentityCredentialOptions {
                 credential_options: value,
                 ..Default::default()
             },
+            ..Default::default()
         }
     }
 }
 
 #[derive(Debug)]
-enum Token {
-    Value(Secret),
-    File {
-        path: String,
-        cache: Arc<RwLock<FileCache>>,
-    },
+struct Token {
+    path: String,
+    cache: Arc<RwLock<FileCache>>,
 }
 
 #[derive(Debug)]
@@ -137,13 +121,13 @@ struct FileCache {
 }
 
 impl Token {
-    fn with_file(path: &str) -> azure_core::Result<Self> {
+    fn new(path: &str) -> azure_core::Result<Self> {
         let last_read = Instant::now();
         let token = std::fs::read_to_string(path).with_context(ErrorKind::Credential, || {
             format!("failed to read federated token from file {}", path)
         })?;
 
-        Ok(Self::File {
+        Ok(Self {
             path: path.into(),
             cache: Arc::new(RwLock::new(FileCache {
                 token: Secret::new(token),
@@ -157,38 +141,238 @@ impl Token {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl ClientAssertion for Token {
     async fn secret(&self) -> azure_core::Result<String> {
-        match self {
-            Self::Value(secret) => Ok(secret.secret().into()),
-            Self::File { path, cache } => {
-                const TIMEOUT: Duration = Duration::from_secs(600);
+        const TIMEOUT: Duration = Duration::from_secs(600);
 
-                let now = Instant::now();
-                let cache = cache.upgradable_read().await;
-                if now - cache.last_read > TIMEOUT {
-                    // TODO: https://github.com/Azure/azure-sdk-for-rust/issues/2002
-                    let path = path.clone();
-                    let (tx, rx) = oneshot::channel();
-                    thread::spawn(move || {
-                        let token = fs::read_to_string(&path)
-                            .with_context(ErrorKind::Credential, || {
-                                format!("failed to read federated token from file {}", &path)
-                            });
-                        tx.send(token)
-                    });
+        let now = Instant::now();
+        let cache = self.cache.upgradable_read().await;
+        if now - cache.last_read > TIMEOUT {
+            // TODO: https://github.com/Azure/azure-sdk-for-rust/issues/2002
+            let path = self.path.clone();
+            let (tx, rx) = oneshot::channel();
+            thread::spawn(move || {
+                let token = fs::read_to_string(&path).with_context(ErrorKind::Credential, || {
+                    format!("failed to read federated token from file {}", &path)
+                });
+                tx.send(token)
+            });
 
-                    let mut write_cache = RwLockUpgradableReadGuard::upgrade(cache).await;
-                    let token = rx.await.map_err(|err| {
-                        azure_core::Error::full(ErrorKind::Io, err, "canceled reading certificate")
-                    })??;
+            let mut write_cache = RwLockUpgradableReadGuard::upgrade(cache).await;
+            let token = rx.await.map_err(|err| {
+                azure_core::Error::full(ErrorKind::Io, err, "canceled reading certificate")
+            })??;
 
-                    write_cache.token = Secret::new(token);
-                    write_cache.last_read = now;
+            write_cache.token = Secret::new(token);
+            write_cache.last_read = now;
 
-                    return Ok(write_cache.token.secret().into());
-                }
+            return Ok(write_cache.token.secret().into());
+        }
 
-                Ok(cache.token.secret().into())
+        Ok(cache.token.secret().into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{env::Env, tests::*};
+    use azure_core::{
+        authority_hosts::AZURE_PUBLIC_CLOUD,
+        http::{
+            headers::{self, content_type, Headers},
+            Body, Method, Request, Response, StatusCode,
+        },
+        Bytes,
+    };
+    use std::{
+        collections::HashMap,
+        env,
+        fs::File,
+        io::Write,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use url::form_urlencoded;
+
+    const FAKE_ASSERTION: &str = "fake assertion";
+
+    pub struct TempFile {
+        pub path: String,
+    }
+
+    impl TempFile {
+        pub fn new(content: &str) -> Self {
+            let n = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+                % 1000;
+            let path = env::temp_dir().join(format!("azure_identity_test_{:03}", n));
+            File::create(&path)
+                .expect("create temp file")
+                .write_all(content.as_bytes())
+                .expect("write temp file");
+
+            Self {
+                path: path.to_string_lossy().to_string(),
             }
         }
+    }
+
+    impl Drop for TempFile {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
+    fn is_valid_request() -> impl Fn(&Request) -> azure_core::Result<()> {
+        let expected_url = format!(
+            "{}{}/oauth2/v2.0/token",
+            AZURE_PUBLIC_CLOUD.as_str(),
+            FAKE_TENANT_ID
+        );
+        move |req: &Request| {
+            assert_eq!(&Method::Post, req.method());
+            assert_eq!(expected_url, req.url().to_string());
+            assert_eq!(
+                req.headers().get_str(&headers::CONTENT_TYPE).unwrap(),
+                content_type::APPLICATION_X_WWW_FORM_URLENCODED.as_str()
+            );
+            let expected_params = [
+                ("client_assertion", FAKE_ASSERTION),
+                (
+                    "client_assertion_type",
+                    "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                ),
+                ("client_id", FAKE_CLIENT_ID),
+                ("grant_type", "client_credentials"),
+                ("scope", &LIVE_TEST_SCOPES.join(" ")),
+            ];
+            let body = match req.body() {
+                Body::Bytes(bytes) => str::from_utf8(bytes).unwrap(),
+                _ => panic!("unexpected body type"),
+            };
+            let actual_params: HashMap<String, String> = form_urlencoded::parse(body.as_bytes())
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            for (key, value) in expected_params.iter() {
+                assert_eq!(
+                    *value,
+                    actual_params
+                        .get(*key)
+                        .unwrap_or_else(|| panic!("no {} in request body", key))
+                );
+            }
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn env_vars() {
+        let temp_file = TempFile::new(FAKE_ASSERTION);
+        let mock = MockSts::new(
+            vec![Response::from_bytes(
+                StatusCode::Ok,
+                Headers::default(),
+                Bytes::from(format!(
+                    r#"{{"access_token":"{}","expires_in":3600,"ext_expires_in":3600,"token_type":"Bearer"}}"#,
+                    FAKE_TOKEN
+                )),
+            )],
+            Some(Arc::new(is_valid_request())),
+        );
+        let cred = WorkloadIdentityCredential::new(Some(WorkloadIdentityCredentialOptions {
+            credential_options: ClientAssertionCredentialOptions {
+                credential_options: TokenCredentialOptions {
+                    env: Env::from(
+                        &[
+                            (AZURE_CLIENT_ID, FAKE_CLIENT_ID),
+                            (AZURE_TENANT_ID, FAKE_TENANT_ID),
+                            (AZURE_FEDERATED_TOKEN_FILE, temp_file.path.as_str()),
+                        ][..],
+                    ),
+                    http_client: Arc::new(mock),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        }))
+        .expect("valid credential");
+
+        let token = cred.get_token(LIVE_TEST_SCOPES).await.expect("token");
+        assert_eq!(FAKE_TOKEN, token.token.secret());
+        assert!(token.expires_on > SystemTime::now());
+    }
+
+    #[test]
+    fn invalid_tenant_id() {
+        let temp_file = TempFile::new(FAKE_ASSERTION);
+        WorkloadIdentityCredential::new(Some(WorkloadIdentityCredentialOptions {
+            client_id: Some(FAKE_CLIENT_ID.to_string()),
+            tenant_id: Some("not a valid tenant".to_string()),
+            token_file_path: Some(temp_file.path.clone()),
+            ..Default::default()
+        }))
+        .expect_err("invalid tenant ID");
+    }
+
+    #[test]
+    fn missing_config() {
+        WorkloadIdentityCredential::new(None).expect_err("missing config");
+    }
+
+    #[tokio::test]
+    async fn no_scopes() {
+        let temp_file = TempFile::new(FAKE_ASSERTION);
+        WorkloadIdentityCredential::new(Some(WorkloadIdentityCredentialOptions {
+            client_id: Some(FAKE_CLIENT_ID.to_string()),
+            tenant_id: Some(FAKE_TENANT_ID.to_string()),
+            token_file_path: Some(temp_file.path.clone()),
+            ..Default::default()
+        }))
+        .expect("valid credential")
+        .get_token(&[])
+        .await
+        .expect_err("no scopes specified");
+    }
+
+    #[tokio::test]
+    async fn options_override_env() {
+        let right_file = TempFile::new(FAKE_ASSERTION);
+        let wrong_file = TempFile::new("wrong assertion");
+        let mock = MockSts::new(
+            vec![Response::from_bytes(
+                StatusCode::Ok,
+                Headers::default(),
+                Bytes::from(format!(
+                    r#"{{"access_token":"{}","expires_in":3600,"ext_expires_in":3600,"token_type":"Bearer"}}"#,
+                    FAKE_TOKEN
+                )),
+            )],
+            Some(Arc::new(is_valid_request())),
+        );
+        let cred = WorkloadIdentityCredential::new(Some(WorkloadIdentityCredentialOptions {
+            client_id: Some(FAKE_CLIENT_ID.to_string()),
+            tenant_id: Some(FAKE_TENANT_ID.to_string()),
+            token_file_path: Some(right_file.path.clone()),
+            credential_options: ClientAssertionCredentialOptions {
+                credential_options: TokenCredentialOptions {
+                    env: Env::from(
+                        &[
+                            (AZURE_CLIENT_ID, "wrong-client-id"),
+                            (AZURE_TENANT_ID, "wrong-tenant-id"),
+                            (AZURE_FEDERATED_TOKEN_FILE, wrong_file.path.as_str()),
+                        ][..],
+                    ),
+                    http_client: Arc::new(mock),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        }))
+        .expect("valid credential");
+
+        let token = cred.get_token(LIVE_TEST_SCOPES).await.expect("token");
+        assert_eq!(FAKE_TOKEN, token.token.secret());
+        assert!(token.expires_on > SystemTime::now());
     }
 }

--- a/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
+++ b/sdk/identity/azure_identity/src/credentials/workload_identity_credentials.rs
@@ -26,8 +26,9 @@ const AZURE_CLIENT_ID: &str = "AZURE_CLIENT_ID";
 const AZURE_FEDERATED_TOKEN_FILE: &str = "AZURE_FEDERATED_TOKEN_FILE";
 const AZURE_TENANT_ID: &str = "AZURE_TENANT_ID";
 
-/// WorkloadIdentityCredential supports Azure workload identity on Kubernetes. See
-/// [Azure Kubernetes Service documentation](https://learn.microsoft.com/azure/aks/workload-identity-overview)
+/// `WorkloadIdentityCredential` supports Azure workload identity on Kubernetes.
+///
+/// See [Azure Kubernetes Service documentation](https://learn.microsoft.com/azure/aks/workload-identity-overview)
 /// for more information.
 #[derive(Debug)]
 pub struct WorkloadIdentityCredential(ClientAssertionCredential<Token>);
@@ -38,7 +39,7 @@ pub struct WorkloadIdentityCredentialOptions {
     /// Options for the [`ClientAssertionCredential`] used by the [`WorkloadIdentityCredential`].
     pub credential_options: ClientAssertionCredentialOptions,
 
-    /// Client ID of the Entra identity. Defaults to the value of the environment variable AZURE_CLIENT_ID.
+    /// Client ID of the Entra identity. Defaults to the value of the environment variable `AZURE_CLIENT_ID`.
     pub client_id: Option<String>,
 
     /// Tenant ID of the Entra identity. Defaults to the value of the environment variable `AZURE_TENANT_ID`.


### PR DESCRIPTION
Removing `from_env()`, moving `new()` arguments into the options bag, and aligning the API with the platform feature and what we implemented in other SDKs. `new()` will read the same environment variables as did `from_env()`, excepting `AZURE_FEDERATED_TOKEN` because the platform doesn't set that, and callers can override those values via options. Also removing the ability to source service account tokens from something other than a file, because Kubernetes always provides them in a file.