### PR TITLE
[Storage] [WIP] `get_account_info` all clients, `get/set_immutability_policy` for BlobClient

### DIFF
--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -4,17 +4,19 @@
 use crate::{
     generated::clients::BlobClient as GeneratedBlobClient,
     generated::models::{
-        BlobClientDownloadResult, BlobClientGetPropertiesResult,
-        BlockBlobClientCommitBlockListResult, BlockBlobClientStageBlockResult,
-        BlockBlobClientUploadResult,
+        BlobClientDeleteImmutabilityPolicyResult, BlobClientDownloadResult,
+        BlobClientGetAccountInfoResult, BlobClientGetPropertiesResult,
+        BlobClientSetImmutabilityPolicyResult, BlockBlobClientCommitBlockListResult,
+        BlockBlobClientStageBlockResult, BlockBlobClientUploadResult,
     },
     models::{AccessTier, BlockList, BlockListType, BlockLookupList},
     pipeline::StorageHeadersPolicy,
-    BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
-    BlobClientOptions, BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions,
-    BlobClientSetTierOptions, BlockBlobClientCommitBlockListOptions,
-    BlockBlobClientGetBlockListOptions, BlockBlobClientStageBlockOptions,
-    BlockBlobClientUploadOptions,
+    BlobClientDeleteImmutabilityPolicyOptions, BlobClientDeleteOptions, BlobClientDownloadOptions,
+    BlobClientGetAccountInfoOptions, BlobClientGetPropertiesOptions, BlobClientOptions,
+    BlobClientSetImmutabilityPolicyOptions, BlobClientSetMetadataOptions,
+    BlobClientSetPropertiesOptions, BlobClientSetTierOptions,
+    BlockBlobClientCommitBlockListOptions, BlockBlobClientGetBlockListOptions,
+    BlockBlobClientStageBlockOptions, BlockBlobClientUploadOptions,
 };
 use azure_core::{
     credentials::TokenCredential,
@@ -249,5 +251,42 @@ impl BlobClient {
         options: Option<BlobClientSetTierOptions<'_>>,
     ) -> Result<Response<()>> {
         self.client.set_tier(tier, options).await
+    }
+
+    /// Gets information related to the Storage account in which the blob resides.
+    /// This includes the `sku_name` and `account_kind`.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional configuration for the request.
+    pub async fn get_account_info(
+        &self,
+        options: Option<BlobClientGetAccountInfoOptions<'_>>,
+    ) -> Result<Response<BlobClientGetAccountInfoResult>> {
+        self.client.get_account_info(options).await
+    }
+
+    /// Sets the immutability policy on the blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional configuration for the request.
+    pub async fn set_immutability_policy(
+        &self,
+        options: Option<BlobClientSetImmutabilityPolicyOptions<'_>>,
+    ) -> Result<Response<BlobClientSetImmutabilityPolicyResult>> {
+        self.client.set_immutability_policy(options).await
+    }
+
+    /// Deletes the immutability policy on the blob.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional configuration for the request.
+    pub async fn delete_immutability_policy(
+        &self,
+        options: Option<BlobClientDeleteImmutabilityPolicyOptions<'_>>,
+    ) -> Result<Response<BlobClientDeleteImmutabilityPolicyResult>> {
+        self.client.delete_immutability_policy(options).await
     }
 }

