### PR TITLE
XML serialization helpers add XML declaration

### DIFF
--- a/sdk/storage/assets.json
+++ b/sdk/storage/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_storage_blob_e3372225c3",
+  "Tag": "rust/azure_storage_blob_c54b1e37ce",
   "TagPrefix": "rust/azure_storage_blob"
 }

--- a/sdk/typespec/typespec_client_core/src/xml.rs
+++ b/sdk/typespec/typespec_client_core/src/xml.rs
@@ -14,6 +14,9 @@ use typespec::error::{ErrorKind, Result, ResultExt};
 /// The UTF8 [byte order marker](https://en.wikipedia.org/wiki/Byte_order_mark).
 const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 
+/// The XML declaration used when serializing.
+const DECLARATION: &str = r#"<?xml version="1.0" encoding="utf-8"?>\n"#;
+
 /// Reads XML from bytes.
 pub fn read_xml_str<T>(body: &str) -> Result<T>
 where
@@ -38,6 +41,7 @@ where
 }
 
 /// Serializes a type to bytes.
+/// Automaticallyl includes the XML declaration.
 pub fn to_xml<T>(value: &T) -> Result<Bytes>
 where
     T: serde::Serialize,
@@ -46,10 +50,11 @@ where
         let t = core::any::type_name::<T>();
         format!("failed to serialize {t} into xml")
     })?;
-    Ok(Bytes::from(value))
+    Ok(Bytes::from(format!("{DECLARATION}{value}")))
 }
 
 /// Serializes a type to bytes with a specified root tag.
+/// Automaticallyl includes the XML declaration.
 pub fn to_xml_with_root<T>(root_tag: &str, value: &T) -> Result<Bytes>
 where
     T: serde::Serialize,
@@ -59,7 +64,7 @@ where
             let t = core::any::type_name::<T>();
             format!("failed to serialize {t} into xml")
         })?;
-    Ok(Bytes::from(value))
+    Ok(Bytes::from(format!("{DECLARATION}{value}")))
 }
 
 /// Returns bytes without the UTF-8 BOM.
@@ -74,7 +79,7 @@ fn slice_bom(bytes: &[u8]) -> &[u8] {
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     #[test]
     fn test_slice_bom() {
@@ -85,13 +90,14 @@ mod test {
         assert_eq!(&[8], slice_bom(bytes));
     }
 
+    #[derive(Deserialize, Serialize, PartialEq, Debug)]
+    #[serde(rename = "Foo")]
+    struct Test {
+        x: String,
+    }
+
     #[test]
     fn reading_xml() -> Result<()> {
-        #[derive(Deserialize, PartialEq, Debug)]
-        #[serde(rename = "Foo")]
-        struct Test {
-            x: String,
-        }
         let test = Test {
             x: "Hello, world!".into(),
         };
@@ -99,13 +105,38 @@ mod test {
         assert_eq!(test, read_xml(xml)?);
 
         let error = read_xml::<Test>(&xml[..xml.len() - 2]).unwrap_err();
-        assert!(format!("{error}").contains("reading_xml::Test"));
+        assert!(format!("{error}").contains("typespec_client_core::xml::test::Test"));
 
         let xml = r#"<?xml version="1.0" encoding="utf-8"?><Foo><x>Hello, world!</x></Foo>"#;
         assert_eq!(test, read_xml_str(xml)?);
 
         let error = read_xml_str::<Test>(&xml[..xml.len() - 2]).unwrap_err();
-        assert!(format!("{error}").contains("reading_xml::Test"));
+        assert!(format!("{error}").contains("typespec_client_core::xml::test::Test"));
+        Ok(())
+    }
+
+    #[test]
+    fn writing_xml() -> Result<()> {
+        assert_eq!(
+            br#"<?xml version="1.0" encoding="utf-8"?>\n<Foo><x>Hello, world!</x></Foo>"#,
+            to_xml(&Test {
+                x: "Hello, world!".to_string()
+            })?
+            .to_vec()
+            .as_slice()
+        );
+
+        assert_eq!(
+            br#"<?xml version="1.0" encoding="utf-8"?>\n<Bob><x>Hello, world!</x></Bob>"#,
+            to_xml_with_root(
+                "Bob",
+                &Test {
+                    x: "Hello, world!".to_string()
+                }
+            )?
+            .to_vec()
+            .as_slice()
+        );
         Ok(())
     }
 }

--- a/sdk/typespec/typespec_client_core/src/xml.rs
+++ b/sdk/typespec/typespec_client_core/src/xml.rs
@@ -41,7 +41,7 @@ where
 }
 
 /// Serializes a type to bytes.
-/// Automaticallyl includes the XML declaration.
+/// Automatically includes the XML declaration.
 pub fn to_xml<T>(value: &T) -> Result<Bytes>
 where
     T: serde::Serialize,
@@ -54,7 +54,7 @@ where
 }
 
 /// Serializes a type to bytes with a specified root tag.
