### PR TITLE
[Storage] Navigation Methods Between Clients + Storage Test Helpers

### DIFF
--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_9f4842ba91",
+  "Tag": "rust/azure_storage_blob_40a76f9180",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_40a76f9180",
+  "Tag": "rust/azure_storage_blob_99380d9553",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -104,8 +104,7 @@ impl BlobClient {
         &self,
         options: Option<BlobClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<BlobClientGetPropertiesResult>> {
-        let response = self.client.get_properties(options).await?;
-        Ok(response)
+        self.client.get_properties(options).await
     }
 
     /// Sets system properties on the blob.
@@ -117,8 +116,7 @@ impl BlobClient {
         &self,
         options: Option<BlobClientSetPropertiesOptions<'_>>,
     ) -> Result<Response<()>> {
-        let response = self.client.set_properties(options).await?;
-        Ok(response)
+        self.client.set_properties(options).await
     }
 
     /// Downloads a blob from the service, including its metadata and properties.
@@ -128,8 +126,7 @@ impl BlobClient {
         &self,
         options: Option<BlobClientDownloadOptions<'_>>,
     ) -> Result<Response<BlobClientDownloadResult>> {
-        let response = self.client.download(options).await?;
-        Ok(response)
+        self.client.download(options).await
     }
 
     /// Creates a new blob from a data source.
@@ -156,10 +153,9 @@ impl BlobClient {
 
         let block_blob_client = self.client.get_block_blob_client();
 
-        let response = block_blob_client
+        block_blob_client
             .upload(data, content_length, Some(options))
-            .await?;
-        Ok(response)
+            .await
     }
 
     /// Sets user-defined metadata for the specified blob as one or more name-value pairs. Each call to this operation
@@ -173,8 +169,7 @@ impl BlobClient {
         &self,
         options: Option<BlobClientSetMetadataOptions<'_>>,
     ) -> Result<Response<()>> {
-        let response = self.client.set_metadata(options).await?;
-        Ok(response)
+        self.client.set_metadata(options).await
     }
 
     /// Deletes the blob.
@@ -186,8 +181,7 @@ impl BlobClient {
         &self,
         options: Option<BlobClientDeleteOptions<'_>>,
     ) -> Result<Response<()>> {
-        let response = self.client.delete(options).await?;
-        Ok(response)
+        self.client.delete(options).await
     }
 
     /// Writes to a blob based on blocks specified by the list of IDs and content that make up the blob.
@@ -202,8 +196,7 @@ impl BlobClient {
         options: Option<BlockBlobClientCommitBlockListOptions<'_>>,
     ) -> Result<Response<BlockBlobClientCommitBlockListResult>> {
         let block_blob_client = self.client.get_block_blob_client();
-        let response = block_blob_client.commit_block_list(blocks, options).await?;
-        Ok(response)
+        block_blob_client.commit_block_list(blocks, options).await
     }
 
     /// Creates a new block to be later committed as part of a blob.
@@ -223,10 +216,9 @@ impl BlobClient {
         options: Option<BlockBlobClientStageBlockOptions<'_>>,
     ) -> Result<Response<BlockBlobClientStageBlockResult>> {
         let block_blob_client = self.client.get_block_blob_client();
-        let response = block_blob_client
+        block_blob_client
             .stage_block(block_id, content_length, body, options)
-            .await?;
-        Ok(response)
+            .await
     }
 
     /// Retrieves the list of blocks that have been uploaded as part of a block blob.
@@ -241,8 +233,7 @@ impl BlobClient {
         options: Option<BlockBlobClientGetBlockListOptions<'_>>,
     ) -> Result<Response<BlockList>> {
         let block_blob_client = self.client.get_block_blob_client();
-        let response = block_blob_client.get_block_list(list_type, options).await?;
-        Ok(response)
+        block_blob_client.get_block_list(list_type, options).await
     }
 
     /// Sets the tier on a blob. Standard tiers are only applicable for Block blobs, while Premium tiers are only applicable

--- a/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
@@ -112,8 +112,7 @@ impl BlobContainerClient {
         &self,
         options: Option<BlobContainerClientCreateOptions<'_>>,
     ) -> Result<Response<()>> {
-        let response = self.client.create(options).await?;
-        Ok(response)
+        self.client.create(options).await
     }
 
     /// Sets user-defined metadata for the specified container as one or more name-value pairs. Each call to this operation
@@ -127,8 +126,7 @@ impl BlobContainerClient {
         &self,
         options: Option<BlobContainerClientSetMetadataOptions<'_>>,
     ) -> Result<Response<()>> {
-        let response = self.client.set_metadata(options).await?;
-        Ok(response)
+        self.client.set_metadata(options).await
     }
 
     /// Marks the specified container for deletion. The container and any blobs contained within are later deleted during garbage collection.
@@ -140,8 +138,7 @@ impl BlobContainerClient {
         &self,
         options: Option<BlobContainerClientDeleteOptions<'_>>,
     ) -> Result<Response<()>> {
-        let response = self.client.delete(options).await?;
-        Ok(response)
+        self.client.delete(options).await
     }
 
     /// Returns all user-defined metadata and system properties for the specified container.
@@ -154,8 +151,6 @@ impl BlobContainerClient {
         &self,
         options: Option<BlobContainerClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<BlobContainerClientGetPropertiesResult>> {
-        let response = self.client.get_properties(options).await?;
-
-        Ok(response)
+        self.client.get_properties(options).await
     }
 }

--- a/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
@@ -79,7 +79,7 @@ impl BlobContainerClient {
     ///
     /// * `blob_name` - The name of the blob.
     /// * `options` - Optional configuration for the client.
-    pub fn get_blob_client(
+    pub fn blob_client(
         &self,
         blob_name: String,
         options: Option<BlobClientOptions>,

--- a/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
@@ -95,7 +95,6 @@ impl BlobServiceClient {
         &self,
         options: Option<BlobServiceClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<StorageServiceProperties>> {
-        let response = self.client.get_properties(options).await?;
-        Ok(response)
+        self.client.get_properties(options).await
     }
 }

--- a/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
@@ -68,7 +68,7 @@ impl BlobServiceClient {
     ///
     /// * `container_name` - The name of the container.
     /// * `options` - Optional configuration for the client.
-    pub fn get_blob_container_client(
+    pub fn blob_container_client(
         &self,
         container_name: String,
         options: Option<BlobContainerClientOptions>,

--- a/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     generated::clients::BlobServiceClient as GeneratedBlobServiceClient,
-    models::StorageServiceProperties, pipeline::StorageHeadersPolicy,
-    BlobServiceClientGetPropertiesOptions, BlobServiceClientOptions,
+    models::StorageServiceProperties, pipeline::StorageHeadersPolicy, BlobContainerClient,
+    BlobContainerClientOptions, BlobServiceClientGetPropertiesOptions, BlobServiceClientOptions,
 };
 use azure_core::{
     credentials::TokenCredential,
@@ -19,6 +19,7 @@ use std::sync::Arc;
 /// A client to interact with an Azure storage account.
 pub struct BlobServiceClient {
     endpoint: Url,
+    credential: Arc<dyn TokenCredential>,
     client: GeneratedBlobServiceClient,
 }
 
@@ -52,12 +53,32 @@ impl BlobServiceClient {
             .per_try_policies
             .push(Arc::new(oauth_token_policy) as Arc<dyn Policy>);
 
-        let client = GeneratedBlobServiceClient::new(endpoint, credential, Some(options))?;
+        let client = GeneratedBlobServiceClient::new(endpoint, credential.clone(), Some(options))?;
 
         Ok(Self {
             endpoint: endpoint.parse()?,
+            credential,
             client,
         })
+    }
+
+    /// Returns a new instance of BlobContainerClient.
+    ///
+    /// # Arguments
+    ///
+    /// * `container_name` - The name of the container.
+    /// * `options` - Optional configuration for the client.
+    pub fn get_blob_container_client(
+        &self,
+        container_name: String,
+        options: Option<BlobContainerClientOptions>,
+    ) -> Result<BlobContainerClient> {
+        BlobContainerClient::new(
+            self.endpoint().as_str(),
+            container_name,
+            self.credential.clone(),
+            options,
+        )
     }
 
     /// Gets the endpoint of the Storage account this client is connected to.

--- a/sdk/storage/azure_storage_blob/tests/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_client.rs
@@ -11,46 +11,19 @@ use azure_storage_blob::{
         AccessTier, BlobClientDownloadResultHeaders, BlobClientGetPropertiesResultHeaders,
         BlockListType, BlockLookupList, LeaseState,
     },
-    BlobClient, BlobClientOptions, BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions,
-    BlobContainerClient, BlobContainerClientOptions, BlockBlobClientUploadOptions,
+    BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions, BlockBlobClientUploadOptions,
 };
-use azure_storage_blob_test::recorded_test_setup;
+use azure_storage_blob_test::{get_blob_client, get_container_client};
 use std::{collections::HashMap, error::Error};
 
 #[recorded::test]
 async fn test_get_blob_properties(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
-    )?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
 
     // Invalid Container Scenario
@@ -61,9 +34,7 @@ async fn test_get_blob_properties(ctx: TestContext) -> Result<(), Box<dyn Error>
     assert_eq!(StatusCode::NotFound, error.unwrap());
 
     container_client.create_container(None).await?;
-
     let data = b"hello rusty world";
-
     blob_client
         .upload(
             RequestContent::from(data.to_vec()),
@@ -95,39 +66,13 @@ async fn test_get_blob_properties(ctx: TestContext) -> Result<(), Box<dyn Error>
 async fn test_set_blob_properties(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
-    )?;
-
     container_client.create_container(None).await?;
+
     let data = b"hello rusty world";
     blob_client
         .upload(
@@ -165,38 +110,12 @@ async fn test_upload_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
 
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
     container_client.create_container(None).await?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
-    )?;
 
     let data = b"hello rusty world";
 
@@ -264,38 +183,12 @@ async fn test_delete_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
 
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
     container_client.create_container(None).await?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
-    )?;
 
     let data = b"hello rusty world";
 
@@ -327,38 +220,13 @@ async fn test_delete_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 async fn test_download_blob(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
     container_client.create_container(None).await?;
 
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
-    )?;
     let data = b"test download content";
     blob_client
         .upload(
@@ -386,38 +254,12 @@ async fn test_set_blob_metadata(ctx: TestContext) -> Result<(), Box<dyn Error>> 
     // Recording Setup
 
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    //Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
     container_client.create_container(None).await?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
-    )?;
 
     let data = b"hello rusty world";
 
@@ -467,38 +309,12 @@ async fn test_set_blob_metadata(ctx: TestContext) -> Result<(), Box<dyn Error>> 
 async fn test_put_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
     container_client.create_container(None).await?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
-    )?;
 
     let block_1 = b"AAA";
     let block_2 = b"BBB";
@@ -566,38 +382,12 @@ async fn test_put_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 async fn test_get_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
     container_client.create_container(None).await?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
-    )?;
 
     let block_1 = b"AAA";
     let block_2 = b"BBB";
@@ -675,36 +465,10 @@ async fn test_get_block_list(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 async fn test_set_access_tier(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-    let blob_name = recording
-        .random_string::<12>(Some("blob"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name.clone(),
-        recording.credential(),
-        Some(container_client_options),
-    )?;
-
-    let blob_client_options = BlobClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-    let blob_client = BlobClient::new(
-        &endpoint,
-        container_name,
-        blob_name,
-        recording.credential(),
-        Some(blob_client_options),
+    let container_client = get_container_client(recording)?;
+    let blob_client = get_blob_client(
+        Some(container_client.container_name().to_string()),
+        recording,
     )?;
     container_client.create_container(None).await?;
 

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -5,34 +5,17 @@ use azure_core::http::StatusCode;
 use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::{
     models::{BlobContainerClientGetPropertiesResultHeaders, LeaseState},
-    BlobContainerClient, BlobContainerClientOptions, BlobContainerClientSetMetadataOptions,
+    BlobContainerClientSetMetadataOptions,
 };
-use azure_storage_blob_test::recorded_test_setup;
+use azure_storage_blob_test::get_container_client;
 use std::{collections::HashMap, error::Error};
 
 #[recorded::test]
 async fn test_create_container(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
+    let container_client = get_container_client(recording)?;
 
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name,
-        recording.credential(),
-        Some(container_client_options),
-    )?;
-
-    // Assert
     container_client.create_container(None).await?;
 
     container_client.delete_container(None).await?;
@@ -43,23 +26,7 @@ async fn test_create_container(ctx: TestContext) -> Result<(), Box<dyn Error>> {
 async fn test_get_container_properties(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name,
-        recording.credential(),
-        Some(container_client_options),
-    )?;
+    let container_client = get_container_client(recording)?;
 
     // Container Doesn't Exists Scenario
     let response = container_client.get_properties(None).await;
@@ -87,23 +54,7 @@ async fn test_get_container_properties(ctx: TestContext) -> Result<(), Box<dyn E
 async fn test_set_container_metadata(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
-    let container_name = recording
-        .random_string::<17>(Some("container"))
-        .to_ascii_lowercase();
-
-    let container_client_options = BlobContainerClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-
-    // Act
-    let container_client = BlobContainerClient::new(
-        &endpoint,
-        container_name,
-        recording.credential(),
-        Some(container_client_options),
-    )?;
+    let container_client = get_container_client(recording)?;
     container_client.create_container(None).await?;
 
     // Set Metadata With Values

--- a/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
@@ -2,29 +2,16 @@
 // Licensed under the MIT License.
 
 use azure_core_test::{recorded, TestContext};
-use azure_storage_blob::{
-    BlobServiceClient, BlobServiceClientGetPropertiesOptions, BlobServiceClientOptions,
-};
-use azure_storage_blob_test::recorded_test_setup;
+use azure_storage_blob::BlobServiceClientGetPropertiesOptions;
+use azure_storage_blob_test::get_blob_service_client;
 use std::error::Error;
 
 #[recorded::test]
 async fn test_get_service_properties(ctx: TestContext) -> Result<(), Box<dyn Error>> {
     // Recording Setup
     let recording = ctx.recording();
-    let (options, endpoint) = recorded_test_setup(recording);
+    let service_client = get_blob_service_client(recording)?;
 
-    let service_client_options = BlobServiceClientOptions {
-        client_options: options.clone(),
-        ..Default::default()
-    };
-
-    // Act
-    let service_client = BlobServiceClient::new(
-        &endpoint,
-        recording.credential(),
-        Some(service_client_options),
-    )?;
     let response = service_client
         .get_properties(Some(BlobServiceClientGetPropertiesOptions::default()))
         .await?;

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -16,7 +16,7 @@ use azure_storage_blob::{
 /// # Arguments
 ///
 /// * `recording` - A reference to a Recording instance.
-pub fn _recorded_test_setup(recording: &Recording) -> (ClientOptions, String) {
+fn recorded_test_setup(recording: &Recording) -> (ClientOptions, String) {
     let mut client_options = ClientOptions::default();
     recording.instrument(&mut client_options);
     let endpoint = format!(
@@ -33,7 +33,7 @@ pub fn _recorded_test_setup(recording: &Recording) -> (ClientOptions, String) {
 ///
 /// * `recording` - A reference to a Recording instance.
 pub fn get_blob_service_client(recording: &Recording) -> Result<BlobServiceClient> {
-    let (options, endpoint) = _recorded_test_setup(recording);
+    let (options, endpoint) = recorded_test_setup(recording);
     let service_client_options = BlobServiceClientOptions {
         client_options: options.clone(),
         ..Default::default()
@@ -54,7 +54,7 @@ pub fn get_container_client(recording: &Recording) -> Result<BlobContainerClient
     let container_name = recording
         .random_string::<17>(Some("container"))
         .to_ascii_lowercase();
-    let (options, endpoint) = _recorded_test_setup(recording);
+    let (options, endpoint) = recorded_test_setup(recording);
     let container_client_options = BlobContainerClientOptions {
         client_options: options.clone(),
         ..Default::default()
@@ -85,7 +85,7 @@ pub fn get_blob_client(
     let blob_name = recording
         .random_string::<12>(Some("blob"))
         .to_ascii_lowercase();
-    let (options, endpoint) = _recorded_test_setup(recording);
+    let (options, endpoint) = recorded_test_setup(recording);
     let blob_client_options = BlobClientOptions {
         client_options: options.clone(),
         ..Default::default()

--- a/sdk/storage/azure_storage_blob_test/src/lib.rs
+++ b/sdk/storage/azure_storage_blob_test/src/lib.rs
@@ -1,10 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-use azure_core::http::ClientOptions;
+use azure_core::{http::ClientOptions, Result};
 use azure_core_test::Recording;
+use azure_storage_blob::{
+    BlobClient, BlobClientOptions, BlobContainerClient, BlobContainerClientOptions,
+    BlobServiceClient, BlobServiceClientOptions,
+};
 
-pub fn recorded_test_setup(recording: &Recording) -> (ClientOptions, String) {
+pub fn _recorded_test_setup(recording: &Recording) -> (ClientOptions, String) {
     let mut client_options = ClientOptions::default();
     recording.instrument(&mut client_options);
     let endpoint = format!(
@@ -13,4 +17,60 @@ pub fn recorded_test_setup(recording: &Recording) -> (ClientOptions, String) {
     );
 
     (client_options, endpoint)
+}
+
+pub fn get_blob_service_client(recording: &Recording) -> Result<BlobServiceClient> {
+    let (options, endpoint) = _recorded_test_setup(recording);
+    let service_client_options = BlobServiceClientOptions {
+        client_options: options.clone(),
+        ..Default::default()
+    };
+    BlobServiceClient::new(
+        &endpoint,
+        recording.credential(),
+        Some(service_client_options),
+    )
+}
+
+pub fn get_container_client(recording: &Recording) -> Result<BlobContainerClient> {
+    let container_name = recording
+        .random_string::<17>(Some("container"))
+        .to_ascii_lowercase();
+    let (options, endpoint) = _recorded_test_setup(recording);
+    let container_client_options = BlobContainerClientOptions {
+        client_options: options.clone(),
+        ..Default::default()
+    };
+    BlobContainerClient::new(
+        &endpoint,
+        container_name,
+        recording.credential(),
+        Some(container_client_options),
+    )
+}
+
+pub fn get_blob_client(
+    container_name: Option<String>,
+    recording: &Recording,
+) -> Result<BlobClient> {
+    let container_name = container_name.unwrap_or(
+        recording
+            .random_string::<17>(Some("container"))
+            .to_ascii_lowercase(),
+    );
+    let blob_name = recording
+        .random_string::<12>(Some("blob"))
+        .to_ascii_lowercase();
+    let (options, endpoint) = _recorded_test_setup(recording);
+    let blob_client_options = BlobClientOptions {
+        client_options: options.clone(),
+        ..Default::default()
+    };
+    BlobClient::new(
+        &endpoint,
+        container_name,
+        blob_name,
+        recording.credential(),
+        Some(blob_client_options),
+    )
 }


### PR DESCRIPTION
This PR introduces the following:

- Navigation methods between clients (`get_container_client`, `get_blob_client`)
- Cleans up the API calls in the handwritten code from unnecessary wrapping/rewrapping
- Refactors test code
              -  Adds helpers to return instrumented instances of each client
              - Adds a basic "upload blob" since many tests need a blob to exists but don't actually care much about the contents