### PR TITLE
Fix auto-baseline condition

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -72,7 +72,7 @@ parameters:
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
-    autoBaseline: ${{ and(eq(variables['Build.DefinitionName'], 'rust - core'), eq(variables['Build.SourceBranchName'], 'main'), eq(variables['System.TeamProject'], 'internal')) }}
+    autoBaseline: ${{ and(eq(variables['Build.DefinitionName'], 'rust - core'), eq(replace(variables['Build.SourceBranchName'], 'refs/heads/',''), 'main'), eq(variables['System.TeamProject'], 'internal')) }}
     stages:
     - stage: Build
       variables:

--- a/eng/pipelines/templates/stages/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-client.yml
@@ -72,7 +72,7 @@ parameters:
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
-    autoBaseline: ${{ and(eq(variables['Build.DefinitionName'], 'rust - core'), eq(replace(variables['Build.SourceBranchName'], 'refs/heads/',''), 'main'), eq(variables['System.TeamProject'], 'internal')) }}
+    autoBaseline: ${{ and(eq(variables['Build.DefinitionName'], 'rust - core'), eq(replace(variables['Build.SourceBranchName'], 'refs/heads/', ''), 'main'), eq(variables['System.TeamProject'], 'internal')) }}
     stages:
     - stage: Build
       variables:


### PR DESCRIPTION
Attempt to fix the auto-baselining condition for the main pipeline. Sometimes the branch name contains "refs/heads/" and sometimes doesn't I'm not sure what causes this but I'm just eliminating that from the equation.