-/// Automaticallyl includes the XML declaration.
+/// Automatically includes the XML declaration.
 pub fn to_xml_with_root<T>(root_tag: &str, value: &T) -> Result<Bytes>
 where
     T: serde::Serialize,

--- a/sdk/typespec/typespec_client_core/src/xml.rs
+++ b/sdk/typespec/typespec_client_core/src/xml.rs
@@ -41,6 +41,7 @@ where
 }
 
 /// Serializes a type to bytes.
+///
 /// Automatically includes the XML declaration.
 pub fn to_xml<T>(value: &T) -> Result<Bytes>
 where
@@ -50,10 +51,14 @@ where
         let t = core::any::type_name::<T>();
         format!("failed to serialize {t} into xml")
     })?;
-    Ok(Bytes::from(format!("{DECLARATION}{value}")))
+    let mut buf = bytes::BytesMut::with_capacity(DECLARATION.len() + value.len());
+    buf.extend_from_slice(DECLARATION.as_bytes());
+    buf.extend_from_slice(value.as_bytes());
+    Ok(buf.into())
 }
 
 /// Serializes a type to bytes with a specified root tag.
+///
 /// Automatically includes the XML declaration.
 pub fn to_xml_with_root<T>(root_tag: &str, value: &T) -> Result<Bytes>
 where
@@ -64,7 +69,10 @@ where
             let t = core::any::type_name::<T>();
             format!("failed to serialize {t} into xml")
         })?;
-    Ok(Bytes::from(format!("{DECLARATION}{value}")))
+    let mut buf = bytes::BytesMut::with_capacity(DECLARATION.len() + value.len());
+    buf.extend_from_slice(DECLARATION.as_bytes());
+    buf.extend_from_slice(value.as_bytes());
+    Ok(buf.into())
 }
 
 /// Returns bytes without the UTF-8 BOM.

--- a/sdk/typespec/typespec_client_core/src/xml.rs
+++ b/sdk/typespec/typespec_client_core/src/xml.rs
@@ -15,7 +15,7 @@ use typespec::error::{ErrorKind, Result, ResultExt};
 const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 
 /// The XML declaration used when serializing.
-const DECLARATION: &[u8; 40] = br#"<?xml version="1.0" encoding="utf-8"?>\n"#;
+const DECLARATION: &[u8; 38] = br#"<?xml version="1.0" encoding="utf-8"?>"#;
 
 /// Reads XML from bytes.
 pub fn read_xml_str<T>(body: &str) -> Result<T>
@@ -126,7 +126,7 @@ mod test {
     #[test]
     fn writing_xml() -> Result<()> {
         assert_eq!(
-            br#"<?xml version="1.0" encoding="utf-8"?>\n<Foo><x>Hello, world!</x></Foo>"#,
+            br#"<?xml version="1.0" encoding="utf-8"?><Foo><x>Hello, world!</x></Foo>"#,
             to_xml(&Test {
                 x: "Hello, world!".to_string()
             })?
@@ -135,7 +135,7 @@ mod test {
         );
 
         assert_eq!(
-            br#"<?xml version="1.0" encoding="utf-8"?>\n<Bob><x>Hello, world!</x></Bob>"#,
+            br#"<?xml version="1.0" encoding="utf-8"?><Bob><x>Hello, world!</x></Bob>"#,
             to_xml_with_root(
                 "Bob",
                 &Test {

--- a/sdk/typespec/typespec_client_core/src/xml.rs
+++ b/sdk/typespec/typespec_client_core/src/xml.rs
@@ -15,7 +15,7 @@ use typespec::error::{ErrorKind, Result, ResultExt};
 const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
 
 /// The XML declaration used when serializing.
-const DECLARATION: &str = r#"<?xml version="1.0" encoding="utf-8"?>\n"#;
+const DECLARATION: &[u8; 40] = br#"<?xml version="1.0" encoding="utf-8"?>\n"#;
 
 /// Reads XML from bytes.
 pub fn read_xml_str<T>(body: &str) -> Result<T>
@@ -52,7 +52,7 @@ where
         format!("failed to serialize {t} into xml")
     })?;
     let mut buf = bytes::BytesMut::with_capacity(DECLARATION.len() + value.len());
-    buf.extend_from_slice(DECLARATION.as_bytes());
+    buf.extend_from_slice(DECLARATION);
     buf.extend_from_slice(value.as_bytes());
     Ok(buf.into())
 }
@@ -70,7 +70,7 @@ where
             format!("failed to serialize {t} into xml")
         })?;
     let mut buf = bytes::BytesMut::with_capacity(DECLARATION.len() + value.len());
-    buf.extend_from_slice(DECLARATION.as_bytes());
+    buf.extend_from_slice(DECLARATION);
     buf.extend_from_slice(value.as_bytes());
     Ok(buf.into())
 }


### PR DESCRIPTION
The XML declaration is automatically prepended to the serialized content.