### PR TITLE
[Cosmos] Cross-Partition queries, with optional external Query Engine integration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,10 +7,6 @@
   },
   "rust-analyzer.cargo.features": "all",
   "rust-analyzer.check.command": "clippy",
-  "rust-analyzer.runnables.extraEnv": {
-    "AZURE_TEST_MODE": "live",
-    "AZURE_COSMOS_CONNECTION_STRING": "emulator"
-  },
   "yaml.format.printWidth": 240,
   "[powershell]": {
     "editor.defaultFormatter": "ms-vscode.powershell",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,10 @@
   },
   "rust-analyzer.cargo.features": "all",
   "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.runnables.extraEnv": {
+    "AZURE_TEST_MODE": "live",
+    "AZURE_COSMOS_CONNECTION_STRING": "emulator"
+  },
   "yaml.format.printWidth": 240,
   "[powershell]": {
     "editor.defaultFormatter": "ms-vscode.powershell",

--- a/eng/dict/rust-custom.txt
+++ b/eng/dict/rust-custom.txt
@@ -2,6 +2,7 @@ bindgen
 cfg
 cfgs
 consts
+deque
 impls
 newtype
 oneshot

--- a/sdk/core/azure_core/src/http/pager.rs
+++ b/sdk/core/azure_core/src/http/pager.rs
@@ -120,6 +120,18 @@ impl<T> PageStream<T> {
             stream: Box::pin(stream),
         }
     }
+
+    /// Creates a [`Pager<T>`] from a raw stream of [`Result<T>`](typespec::Result<T>) values.
+    ///
+    /// This constructor is used when you are implementing a completely custom stream and want to use it as a pager.
+    pub fn from_stream<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<T, Error>> + Send + 'static,
+    {
+        Self {
+            stream: Box::pin(stream),
+        }
+    }
 }
 
 impl<T> futures::Stream for PageStream<T> {

--- a/sdk/cosmos/assets.json
+++ b/sdk/cosmos/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_data_cosmos_43a7f435b6",
+  "Tag": "rust/azure_data_cosmos_ff23846344",
   "TagPrefix": "rust/azure_data_cosmos"
 }

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -25,7 +25,7 @@ url.workspace = true
 
 [dev-dependencies]
 azure_identity.workspace = true
-azure_core_test.workspace = true
+azure_core_test = { workspace = true, features = ["tracing"] }
 clap.workspace = true
 reqwest.workspace = true
 time.workspace = true

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -38,7 +38,7 @@ workspace = true
 [features]
 default = ["hmac_rust"]
 key_auth = [] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
-query_engine = [] # Enables support for the PREVIEW external query engine
+query_engine = ["serde_json/raw_value"] # Enables support for the PREVIEW external query engine
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
 

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -38,7 +38,7 @@ workspace = true
 [features]
 default = ["hmac_rust"]
 key_auth = [] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
-query_engine = [] # Enables support for the PREVIEW external query engine
+preview_query_engine = [] # Enables support for the PREVIEW external query engine
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
 

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -25,7 +25,7 @@ url.workspace = true
 
 [dev-dependencies]
 azure_identity.workspace = true
-azure_core_test = { workspace = true, features = ["tracing"] }
+azure_core_test.workspace = true
 clap.workspace = true
 reqwest.workspace = true
 time.workspace = true
@@ -38,7 +38,7 @@ workspace = true
 [features]
 default = ["hmac_rust"]
 key_auth = [] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
-query_engine = ["serde_json/raw_value"] # Enables support for the PREVIEW external query engine
+query_engine = [] # Enables support for the PREVIEW external query engine
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
 

--- a/sdk/cosmos/azure_data_cosmos/Cargo.toml
+++ b/sdk/cosmos/azure_data_cosmos/Cargo.toml
@@ -38,6 +38,7 @@ workspace = true
 [features]
 default = ["hmac_rust"]
 key_auth = [] # Enables support for key-based authentication (Primary Keys and Resource Tokens)
+query_engine = [] # Enables support for the PREVIEW external query engine
 hmac_rust = ["azure_core/hmac_rust"]
 hmac_openssl = ["azure_core/hmac_openssl"]
 