--- a/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
@@ -3,10 +3,14 @@
 
 use crate::{
     generated::clients::BlobContainerClient as GeneratedBlobContainerClient,
-    generated::models::BlobContainerClientGetPropertiesResult, pipeline::StorageHeadersPolicy,
+    generated::models::{
+        BlobContainerClientGetAccountInfoResult, BlobContainerClientGetPropertiesResult,
+    },
+    pipeline::StorageHeadersPolicy,
     BlobClient, BlobClientOptions, BlobContainerClientCreateOptions,
-    BlobContainerClientDeleteOptions, BlobContainerClientGetPropertiesOptions,
-    BlobContainerClientOptions, BlobContainerClientSetMetadataOptions,
+    BlobContainerClientDeleteOptions, BlobContainerClientGetAccountInfoOptions,
+    BlobContainerClientGetPropertiesOptions, BlobContainerClientOptions,
+    BlobContainerClientSetMetadataOptions,
 };
 use azure_core::{
     credentials::TokenCredential,
@@ -152,5 +156,18 @@ impl BlobContainerClient {
         options: Option<BlobContainerClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<BlobContainerClientGetPropertiesResult>> {
         self.client.get_properties(options).await
+    }
+
+    /// Gets information related to the Storage account in which the container resides.
+    /// This includes the `sku_name` and `account_kind`.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional configuration for the request.
+    pub async fn get_account_info(
+        &self,
+        options: Option<BlobContainerClientGetAccountInfoOptions<'_>>,
+    ) -> Result<Response<BlobContainerClientGetAccountInfoResult>> {
+        self.client.get_account_info(options).await
     }
 }

--- a/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
@@ -3,8 +3,10 @@
 
 use crate::{
     generated::clients::BlobServiceClient as GeneratedBlobServiceClient,
-    models::StorageServiceProperties, pipeline::StorageHeadersPolicy, BlobContainerClient,
-    BlobContainerClientOptions, BlobServiceClientGetPropertiesOptions, BlobServiceClientOptions,
+    generated::models::BlobServiceClientGetAccountInfoResult, models::StorageServiceProperties,
+    pipeline::StorageHeadersPolicy, BlobContainerClient, BlobContainerClientOptions,
+    BlobServiceClientGetAccountInfoOptions, BlobServiceClientGetPropertiesOptions,
+    BlobServiceClientOptions,
 };
 use azure_core::{
     credentials::TokenCredential,
@@ -96,5 +98,18 @@ impl BlobServiceClient {
         options: Option<BlobServiceClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<StorageServiceProperties>> {
         self.client.get_properties(options).await
+    }
+
+    /// Gets information related to the Storage account.
+    /// This includes the `sku_name` and `account_kind`.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional configuration for the request.
+    pub async fn get_account_info(
+        &self,
+        options: Option<BlobServiceClientGetAccountInfoOptions<'_>>,
+    ) -> Result<Response<BlobServiceClientGetAccountInfoResult>> {
+        self.client.get_account_info(options).await
     }
 }

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -16,10 +16,13 @@ pub use crate::generated::clients::{
     BlobClientOptions, BlobContainerClientOptions, BlobServiceClientOptions,
 };
 pub use crate::generated::models::{
-    BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
-    BlobClientSetMetadataOptions, BlobClientSetPropertiesOptions, BlobClientSetTierOptions,
-    BlobContainerClientCreateOptions, BlobContainerClientDeleteOptions,
+    BlobClientDeleteImmutabilityPolicyOptions, BlobClientDeleteOptions, BlobClientDownloadOptions,
+    BlobClientGetAccountInfoOptions, BlobClientGetPropertiesOptions,
+    BlobClientSetImmutabilityPolicyOptions, BlobClientSetMetadataOptions,
+    BlobClientSetPropertiesOptions, BlobClientSetTierOptions, BlobContainerClientCreateOptions,
+    BlobContainerClientDeleteOptions, BlobContainerClientGetAccountInfoOptions,
     BlobContainerClientGetPropertiesOptions, BlobContainerClientSetMetadataOptions,
+    BlobImmutabilityPolicyMode, BlobServiceClientGetAccountInfoOptions,
     BlobServiceClientGetPropertiesOptions, BlockBlobClientCommitBlockListOptions,
     BlockBlobClientGetBlockListOptions, BlockBlobClientStageBlockOptions,
     BlockBlobClientUploadOptions,
@@ -27,12 +30,16 @@ pub use crate::generated::models::{
 
 pub mod models {
     pub use crate::generated::models::{
-        AccessTier, ArchiveStatus, BlobClientDownloadResult, BlobClientDownloadResultHeaders,
+        AccessTier, AccountKind, ArchiveStatus, BlobClientDeleteImmutabilityPolicyResult,
+        BlobClientDeleteImmutabilityPolicyResultHeaders, BlobClientDownloadResult,
+        BlobClientDownloadResultHeaders, BlobClientGetAccountInfoResultHeaders,
         BlobClientGetPropertiesResult, BlobClientGetPropertiesResultHeaders,
-        BlobContainerClientGetPropertiesResult, BlobContainerClientGetPropertiesResultHeaders,
-        BlobImmutabilityPolicyMode, BlobType, BlockBlobClientCommitBlockListResult,
-        BlockBlobClientStageBlockResult, BlockBlobClientUploadResult, BlockList, BlockListType,
-        BlockLookupList, CopyStatus, LeaseState, LeaseStatus, PublicAccessType, RehydratePriority,
-        StorageServiceProperties,
+        BlobClientSetImmutabilityPolicyResult, BlobClientSetImmutabilityPolicyResultHeaders,
+        BlobContainerClientGetAccountInfoResultHeaders, BlobContainerClientGetPropertiesResult,
+        BlobContainerClientGetPropertiesResultHeaders, BlobImmutabilityPolicyMode,
+        BlobServiceClientGetAccountInfoResultHeaders, BlobType,
+        BlockBlobClientCommitBlockListResult, BlockBlobClientStageBlockResult,
+        BlockBlobClientUploadResult, BlockList, BlockListType, BlockLookupList, CopyStatus,
+        LeaseState, LeaseStatus, PublicAccessType, RehydratePriority, StorageServiceProperties,
     };
 }

--- a/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_container_client.rs
@@ -4,7 +4,10 @@
 use azure_core::http::StatusCode;
 use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::{
-    models::{BlobContainerClientGetPropertiesResultHeaders, LeaseState},
+    models::{
+        AccountKind, BlobContainerClientGetAccountInfoResultHeaders,
+        BlobContainerClientGetPropertiesResultHeaders, LeaseState,
+    },
     BlobContainerClientSetMetadataOptions,
 };
 use azure_storage_blob_test::get_container_client;
@@ -81,5 +84,24 @@ async fn test_set_container_metadata(ctx: TestContext) -> Result<(), Box<dyn Err
     assert_eq!(HashMap::new(), response_metadata);
 
     container_client.delete_container(None).await?;
+    Ok(())
+}
+
+#[recorded::test]
+async fn test_get_account_info(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    // Recording Setup
+    let recording = ctx.recording();
+    let container_client = get_container_client(recording)?;
+
+    // Act
+    let response = container_client.get_account_info(None).await?;
+
+    // Assert
+    let sku_name = response.sku_name()?;
+    let account_kind = response.account_kind()?;
+
+    assert!(sku_name.is_some());
+    assert_eq!(AccountKind::StorageV2, account_kind.unwrap());
+
     Ok(())
 }

--- a/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 use azure_core_test::{recorded, TestContext};
-use azure_storage_blob::BlobServiceClientGetPropertiesOptions;
+use azure_storage_blob::{
+    models::{AccountKind, BlobServiceClientGetAccountInfoResultHeaders},
+    BlobServiceClientGetPropertiesOptions,
+};
 use azure_storage_blob_test::get_blob_service_client;
 use std::error::Error;
 
@@ -20,5 +23,24 @@ async fn test_get_service_properties(ctx: TestContext) -> Result<(), Box<dyn Err
     let storage_service_properties = response.into_body().await?;
     let hour_metrics = storage_service_properties.hour_metrics;
     assert!(hour_metrics.is_some());
+    Ok(())
+}
+
+#[recorded::test]
+async fn test_get_account_info(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    // Recording Setup
+    let recording = ctx.recording();
+    let service_client = get_blob_service_client(recording)?;
+
+    // Act
+    let response = service_client.get_account_info(None).await?;
+
+    // Assert
+    let sku_name = response.sku_name()?;
+    let account_kind = response.account_kind()?;
+
+    assert!(sku_name.is_some());
+    assert_eq!(AccountKind::StorageV2, account_kind.unwrap());
+
     Ok(())
 }


### PR DESCRIPTION
Notes:

- We need to add versioning support (i.e. how to signify this is against the versioned account, will need to add additional bicep entry for versioned Storage account)
- How to set `ImmutableStorageWithVersioning` without management client
- There are no test recordings 
- There is no adjustments to TypeSpec (yet)