--- a/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
+++ b/sdk/cosmos/azure_data_cosmos/examples/cosmos/query.rs
@@ -25,7 +25,7 @@ enum Subcommands {
 
         /// The partition key to use when querying the container. Currently this only supports a single string partition key.
         #[arg(long, short)]
-        partition_key: String,
+        partition_key: Option<String>,
     },
     Databases {
         /// The query to execute.
@@ -52,7 +52,11 @@ impl QueryCommand {
                 let db_client = client.database_client(&database);
                 let container_client = db_client.container_client(&container);
 
-                let pk = PartitionKey::from(&partition_key);
+                let pk = match partition_key {
+                    Some(pk) => PartitionKey::from(pk),
+                    None => PartitionKey::EMPTY,
+                };
+
                 let mut items =
                     container_client.query_items::<serde_json::Value>(&query, pk, None)?;
 

--- a/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/container_client.rs
@@ -689,12 +689,12 @@ impl ContainerClient {
         partition_key: impl Into<PartitionKey>,
         options: Option<QueryOptions<'_>>,
     ) -> azure_core::Result<FeedPager<T>> {
-        #[allow(unused_mut)] // This is used in the #[cfg(feature = "query_engine")] block
+        #[cfg_attr(not(feature = "preview_query_engine"), allow(unused_mut))]
         let mut options = options.unwrap_or_default();
         let partition_key = partition_key.into();
         let query = query.into();
 
-        #[cfg(feature = "query_engine")]
+        #[cfg(feature = "preview_query_engine")]
         if partition_key.is_empty() {
             if let Some(query_engine) = options.query_engine.take() {
                 return crate::query::executor::QueryExecutor::new(

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -10,7 +10,11 @@ use crate::{
 };
 use azure_core::{
     credentials::TokenCredential,
-    http::{request::Request, response::Response, Method, Url},
+    http::{
+        request::{options::ContentType, Request},
+        response::Response,
+        Method, Url,
+    },
 };
 use serde::Serialize;
 use std::sync::Arc;
@@ -135,13 +139,13 @@ impl CosmosClient {
     ) -> azure_core::Result<FeedPager<DatabaseProperties>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.databases_link);
-        let base_request = Request::new(url, Method::Post);
 
         self.pipeline.send_query_request(
             options.method_options.context,
             query.into(),
-            base_request,
+            url,
             self.databases_link.clone(),
+            |_| Ok(()),
         )
     }
 
@@ -167,6 +171,7 @@ impl CosmosClient {
         let url = self.pipeline.url(&self.databases_link);
         let mut req = Request::new(url, Method::Post);
         req.insert_headers(&options.throughput)?;
+        req.insert_headers(&ContentType::APPLICATION_JSON)?;
         req.set_json(&RequestBody { id })?;
 
         self.pipeline

--- a/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/database_client.rs
@@ -11,7 +11,11 @@ use crate::{
     ThroughputOptions,
 };
 
-use azure_core::http::{request::Request, response::Response, Method};
+use azure_core::http::{
+    request::{options::ContentType, Request},
+    response::Response,
+    Method,
+};
 
 /// A client for working with a specific database in a Cosmos DB account.
 ///
@@ -110,13 +114,13 @@ impl DatabaseClient {
     ) -> azure_core::Result<FeedPager<ContainerProperties>> {
         let options = options.unwrap_or_default();
         let url = self.pipeline.url(&self.containers_link);
-        let base_request = Request::new(url, Method::Post);
 
         self.pipeline.send_query_request(
             options.method_options.context,
             query.into(),
-            base_request,
+            url,
             self.containers_link.clone(),
+            |_| Ok(()),
         )
     }
 
@@ -136,6 +140,7 @@ impl DatabaseClient {
         let url = self.pipeline.url(&self.containers_link);
         let mut req = Request::new(url, Method::Post);
         req.insert_headers(&options.throughput)?;
+        req.insert_headers(&ContentType::APPLICATION_JSON)?;
         req.set_json(&properties)?;
 
         self.pipeline

--- a/sdk/cosmos/azure_data_cosmos/src/constants.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/constants.rs
@@ -13,8 +13,14 @@ use azure_core::http::{
 
 pub const QUERY: HeaderName = HeaderName::from_static("x-ms-documentdb-query");
 pub const PARTITION_KEY: HeaderName = HeaderName::from_static("x-ms-documentdb-partitionkey");
+pub const PARTITION_KEY_RANGE_ID: HeaderName =
+    HeaderName::from_static("x-ms-documentdb-partitionkeyrangeid");
 pub const QUERY_ENABLE_CROSS_PARTITION: HeaderName =
     HeaderName::from_static("x-ms-documentdb-query-enablecrosspartition");
+pub const IS_QUERY_PLAN_REQUEST: HeaderName =
+    HeaderName::from_static("x-ms-cosmos-is-query-plan-request");
+pub const SUPPORTED_QUERY_FEATURES: HeaderName =
+    HeaderName::from_static("x-ms-cosmos-supported-query-features");
 pub const CONTINUATION: HeaderName = HeaderName::from_static("x-ms-continuation");
 pub const INDEX_METRICS: HeaderName = HeaderName::from_static("x-ms-cosmos-index-utilization");
 pub const QUERY_METRICS: HeaderName = HeaderName::from_static("x-ms-documentdb-query-metrics");

--- a/sdk/cosmos/azure_data_cosmos/src/constants.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/constants.rs
@@ -13,6 +13,8 @@ use azure_core::http::{
 
 pub const QUERY: HeaderName = HeaderName::from_static("x-ms-documentdb-query");
 pub const PARTITION_KEY: HeaderName = HeaderName::from_static("x-ms-documentdb-partitionkey");
+pub const QUERY_ENABLE_CROSS_PARTITION: HeaderName =
+    HeaderName::from_static("x-ms-documentdb-query-enablecrosspartition");
 pub const CONTINUATION: HeaderName = HeaderName::from_static("x-ms-continuation");
 pub const INDEX_METRICS: HeaderName = HeaderName::from_static("x-ms-cosmos-index-utilization");
 pub const QUERY_METRICS: HeaderName = HeaderName::from_static("x-ms-documentdb-query-metrics");

--- a/sdk/cosmos/azure_data_cosmos/src/feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/feed.rs
@@ -26,7 +26,7 @@ pub struct FeedPage<T> {
 
 impl<T> FeedPage<T> {
     /// Creates a new `FeedPage` instance.
-    #[allow(dead_code)] // Used in the query_engine feature
+    #[cfg_attr(not(feature = "preview_query_engine"), allow(dead_code))]
     pub(crate) fn new(items: Vec<T>, continuation: Option<String>, headers: Headers) -> Self {
         Self {
             items,

--- a/sdk/cosmos/azure_data_cosmos/src/feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/feed.rs
@@ -11,6 +11,7 @@ use crate::constants;
 /// Cosmos DB queries can be executed using non-HTTP transports, depending on the circumstances.
 /// They may also produce results that don't directly correlate to specific HTTP responses (as in the case of cross-partition queries).
 /// Because of this, Cosmos DB query responses use `FeedPage` to represent the results, rather than a more generic type like [`Response`](azure_core::http::Response).
+#[derive(Debug)]
 pub struct FeedPage<T> {
     /// The items in the response.
     items: Vec<T>,
@@ -24,6 +25,16 @@ pub struct FeedPage<T> {
 }
 
 impl<T> FeedPage<T> {
+    /// Creates a new `FeedPage` instance.
+    #[allow(dead_code)] // Used in the query_engine feature
+    pub(crate) fn new(items: Vec<T>, continuation: Option<String>, headers: Headers) -> Self {
+        Self {
+            items,
+            continuation,
+            headers,
+        }
+    }
+
     /// Gets the items in this page of results.
     pub fn items(&self) -> &[T] {
         &self.items

--- a/sdk/cosmos/azure_data_cosmos/src/lib.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/lib.rs
@@ -16,7 +16,7 @@ mod feed;
 mod options;
 mod partition_key;
 pub(crate) mod pipeline;
-mod query;
+pub mod query;
 pub(crate) mod resource_context;
 pub(crate) mod utils;
 
@@ -27,6 +27,6 @@ pub use clients::CosmosClient;
 
 pub use options::*;
 pub use partition_key::*;
-pub use query::*;
+pub use query::Query;
 
 pub use feed::{FeedPage, FeedPager};

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -70,6 +70,13 @@ pub struct QueryDatabasesOptions<'a> {
 #[derive(Clone, Default)]
 pub struct QueryOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
+
+    /// An external query engine to use for executing the query.
+    ///
+    /// NOTE: This is an unstable feature and may change in the future.
+    /// Specifically, the query engine may be built-in to the SDK in the future, and this option may be removed entirely.
+    #[cfg(feature = "query_engine")]
+    pub query_engine: Option<std::sync::Arc<dyn crate::query::QueryEngine>>,
 }
 
 /// Options to be passed to [`ContainerClient::read()`](crate::clients::ContainerClient::read()).

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -75,7 +75,7 @@ pub struct QueryOptions<'a> {
     ///
     /// NOTE: This is an unstable feature and may change in the future.
     /// Specifically, the query engine may be built-in to the SDK in the future, and this option may be removed entirely.
-    #[cfg(feature = "query_engine")]
+    #[cfg(feature = "preview_query_engine")]
     pub query_engine: Option<crate::query::QueryEngineRef>,
 }
 
@@ -85,7 +85,7 @@ impl QueryOptions<'_> {
             method_options: ClientMethodOptions {
                 context: self.method_options.context.into_owned(),
             },
-            #[cfg(feature = "query_engine")]
+            #[cfg(feature = "preview_query_engine")]
             query_engine: self.query_engine,
         }
     }

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -76,7 +76,19 @@ pub struct QueryOptions<'a> {
     /// NOTE: This is an unstable feature and may change in the future.
     /// Specifically, the query engine may be built-in to the SDK in the future, and this option may be removed entirely.
     #[cfg(feature = "query_engine")]
-    pub query_engine: Option<std::sync::Arc<dyn crate::query::QueryEngine>>,
+    pub query_engine: Option<crate::query::QueryEngineRef>,
+}
+
+impl QueryOptions<'_> {
+    pub fn into_owned(self) -> QueryOptions<'static> {
+        QueryOptions {
+            method_options: ClientMethodOptions {
+                context: self.method_options.context.into_owned(),
+            },
+            #[cfg(feature = "query_engine")]
+            query_engine: self.query_engine,
+        }
+    }
 }
 
 /// Options to be passed to [`ContainerClient::read()`](crate::clients::ContainerClient::read()).

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -84,7 +84,7 @@ impl PartitionKey {
     /// An empty list of partition key values, which is used to signal a cross-partition query, when querying a container.
     pub const EMPTY: PartitionKey = PartitionKey(Vec::new());
 
-    #[allow(dead_code)] // Used in the query_engine feature.
+    #[cfg_attr(not(feature = "preview_query_engine"), allow(dead_code))]
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -78,10 +78,14 @@ use crate::constants;
 pub struct PartitionKey(Vec<PartitionKeyValue>);
 
 impl PartitionKey {
+    /// A single null partition key value, which can be used as the sole partition key or as part of a hierarchical partition key.
     pub const NULL: PartitionKeyValue = PartitionKeyValue(InnerPartitionKeyValue::Null);
+
+    /// An empty list of partition key values, which is used to signal a cross-partition query, when querying a container.
     pub const EMPTY: PartitionKey = PartitionKey(Vec::new());
 
-    pub fn is_empty(&self) -> bool {
+    #[allow(dead_code)] // Used in the query_engine feature.
+    pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -35,23 +35,23 @@ use crate::constants;
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
-///     Some(("parent", "child")),
+///     ("parent", "child"),
 ///     None).unwrap();
 /// ```
 ///
 /// Null values can be represented in one of two ways.
-/// First, you can use an empty tuple (`()`) anywhere a `PartitionKey` is expected:
+/// First, you can use the value [`PartitionKey::NULL`]:
 ///
 /// ```rust,no_run
-/// # use azure_data_cosmos::clients::ContainerClient;
+/// # use azure_data_cosmos::{clients::ContainerClient, PartitionKey};
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
-///     Some(()), // A null value in a single-level partition key.
+///     PartitionKey::NULL,
 ///     None).unwrap();
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
-///     Some(("a", (), "b")), // A null value within a hierarchical partition key.
+///     ("a", PartitionKey::NULL, "b"), // A null value within a hierarchical partition key.
 ///     None).unwrap();
 /// ```
 ///
@@ -81,8 +81,8 @@ impl PartitionKey {
     pub const NULL: PartitionKeyValue = PartitionKeyValue(InnerPartitionKeyValue::Null);
     pub const EMPTY: PartitionKey = PartitionKey(Vec::new());
 
-    pub(crate) fn values(&self) -> &[PartitionKeyValue] {
-        &self.0
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     pub fn empty() {
         let partition_key = PartitionKey::from(());
-        assert_eq!(Vec::<PartitionKeyValue>::new(), partition_key.values());
+        assert_eq!(Vec::<PartitionKeyValue>::new(), partition_key.0);
 
         let mut headers_iter = partition_key.as_headers().unwrap();
         let (name, value) = headers_iter.next().unwrap();

--- a/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/partition_key.rs
@@ -7,24 +7,6 @@ use azure_core::http::headers::{AsHeaders, HeaderName, HeaderValue};
 
 use crate::constants;
 
-/// Describes the partition strategy that will be used when querying.
-///
-/// Currently, the only supported strategy is [`QueryPartitionStrategy::SinglePartition`], which executes the query against a single partition, specified by the [`PartitionKey`] provided.
-///
-/// [`QueryPartitionStrategy`] implements [`From`] for any type that is convertible to a `PartitionKey`.
-/// This allows you to use any of the syntaxes specified in the [`PartitionKey`] docs any place an [`Into<QueryPartitionStrategy>`] is expected.
-#[derive(Debug, Clone)]
-pub enum QueryPartitionStrategy {
-    SinglePartition(PartitionKey),
-}
-
-impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
-    /// Converts the provided value to a [`QueryPartitionStrategy::SinglePartition`], specifying that a query should be executed over only the partition defined by this [`PartitionKey`].
-    fn from(value: T) -> Self {
-        QueryPartitionStrategy::SinglePartition(value.into())
-    }
-}
-
 /// Specifies a partition key value, usually used when querying a specific partition.
 ///
 /// # Specifying a partition key
@@ -53,7 +35,7 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
-///     ("parent", "child"),
+///     Some(("parent", "child")),
 ///     None).unwrap();
 /// ```
 ///
@@ -65,11 +47,11 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 /// # let container_client: ContainerClient = panic!("this is a non-running example");
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
-///     (), // A null value in a single-level partition key.
+///     Some(()), // A null value in a single-level partition key.
 ///     None).unwrap();
 /// container_client.query_items::<serde_json::Value>(
 ///     "SELECT * FROM c",
-///     ("a", (), "b"), // A null value within a hierarchical partition key.
+///     Some(("a", (), "b")), // A null value within a hierarchical partition key.
 ///     None).unwrap();
 /// ```
 ///
@@ -95,6 +77,15 @@ impl<T: Into<PartitionKey>> From<T> for QueryPartitionStrategy {
 #[derive(Debug, Clone)]
 pub struct PartitionKey(Vec<PartitionKeyValue>);
 
+impl PartitionKey {
+    pub const NULL: PartitionKeyValue = PartitionKeyValue(InnerPartitionKeyValue::Null);
+    pub const EMPTY: PartitionKey = PartitionKey(Vec::new());
+
+    pub(crate) fn values(&self) -> &[PartitionKeyValue] {
+        &self.0
+    }
+}
+
 impl AsHeaders for PartitionKey {
     type Error = azure_core::Error;
     type Iter = std::iter::Once<(HeaderName, HeaderValue)>;
@@ -104,6 +95,15 @@ impl AsHeaders for PartitionKey {
         // The partition key is sent in an HTTP header, when used to set the partition key for a query.
         // It's not safe to use non-ASCII characters in HTTP headers, and serde_json will not escape non-ASCII characters if they are otherwise valid as UTF-8.
         // So, we do some conversion by hand, with the help of Rust's own `encode_utf16` method which gives us the necessary code points for non-ASCII values, and produces surrogate pairs as needed.
+
+        // Quick shortcut for empty partition keys list, which also prevents a bug when we pop the trailing comma for an empty list.
+        if self.0.is_empty() {
+            // An empty partition key means a cross partition query
+            return Ok(std::iter::once((
+                constants::QUERY_ENABLE_CROSS_PARTITION,
+                HeaderValue::from_static("True"),
+            )));
+        }
 
         let mut json = String::new();
         let mut utf_buf = [0; 2]; // A buffer for encoding UTF-16 characters.
@@ -157,11 +157,11 @@ impl AsHeaders for PartitionKey {
 /// Represents a value for a single partition key.
 ///
 /// You shouldn't need to construct this type directly. The various implementations of [`Into<PartitionKey>`] will handle it for you.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PartitionKeyValue(InnerPartitionKeyValue);
 
 // We don't want to expose the implementation details of PartitionKeyValue (specifically the use of serde_json::Number), so we use this inner private enum to store the data.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum InnerPartitionKeyValue {
     Null,
     String(Cow<'static, str>),
@@ -171,12 +171,6 @@ enum InnerPartitionKeyValue {
 impl From<InnerPartitionKeyValue> for PartitionKeyValue {
     fn from(value: InnerPartitionKeyValue) -> Self {
         PartitionKeyValue(value)
-    }
-}
-
-impl From<()> for PartitionKeyValue {
-    fn from(_: ()) -> Self {
-        InnerPartitionKeyValue::Null.into()
     }
 }
 
@@ -265,6 +259,12 @@ impl<T: Into<PartitionKeyValue>> From<Option<T>> for PartitionKeyValue {
     }
 }
 
+impl From<()> for PartitionKey {
+    fn from(_: ()) -> Self {
+        PartitionKey::EMPTY
+    }
+}
+
 impl<T: Into<PartitionKeyValue>> From<T> for PartitionKey {
     fn from(value: T) -> Self {
         PartitionKey(vec![value.into()])
@@ -290,7 +290,7 @@ impl_from_tuple!(0 A 1 B 2 C);
 
 #[cfg(test)]
 mod tests {
-    use crate::{constants, PartitionKey, QueryPartitionStrategy};
+    use crate::{constants, PartitionKey, PartitionKeyValue};
     use typespec_client_core::http::headers::AsHeaders;
 
     fn key_to_string(v: impl Into<PartitionKey>) -> String {
@@ -302,18 +302,16 @@ mod tests {
     }
 
     /// Validates that a given value is `impl Into<QueryPartitionStrategy>` and works as-expected.
-    fn key_to_single_partition_strategy_string(v: impl Into<QueryPartitionStrategy>) -> String {
-        let strategy = v.into();
-        let QueryPartitionStrategy::SinglePartition(key) = strategy;
-        key_to_string(key)
+    fn key_to_single_string_partition_key(v: Option<impl Into<PartitionKey>>) -> Option<String> {
+        v.map(|k| key_to_string(k))
     }
 
     #[test]
     pub fn static_str() {
         assert_eq!(key_to_string("my_partition_key"), r#"["my_partition_key"]"#);
         assert_eq!(
-            key_to_single_partition_strategy_string("my_partition_key"),
-            r#"["my_partition_key"]"#
+            key_to_single_string_partition_key(Some("my_partition_key")).as_deref(),
+            Some(r#"["my_partition_key"]"#)
         );
     }
 
@@ -349,7 +347,11 @@ mod tests {
 
     #[test]
     pub fn null_value() {
-        assert_eq!(key_to_string(()), r#"[null]"#);
+        assert_eq!(key_to_string(PartitionKey::NULL), r#"[null]"#);
+        assert_eq!(
+            key_to_string((PartitionKey::NULL, PartitionKey::NULL, PartitionKey::NULL)),
+            r#"[null,null,null]"#
+        );
     }
 
     #[test]
@@ -361,8 +363,19 @@ mod tests {
     #[test]
     pub fn tuple() {
         assert_eq!(
-            key_to_string((42u8, "my_partition_key", ())),
+            key_to_string((42u8, "my_partition_key", PartitionKey::NULL)),
             r#"[42,"my_partition_key",null]"#
         );
+    }
+
+    #[test]
+    pub fn empty() {
+        let partition_key = PartitionKey::from(());
+        assert_eq!(Vec::<PartitionKeyValue>::new(), partition_key.values());
+
+        let mut headers_iter = partition_key.as_headers().unwrap();
+        let (name, value) = headers_iter.next().unwrap();
+        assert_eq!(constants::QUERY_ENABLE_CROSS_PARTITION, name);
+        assert_eq!("True", value.as_str());
     }
 }

--- a/sdk/cosmos/azure_data_cosmos/src/query/engine.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/engine.rs
@@ -1,0 +1,61 @@
+/// Represents a request from the query pipeline for data from a specific partition key range.
+pub struct QueryRequest {
+    /// The ID of the partition key range to query.
+    pub partition_key_range_id: String,
+
+    /// The continuation to use, if any.
+    pub continuation: Option<String>,
+}
+
+/// The request of a single-partition query for a specific partition key range.
+pub struct QueryResult<'a> {
+    pub partition_key_range_id: &'a str,
+    pub next_continuation: Option<String>,
+    pub result: &'a [u8],
+}
+
+/// The result of running a single turn of the query pipeline.
+pub struct PipelineResult {
+    /// Indicates if the pipeline is complete.
+    pub is_completed: bool,
+
+    /// The items yielded by the pipeline.
+    pub items: Vec<Vec<u8>>,
+
+    /// Additional requests that must be made before the pipeline can continue.
+    pub requests: Vec<QueryRequest>,
+}
+
+/// Provides an interface to a query pipeline, which aggregates data from multiple single partition queries into a single cross-partition result set.
+pub trait QueryPipeline {
+    /// The query to be executed, which may have been modified by the gateway when generating a query plan.
+    fn query(&self) -> &str;
+
+    /// Indicates if the pipeline is complete.
+    fn complete(&self) -> bool;
+
+    /// Runs a single turn of the pipeline, returning the result of that turn.
+    fn run(&mut self) -> azure_core::Result<PipelineResult>;
+
+    /// Provides additional single-partition data to the pipeline.
+    fn provide_data(&mut self, data: QueryResult) -> azure_core::Result<()>;
+}
+
+/// Provides an interface to a query engine, which constructs query pipelines.
+pub trait QueryEngine {
+    /// Creates a new query pipeline for the given query, plan, and partition key ranges.
+    ///
+    /// ## Arguments
+    /// * `query` - The query to be executed.
+    /// * `plan` - The JSON-encoded query plan describing the query (usually provided by the gateway).
+    /// * `pkranges` - The JSON-encoded partition key ranges to be queried (usually provided by the gateway).
+    fn create_pipeline(
+        &self,
+        query: &str,
+        plan: &[u8],
+        pkranges: &[u8],
+    ) -> azure_core::Result<Box<dyn QueryPipeline>>;
+
+    /// Gets a comma-separates list of features supported by this query engine, suitable for use in the 'x-ms-cosmos-supported-query-features' header when requesting a query plan.
+    fn supported_features(&self) -> azure_core::Result<&str>;
+}

--- a/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
@@ -76,7 +76,7 @@ impl<T: DeserializeOwned + 'static> QueryExecutor<T> {
                 let query_plan = get_query_plan(
                     &self.http_pipeline,
                     &self.items_link,
-                    self.context.into_borrowed(),
+                    self.context.to_borrowed(),
                     &self.query,
                     self.query_engine.supported_features()?,
                 )
@@ -87,7 +87,7 @@ impl<T: DeserializeOwned + 'static> QueryExecutor<T> {
                 let pkranges = get_pkranges(
                     &self.http_pipeline,
                     &self.container_link,
-                    self.context.into_borrowed(),
+                    self.context.to_borrowed(),
                 )
                 .await?
                 .into_raw_body()
@@ -134,7 +134,7 @@ impl<T: DeserializeOwned + 'static> QueryExecutor<T> {
                 let resp: Response = self
                     .http_pipeline
                     .send(
-                        self.context.into_borrowed(),
+                        self.context.to_borrowed(),
                         &mut query_request,
                         self.items_link.clone(),
                     )

--- a/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
@@ -1,0 +1,202 @@
+use azure_core::http::{headers::Headers, Context, Method, Request, Response};
+use serde::de::DeserializeOwned;
+
+use crate::{
+    constants,
+    pipeline::{self, CosmosPipeline},
+    query::{OwnedQueryPipeline, QueryEngineRef, QueryResult},
+    resource_context::{ResourceLink, ResourceType},
+    FeedPage, FeedPager, Query, QueryOptions,
+};
+
+pub struct QueryExecutor<T: DeserializeOwned> {
+    http_pipeline: CosmosPipeline,
+    container_link: ResourceLink,
+    items_link: ResourceLink,
+    context: Context<'static>,
+    query_engine: QueryEngineRef,
+    base_request: Request,
+    query: Query,
+    pipeline: Option<OwnedQueryPipeline>,
+
+    // Why is our phantom type a function? Because that represents how we _use_ the type T.
+    // Normally, PhantomData<T> is only Send/Sync if T is, because PhantomData is indicating that while we don't _name_ T in a field, we should act as though we have a field of type T.
+    // However, we don't store any T values in this, we only RETURN them.
+    // That means we use a function pointer to indicate that we don't actually operate on T directly, we just return it.
+    // Because of this, PhantomData<fn() -> T> is Send/Sync even if T isn't (see https://doc.rust-lang.org/stable/nomicon/phantom-data.html#table-of-phantomdata-patterns)
+    phantom: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<T: DeserializeOwned + 'static> QueryExecutor<T> {
+    pub fn new(
+        http_pipeline: CosmosPipeline,
+        container_link: ResourceLink,
+        query: Query,
+        options: QueryOptions<'_>,
+        query_engine: QueryEngineRef,
+    ) -> azure_core::Result<Self> {
+        let items_link = container_link.feed(ResourceType::Items);
+        let context = options.method_options.context.into_owned();
+        let base_request =
+            pipeline::create_base_query_request(http_pipeline.url(&items_link), &query)?;
+        Ok(Self {
+            http_pipeline,
+            container_link,
+            items_link,
+            context,
+            query_engine,
+            base_request,
+            query,
+            pipeline: None,
+            phantom: std::marker::PhantomData,
+        })
+    }
+
+    pub fn into_stream(self) -> azure_core::Result<FeedPager<T>> {
+        Ok(FeedPager::from_stream(futures::stream::try_unfold(
+            self,
+            |mut state| async move {
+                let val = state.step().await?;
+                Ok(val.map(|item| (item, state)))
+            },
+        )))
+    }
+
+    /// Executes a single step of the query execution.
+    ///
+    /// # Returns
+    ///
+    /// An item to yield, or None if execution is complete.
+    #[tracing::instrument(skip_all)]
+    async fn step(&mut self) -> azure_core::Result<Option<FeedPage<T>>> {
+        let pipeline = match self.pipeline.as_mut() {
+            Some(pipeline) => pipeline,
+            None => {
+                // Initialize the pipeline.
+                let query_plan = get_query_plan(
+                    &self.http_pipeline,
+                    &self.items_link,
+                    self.context.into_borrowed(),
+                    &self.query,
+                    self.query_engine.supported_features()?,
+                )
+                .await?
+                .into_raw_body()
+                .collect()
+                .await?;
+                let pkranges = get_pkranges(
+                    &self.http_pipeline,
+                    &self.container_link,
+                    self.context.into_borrowed(),
+                )
+                .await?
+                .into_raw_body()
+                .collect()
+                .await?;
+
+                let pipeline =
+                    self.query_engine
+                        .create_pipeline(&self.query.text, &query_plan, &pkranges)?;
+                self.pipeline = Some(pipeline);
+                self.pipeline.as_mut().expect("we just set it")
+            }
+        };
+
+        // Execute the pipeline to get a page of results
+        while !pipeline.complete() {
+            // Run the pipeline
+            let results = pipeline.run()?;
+
+            // If we got items, go ahead and return them. The next time we call the pipeline, we'll get no items and just requests.
+            if !results.items.is_empty() {
+                // Deserialize the items
+                let items = results
+                    .items
+                    .into_iter()
+                    .map(|item| serde_json::from_slice::<T>(&item))
+                    .collect::<Result<Vec<_>, _>>()?;
+
+                // TODO: Provide a continuation token.
+                return Ok(Some(FeedPage::new(items, None, Headers::new())));
+            }
+
+            // No items, so make any requests we need to make and provide them to the pipeline.
+            for request in results.requests {
+                let mut query_request = self.base_request.clone();
+                query_request.insert_header(
+                    constants::PARTITION_KEY_RANGE_ID,
+                    request.partition_key_range_id.clone(),
+                );
+                if let Some(continuation) = request.continuation {
+                    query_request.insert_header(constants::CONTINUATION, continuation);
+                }
+
+                let resp: Response = self
+                    .http_pipeline
+                    .send(
+                        self.context.into_borrowed(),
+                        &mut query_request,
+                        self.items_link.clone(),
+                    )
+                    .await?;
+
+                let next_continuation =
+                    resp.headers().get_optional_string(&constants::CONTINUATION);
+                let body = resp.into_raw_body().collect().await?;
+
+                let result = QueryResult {
+                    partition_key_range_id: &request.partition_key_range_id,
+                    next_continuation,
+                    result: &body,
+                };
+
+                pipeline.provide_data(result)?;
+            }
+
+            // No items, but we provided more data (probably), so continue the loop.
+            // If there were no more requests to make, the pipeline will be marked complete above
+        }
+
+        // If we get here, the pipeline is complete and we have no items to return.
+        Ok(None)
+    }
+}
+
+// This isn't an inherent method on QueryExecutor because that would force the whole executor to be Sync, which would force the pipeline to be Sync.
+#[tracing::instrument(skip_all)]
+async fn get_query_plan(
+    http_pipeline: &CosmosPipeline,
+    items_link: &ResourceLink,
+    context: Context<'_>,
+    query: &Query,
+    supported_features: &str,
+) -> azure_core::Result<Response> {
+    let url = http_pipeline.url(items_link);
+    let mut request = pipeline::create_base_query_request(url, query)?;
+    request.insert_header(constants::QUERY_ENABLE_CROSS_PARTITION, "True");
+    request.insert_header(constants::IS_QUERY_PLAN_REQUEST, "True");
+    request.insert_header(
+        constants::SUPPORTED_QUERY_FEATURES,
+        supported_features.to_string(),
+    );
+
+    http_pipeline
+        .send(context, &mut request, items_link.clone())
+        .await
+}
+
+// This isn't an inherent method on QueryExecutor because that would force the whole executor to be Sync, which would force the pipeline to be Sync.
+#[tracing::instrument(skip_all)]
+async fn get_pkranges(
+    http_pipeline: &CosmosPipeline,
+    container_link: &ResourceLink,
+    context: Context<'_>,
+) -> azure_core::Result<Response> {
+    let pkranges_link = container_link.feed(ResourceType::PartitionKeyRanges);
+    let url = http_pipeline.url(&pkranges_link);
+    let mut base_request = Request::new(url, Method::Get);
+
+    http_pipeline
+        .send(context, &mut base_request, pkranges_link)
+        .await
+}

--- a/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
@@ -76,7 +76,7 @@ impl<T: DeserializeOwned + 'static> QueryExecutor<T> {
                 let query_plan = get_query_plan(
                     &self.http_pipeline,
                     &self.items_link,
-                    self.context.to_borrowed(),
+                    Context::with_context(&self.context),
                     &self.query,
                     self.query_engine.supported_features()?,
                 )
@@ -87,7 +87,7 @@ impl<T: DeserializeOwned + 'static> QueryExecutor<T> {
                 let pkranges = get_pkranges(
                     &self.http_pipeline,
                     &self.container_link,
-                    self.context.to_borrowed(),
+                    Context::with_context(&self.context),
                 )
                 .await?
                 .into_raw_body()
@@ -134,7 +134,7 @@ impl<T: DeserializeOwned + 'static> QueryExecutor<T> {
                 let resp: Response = self
                     .http_pipeline
                     .send(
-                        self.context.to_borrowed(),
+                        Context::with_context(&self.context),
                         &mut query_request,
                         self.items_link.clone(),
                     )

--- a/sdk/cosmos/azure_data_cosmos/src/query/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/mod.rs
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+//! Models and components used to represents and execute queries.
+
 use serde::Serialize;
 
 #[cfg(feature = "query_engine")]
 mod engine;
+
+#[cfg(feature = "query_engine")]
+pub(crate) mod executor;
 
 #[cfg(feature = "query_engine")]
 pub use engine::*;
@@ -61,8 +66,11 @@ pub use engine::*;
 /// ```
 #[derive(Clone, Debug, Serialize)]
 pub struct Query {
-    query: String,
+    /// The query text itself.
+    #[serde(rename = "query")]
+    text: String,
 
+    /// A list of parameters used in the query and their associated value.
     #[serde(skip_serializing_if = "Vec::is_empty")] // Don't serialize an empty array.
     parameters: Vec<QueryParameter>,
 }
@@ -90,7 +98,7 @@ impl<T: Into<String>> From<T> for Query {
     fn from(value: T) -> Self {
         let query = value.into();
         Self {
-            query,
+            text: query,
             parameters: vec![],
         }
     }

--- a/sdk/cosmos/azure_data_cosmos/src/query/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/mod.rs
@@ -5,13 +5,13 @@
 
 use serde::Serialize;
 
-#[cfg(feature = "query_engine")]
+#[cfg(feature = "preview_query_engine")]
 mod engine;
 
-#[cfg(feature = "query_engine")]
+#[cfg(feature = "preview_query_engine")]
 pub(crate) mod executor;
 
-#[cfg(feature = "query_engine")]
+#[cfg(feature = "preview_query_engine")]
 pub use engine::*;
 
 /// Represents a Cosmos DB Query, with optional parameters.

--- a/sdk/cosmos/azure_data_cosmos/src/query/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/mod.rs
@@ -3,6 +3,12 @@
 
 use serde::Serialize;
 
+#[cfg(feature = "query_engine")]
+mod engine;
+
+#[cfg(feature = "query_engine")]
+pub use engine::*;
+
 /// Represents a Cosmos DB Query, with optional parameters.
 ///
 /// # Examples

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_containers.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_containers.rs
@@ -12,19 +12,15 @@ use azure_data_cosmos::{
     },
     CreateContainerOptions, Query,
 };
+use futures::TryStreamExt;
 
-use framework::TestAccount;
+use framework::{test_data, TestAccount};
 
 #[recorded::test]
 pub async fn container_crud(context: TestContext) -> Result<(), Box<dyn Error>> {
-    use azure_data_cosmos::models::PartitionKeyKind;
-    use futures::TryStreamExt;
-
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
-    let test_db_id = account.unique_db("DatabaseCRUD");
-    cosmos_client.create_database(&test_db_id, None).await?;
-    let db_client = cosmos_client.database_client(&test_db_id);
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
 
     // Create the container
     let properties = ContainerProperties {
@@ -161,9 +157,7 @@ pub async fn container_crud(context: TestContext) -> Result<(), Box<dyn Error>> 
 pub async fn container_crud_autoscale(context: TestContext) -> Result<(), Box<dyn Error>> {
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
-    let test_db_id = account.unique_db("DatabaseCRUD");
-    cosmos_client.create_database(&test_db_id, None).await?;
-    let db_client = cosmos_client.database_client(&test_db_id);
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
 
     // Create the container
     let properties = ContainerProperties {
@@ -214,9 +208,7 @@ pub async fn container_crud_autoscale(context: TestContext) -> Result<(), Box<dy
 pub async fn container_crud_hierarchical_pk(context: TestContext) -> Result<(), Box<dyn Error>> {
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
-    let test_db_id = account.unique_db("DatabaseCRUD");
-    cosmos_client.create_database(&test_db_id, None).await?;
-    let db_client = cosmos_client.database_client(&test_db_id);
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
 
     // Create the container
     let properties = ContainerProperties {

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_databases.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_databases.rs
@@ -7,11 +7,10 @@ use std::error::Error;
 use azure_core_test::{recorded, TestContext};
 use azure_data_cosmos::{models::ThroughputProperties, CreateDatabaseOptions, Query};
 use framework::TestAccount;
+use futures::TryStreamExt;
 
 #[recorded::test]
 pub async fn database_crud(context: TestContext) -> Result<(), Box<dyn Error>> {
-    use futures::TryStreamExt;
-
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
@@ -1,8 +1,7 @@
 #![cfg(feature = "key_auth")]
 
-use std::{borrow::Cow, error::Error};
+use std::error::Error;
 
-use azure_core::error::ErrorKind;
 use azure_core::{error::HttpError, http::StatusCode};
 use azure_core_test::{recorded, TestContext};
 use azure_data_cosmos::Query;

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
@@ -3,82 +3,22 @@
 use std::{borrow::Cow, error::Error};
 
 use azure_core_test::{recorded, TestContext};
-use azure_data_cosmos::{
-    clients::ContainerClient, models::ContainerProperties, CosmosClient, Query,
-};
-use framework::TestAccount;
+use azure_data_cosmos::Query;
+use framework::{test_data, MockItem, TestAccount};
 use futures::TryStreamExt;
-use serde::{Deserialize, Serialize};
 
 mod framework;
-
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
-struct TestItem {
-    id: Cow<'static, str>,
-    partition_key: Option<Cow<'static, str>>,
-    some_value: usize,
-}
-
-const TEST_DATA: [TestItem; 4] = [
-    TestItem {
-        id: Cow::Borrowed("Item1"),
-        partition_key: Some(Cow::Borrowed("Partition1")),
-        some_value: 1,
-    },
-    TestItem {
-        id: Cow::Borrowed("Item2"),
-        partition_key: Some(Cow::Borrowed("Partition1")),
-        some_value: 2,
-    },
-    TestItem {
-        id: Cow::Borrowed("Item3"),
-        partition_key: Some(Cow::Borrowed("Partition2")),
-        some_value: 3,
-    },
-    TestItem {
-        id: Cow::Borrowed("Item4"),
-        partition_key: Some(Cow::Borrowed("Partition2")),
-        some_value: 4,
-    },
-];
-
-async fn create_container(
-    account: &TestAccount,
-    cosmos_client: &CosmosClient,
-) -> azure_core::Result<ContainerClient> {
-    let test_db_id = account.unique_db("ItemCRUD");
-
-    // Create a database and a container
-    cosmos_client.create_database(&test_db_id, None).await?;
-    let db_client = cosmos_client.database_client(&test_db_id);
-    db_client
-        .create_container(
-            ContainerProperties {
-                id: "Container".into(),
-                partition_key: "/partition_key".into(),
-                ..Default::default()
-            },
-            None,
-        )
-        .await?;
-    let container_client = db_client.container_client("Container");
-    // Create some items
-    for item in TEST_DATA.iter() {
-        let pk = item.partition_key.clone().unwrap();
-        container_client.create_item(pk, &item, None).await?;
-    }
-
-    Ok(container_client)
-}
 
 #[recorded::test]
 pub async fn single_partition_query(context: TestContext) -> Result<(), Box<dyn Error>> {
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
-    let container_client = create_container(&account, &cosmos_client).await?;
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
+    let container_client = test_data::create_container_with_items(db_client, None).await?;
 
-    let mut results = container_client.query_items("select * from docs c", "Partition1", None)?;
-    let mut items: Vec<TestItem> = Vec::new();
+    let mut results =
+        container_client.query_items("select * from docs c", Some("partition0"), None)?;
+    let mut items: Vec<MockItem> = Vec::new();
     while let Some(page) = results.try_next().await? {
         items.extend(page.into_items());
     }
@@ -98,7 +38,7 @@ pub async fn single_partition_query_with_parameters(
 
     let query = Query::from("select * from c where c.some_value = @some_value")
         .with_parameter("@some_value", 2)?;
-    let mut results = container_client.query_items(query, "Partition1", None)?;
+    let mut results = container_client.query_items(query, Some("Partition1"), None)?;
     let mut items: Vec<TestItem> = Vec::new();
     while let Some(page) = results.try_next().await? {
         items.extend(page.into_items());
@@ -118,7 +58,33 @@ pub async fn single_partition_query_with_projection(
     let container_client = create_container(&account, &cosmos_client).await?;
 
     let mut results =
-        container_client.query_items("select value c.id from c", "Partition1", None)?;
+        container_client.query_items("select value c.id from c", Some("Partition1"), None)?;
+    let mut items: Vec<Cow<'static, str>> = Vec::new();
+    while let Some(page) = results.try_next().await? {
+        items.extend(page.into_items());
+    }
+    assert_eq!(
+        TEST_DATA[0..2]
+            .iter()
+            .map(|t| t.id.clone())
+            .collect::<Vec<_>>(),
+        items
+    );
+
+    account.cleanup().await?;
+    Ok(())
+}
+
+#[recorded::test]
+pub async fn cross_partition_query_with_projection_and_filter(
+    context: TestContext,
+) -> Result<(), Box<dyn Error>> {
+    let account = TestAccount::from_env(context, None).await?;
+    let cosmos_client = account.connect_with_key(None)?;
+    let container_client = create_container(&account, &cosmos_client).await?;
+
+    let mut results =
+        container_client.query_items("select value c.id from c", Some("Partition1"), None)?;
     let mut items: Vec<Cow<'static, str>> = Vec::new();
     while let Some(page) = results.try_next().await? {
         items.extend(page.into_items());

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
@@ -14,7 +14,7 @@ fn collect_matching_items(
     items: &[MockItem],
     predicate: impl Fn(&MockItem) -> bool,
 ) -> Vec<MockItem> {
-    items.iter().filter(|p| predicate(*p)).cloned().collect()
+    items.iter().filter(|p| predicate(p)).cloned().collect()
 }
 
 #[recorded::test]

--- a/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/cosmos_query.rs
@@ -2,6 +2,8 @@
 
 use std::{borrow::Cow, error::Error};
 
+use azure_core::error::ErrorKind;
+use azure_core::{error::HttpError, http::StatusCode};
 use azure_core_test::{recorded, TestContext};
 use azure_data_cosmos::Query;
 use framework::{test_data, MockItem, TestAccount};
@@ -9,20 +11,31 @@ use futures::TryStreamExt;
 
 mod framework;
 
+fn collect_matching_items(
+    items: &[MockItem],
+    predicate: impl Fn(&MockItem) -> bool,
+) -> Vec<MockItem> {
+    items.iter().filter(|p| predicate(*p)).cloned().collect()
+}
+
 #[recorded::test]
 pub async fn single_partition_query(context: TestContext) -> Result<(), Box<dyn Error>> {
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
     let db_client = test_data::create_database(&account, &cosmos_client).await?;
-    let container_client = test_data::create_container_with_items(db_client, None).await?;
+    let items = test_data::generate_mock_items(10, 10);
+    let container_client =
+        test_data::create_container_with_items(db_client, items.clone(), None).await?;
 
-    let mut results =
-        container_client.query_items("select * from docs c", Some("partition0"), None)?;
-    let mut items: Vec<MockItem> = Vec::new();
+    let mut results = container_client.query_items("select * from docs c", "partition0", None)?;
+    let mut result_items: Vec<MockItem> = Vec::new();
     while let Some(page) = results.try_next().await? {
-        items.extend(page.into_items());
+        result_items.extend(page.into_items());
     }
-    assert_eq!(TEST_DATA[0..2].to_vec(), items);
+    assert_eq!(
+        collect_matching_items(&items, |p| p.partition_key == "partition0"),
+        result_items
+    );
 
     account.cleanup().await?;
     Ok(())
@@ -34,16 +47,30 @@ pub async fn single_partition_query_with_parameters(
 ) -> Result<(), Box<dyn Error>> {
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
-    let container_client = create_container(&account, &cosmos_client).await?;
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
+    let items = test_data::generate_mock_items(10, 10);
+    let container_client =
+        test_data::create_container_with_items(db_client, items.clone(), None).await?;
 
-    let query = Query::from("select * from c where c.some_value = @some_value")
-        .with_parameter("@some_value", 2)?;
-    let mut results = container_client.query_items(query, Some("Partition1"), None)?;
-    let mut items: Vec<TestItem> = Vec::new();
+    // Find a merge order value in partition1's items
+    let merge_order = items
+        .iter()
+        .find(|p| p.partition_key == "partition1")
+        .expect("No items in partition1")
+        .merge_order;
+
+    // Query for items with that merge order
+    let query = Query::from("select * from c where c.mergeOrder = @some_value")
+        .with_parameter("@some_value", merge_order)?;
+    let mut results = container_client.query_items(query, "partition1", None)?;
+    let mut result_items: Vec<MockItem> = Vec::new();
     while let Some(page) = results.try_next().await? {
-        items.extend(page.into_items());
+        result_items.extend(page.into_items());
     }
-    assert_eq!(TEST_DATA[1..2].to_vec(), items);
+    assert_eq!(
+        collect_matching_items(&items, |p| p.merge_order == merge_order),
+        result_items
+    );
 
     account.cleanup().await?;
     Ok(())
@@ -55,20 +82,24 @@ pub async fn single_partition_query_with_projection(
 ) -> Result<(), Box<dyn Error>> {
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
-    let container_client = create_container(&account, &cosmos_client).await?;
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
+    let items = test_data::generate_mock_items(10, 10);
+    let container_client =
+        test_data::create_container_with_items(db_client, items.clone(), None).await?;
 
     let mut results =
-        container_client.query_items("select value c.id from c", Some("Partition1"), None)?;
-    let mut items: Vec<Cow<'static, str>> = Vec::new();
+        container_client.query_items("select value c.id from c", "partition1", None)?;
+    let mut result_items: Vec<String> = Vec::new();
     while let Some(page) = results.try_next().await? {
-        items.extend(page.into_items());
+        result_items.extend(page.into_items());
     }
     assert_eq!(
-        TEST_DATA[0..2]
-            .iter()
-            .map(|t| t.id.clone())
-            .collect::<Vec<_>>(),
         items
+            .iter()
+            .filter(|p| p.partition_key == "partition1")
+            .map(|p| p.id.to_string())
+            .collect::<Vec<_>>(),
+        result_items
     );
 
     account.cleanup().await?;
@@ -81,21 +112,61 @@ pub async fn cross_partition_query_with_projection_and_filter(
 ) -> Result<(), Box<dyn Error>> {
     let account = TestAccount::from_env(context, None).await?;
     let cosmos_client = account.connect_with_key(None)?;
-    let container_client = create_container(&account, &cosmos_client).await?;
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
+    let items = test_data::generate_mock_items(10, 10);
+    let container_client =
+        test_data::create_container_with_items(db_client, items.clone(), None).await?;
 
-    let mut results =
-        container_client.query_items("select value c.id from c", Some("Partition1"), None)?;
-    let mut items: Vec<Cow<'static, str>> = Vec::new();
+    let mut results = container_client.query_items(
+        "select value c.id from c where c.mergeOrder between 40 and 60",
+        (),
+        None,
+    )?;
+    let mut result_items: Vec<String> = Vec::new();
     while let Some(page) = results.try_next().await? {
-        items.extend(page.into_items());
+        result_items.extend(page.into_items());
     }
     assert_eq!(
-        TEST_DATA[0..2]
-            .iter()
-            .map(|t| t.id.clone())
-            .collect::<Vec<_>>(),
         items
+            .iter()
+            .filter(|p| p.merge_order >= 40 && p.merge_order <= 60)
+            .map(|p| p.id.to_string())
+            .collect::<Vec<_>>(),
+        result_items
     );
+
+    account.cleanup().await?;
+    Ok(())
+}
+
+#[recorded::test]
+pub async fn cross_partition_query_with_order_by_fails_without_query_engine(
+    context: TestContext,
+) -> Result<(), Box<dyn Error>> {
+    let account = TestAccount::from_env(context, None).await?;
+    let cosmos_client = account.connect_with_key(None)?;
+    let db_client = test_data::create_database(&account, &cosmos_client).await?;
+    let items = test_data::generate_mock_items(10, 10);
+    let container_client =
+        test_data::create_container_with_items(db_client, items.clone(), None).await?;
+
+    let mut pager = container_client.query_items::<String>(
+        "select value c.id from c order by c.mergeOrder",
+        (),
+        None,
+    )?;
+    let result = pager.try_next().await;
+
+    let Err(err) = result else {
+        panic!("expected an error but got a successful result");
+    };
+    assert_eq!(Some(StatusCode::BadRequest), err.http_status());
+
+    let http_err: HttpError = err.into_downcast().expect("expected an HttpError");
+    let message = http_err.error_message().expect("message should be present");
+    assert!(message.starts_with(
+        "The provided cross partition query can not be directly served by the gateway."
+    ));
 
     account.cleanup().await?;
     Ok(())

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -16,7 +16,7 @@ pub use test_account::TestAccount;
 use serde::{Deserialize, Serialize};
 
 /// Represents a single item in the mock engine.
-#[derive(Deserialize, Serialize)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MockItem {
     /// The ID of the item.

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -11,7 +11,7 @@
 mod test_account;
 pub mod test_data;
 
-#[cfg(feature = "query_engine")]
+#[cfg(feature = "preview_query_engine")]
 pub mod query_engine;
 
 pub use test_account::TestAccount;

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -6,5 +6,23 @@
 //! The framework allows tests to easily run against real Cosmos DB instances, the local emulator, or a mock server using test-proxy.
 
 mod test_account;
+pub mod test_data;
+
+#[cfg(feature = "query_engine")]
+pub mod query_engine;
 
 pub use test_account::TestAccount;
+
+use serde::{Deserialize, Serialize};
+
+/// Represents a single item in the mock engine.
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MockItem {
+    /// The ID of the item.
+    pub id: String,
+    /// The partition key of the item.
+    pub partition_key: String,
+    /// The global merge order of the item, which will be used by the mock query pipeline to sort items.
+    pub merge_order: usize,
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/mod.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+// Some tests don't use all the features of this module.
+#![allow(dead_code)]
+
 //! Provides a framework for integration tests for the Azure Cosmos DB service.
 //!
 //! The framework allows tests to easily run against real Cosmos DB instances, the local emulator, or a mock server using test-proxy.

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/query_engine.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/query_engine.rs
@@ -1,0 +1,240 @@
+use std::cell::RefCell;
+
+use serde::{Deserialize, Serialize};
+
+use azure_data_cosmos::query::{PipelineResult, QueryEngine, QueryPipeline};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PartitionKeyRange {
+    pub id: String,
+    pub min_inclusive: String,
+    pub max_exclusive: String,
+}
+
+#[derive(Deserialize)]
+struct PkRanges {
+    #[serde(rename = "PartitionKeyRanges")]
+    pub ranges: Vec<PartitionKeyRange>,
+}
+
+#[derive(Deserialize)]
+struct DocumentPayload<T> {
+    #[serde(rename = "Documents")]
+    pub documents: Vec<T>,
+}
+
+/// Represents a single item in the mock engine.
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MockItem {
+    /// The ID of the item.
+    pub id: String,
+    /// The partition key of the item.
+    pub partition_key: String,
+    /// The global merge order of the item, which will be used by the mock pipeline to sort items.
+    pub merge_order: usize,
+}
+
+/// A mock query engine that can be used for testing.
+struct MockQueryEngine {
+    /// An error to return when creating a pipeline.
+    pub create_error: RefCell<Option<azure_core::Error>>,
+}
+
+impl QueryEngine for MockQueryEngine {
+    fn create_pipeline(
+        &self,
+        query: &str,
+        _plan: &[u8],
+        pkranges: &[u8],
+    ) -> azure_core::Result<Box<dyn QueryPipeline>> {
+        // 'take' might panic if create_error is already borrowed, but that shouldn't happen in these tests.
+        if let Some(err) = self.create_error.take() {
+            return Err(err);
+        }
+
+        // Deserialize the partition key ranges.
+        let pkranges: PkRanges = serde_json::from_slice(pkranges)?;
+
+        // Create a mock pipeline with the partition key ranges.
+        let pipeline = MockQueryPipeline::new(query.to_string(), pkranges.ranges);
+
+        Ok(Box::new(pipeline))
+    }
+
+    fn supported_features(&self) -> azure_core::Result<&str> {
+        Ok("OrderBy")
+    }
+}
+
+struct PartitionState {
+    range: PartitionKeyRange,
+    started: bool,
+    queue: Vec<MockItem>,
+    next_continuation: Option<String>,
+}
+
+impl PartitionState {
+    pub fn exhausted(&self) -> bool {
+        self.queue.is_empty() && self.started && self.next_continuation.is_none()
+    }
+
+    pub fn provide_data(&mut self, items: Vec<MockItem>, continuation: Option<String>) {
+        self.started = true;
+        self.queue.extend(items);
+        self.next_continuation = continuation;
+    }
+
+    pub fn pop_item(&mut self) -> azure_core::Result<Option<Vec<u8>>> {
+        match self.queue.pop() {
+            Some(item) => {
+                let item = serde_json::to_vec(&item)?;
+                Ok(Some(item))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+struct MockQueryPipeline {
+    query: String,
+    partitions: Vec<PartitionState>,
+    completed: bool,
+}
+
+impl MockQueryPipeline {
+    pub fn new(query: String, pkranges: Vec<PartitionKeyRange>) -> Self {
+        let partitions = pkranges
+            .into_iter()
+            .map(|range| PartitionState {
+                range,
+                started: false,
+                queue: vec![],
+                next_continuation: None,
+            })
+            .collect();
+
+        Self {
+            query,
+            partitions,
+            completed: false,
+        }
+    }
+
+    fn get_requests(&self) -> Vec<azure_data_cosmos::query::QueryRequest> {
+        self.partitions
+            .iter()
+            .filter(|state| !state.exhausted())
+            .map(|state| azure_data_cosmos::query::QueryRequest {
+                partition_key_range_id: state.range.id.clone(),
+                continuation: if state.started {
+                    state.next_continuation.clone()
+                } else {
+                    None
+                },
+            })
+            .collect()
+    }
+}
+
+impl QueryPipeline for MockQueryPipeline {
+    fn query(&self) -> &str {
+        &self.query
+    }
+
+    fn complete(&self) -> bool {
+        self.completed
+    }
+
+    fn run(&mut self) -> azure_core::Result<azure_data_cosmos::query::PipelineResult> {
+        let mut items = Vec::new();
+        loop {
+            let mut state = None;
+            for (index, partition) in self.partitions.iter().enumerate() {
+                if !partition.started {
+                    // If any partition hasn't started, just return the requests with no items.
+                    return Ok(PipelineResult {
+                        is_completed: false,
+                        items: vec![],
+                        requests: self.get_requests(),
+                    });
+                }
+
+                if partition.exhausted() {
+                    // No need to check exhausted partitions.
+                    continue;
+                }
+
+                // Peek the next item in the partition.
+                let item = partition.queue.first();
+                match (item, state) {
+                    (Some(item), None) => {
+                        state = Some((index, item.merge_order));
+                    }
+                    (Some(item), Some((partition, lowest_merge_order))) => {
+                        if item.merge_order < lowest_merge_order {
+                            state = Some((partition, item.merge_order));
+                        }
+                    }
+                    _ => panic!("Unexpected state"),
+                }
+            }
+
+            if let Some((index, _)) = state {
+                // Add this item to the result.
+                if let Some(item) = self.partitions[index].pop_item()? {
+                    items.push(item);
+                }
+            } else {
+                // All partitions are exhausted, or have no items to produce
+                break;
+            }
+
+            // We've added an item, so we loop back around to check for more.
+        }
+
+        let requests = self.get_requests();
+
+        if items.is_empty() && requests.is_empty() {
+            // If there are no items and no requests, we are done.
+            self.completed = true;
+        }
+
+        Ok(PipelineResult {
+            is_completed: self.completed,
+            items,
+            requests,
+        })
+    }
+
+    fn provide_data(
+        &mut self,
+        data: azure_data_cosmos::query::QueryResult,
+    ) -> azure_core::Result<()> {
+        let payload: DocumentPayload<MockItem> =
+            serde_json::from_slice(data.result).map_err(|_| {
+                azure_core::Error::message(
+                    azure_core::error::ErrorKind::Other,
+                    "Failed to deserialize payload",
+                )
+            })?;
+
+        let partition_state = self
+            .partitions
+            .iter_mut()
+            .find(|state| state.range.id == data.partition_key_range_id);
+        if let Some(partition_state) = partition_state {
+            partition_state.provide_data(payload.documents, data.next_continuation);
+            Ok(())
+        } else {
+            Err(azure_core::Error::message(
+                azure_core::error::ErrorKind::Other,
+                format!(
+                    "Partition key range {} not found",
+                    data.partition_key_range_id
+                ),
+            ))
+        }
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_data/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_data/mod.rs
@@ -1,0 +1,76 @@
+use azure_data_cosmos::{
+    clients::{ContainerClient, DatabaseClient},
+    models::{ContainerProperties, ThroughputProperties},
+    CosmosClient, CreateContainerOptions,
+};
+
+use super::{MockItem, TestAccount};
+
+const ITEMS_PER_PARTITION: usize = 10;
+const PARTITION_COUNT: usize = 10;
+
+pub fn generate_mock_items(
+    partition_indexes: impl Iterator<Item = usize>,
+    item_indexes: impl Iterator<Item = usize>,
+) -> Vec<MockItem> {
+    let mut items = Vec::new();
+    for i in partition_indexes {
+        let partition_key = format!("partition{}", partition_index);
+        for j in item_indexes {
+            items.push(MockItem {
+                id: format!("{}", partition_index * ITEMS_PER_PARTITION + item_index),
+                partition_key: partition_key.clone(),
+                merge_order: partition_index + item_index * PARTITION_COUNT,
+            })
+        }
+    }
+}
+
+/// Creates a batch of simple mock items
+pub async fn create_container_with_items(
+    db: DatabaseClient,
+    throughput: Option<ThroughputProperties>,
+) -> azure_core::Result<ContainerClient> {
+    let properties = ContainerProperties {
+        id: "TestContainer".into(),
+        partition_key: "/partitionKey".into(),
+        ..Default::default()
+    };
+    db.create_container(
+        properties,
+        Some(CreateContainerOptions {
+            throughput,
+            ..Default::default()
+        }),
+    )
+    .await?;
+
+    let container_client = db.container_client("TestContainer");
+
+    for i in 0..PARTITION_COUNT {
+        for j in 0..ITEMS_PER_PARTITION {
+            let item = generate_mock_item(i, j);
+            container_client
+                .create_item(item.partition_key.clone(), item, None)
+                .await?;
+        }
+    }
+
+    Ok(container_client)
+}
+
+pub async fn create_database(
+    account: &TestAccount,
+    cosmos_client: &CosmosClient,
+) -> azure_core::Result<DatabaseClient> {
+    // The TestAccount has a unique context_id that includes the test name.
+    let db_name = account.unique_db("TestData");
+    let props = cosmos_client
+        .create_database(&db_name, None)
+        .await?
+        .into_body()
+        .await?;
+
+    let db_client = cosmos_client.database_client(&props.id);
+    Ok(db_client)
+}

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_data/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_data/mod.rs
@@ -1,3 +1,4 @@
+use azure_core::http::StatusCode;
 use azure_data_cosmos::{
     clients::{ContainerClient, DatabaseClient},
     models::{ContainerProperties, ThroughputProperties},
@@ -9,26 +10,29 @@ use super::{MockItem, TestAccount};
 const ITEMS_PER_PARTITION: usize = 10;
 const PARTITION_COUNT: usize = 10;
 
-pub fn generate_mock_items(
-    partition_indexes: impl Iterator<Item = usize>,
-    item_indexes: impl Iterator<Item = usize>,
-) -> Vec<MockItem> {
+pub fn generate_mock_item(partition_index: usize, item_index: usize) -> MockItem {
+    let partition_key = format!("partition{}", partition_index);
+    MockItem {
+        id: format!("{}", partition_index * ITEMS_PER_PARTITION + item_index),
+        partition_key: partition_key.clone(),
+        merge_order: partition_index + item_index * PARTITION_COUNT,
+    }
+}
+
+pub fn generate_mock_items(partition_count: usize, items_per_partition: usize) -> Vec<MockItem> {
     let mut items = Vec::new();
-    for i in partition_indexes {
-        let partition_key = format!("partition{}", partition_index);
-        for j in item_indexes {
-            items.push(MockItem {
-                id: format!("{}", partition_index * ITEMS_PER_PARTITION + item_index),
-                partition_key: partition_key.clone(),
-                merge_order: partition_index + item_index * PARTITION_COUNT,
-            })
+    for i in 0..partition_count {
+        for j in 0..items_per_partition {
+            items.push(generate_mock_item(i, j));
         }
     }
+    items
 }
 
 /// Creates a batch of simple mock items
 pub async fn create_container_with_items(
     db: DatabaseClient,
+    items: Vec<MockItem>,
     throughput: Option<ThroughputProperties>,
 ) -> azure_core::Result<ContainerClient> {
     let properties = ContainerProperties {
@@ -47,13 +51,10 @@ pub async fn create_container_with_items(
 
     let container_client = db.container_client("TestContainer");
 
-    for i in 0..PARTITION_COUNT {
-        for j in 0..ITEMS_PER_PARTITION {
-            let item = generate_mock_item(i, j);
-            container_client
-                .create_item(item.partition_key.clone(), item, None)
-                .await?;
-        }
+    for item in items {
+        container_client
+            .create_item(item.partition_key.clone(), item, None)
+            .await?;
     }
 
     Ok(container_client)
@@ -65,11 +66,26 @@ pub async fn create_database(
 ) -> azure_core::Result<DatabaseClient> {
     // The TestAccount has a unique context_id that includes the test name.
     let db_name = account.unique_db("TestData");
-    let props = cosmos_client
-        .create_database(&db_name, None)
-        .await?
-        .into_body()
-        .await?;
+    let response = match cosmos_client.create_database(&db_name, None).await {
+        // The database creation was successful.
+        Ok(props) => props,
+        Err(e) if e.http_status() == Some(StatusCode::Conflict) => {
+            // The database already exists, from a previous test run.
+            // Delete it and re-create it.
+            let db_client = cosmos_client.database_client(&db_name);
+            db_client.delete(None).await?;
+
+            // Re-create the database.
+
+            cosmos_client.create_database(&db_name, None).await?
+        }
+        Err(e) => {
+            // Some other error occurred.
+            return Err(e);
+        }
+    };
+
+    let props = response.into_body().await?;
 
     let db_client = cosmos_client.database_client(&props.id);
     Ok(db_client)

--- a/sdk/cosmos/azure_data_cosmos/tests/query_engine.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/query_engine.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "query_engine")]
+#![cfg(feature = "preview_query_engine")]
 
 mod framework;
 

--- a/sdk/cosmos/azure_data_cosmos/tests/query_engine.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/query_engine.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "query_engine")]
+
+mod framework;
+
+use azure_core_test::{recorded, TestContext};
+use azure_data_cosmos::{
+    clients::{ContainerClient, DatabaseClient},
+    models::{ContainerProperties, ThroughputProperties},
+    CreateContainerOptions, QueryOptions,
+};
+use framework::{query_engine::MockItem, TestAccount};
+
+const RU_COUNT: usize = 40000;
+const ITEMS_PER_PARTITION: usize = 10;
+
+#[recorded::test]
+pub async fn query_via_query_engine(
+    context: TestContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let account = TestAccount::from_env(context, None).await?;
+    let cosmos_client = account.connect_with_key(None)?;
+
+    let test_db_id = account.unique_db("QueryViaQueryEngine");
+
+    // Create a database
+    cosmos_client
+        .create_database(&test_db_id, None)
+        .await?
+        .into_body()
+        .await?;
+    let db_client = cosmos_client.database_client(&test_db_id);
+
+    // let container = create_test_items(&db_client).await?;
+    // let pager = container.query_items(
+    //     "SELECT * FROM c ORDER BY c.merge_order",
+    //     None,
+    //     Some(QueryOptions {
+    //         query_engine: todo!(),
+    //         ..Default::default()
+    //     }),
+    // )?;
+
+    todo!()
+}

--- a/sdk/typespec/typespec_client_core/src/http/context.rs
+++ b/sdk/typespec/typespec_client_core/src/http/context.rs
@@ -15,6 +15,16 @@ pub struct Context<'a> {
     type_map: Cow<'a, HashMap<TypeId, Arc<dyn Any + Send + Sync>>>,
 }
 
+impl Context<'static> {
+    /// Creates a new [`Context`] that borrows from the current [`Context`].
+    pub fn into_borrowed(&self) -> Context<'_> {
+        let type_map = self.type_map.as_ref();
+        Context {
+            type_map: Cow::Borrowed(type_map),
+        }
+    }
+}
+
 impl<'a> Context<'a> {
     /// Creates a new, empty `Context`.
     pub fn new() -> Self {

--- a/sdk/typespec/typespec_client_core/src/http/context.rs
+++ b/sdk/typespec/typespec_client_core/src/http/context.rs
@@ -15,16 +15,6 @@ pub struct Context<'a> {
     type_map: Cow<'a, HashMap<TypeId, Arc<dyn Any + Send + Sync>>>,
 }
 
-impl Context<'static> {
-    /// Creates a new [`Context`] that borrows from the current [`Context`].
-    pub fn to_borrowed(&self) -> Context<'_> {
-        let type_map = self.type_map.as_ref();
-        Context {
-            type_map: Cow::Borrowed(type_map),
-        }
-    }
-}
-
 impl<'a> Context<'a> {
     /// Creates a new, empty `Context`.
     pub fn new() -> Self {

--- a/sdk/typespec/typespec_client_core/src/http/context.rs
+++ b/sdk/typespec/typespec_client_core/src/http/context.rs
@@ -17,7 +17,7 @@ pub struct Context<'a> {
 
 impl Context<'static> {
     /// Creates a new [`Context`] that borrows from the current [`Context`].
-    pub fn into_borrowed(&self) -> Context<'_> {
+    pub fn to_borrowed(&self) -> Context<'_> {
         let type_map = self.type_map.as_ref();
         Context {
             type_map: Cow::Borrowed(type_map),


### PR DESCRIPTION
This PR adds support for cross-partition queries. To do this, I've adjusted the syntax for the `query_items` method. As a reminder, this is the signature for that method:

```rust
pub fn query_items<T: DeserializeOwned + 'static>(
    &self,
    query: impl Into<Query>,
    partition_key: impl Into<PartitionKey>,
    options: Option<QueryOptions<'_>>,
) -> azure_core::Result<FeedPager<T>> {
```

The `partition_key` parameter accepts anything that can be converted to a `PartitionKey`. **Prior** to this PR, that meant (simplifying a bit):

* `&str`, `String`, all signed and unsigned integers, `f32`, and `f64` -> Represented a single string partition key value
* `Option<T>` where `T` is `Into<PartitionKey>` -> If the value was `Some`, then we used it as the partition key, otherwise we used an explicit `null`
* `(T1, T2)` where `T1` and `T2` are `Into<PartitionKey>` -> A two-level hierarchical PK
* `(T1, T2, T3)` where `T1`, and `T2` are `Into<PartitionKey>` -> A three-level hierarchical PK
* `()` -> An explicit `null` value. **This is where a change was made, but keep reading for more detail**

Originally, I planned to change `partition_key` so that it could accept some kind of sentinel value for a cross-partition query (`QueryPartitionStrategy::CrossPartition`), but that felt clunkier than I wanted (I suspected this when we designed the API originally but punted the problem). Then, I considered changing it to an `Option<impl Into<PartitionKey>>`, but that conflicted with support for `Option<T>` to represent potentially-null partition keys.

What I landed on is based on what we're doing in Go. A `PartitionKey` is, and has always been, a **list** of no more than 3 values. That's how it's represented in the underlying data structure, and how it's represented in the header. So, much like we did in Go, I changed our approach in Rust so that an "empty" list of partition key values indicated that a cross-partition query was desired. This means that `()`, which used to signify a single explicit `null` partition key value, now signifies an empty partition key list. A cross-partition query is thus written:

```rust
container.query_items("SELECT * FROM c", (), None)
```

This meant that we didn't have a value for explicit `null`. We still support `Option<T>::None` (where `T` is `Into<PartitionKey>`) but that makes it very clunky to specify a null literal since you have to specify a `T`, and spell out `Option::<String>::None`. The reason we support `Option<T>` is so that if you _have_ an `Option<String>` or similar in your code already, you can just pass it in. To solve that, I added `PartitionKey::NULL`, which is a `pub const` that specifies an explicit null value. So, if you want to write a query that was constrained to the partition with a `null` partition key, you write this: 

```rust
container.query_items("SELECT * FROM c", PartitionKey::NULL, None)
```

Seems reasonable, especially since I suspect `null` partition keys are quite rare.

---

Cross-partition queries are by default executed on the Gateway, which [significantly restricts query operators you can use](https://learn.microsoft.com/en-us/rest/api/cosmos-db/querying-cosmosdb-resources-using-the-rest-api#queries-that-cannot-be-served-by-gateway) to only projections and filters. However, **if** you reference `azure_data_cosmos` with the newly-added `query_engine` feature (it's behind a feature flag because it's still somewhat experimental and we may fold it in to the package entirely), you can specify `QueryOptions::query_engine` when making a query and use an externally-provided query engine (much like the support we're adding to Go). For example:

```rust
let query_engine = SomeExternalQueryEngine::new();
container.query_items("SELECT * FROM c", (), Some(QueryOptions {
    query_engine: Some(query_engine),
    ..Default::default()
}))
```

To support this, I've added a few abstractions (traits) to `azure_data_cosmos` that we'll implement in the separate Rust crate containing the query engine.

Before this feature goes in to GA, I strongly suspect we'll switch to actually _embed_ this query engine in the Rust SDK, since the query engine is itself written in Rust. Unlike other languages which will use FFI to call the query engine, there is little reason **not** to use the query engine from the Rust SDK, so folding it in as a standard dependency (`azure_data_cosmos` would depend upon the query engine crate and use it directly) seems reasonable, but for now, we're using this abstraction.