### PR TITLE
Added `AmqpSimpleValue` to enable compile time checks on AmqpApplicationProperties; Reworked type conversions to remove unnecessary clones.

### DIFF
--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -93,7 +93,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             if let Some(offered_capabilities) = options.offered_capabilities {
                 builder = builder.set_offered_capabilities(
                     offered_capabilities
-                        .iter()
+                        .into_iter()
                         .map(|capability| capability.into())
                         .collect(),
                 );
@@ -101,7 +101,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             if let Some(desired_capabilities) = options.desired_capabilities {
                 builder = builder.set_desired_capabilities(
                     desired_capabilities
-                        .iter()
+                        .into_iter()
                         .map(|capability| capability.into())
                         .collect(),
                 );
@@ -110,7 +110,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
                 builder = builder.properties(
                     properties
                         .iter()
-                        .map(|(k, v)| ((&k).into(), v.into()))
+                        .map(|(k, v)| (k.into(), v.into()))
                         .collect(),
                 );
             }
@@ -163,7 +163,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             .borrow_mut()
             .close_with_error(fe2o3_amqp::types::definitions::Error::new(
                 fe2o3_amqp::types::definitions::ErrorCondition::Custom(
-                    fe2o3_amqp_types::primitives::Symbol::from(&condition),
+                    fe2o3_amqp_types::primitives::Symbol::from(condition),
                 ),
                 description,
                 info.map(|i| i.into()),

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -92,18 +92,12 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             }
             if let Some(offered_capabilities) = options.offered_capabilities {
                 builder = builder.set_offered_capabilities(
-                    offered_capabilities
-                        .into_iter()
-                        .map(|capability| capability.into())
-                        .collect(),
+                    offered_capabilities.into_iter().map(Into::into).collect(),
                 );
             }
             if let Some(desired_capabilities) = options.desired_capabilities {
                 builder = builder.set_desired_capabilities(
-                    desired_capabilities
-                        .into_iter()
-                        .map(|capability| capability.into())
-                        .collect(),
+                    desired_capabilities.into_iter().map(Into::into).collect(),
                 );
             }
             if let Some(properties) = options.properties {
@@ -166,7 +160,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
                     fe2o3_amqp_types::primitives::Symbol::from(condition),
                 ),
                 description,
-                info.map(|i| i.into()),
+                info.map(Into::into),
             ))
             .await
             .map_err(|e| azure_core::Error::from(Fe2o3ConnectionError(e)));

--- a/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/connection.rs
@@ -74,39 +74,45 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             if let Some(idle_timeout) = options.idle_timeout {
                 builder = builder.idle_time_out(idle_timeout.whole_milliseconds() as u32);
             }
-            if let Some(outgoing_locales) = options.outgoing_locales.as_ref() {
-                for locale in outgoing_locales {
-                    builder = builder.add_outgoing_locales(locale.as_str());
-                }
+            if let Some(outgoing_locales) = options.outgoing_locales {
+                builder = builder.set_outgoing_locales(
+                    outgoing_locales
+                        .into_iter()
+                        .map(fe2o3_amqp_types::primitives::Symbol::from)
+                        .collect(),
+                );
             }
             if let Some(incoming_locales) = options.incoming_locales {
-                for locale in incoming_locales {
-                    builder = builder.add_incoming_locales(locale);
-                }
+                builder = builder.set_incoming_locales(
+                    incoming_locales
+                        .into_iter()
+                        .map(fe2o3_amqp_types::primitives::Symbol::from)
+                        .collect(),
+                );
             }
-            if let Some(offered_capabilities) = options.offered_capabilities.as_ref() {
-                for capability in offered_capabilities {
-                    let capability: fe2o3_amqp_types::primitives::Symbol =
-                        capability.clone().into();
-                    builder = builder.add_offered_capabilities(capability);
-                }
+            if let Some(offered_capabilities) = options.offered_capabilities {
+                builder = builder.set_offered_capabilities(
+                    offered_capabilities
+                        .iter()
+                        .map(|capability| capability.into())
+                        .collect(),
+                );
             }
-            if let Some(desired_capabilities) = options.desired_capabilities.as_ref() {
-                for capability in desired_capabilities {
-                    let capability: fe2o3_amqp_types::primitives::Symbol =
-                        capability.clone().into();
-                    builder = builder.add_desired_capabilities(capability);
-                }
+            if let Some(desired_capabilities) = options.desired_capabilities {
+                builder = builder.set_desired_capabilities(
+                    desired_capabilities
+                        .iter()
+                        .map(|capability| capability.into())
+                        .collect(),
+                );
             }
-            if let Some(properties) = options.properties.as_ref() {
-                let mut fields = fe2o3_amqp::types::definitions::Fields::new();
-                for property in properties.iter() {
-                    let k = fe2o3_amqp_types::primitives::Symbol::from(property.0);
-                    let v = fe2o3_amqp_types::primitives::Value::from(property.1);
-
-                    fields.insert(k, v);
-                }
-                builder = builder.properties(fields);
+            if let Some(properties) = options.properties {
+                builder = builder.properties(
+                    properties
+                        .iter()
+                        .map(|(k, v)| ((&k).into(), v.into()))
+                        .collect(),
+                );
             }
             if let Some(buffer_size) = options.buffer_size {
                 builder = builder.buffer_size(buffer_size);
@@ -157,7 +163,7 @@ impl AmqpConnectionApis for Fe2o3AmqpConnection {
             .borrow_mut()
             .close_with_error(fe2o3_amqp::types::definitions::Error::new(
                 fe2o3_amqp::types::definitions::ErrorCondition::Custom(
-                    fe2o3_amqp_types::primitives::Symbol::from(condition),
+                    fe2o3_amqp_types::primitives::Symbol::from(&condition),
                 ),
                 description,
                 info.map(|i| i.into()),

--- a/sdk/core/azure_core_amqp/src/fe2o3/error.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/error.rs
@@ -50,35 +50,54 @@ impl From<&fe2o3_amqp_types::definitions::ErrorCondition> for AmqpErrorCondition
     fn from(e: &fe2o3_amqp_types::definitions::ErrorCondition) -> Self {
         match e {
             fe2o3_amqp_types::definitions::ErrorCondition::AmqpError(amqp_error) => {
-                AmqpErrorCondition::from(fe2o3_amqp_types::primitives::Symbol::from(amqp_error))
+                AmqpErrorCondition::from(amqp_error)
             }
             fe2o3_amqp_types::definitions::ErrorCondition::ConnectionError(connection_error) => {
-                AmqpErrorCondition::from(fe2o3_amqp_types::primitives::Symbol::from(
-                    connection_error,
-                ))
+                AmqpErrorCondition::from(connection_error)
             }
             fe2o3_amqp_types::definitions::ErrorCondition::SessionError(session_error) => {
-                AmqpErrorCondition::from(fe2o3_amqp_types::primitives::Symbol::from(session_error))
+                AmqpErrorCondition::from(session_error)
             }
             fe2o3_amqp_types::definitions::ErrorCondition::LinkError(link_error) => {
-                AmqpErrorCondition::from(fe2o3_amqp_types::primitives::Symbol::from(link_error))
+                AmqpErrorCondition::from(link_error)
             }
             fe2o3_amqp_types::definitions::ErrorCondition::Custom(symbol) => {
-                // from_str can never fail because the symbol is guaranteed to be a valid AMQP symbol.
-                AmqpErrorCondition::from_str(symbol.0.as_str()).unwrap()
+                AmqpErrorCondition::from(crate::AmqpSymbol::from(symbol))
             }
         }
     }
 }
 
-impl From<fe2o3_amqp_types::primitives::Symbol> for AmqpErrorCondition {
-    fn from(e: fe2o3_amqp_types::primitives::Symbol) -> Self {
+// Implement specific From traits for the error types we need instead of using a generic implementation
+impl From<&fe2o3_amqp_types::definitions::AmqpError> for AmqpErrorCondition {
+    fn from(e: &fe2o3_amqp_types::definitions::AmqpError) -> Self {
         // Note that the `from_str` implementation from `create_extensible_enum` will
         // never return an error. So the `unwrap` is there to silence the compiler.
-        AmqpErrorCondition::from_str(e.0.as_str()).unwrap()
+        AmqpErrorCondition::from_str(fe2o3_amqp_types::primitives::Symbol::from(e).as_str())
+            .unwrap()
     }
 }
 
+impl From<&fe2o3_amqp_types::definitions::ConnectionError> for AmqpErrorCondition {
+    fn from(e: &fe2o3_amqp_types::definitions::ConnectionError) -> Self {
+        AmqpErrorCondition::from_str(fe2o3_amqp_types::primitives::Symbol::from(e).as_str())
+            .unwrap()
+    }
+}
+
+impl From<&fe2o3_amqp_types::definitions::SessionError> for AmqpErrorCondition {
+    fn from(e: &fe2o3_amqp_types::definitions::SessionError) -> Self {
+        AmqpErrorCondition::from_str(fe2o3_amqp_types::primitives::Symbol::from(e).as_str())
+            .unwrap()
+    }
+}
+
+impl From<&fe2o3_amqp_types::definitions::LinkError> for AmqpErrorCondition {
+    fn from(e: &fe2o3_amqp_types::definitions::LinkError) -> Self {
+        AmqpErrorCondition::from_str(fe2o3_amqp_types::primitives::Symbol::from(e).as_str())
+            .unwrap()
+    }
+}
 impl From<fe2o3_amqp_types::definitions::Error> for AmqpDescribedError {
     fn from(e: fe2o3_amqp_types::definitions::Error) -> Self {
         AmqpDescribedError::new(

--- a/sdk/core/azure_core_amqp/src/fe2o3/error.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/error.rs
@@ -103,7 +103,7 @@ impl From<fe2o3_amqp_types::definitions::Error> for AmqpDescribedError {
         AmqpDescribedError::new(
             (&e.condition).into(),
             e.description,
-            e.info.unwrap_or_default().into(),
+            (&e.info.unwrap_or_default()).into(),
         )
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/management.rs
@@ -7,6 +7,7 @@ use crate::{
     error::AmqpErrorKind,
     management::AmqpManagementApis,
     session::AmqpSession,
+    simple_value::AmqpSimpleValue,
     value::{AmqpOrderedMap, AmqpValue},
     AmqpError,
 };
@@ -92,7 +93,7 @@ impl AmqpManagementApis for Fe2o3AmqpManagement {
     async fn call(
         &self,
         operation_type: String,
-        application_properties: AmqpOrderedMap<String, AmqpValue>,
+        application_properties: AmqpOrderedMap<String, AmqpSimpleValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>> {
         let mut management = self
             .management
@@ -161,14 +162,14 @@ impl From<fe2o3_amqp_management::error::AttachError> for AmqpError {
 struct WithApplicationPropertiesRequest<'a> {
     entity_type: String,
     access_token: &'a AccessToken,
-    application_properties: AmqpOrderedMap<String, AmqpValue>,
+    application_properties: AmqpOrderedMap<String, AmqpSimpleValue>,
 }
 
 impl<'a> WithApplicationPropertiesRequest<'a> {
     pub fn new(
         entity_type: String,
         access_token: &'a AccessToken,
-        application_properties: AmqpOrderedMap<String, AmqpValue>,
+        application_properties: AmqpOrderedMap<String, AmqpSimpleValue>,
     ) -> Self {
         Self {
             entity_type,

--- a/sdk/core/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/management.rs
@@ -113,7 +113,7 @@ impl AmqpManagementApis for Fe2o3AmqpManagement {
             let e = AmqpError::try_from(e)?;
             Err(e.into())
         } else {
-            Ok(response.unwrap().entity_attributes.into())
+            Ok((&response.unwrap().entity_attributes).into())
         }
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/management.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/management.rs
@@ -118,14 +118,6 @@ impl AmqpManagementApis for Fe2o3AmqpManagement {
     }
 }
 
-// impl TryFrom<Fe2o3ManagementError> for azure_core::Error {
-//     type Error = azure_core::Error;
-//     fn try_from(e: Fe2o3ManagementError) -> std::result::Result<Self, Self::Error> {
-//         let e = AmqpError::try_from(e.0)?;
-//         Ok(e.into())
-//     }
-// }
-
 impl TryFrom<fe2o3_amqp_management::error::Error> for AmqpError {
     type Error = azure_core::Error;
     fn try_from(e: fe2o3_amqp_management::error::Error) -> std::result::Result<Self, Self::Error> {

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -8,23 +8,24 @@ use crate::{
         AmqpAnnotationKey, AmqpAnnotations, AmqpApplicationProperties, AmqpMessageHeader,
         AmqpMessageId, AmqpMessageProperties,
     },
+    simple_value::AmqpSimpleValue,
     value::{AmqpOrderedMap, AmqpValue},
 };
 
-impl From<fe2o3_amqp_types::messaging::MessageId> for AmqpMessageId {
-    fn from(message_id: fe2o3_amqp_types::messaging::MessageId) -> Self {
+impl From<&fe2o3_amqp_types::messaging::MessageId> for AmqpMessageId {
+    fn from(message_id: &fe2o3_amqp_types::messaging::MessageId) -> Self {
         match message_id {
             fe2o3_amqp_types::messaging::MessageId::String(message_id) => {
-                AmqpMessageId::String(message_id)
+                AmqpMessageId::String(message_id.clone())
             }
             fe2o3_amqp_types::messaging::MessageId::Uuid(message_id) => {
-                AmqpMessageId::Uuid(message_id.into())
+                AmqpMessageId::Uuid(azure_core::Uuid::from_bytes(*message_id.as_inner()))
             }
             fe2o3_amqp_types::messaging::MessageId::Binary(message_id) => {
                 AmqpMessageId::Binary(message_id.to_vec())
             }
             fe2o3_amqp_types::messaging::MessageId::Ulong(message_id) => {
-                AmqpMessageId::Ulong(message_id)
+                AmqpMessageId::Ulong(*message_id)
             }
         }
     }
@@ -54,7 +55,7 @@ fn test_message_id_conversion() {
     use azure_core::Uuid;
     {
         let message_id = fe2o3_amqp_types::messaging::MessageId::String("test".into());
-        let amqp_message_id: AmqpMessageId = message_id.clone().into();
+        let amqp_message_id: AmqpMessageId = (&message_id).into();
         assert_eq!(amqp_message_id, AmqpMessageId::String("test".into()));
         let fe2o3_message_id: fe2o3_amqp_types::messaging::MessageId = amqp_message_id.into();
         assert_eq!(fe2o3_message_id, message_id);
@@ -63,7 +64,7 @@ fn test_message_id_conversion() {
     {
         let uuid = Uuid::new_v4();
         let message_id = fe2o3_amqp_types::messaging::MessageId::Uuid(uuid.into());
-        let amqp_message_id: AmqpMessageId = message_id.clone().into();
+        let amqp_message_id: AmqpMessageId = (&message_id).into();
         assert_eq!(amqp_message_id, AmqpMessageId::from(uuid));
 
         let fe2o3_message_id: fe2o3_amqp_types::messaging::MessageId = amqp_message_id.into();
@@ -72,7 +73,7 @@ fn test_message_id_conversion() {
 
     {
         let message_id = fe2o3_amqp_types::messaging::MessageId::Binary(vec![1, 2, 3].into());
-        let amqp_message_id: AmqpMessageId = message_id.clone().into();
+        let amqp_message_id: AmqpMessageId = (&message_id).into();
         assert_eq!(amqp_message_id, AmqpMessageId::Binary(vec![1, 2, 3]));
         let fe2o3_message_id: fe2o3_amqp_types::messaging::MessageId = amqp_message_id.into();
         assert_eq!(fe2o3_message_id, message_id);
@@ -80,7 +81,7 @@ fn test_message_id_conversion() {
 
     {
         let message_id = fe2o3_amqp_types::messaging::MessageId::Ulong(1);
-        let amqp_message_id: AmqpMessageId = message_id.clone().into();
+        let amqp_message_id: AmqpMessageId = (&message_id).into();
         assert_eq!(amqp_message_id, AmqpMessageId::Ulong(1));
         let fe2o3_message_id: fe2o3_amqp_types::messaging::MessageId = amqp_message_id.into();
         assert_eq!(fe2o3_message_id, message_id);
@@ -93,7 +94,7 @@ fn test_message_id_conversion() {
             message_id,
             fe2o3_amqp_types::messaging::MessageId::String("test".into())
         );
-        let amqp_round_trip: AmqpMessageId = message_id.into();
+        let amqp_round_trip: AmqpMessageId = (&message_id).into();
         assert_eq!(amqp_round_trip, amqp_message_id);
     }
     {
@@ -106,7 +107,7 @@ fn test_message_id_conversion() {
                 uuid
             ))
         );
-        let amqp_round_trip: AmqpMessageId = message_id.into();
+        let amqp_round_trip: AmqpMessageId = (&message_id).into();
         assert_eq!(amqp_round_trip, amqp_message_id);
     }
     {
@@ -116,25 +117,25 @@ fn test_message_id_conversion() {
             message_id,
             fe2o3_amqp_types::messaging::MessageId::Binary(vec![1, 2, 3].into())
         );
-        let amqp_round_trip: AmqpMessageId = message_id.into();
+        let amqp_round_trip: AmqpMessageId = (&message_id).into();
         assert_eq!(amqp_round_trip, amqp_message_id);
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::ApplicationProperties>
+impl From<&fe2o3_amqp_types::messaging::ApplicationProperties>
     for crate::messaging::AmqpApplicationProperties
 {
-    fn from(application_properties: fe2o3_amqp_types::messaging::ApplicationProperties) -> Self {
-        let mut properties = AmqpOrderedMap::<String, AmqpValue>::new();
-        for (key, value) in application_properties.0 {
-            properties.insert(key, value.into());
+    fn from(application_properties: &fe2o3_amqp_types::messaging::ApplicationProperties) -> Self {
+        let mut properties = AmqpOrderedMap::<String, AmqpSimpleValue>::new();
+        for (key, value) in application_properties.0.iter() {
+            properties.insert(key.clone(), value.into());
         }
         AmqpApplicationProperties(properties)
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
-    fn from(header: fe2o3_amqp_types::messaging::Header) -> Self {
+impl From<&fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
+    fn from(header: &fe2o3_amqp_types::messaging::Header) -> Self {
         AmqpMessageHeader {
             durable: header.durable,
             priority: header.priority.into(),
@@ -145,8 +146,8 @@ impl From<fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
     }
 }
 
-impl From<AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
-    fn from(header: AmqpMessageHeader) -> Self {
+impl From<&AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
+    fn from(header: &AmqpMessageHeader) -> Self {
         fe2o3_amqp_types::messaging::Header {
             durable: header.durable,
             priority: fe2o3_amqp_types::messaging::Priority(header.priority),
@@ -157,25 +158,23 @@ impl From<AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
     }
 }
 
-impl From<crate::messaging::AmqpApplicationProperties>
+impl From<&crate::messaging::AmqpApplicationProperties>
     for fe2o3_amqp_types::messaging::ApplicationProperties
 {
-    fn from(application_properties: AmqpApplicationProperties) -> Self {
+    fn from(application_properties: &AmqpApplicationProperties) -> Self {
         let mut properties_builder = fe2o3_amqp_types::messaging::ApplicationProperties::builder();
-        for (key, value) in application_properties.0 {
+        for (key, value) in application_properties.0.iter() {
             properties_builder = properties_builder.insert(key, value);
         }
         properties_builder.build()
     }
 }
 
-impl From<crate::messaging::AmqpAnnotationKey>
-    for fe2o3_amqp_types::messaging::annotations::OwnedKey
-{
-    fn from(key: AmqpAnnotationKey) -> Self {
+impl From<&AmqpAnnotationKey> for fe2o3_amqp_types::messaging::annotations::OwnedKey {
+    fn from(key: &AmqpAnnotationKey) -> Self {
         match key {
             AmqpAnnotationKey::Ulong(key) => {
-                fe2o3_amqp_types::messaging::annotations::OwnedKey::Ulong(key)
+                fe2o3_amqp_types::messaging::annotations::OwnedKey::Ulong(*key)
             }
             AmqpAnnotationKey::Symbol(key) => {
                 fe2o3_amqp_types::messaging::annotations::OwnedKey::Symbol(key.into())
@@ -184,13 +183,13 @@ impl From<crate::messaging::AmqpAnnotationKey>
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::annotations::OwnedKey>
+impl From<&fe2o3_amqp_types::messaging::annotations::OwnedKey>
     for crate::messaging::AmqpAnnotationKey
 {
-    fn from(key: fe2o3_amqp_types::messaging::annotations::OwnedKey) -> Self {
+    fn from(key: &fe2o3_amqp_types::messaging::annotations::OwnedKey) -> Self {
         match key {
             fe2o3_amqp_types::messaging::annotations::OwnedKey::Ulong(key) => {
-                crate::messaging::AmqpAnnotationKey::Ulong(key)
+                crate::messaging::AmqpAnnotationKey::Ulong(*key)
             }
             fe2o3_amqp_types::messaging::annotations::OwnedKey::Symbol(key) => {
                 crate::messaging::AmqpAnnotationKey::Symbol(key.into())
@@ -203,77 +202,78 @@ impl From<fe2o3_amqp_types::messaging::annotations::OwnedKey>
 fn test_owned_key_conversion() {
     {
         let fe2o3_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::Ulong(1995);
-        let amqp_key = AmqpAnnotationKey::from(fe2o3_key.clone());
+        let amqp_key = AmqpAnnotationKey::from(&fe2o3_key);
 
         assert_eq!(amqp_key, AmqpAnnotationKey::Ulong(1995));
-        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(amqp_key);
+        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(&amqp_key);
         assert_eq!(round_trip_key, fe2o3_key);
     }
 
     {
         let fe2o3_key =
             fe2o3_amqp_types::messaging::annotations::OwnedKey::Symbol("OwnedSymbol".into());
-        let amqp_key = AmqpAnnotationKey::from(fe2o3_key.clone());
+        let amqp_key = AmqpAnnotationKey::from(&fe2o3_key);
 
         assert_eq!(amqp_key, AmqpAnnotationKey::Symbol("OwnedSymbol".into()));
-        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(amqp_key);
+        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(&amqp_key);
         assert_eq!(round_trip_key, fe2o3_key);
     }
 }
 
-impl From<crate::messaging::AmqpAnnotations> for fe2o3_amqp_types::messaging::Annotations {
-    fn from(annotations: AmqpAnnotations) -> Self {
+impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::Annotations {
+    fn from(annotations: &AmqpAnnotations) -> Self {
         let mut message_annotations = fe2o3_amqp_types::messaging::Annotations::new();
-        for (key, value) in annotations.0 {
-            message_annotations.insert(key.into(), value.into());
+        for (key, value) in annotations.0.iter() {
+            message_annotations.insert((&key).into(), value.into());
         }
         message_annotations
     }
 }
 
-impl From<AmqpAnnotations> for fe2o3_amqp_types::messaging::DeliveryAnnotations {
-    fn from(annotations: AmqpAnnotations) -> Self {
+impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::DeliveryAnnotations {
+    fn from(annotations: &AmqpAnnotations) -> Self {
         fe2o3_amqp_types::messaging::DeliveryAnnotations(
             annotations
                 .0
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
+                .iter()
+                .map(|(k, v)| ((&k).into(), v.into()))
                 .collect(),
         )
     }
 }
 
-impl From<AmqpAnnotations> for fe2o3_amqp_types::messaging::MessageAnnotations {
-    fn from(annotations: AmqpAnnotations) -> Self {
+impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::MessageAnnotations {
+    fn from(annotations: &AmqpAnnotations) -> Self {
         fe2o3_amqp_types::messaging::MessageAnnotations(
             annotations
                 .0
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
+                .iter()
+                .map(|(k, v)| ((&k).into(), v.into()))
                 .collect(),
         )
     }
 }
 
-impl From<AmqpAnnotations> for fe2o3_amqp_types::messaging::Footer {
-    fn from(annotations: AmqpAnnotations) -> Self {
+impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::Footer {
+    fn from(annotations: &AmqpAnnotations) -> Self {
         fe2o3_amqp_types::messaging::Footer(
             annotations
                 .0
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
+                .iter()
+                .map(|(k, v)| ((&k).into(), v.into()))
                 .collect(),
         )
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::Annotations> for AmqpAnnotations {
-    fn from(annotations: fe2o3_amqp_types::messaging::Annotations) -> Self {
-        let mut amqp_annotations = AmqpOrderedMap::<AmqpAnnotationKey, AmqpValue>::new();
-        for (key, value) in annotations {
-            amqp_annotations.insert(key.into(), value.into());
-        }
-        AmqpAnnotations(amqp_annotations)
+impl From<&fe2o3_amqp_types::messaging::Annotations> for AmqpAnnotations {
+    fn from(annotations: &fe2o3_amqp_types::messaging::Annotations) -> Self {
+        AmqpAnnotations(
+            annotations
+                .iter()
+                .map(|(k, v)| (AmqpAnnotationKey::from(k), AmqpValue::from(v)))
+                .collect::<AmqpOrderedMap<AmqpAnnotationKey, AmqpValue>>(),
+        )
     }
 }
 
@@ -285,7 +285,7 @@ fn test_message_annotation_conversion() {
             (AmqpAnnotationKey::Symbol("test".into()), "test"),
         ]);
 
-        let fe2o3_annotations = fe2o3_amqp_types::messaging::Annotations::from(annotations.clone());
+        let fe2o3_annotations = fe2o3_amqp_types::messaging::Annotations::from(&annotations);
 
         // There does not appear to be a From<OrderedMap<>> for Annotations.
         let mut annotations_to_test = fe2o3_amqp_types::messaging::Annotations::new();
@@ -299,7 +299,7 @@ fn test_message_annotation_conversion() {
         );
         assert_eq!(fe2o3_annotations, annotations_to_test);
 
-        let amqp_round_trip: AmqpAnnotations = fe2o3_annotations.into();
+        let amqp_round_trip: AmqpAnnotations = (&fe2o3_annotations).into();
         assert_eq!(amqp_round_trip, annotations);
     }
 
@@ -314,7 +314,7 @@ fn test_message_annotation_conversion() {
             "test".into(),
         );
 
-        let annotations = AmqpAnnotations::from(fe2o3_annotations.clone());
+        let annotations = AmqpAnnotations::from(&fe2o3_annotations);
         assert_eq!(
             annotations,
             AmqpAnnotations::from(vec![
@@ -323,60 +323,60 @@ fn test_message_annotation_conversion() {
             ])
         );
 
-        let fe2o3_round_trip: fe2o3_amqp_types::messaging::Annotations = annotations.into();
+        let fe2o3_round_trip: fe2o3_amqp_types::messaging::Annotations = (&annotations).into();
         assert_eq!(fe2o3_round_trip, fe2o3_annotations);
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
-    fn from(properties: fe2o3_amqp_types::messaging::Properties) -> Self {
+impl From<&fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
+    fn from(properties: &fe2o3_amqp_types::messaging::Properties) -> Self {
         let mut amqp_message_properties = AmqpMessageProperties::default();
 
-        if let Some(message_id) = properties.message_id {
+        if let Some(message_id) = &properties.message_id {
             amqp_message_properties.message_id = Some(message_id.into());
         }
-        if let Some(user_id) = properties.user_id {
+        if let Some(user_id) = &properties.user_id {
             amqp_message_properties.user_id = Some(user_id.to_vec());
         }
-        if let Some(to) = properties.to {
-            amqp_message_properties.to = Some(to);
+        if let Some(to) = &properties.to {
+            amqp_message_properties.to = Some(to.clone());
         }
-        if let Some(subject) = properties.subject {
-            amqp_message_properties.subject = Some(subject);
+        if let Some(subject) = &properties.subject {
+            amqp_message_properties.subject = Some(subject.clone());
         }
-        if let Some(reply_to) = properties.reply_to {
-            amqp_message_properties.reply_to = Some(reply_to);
+        if let Some(reply_to) = &properties.reply_to {
+            amqp_message_properties.reply_to = Some(reply_to.clone());
         }
-        if let Some(correlation_id) = properties.correlation_id {
+        if let Some(correlation_id) = &properties.correlation_id {
             amqp_message_properties.correlation_id = Some(correlation_id.into());
         }
-        if let Some(content_type) = properties.content_type {
+        if let Some(content_type) = &properties.content_type {
             amqp_message_properties.content_type = Some(content_type.into());
         }
-        if let Some(content_encoding) = properties.content_encoding {
+        if let Some(content_encoding) = &properties.content_encoding {
             amqp_message_properties.content_encoding = Some(content_encoding.into());
         }
-        if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
+        if let Some(absolute_expiry_time) = &properties.absolute_expiry_time {
             amqp_message_properties.absolute_expiry_time = Some(absolute_expiry_time.into());
         }
-        if let Some(creation_time) = properties.creation_time {
+        if let Some(creation_time) = &properties.creation_time {
             amqp_message_properties.creation_time = Some(creation_time.into());
         }
-        if let Some(group_id) = properties.group_id {
-            amqp_message_properties.group_id = Some(group_id);
+        if let Some(group_id) = &properties.group_id {
+            amqp_message_properties.group_id = Some(group_id.clone());
         }
         if let Some(group_sequence) = properties.group_sequence {
             amqp_message_properties.group_sequence = Some(group_sequence);
         }
-        if let Some(reply_to_group_id) = properties.reply_to_group_id {
-            amqp_message_properties.reply_to_group_id = Some(reply_to_group_id);
+        if let Some(reply_to_group_id) = &properties.reply_to_group_id {
+            amqp_message_properties.reply_to_group_id = Some(reply_to_group_id.clone());
         }
         amqp_message_properties
     }
 }
 
-impl From<AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
-    fn from(properties: AmqpMessageProperties) -> Self {
+impl From<&AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
+    fn from(properties: &AmqpMessageProperties) -> Self {
         let mut properties_builder = fe2o3_amqp_types::messaging::Properties::builder();
 
         if let Some(message_id) = &properties.message_id {
@@ -385,39 +385,38 @@ impl From<AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
         if let Some(user_id) = &properties.user_id {
             properties_builder = properties_builder.user_id(user_id.clone());
         }
-        if let Some(to) = properties.to {
+        if let Some(to) = &properties.to {
             properties_builder = properties_builder.to(to.clone());
         }
-        if let Some(subject) = properties.subject {
+        if let Some(subject) = &properties.subject {
             properties_builder = properties_builder.subject(subject.clone());
         }
-        if let Some(reply_to) = properties.reply_to {
+        if let Some(reply_to) = &properties.reply_to {
             properties_builder = properties_builder.reply_to(reply_to.clone());
         }
-        if let Some(correlation_id) = properties.correlation_id {
+        if let Some(correlation_id) = &properties.correlation_id {
             properties_builder = properties_builder.correlation_id(correlation_id.clone());
         }
-        if let Some(content_type) = properties.content_type {
-            properties_builder = properties_builder.content_type(content_type.clone());
+        if let Some(content_type) = &properties.content_type {
+            properties_builder = properties_builder.content_type(content_type);
         }
-        if let Some(content_encoding) = properties.content_encoding {
-            properties_builder = properties_builder.content_encoding(content_encoding.clone());
+        if let Some(content_encoding) = &properties.content_encoding {
+            properties_builder = properties_builder.content_encoding(content_encoding);
         }
-        if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
+        if let Some(absolute_expiry_time) = &properties.absolute_expiry_time {
             properties_builder =
-                properties_builder.absolute_expiry_time(Some(absolute_expiry_time.clone().into()));
+                properties_builder.absolute_expiry_time(Some(absolute_expiry_time.into()));
         }
-        if let Some(creation_time) = properties.creation_time {
-            properties_builder =
-                properties_builder.creation_time(Some(creation_time.clone().into()));
+        if let Some(creation_time) = &properties.creation_time {
+            properties_builder = properties_builder.creation_time(Some(creation_time.into()));
         }
-        if let Some(group_id) = properties.group_id {
+        if let Some(group_id) = &properties.group_id {
             properties_builder = properties_builder.group_id(group_id.clone());
         }
-        if let Some(group_sequence) = properties.group_sequence {
-            properties_builder = properties_builder.group_sequence(group_sequence);
+        if let Some(group_sequence) = &properties.group_sequence {
+            properties_builder = properties_builder.group_sequence(*group_sequence);
         }
-        if let Some(reply_to_group_id) = properties.reply_to_group_id {
+        if let Some(reply_to_group_id) = &properties.reply_to_group_id {
             properties_builder = properties_builder.reply_to_group_id(reply_to_group_id.clone());
         }
         properties_builder.build()
@@ -447,8 +446,8 @@ fn test_properties_conversion() {
             reply_to_group_id: Some("reply_to_group_id".into()),
         };
 
-        let amqp_properties = AmqpMessageProperties::from(properties.clone());
-        let roundtrip_properties = fe2o3_amqp_types::messaging::Properties::from(amqp_properties);
+        let amqp_properties = AmqpMessageProperties::from(&properties);
+        let roundtrip_properties = fe2o3_amqp_types::messaging::Properties::from(&amqp_properties);
         assert_eq!(properties, roundtrip_properties);
     }
 
@@ -477,9 +476,9 @@ fn test_properties_conversion() {
             user_id: Some(vec![1, 2, 3]),
         };
 
-        let fe2o3_properties: fe2o3_amqp_types::messaging::Properties = properties.clone().into();
+        let fe2o3_properties: fe2o3_amqp_types::messaging::Properties = (&properties).into();
 
-        let amqp_round_trip = AmqpMessageProperties::from(fe2o3_properties);
+        let amqp_round_trip = AmqpMessageProperties::from(&fe2o3_properties);
         assert_eq!(properties, amqp_round_trip);
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -199,7 +199,7 @@ impl From<&AmqpApplicationProperties> for fe2o3_amqp_types::messaging::Applicati
             application_properties
                 .0
                 .iter()
-                .map(|(k, v)| (k, v.into()))
+                .map(|(k, v)| (k.clone(), v.into()))
                 .collect(),
         )
     }
@@ -421,16 +421,16 @@ fn test_message_annotation_conversion() {
 impl From<&fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
     fn from(properties: &fe2o3_amqp_types::messaging::Properties) -> Self {
         let amqp_message_properties = AmqpMessageProperties {
-            message_id: properties.message_id.as_ref().map(|m| m.into()),
+            message_id: properties.message_id.as_ref().map(Into::into),
             user_id: properties.user_id.as_ref().map(|u| u.to_vec()),
             to: properties.to.clone(),
             subject: properties.subject.clone(),
             reply_to: properties.reply_to.clone(),
-            correlation_id: properties.correlation_id.as_ref().map(|c| c.into()),
-            content_type: properties.content_type.as_ref().map(|c| c.into()),
-            content_encoding: properties.content_encoding.as_ref().map(|c| c.into()),
-            absolute_expiry_time: properties.absolute_expiry_time.as_ref().map(|t| t.into()),
-            creation_time: properties.creation_time.as_ref().map(|t| t.into()),
+            correlation_id: properties.correlation_id.as_ref().map(Into::into),
+            content_type: properties.content_type.as_ref().map(Into::into),
+            content_encoding: properties.content_encoding.as_ref().map(Into::into),
+            absolute_expiry_time: properties.absolute_expiry_time.as_ref().map(Into::into),
+            creation_time: properties.creation_time.as_ref().map(Into::into),
             group_id: properties.group_id.clone(),
             group_sequence: properties.group_sequence,
             reply_to_group_id: properties.reply_to_group_id.clone(),
@@ -442,16 +442,16 @@ impl From<&fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
 impl From<fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
     fn from(properties: fe2o3_amqp_types::messaging::Properties) -> Self {
         AmqpMessageProperties {
-            message_id: properties.message_id.map(|m| m.into()),
+            message_id: properties.message_id.map(Into::into),
             user_id: properties.user_id.map(|u| u.to_vec()),
             to: properties.to,
             subject: properties.subject,
             reply_to: properties.reply_to,
-            correlation_id: properties.correlation_id.map(|c| c.into()),
-            content_type: properties.content_type.map(|c| c.into()),
-            content_encoding: properties.content_encoding.map(|c| c.into()),
-            absolute_expiry_time: properties.absolute_expiry_time.map(|t| t.into()),
-            creation_time: properties.creation_time.map(|t| t.into()),
+            correlation_id: properties.correlation_id.map(Into::into),
+            content_type: properties.content_type.map(Into::into),
+            content_encoding: properties.content_encoding.map(Into::into),
+            absolute_expiry_time: properties.absolute_expiry_time.map(Into::into),
+            creation_time: properties.creation_time.map(Into::into),
             group_id: properties.group_id,
             group_sequence: properties.group_sequence,
             reply_to_group_id: properties.reply_to_group_id,
@@ -462,16 +462,16 @@ impl From<fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
 impl From<AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
     fn from(properties: AmqpMessageProperties) -> Self {
         Self {
-            message_id: properties.message_id.map(|m| m.into()),
-            user_id: properties.user_id.map(|u| u.into()),
+            message_id: properties.message_id.map(Into::into),
+            user_id: properties.user_id.map(Into::into),
             to: properties.to,
             subject: properties.subject,
             reply_to: properties.reply_to,
-            correlation_id: properties.correlation_id.map(|c| c.into()),
-            content_type: properties.content_type.map(|c| c.into()),
-            content_encoding: properties.content_encoding.map(|c| c.into()),
-            absolute_expiry_time: properties.absolute_expiry_time.map(|t| t.into()),
-            creation_time: properties.creation_time.map(|t| t.into()),
+            correlation_id: properties.correlation_id.map(Into::into),
+            content_type: properties.content_type.map(Into::into),
+            content_encoding: properties.content_encoding.map(Into::into),
+            absolute_expiry_time: properties.absolute_expiry_time.map(Into::into),
+            creation_time: properties.creation_time.map(Into::into),
             group_id: properties.group_id,
             group_sequence: properties.group_sequence,
             reply_to_group_id: properties.reply_to_group_id,
@@ -482,7 +482,7 @@ impl From<AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
 impl From<&AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
     fn from(properties: &AmqpMessageProperties) -> Self {
         Self {
-            message_id: properties.message_id.as_ref().map(|m| m.into()),
+            message_id: properties.message_id.as_ref().map(Into::into),
             user_id: properties
                 .user_id
                 .as_ref()
@@ -490,11 +490,11 @@ impl From<&AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
             to: properties.to.clone(),
             subject: properties.subject.clone(),
             reply_to: properties.reply_to.clone(),
-            correlation_id: properties.correlation_id.as_ref().map(|c| c.into()),
-            content_type: properties.content_type.as_ref().map(|c| c.into()),
-            content_encoding: properties.content_encoding.as_ref().map(|c| c.into()),
-            absolute_expiry_time: properties.absolute_expiry_time.as_ref().map(|t| t.into()),
-            creation_time: properties.creation_time.as_ref().map(|t| t.into()),
+            correlation_id: properties.correlation_id.as_ref().map(Into::into),
+            content_type: properties.content_type.as_ref().map(Into::into),
+            content_encoding: properties.content_encoding.as_ref().map(Into::into),
+            absolute_expiry_time: properties.absolute_expiry_time.as_ref().map(Into::into),
+            creation_time: properties.creation_time.as_ref().map(Into::into),
             group_id: properties.group_id.clone(),
             group_sequence: properties.group_sequence,
             reply_to_group_id: properties.reply_to_group_id.clone(),

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -158,9 +158,7 @@ impl From<&AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
     }
 }
 
-impl From<&crate::messaging::AmqpApplicationProperties>
-    for fe2o3_amqp_types::messaging::ApplicationProperties
-{
+impl From<&AmqpApplicationProperties> for fe2o3_amqp_types::messaging::ApplicationProperties {
     fn from(application_properties: &AmqpApplicationProperties) -> Self {
         let mut properties_builder = fe2o3_amqp_types::messaging::ApplicationProperties::builder();
         for (key, value) in application_properties.0.iter() {
@@ -224,7 +222,7 @@ impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::Annotations {
     fn from(annotations: &AmqpAnnotations) -> Self {
         let mut message_annotations = fe2o3_amqp_types::messaging::Annotations::new();
         for (key, value) in annotations.0.iter() {
-            message_annotations.insert((&key).into(), value.into());
+            message_annotations.insert(key.as_ref().into(), value.into());
         }
         message_annotations
     }
@@ -236,7 +234,7 @@ impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::DeliveryAnnotations
             annotations
                 .0
                 .iter()
-                .map(|(k, v)| ((&k).into(), v.into()))
+                .map(|(k, v)| (k.as_ref().into(), v.into()))
                 .collect(),
         )
     }
@@ -248,7 +246,7 @@ impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::MessageAnnotations 
             annotations
                 .0
                 .iter()
-                .map(|(k, v)| ((&k).into(), v.into()))
+                .map(|(k, v)| (k.as_ref().into(), v.into()))
                 .collect(),
         )
     }
@@ -260,7 +258,7 @@ impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::Footer {
             annotations
                 .0
                 .iter()
-                .map(|(k, v)| ((&k).into(), v.into()))
+                .map(|(k, v)| (k.as_ref().into(), v.into()))
                 .collect(),
         )
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_fields.rs
@@ -31,6 +31,25 @@ impl From<&fe2o3_amqp_types::messaging::MessageId> for AmqpMessageId {
     }
 }
 
+impl From<fe2o3_amqp_types::messaging::MessageId> for AmqpMessageId {
+    fn from(message_id: fe2o3_amqp_types::messaging::MessageId) -> Self {
+        match message_id {
+            fe2o3_amqp_types::messaging::MessageId::String(message_id) => {
+                AmqpMessageId::String(message_id)
+            }
+            fe2o3_amqp_types::messaging::MessageId::Uuid(message_id) => {
+                AmqpMessageId::Uuid(azure_core::Uuid::from_bytes(message_id.into_inner()))
+            }
+            fe2o3_amqp_types::messaging::MessageId::Binary(message_id) => {
+                AmqpMessageId::Binary(message_id.to_vec())
+            }
+            fe2o3_amqp_types::messaging::MessageId::Ulong(message_id) => {
+                AmqpMessageId::Ulong(message_id)
+            }
+        }
+    }
+}
+
 impl From<AmqpMessageId> for fe2o3_amqp_types::messaging::MessageId {
     fn from(message_id: AmqpMessageId) -> Self {
         match message_id {
@@ -122,15 +141,25 @@ fn test_message_id_conversion() {
     }
 }
 
-impl From<&fe2o3_amqp_types::messaging::ApplicationProperties>
-    for crate::messaging::AmqpApplicationProperties
-{
+impl From<&fe2o3_amqp_types::messaging::ApplicationProperties> for AmqpApplicationProperties {
     fn from(application_properties: &fe2o3_amqp_types::messaging::ApplicationProperties) -> Self {
         let mut properties = AmqpOrderedMap::<String, AmqpSimpleValue>::new();
         for (key, value) in application_properties.0.iter() {
             properties.insert(key.clone(), value.into());
         }
         AmqpApplicationProperties(properties)
+    }
+}
+
+impl From<fe2o3_amqp_types::messaging::ApplicationProperties> for AmqpApplicationProperties {
+    fn from(application_properties: fe2o3_amqp_types::messaging::ApplicationProperties) -> Self {
+        AmqpApplicationProperties(
+            application_properties
+                .0
+                .into_iter()
+                .map(|(k, v)| (k.clone(), v.into()))
+                .collect(),
+        )
     }
 }
 
@@ -145,9 +174,20 @@ impl From<&fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
         }
     }
 }
+impl From<fe2o3_amqp_types::messaging::Header> for AmqpMessageHeader {
+    fn from(header: fe2o3_amqp_types::messaging::Header) -> Self {
+        AmqpMessageHeader {
+            durable: header.durable,
+            priority: header.priority.into(),
+            time_to_live: header.ttl.map(|t| Duration::from_millis(t as u64)),
+            first_acquirer: (header.first_acquirer),
+            delivery_count: (header.delivery_count),
+        }
+    }
+}
 
-impl From<&AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
-    fn from(header: &AmqpMessageHeader) -> Self {
+impl From<AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
+    fn from(header: AmqpMessageHeader) -> Self {
         fe2o3_amqp_types::messaging::Header {
             durable: header.durable,
             priority: fe2o3_amqp_types::messaging::Priority(header.priority),
@@ -158,8 +198,8 @@ impl From<&AmqpMessageHeader> for fe2o3_amqp_types::messaging::Header {
     }
 }
 
-impl From<&AmqpApplicationProperties> for fe2o3_amqp_types::messaging::ApplicationProperties {
-    fn from(application_properties: &AmqpApplicationProperties) -> Self {
+impl From<AmqpApplicationProperties> for fe2o3_amqp_types::messaging::ApplicationProperties {
+    fn from(application_properties: AmqpApplicationProperties) -> Self {
         let mut properties_builder = fe2o3_amqp_types::messaging::ApplicationProperties::builder();
         for (key, value) in application_properties.0.iter() {
             properties_builder = properties_builder.insert(key, value);
@@ -168,11 +208,11 @@ impl From<&AmqpApplicationProperties> for fe2o3_amqp_types::messaging::Applicati
     }
 }
 
-impl From<&AmqpAnnotationKey> for fe2o3_amqp_types::messaging::annotations::OwnedKey {
-    fn from(key: &AmqpAnnotationKey) -> Self {
+impl From<AmqpAnnotationKey> for fe2o3_amqp_types::messaging::annotations::OwnedKey {
+    fn from(key: AmqpAnnotationKey) -> Self {
         match key {
             AmqpAnnotationKey::Ulong(key) => {
-                fe2o3_amqp_types::messaging::annotations::OwnedKey::Ulong(*key)
+                fe2o3_amqp_types::messaging::annotations::OwnedKey::Ulong(key)
             }
             AmqpAnnotationKey::Symbol(key) => {
                 fe2o3_amqp_types::messaging::annotations::OwnedKey::Symbol(key.into())
@@ -203,7 +243,7 @@ fn test_owned_key_conversion() {
         let amqp_key = AmqpAnnotationKey::from(&fe2o3_key);
 
         assert_eq!(amqp_key, AmqpAnnotationKey::Ulong(1995));
-        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(&amqp_key);
+        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(amqp_key);
         assert_eq!(round_trip_key, fe2o3_key);
     }
 
@@ -213,59 +253,51 @@ fn test_owned_key_conversion() {
         let amqp_key = AmqpAnnotationKey::from(&fe2o3_key);
 
         assert_eq!(amqp_key, AmqpAnnotationKey::Symbol("OwnedSymbol".into()));
-        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(&amqp_key);
+        let round_trip_key = fe2o3_amqp_types::messaging::annotations::OwnedKey::from(amqp_key);
         assert_eq!(round_trip_key, fe2o3_key);
     }
 }
 
-impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::Annotations {
-    fn from(annotations: &AmqpAnnotations) -> Self {
-        let mut message_annotations = fe2o3_amqp_types::messaging::Annotations::new();
-        for (key, value) in annotations.0.iter() {
-            message_annotations.insert(key.as_ref().into(), value.into());
-        }
-        message_annotations
+impl From<AmqpAnnotations> for fe2o3_amqp_types::messaging::Annotations {
+    fn from(annotations: AmqpAnnotations) -> Self {
+        annotations
+            .0
+            .iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect::<fe2o3_amqp_types::messaging::Annotations>()
     }
 }
 
-impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::DeliveryAnnotations {
-    fn from(annotations: &AmqpAnnotations) -> Self {
-        fe2o3_amqp_types::messaging::DeliveryAnnotations(
-            annotations
-                .0
-                .iter()
-                .map(|(k, v)| (k.as_ref().into(), v.into()))
-                .collect(),
-        )
+impl From<AmqpAnnotations> for fe2o3_amqp_types::messaging::DeliveryAnnotations {
+    fn from(annotations: AmqpAnnotations) -> Self {
+        fe2o3_amqp_types::messaging::DeliveryAnnotations(annotations.into())
     }
 }
 
-impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::MessageAnnotations {
-    fn from(annotations: &AmqpAnnotations) -> Self {
-        fe2o3_amqp_types::messaging::MessageAnnotations(
-            annotations
-                .0
-                .iter()
-                .map(|(k, v)| (k.as_ref().into(), v.into()))
-                .collect(),
-        )
+impl From<AmqpAnnotations> for fe2o3_amqp_types::messaging::MessageAnnotations {
+    fn from(annotations: AmqpAnnotations) -> Self {
+        fe2o3_amqp_types::messaging::MessageAnnotations(annotations.into())
     }
 }
 
-impl From<&AmqpAnnotations> for fe2o3_amqp_types::messaging::Footer {
-    fn from(annotations: &AmqpAnnotations) -> Self {
-        fe2o3_amqp_types::messaging::Footer(
-            annotations
-                .0
-                .iter()
-                .map(|(k, v)| (k.as_ref().into(), v.into()))
-                .collect(),
-        )
+impl From<AmqpAnnotations> for fe2o3_amqp_types::messaging::Footer {
+    fn from(annotations: AmqpAnnotations) -> Self {
+        fe2o3_amqp_types::messaging::Footer(annotations.into())
     }
 }
-
 impl From<&fe2o3_amqp_types::messaging::Annotations> for AmqpAnnotations {
     fn from(annotations: &fe2o3_amqp_types::messaging::Annotations) -> Self {
+        AmqpAnnotations(
+            annotations
+                .iter()
+                .map(|(k, v)| (AmqpAnnotationKey::from(k), AmqpValue::from(v)))
+                .collect::<AmqpOrderedMap<AmqpAnnotationKey, AmqpValue>>(),
+        )
+    }
+}
+
+impl From<fe2o3_amqp_types::messaging::Annotations> for AmqpAnnotations {
+    fn from(annotations: fe2o3_amqp_types::messaging::Annotations) -> Self {
         AmqpAnnotations(
             annotations
                 .iter()
@@ -283,7 +315,7 @@ fn test_message_annotation_conversion() {
             (AmqpAnnotationKey::Symbol("test".into()), "test"),
         ]);
 
-        let fe2o3_annotations = fe2o3_amqp_types::messaging::Annotations::from(&annotations);
+        let fe2o3_annotations = fe2o3_amqp_types::messaging::Annotations::from(annotations.clone());
 
         // There does not appear to be a From<OrderedMap<>> for Annotations.
         let mut annotations_to_test = fe2o3_amqp_types::messaging::Annotations::new();
@@ -321,7 +353,7 @@ fn test_message_annotation_conversion() {
             ])
         );
 
-        let fe2o3_round_trip: fe2o3_amqp_types::messaging::Annotations = (&annotations).into();
+        let fe2o3_round_trip: fe2o3_amqp_types::messaging::Annotations = annotations.into();
         assert_eq!(fe2o3_round_trip, fe2o3_annotations);
     }
 }
@@ -373,8 +405,55 @@ impl From<&fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
     }
 }
 
-impl From<&AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
-    fn from(properties: &AmqpMessageProperties) -> Self {
+impl From<fe2o3_amqp_types::messaging::Properties> for AmqpMessageProperties {
+    fn from(properties: fe2o3_amqp_types::messaging::Properties) -> Self {
+        let mut amqp_message_properties = AmqpMessageProperties::default();
+
+        if let Some(message_id) = properties.message_id {
+            amqp_message_properties.message_id = Some(message_id.into());
+        }
+        if let Some(user_id) = properties.user_id {
+            amqp_message_properties.user_id = Some(user_id.to_vec());
+        }
+        if let Some(to) = properties.to {
+            amqp_message_properties.to = Some(to);
+        }
+        if let Some(subject) = properties.subject {
+            amqp_message_properties.subject = Some(subject);
+        }
+        if let Some(reply_to) = properties.reply_to {
+            amqp_message_properties.reply_to = Some(reply_to);
+        }
+        if let Some(correlation_id) = properties.correlation_id {
+            amqp_message_properties.correlation_id = Some(correlation_id.into());
+        }
+        if let Some(content_type) = properties.content_type {
+            amqp_message_properties.content_type = Some(content_type.into());
+        }
+        if let Some(content_encoding) = properties.content_encoding {
+            amqp_message_properties.content_encoding = Some(content_encoding.into());
+        }
+        if let Some(absolute_expiry_time) = properties.absolute_expiry_time {
+            amqp_message_properties.absolute_expiry_time = Some(absolute_expiry_time.into());
+        }
+        if let Some(creation_time) = properties.creation_time {
+            amqp_message_properties.creation_time = Some(creation_time.into());
+        }
+        if let Some(group_id) = properties.group_id {
+            amqp_message_properties.group_id = Some(group_id);
+        }
+        if let Some(group_sequence) = properties.group_sequence {
+            amqp_message_properties.group_sequence = Some(group_sequence);
+        }
+        if let Some(reply_to_group_id) = properties.reply_to_group_id {
+            amqp_message_properties.reply_to_group_id = Some(reply_to_group_id);
+        }
+        amqp_message_properties
+    }
+}
+
+impl From<AmqpMessageProperties> for fe2o3_amqp_types::messaging::Properties {
+    fn from(properties: AmqpMessageProperties) -> Self {
         let mut properties_builder = fe2o3_amqp_types::messaging::Properties::builder();
 
         if let Some(message_id) = &properties.message_id {
@@ -445,7 +524,7 @@ fn test_properties_conversion() {
         };
 
         let amqp_properties = AmqpMessageProperties::from(&properties);
-        let roundtrip_properties = fe2o3_amqp_types::messaging::Properties::from(&amqp_properties);
+        let roundtrip_properties = fe2o3_amqp_types::messaging::Properties::from(amqp_properties);
         assert_eq!(properties, roundtrip_properties);
     }
 
@@ -474,7 +553,7 @@ fn test_properties_conversion() {
             user_id: Some(vec![1, 2, 3]),
         };
 
-        let fe2o3_properties: fe2o3_amqp_types::messaging::Properties = (&properties).into();
+        let fe2o3_properties: fe2o3_amqp_types::messaging::Properties = properties.clone().into();
 
         let amqp_round_trip = AmqpMessageProperties::from(&fe2o3_properties);
         assert_eq!(properties, amqp_round_trip);

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -51,10 +51,10 @@ impl From<AmqpSource> for fe2o3_amqp_types::messaging::Source {
             builder = builder.default_outcome(default_outcome.into());
         }
         if let Some(outcomes) = source.outcomes {
-            builder = builder.outcomes(outcomes.into_iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
+            builder = builder.outcomes(outcomes.into_iter().map(Into::into).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
         }
         if let Some(capabilities) = source.capabilities {
-            builder = builder.capabilities(capabilities.into_iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
+            builder = builder.capabilities(capabilities.into_iter().map(Into::into).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
         }
         builder.build()
     }
@@ -97,11 +97,11 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
         }
         if let Some(outcomes) = source.outcomes {
             amqp_source_builder =
-                amqp_source_builder.with_outcomes(outcomes.iter().map(|o| o.into()).collect());
+                amqp_source_builder.with_outcomes(outcomes.iter().map(Into::into).collect());
         }
         if let Some(capabilities) = source.capabilities {
             amqp_source_builder = amqp_source_builder
-                .with_capabilities(capabilities.iter().map(|c| c.into()).collect());
+                .with_capabilities(capabilities.iter().map(Into::into).collect());
         }
         amqp_source_builder.build()
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -60,46 +60,47 @@ impl From<AmqpSource> for fe2o3_amqp_types::messaging::Source {
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
-    fn from(source: fe2o3_amqp_types::messaging::Source) -> Self {
+impl From<&fe2o3_amqp_types::messaging::Source> for AmqpSource {
+    fn from(source: &fe2o3_amqp_types::messaging::Source) -> Self {
         let mut amqp_source_builder = AmqpSource::builder();
 
-        if let Some(address) = source.address {
-            amqp_source_builder = amqp_source_builder.with_address(address);
+        if let Some(address) = &source.address {
+            amqp_source_builder = amqp_source_builder.with_address(address.clone());
         }
         amqp_source_builder = amqp_source_builder
-            .with_durable(source.durable.into())
-            .with_expiry_policy(source.expiry_policy.into())
+            .with_durable((&source.durable).into())
+            .with_expiry_policy((&source.expiry_policy).into())
             .with_timeout(source.timeout)
             .with_dynamic(source.dynamic);
 
-        if let Some(dynamic_node_properties) = source.dynamic_node_properties {
-            let dynamic_node_properties: AmqpOrderedMap<AmqpSymbol, AmqpValue> =
+        if let Some(dynamic_node_properties) = &source.dynamic_node_properties {
+            amqp_source_builder = amqp_source_builder.with_dynamic_node_properties(
                 dynamic_node_properties
                     .iter()
                     .map(|(k, v)| (k.into(), v.into()))
-                    .collect();
-
-            amqp_source_builder =
-                amqp_source_builder.with_dynamic_node_properties(dynamic_node_properties);
+                    .collect::<AmqpOrderedMap<AmqpSymbol, AmqpValue>>(),
+            );
         }
-        if let Some(distribution_mode) = source.distribution_mode {
+        if let Some(distribution_mode) = &source.distribution_mode {
             amqp_source_builder =
                 amqp_source_builder.with_distribution_mode(distribution_mode.into());
         }
-        if let Some(filter) = source.filter {
-            let filter: AmqpOrderedMap<AmqpSymbol, AmqpValue> =
-                filter.iter().map(|(k, v)| (k.into(), v.into())).collect();
-            amqp_source_builder = amqp_source_builder.with_filter(filter);
+        if let Some(filter) = &source.filter {
+            amqp_source_builder = amqp_source_builder.with_filter(
+                filter
+                    .iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect::<AmqpOrderedMap<AmqpSymbol, AmqpValue>>(),
+            );
         }
-        if let Some(default_outcome) = source.default_outcome {
+        if let Some(default_outcome) = &source.default_outcome {
             amqp_source_builder = amqp_source_builder.with_default_outcome(default_outcome.into());
         }
-        if let Some(outcomes) = source.outcomes {
+        if let Some(outcomes) = &source.outcomes {
             amqp_source_builder =
                 amqp_source_builder.with_outcomes(outcomes.iter().map(|o| o.into()).collect());
         }
-        if let Some(capabilities) = source.capabilities {
+        if let Some(capabilities) = &source.capabilities {
             amqp_source_builder = amqp_source_builder
                 .with_capabilities(capabilities.iter().map(|c| c.into()).collect());
         }
@@ -138,7 +139,7 @@ fn message_source_conversion_fe2o3_amqp() {
         )])
         .build();
 
-    let amqp_source = AmqpSource::from(fe2o3_source.clone());
+    let amqp_source = AmqpSource::from(&fe2o3_source);
     let round_trip = fe2o3_amqp_types::messaging::Source::from(amqp_source);
 
     // fe2o3 source does not implement PartialEq
@@ -223,7 +224,7 @@ fn message_source_conversion_amqp_fe2o3() {
 
     let fe2o3_source = fe2o3_amqp_types::messaging::Source::from(amqp_source.clone());
 
-    let round_trip = AmqpSource::from(fe2o3_source);
+    let round_trip = AmqpSource::from(&fe2o3_source);
 
     assert_eq!(amqp_source, round_trip);
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 
-use fe2o3_amqp_types::definitions::Fields;
-
 use crate::{
     messaging::AmqpSource,
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
@@ -31,15 +29,12 @@ impl From<AmqpSource> for fe2o3_amqp_types::messaging::Source {
             builder = builder.dynamic(dynamic);
         }
         if let Some(dynamic_node_properties) = source.dynamic_node_properties {
-            let fields: Fields = Fields::new();
-            let fields = dynamic_node_properties
-                .into_iter()
-                .fold(fields, |mut fields, (k, v)| {
-                    fields.insert(k.into(), v.into());
-                    fields
-                });
-
-            builder = builder.dynamic_node_properties(fields);
+            builder = builder.dynamic_node_properties(
+                dynamic_node_properties
+                    .iter()
+                    .map(|(k, v)| (k.0.into(), v.into()))
+                    .collect::<fe2o3_amqp_types::definitions::Fields>(),
+            );
         }
         if let Some(distribution_mode) = source.distribution_mode {
             builder = builder.distribution_mode(distribution_mode.into());
@@ -47,25 +42,19 @@ impl From<AmqpSource> for fe2o3_amqp_types::messaging::Source {
         if let Some(filter) = source.filter {
             builder = builder.filter(
                 filter
-                    .into_iter()
-                    .map(|(k, v)| (k.into(), v.into()))
-                    .collect(),
+                    .iter()
+                    .map(|(k, v)| (k.0.into(), v.into()))
+                    .collect::<fe2o3_amqp_types::messaging::FilterSet>(),
             );
         }
         if let Some(default_outcome) = source.default_outcome {
             builder = builder.default_outcome(default_outcome.into());
         }
         if let Some(outcomes) = source.outcomes {
-            let outcomes: fe2o3_amqp_types::primitives::Array<
-                fe2o3_amqp_types::primitives::Symbol,
-            > = outcomes.into_iter().map(|o| o.into()).collect();
-            builder = builder.outcomes(outcomes);
+            builder = builder.outcomes(outcomes.iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
         }
         if let Some(capabilities) = source.capabilities {
-            let capabilities: fe2o3_amqp_types::primitives::Array<
-                fe2o3_amqp_types::primitives::Symbol,
-            > = capabilities.into_iter().map(|c| c.into()).collect();
-            builder = builder.capabilities(capabilities);
+            builder = builder.capabilities(capabilities.iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
         }
         builder.build()
     }
@@ -87,7 +76,7 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
         if let Some(dynamic_node_properties) = source.dynamic_node_properties {
             let dynamic_node_properties: AmqpOrderedMap<AmqpSymbol, AmqpValue> =
                 dynamic_node_properties
-                    .into_iter()
+                    .iter()
                     .map(|(k, v)| (k.into(), v.into()))
                     .collect();
 
@@ -99,10 +88,8 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
                 amqp_source_builder.with_distribution_mode(distribution_mode.into());
         }
         if let Some(filter) = source.filter {
-            let filter: AmqpOrderedMap<AmqpSymbol, AmqpValue> = filter
-                .into_iter()
-                .map(|(k, v)| (k.into(), v.into()))
-                .collect();
+            let filter: AmqpOrderedMap<AmqpSymbol, AmqpValue> =
+                filter.iter().map(|(k, v)| (k.into(), v.into())).collect();
             amqp_source_builder = amqp_source_builder.with_filter(filter);
         }
         if let Some(default_outcome) = source.default_outcome {
@@ -110,11 +97,11 @@ impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
         }
         if let Some(outcomes) = source.outcomes {
             amqp_source_builder =
-                amqp_source_builder.with_outcomes(outcomes.into_iter().map(|o| o.into()).collect());
+                amqp_source_builder.with_outcomes(outcomes.iter().map(|o| o.into()).collect());
         }
         if let Some(capabilities) = source.capabilities {
             amqp_source_builder = amqp_source_builder
-                .with_capabilities(capabilities.into_iter().map(|c| c.into()).collect());
+                .with_capabilities(capabilities.iter().map(|c| c.into()).collect());
         }
         amqp_source_builder.build()
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -60,20 +60,19 @@ impl From<AmqpSource> for fe2o3_amqp_types::messaging::Source {
     }
 }
 
-impl From<&fe2o3_amqp_types::messaging::Source> for AmqpSource {
-    fn from(source: &fe2o3_amqp_types::messaging::Source) -> Self {
-        let mut amqp_source_builder = AmqpSource::builder();
-
-        if let Some(address) = &source.address {
-            amqp_source_builder = amqp_source_builder.with_address(address.clone());
-        }
-        amqp_source_builder = amqp_source_builder
-            .with_durable((&source.durable).into())
-            .with_expiry_policy((&source.expiry_policy).into())
+impl From<fe2o3_amqp_types::messaging::Source> for AmqpSource {
+    fn from(source: fe2o3_amqp_types::messaging::Source) -> Self {
+        let mut amqp_source_builder = AmqpSource::builder()
+            .with_durable(source.durable.into())
+            .with_expiry_policy(source.expiry_policy.into())
             .with_timeout(source.timeout)
             .with_dynamic(source.dynamic);
 
-        if let Some(dynamic_node_properties) = &source.dynamic_node_properties {
+        if let Some(address) = source.address {
+            amqp_source_builder = amqp_source_builder.with_address(address);
+        }
+
+        if let Some(dynamic_node_properties) = source.dynamic_node_properties {
             amqp_source_builder = amqp_source_builder.with_dynamic_node_properties(
                 dynamic_node_properties
                     .iter()
@@ -81,11 +80,11 @@ impl From<&fe2o3_amqp_types::messaging::Source> for AmqpSource {
                     .collect::<AmqpOrderedMap<AmqpSymbol, AmqpValue>>(),
             );
         }
-        if let Some(distribution_mode) = &source.distribution_mode {
+        if let Some(distribution_mode) = source.distribution_mode {
             amqp_source_builder =
                 amqp_source_builder.with_distribution_mode(distribution_mode.into());
         }
-        if let Some(filter) = &source.filter {
+        if let Some(filter) = source.filter {
             amqp_source_builder = amqp_source_builder.with_filter(
                 filter
                     .iter()
@@ -93,14 +92,14 @@ impl From<&fe2o3_amqp_types::messaging::Source> for AmqpSource {
                     .collect::<AmqpOrderedMap<AmqpSymbol, AmqpValue>>(),
             );
         }
-        if let Some(default_outcome) = &source.default_outcome {
+        if let Some(default_outcome) = source.default_outcome {
             amqp_source_builder = amqp_source_builder.with_default_outcome(default_outcome.into());
         }
-        if let Some(outcomes) = &source.outcomes {
+        if let Some(outcomes) = source.outcomes {
             amqp_source_builder =
                 amqp_source_builder.with_outcomes(outcomes.iter().map(|o| o.into()).collect());
         }
-        if let Some(capabilities) = &source.capabilities {
+        if let Some(capabilities) = source.capabilities {
             amqp_source_builder = amqp_source_builder
                 .with_capabilities(capabilities.iter().map(|c| c.into()).collect());
         }
@@ -139,7 +138,7 @@ fn message_source_conversion_fe2o3_amqp() {
         )])
         .build();
 
-    let amqp_source = AmqpSource::from(&fe2o3_source);
+    let amqp_source = AmqpSource::from(fe2o3_source.clone());
     let round_trip = fe2o3_amqp_types::messaging::Source::from(amqp_source);
 
     // fe2o3 source does not implement PartialEq
@@ -224,7 +223,7 @@ fn message_source_conversion_amqp_fe2o3() {
 
     let fe2o3_source = fe2o3_amqp_types::messaging::Source::from(amqp_source.clone());
 
-    let round_trip = AmqpSource::from(&fe2o3_source);
+    let round_trip = AmqpSource::from(fe2o3_source);
 
     assert_eq!(amqp_source, round_trip);
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/message_source.rs
@@ -51,10 +51,10 @@ impl From<AmqpSource> for fe2o3_amqp_types::messaging::Source {
             builder = builder.default_outcome(default_outcome.into());
         }
         if let Some(outcomes) = source.outcomes {
-            builder = builder.outcomes(outcomes.iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
+            builder = builder.outcomes(outcomes.into_iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
         }
         if let Some(capabilities) = source.capabilities {
-            builder = builder.capabilities(capabilities.iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
+            builder = builder.capabilities(capabilities.into_iter().map(|o| o.into()).collect::<fe2o3_amqp_types::primitives::Array<fe2o3_amqp_types::primitives::Symbol>>());
         }
         builder.build()
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -57,10 +57,10 @@ impl AmqpDeliveryApis for Fe2o3AmqpDelivery {
     }
 
     fn into_message(mut self) -> crate::messaging::AmqpMessage {
-        self.message
-            .take()
-            .unwrap_or_else(|| AmqpMessage::from(self.delivery.into_message()))
-        //        AmqpMessage::from(self.delivery.into_message())
+        match self.message.take() {
+            Some(msg) => msg,
+            None => AmqpMessage::from(self.delivery.into_message()),
+        }
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -57,10 +57,10 @@ impl AmqpDeliveryApis for Fe2o3AmqpDelivery {
     }
 
     fn into_message(mut self) -> crate::messaging::AmqpMessage {
-        self.message();
-        self.message.take().unwrap_or_else(|| {
-            panic!("Message not set. This should never happen. Please report this issue.")
-        })
+        self.message
+            .take()
+            .unwrap_or_else(|| AmqpMessage::from(self.delivery.into_message()))
+        //        AmqpMessage::from(self.delivery.into_message())
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -64,8 +64,8 @@ impl AmqpDeliveryApis for Fe2o3AmqpDelivery {
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::Outcome> for AmqpOutcome {
-    fn from(outcome: fe2o3_amqp_types::messaging::Outcome) -> Self {
+impl From<&fe2o3_amqp_types::messaging::Outcome> for AmqpOutcome {
+    fn from(outcome: &fe2o3_amqp_types::messaging::Outcome) -> Self {
         match outcome {
             fe2o3_amqp_types::messaging::Outcome::Accepted(_) => AmqpOutcome::Accepted,
             fe2o3_amqp_types::messaging::Outcome::Released(_) => AmqpOutcome::Released,
@@ -109,15 +109,15 @@ fn test_outcome_round_trip() {
 
     for outcome in outcomes {
         let fe2o3_outcome: fe2o3_amqp_types::messaging::Outcome = outcome.clone().into();
-        let amqp_outcome: AmqpOutcome = fe2o3_outcome.into();
+        let amqp_outcome: AmqpOutcome = (&fe2o3_outcome).into();
         assert_eq!(outcome, amqp_outcome);
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::TerminusDurability>
+impl From<&fe2o3_amqp_types::messaging::TerminusDurability>
     for crate::messaging::TerminusDurability
 {
-    fn from(durability: fe2o3_amqp_types::messaging::TerminusDurability) -> Self {
+    fn from(durability: &fe2o3_amqp_types::messaging::TerminusDurability) -> Self {
         match durability {
             fe2o3_amqp_types::messaging::TerminusDurability::None => TerminusDurability::None,
             fe2o3_amqp_types::messaging::TerminusDurability::Configuration => {
@@ -157,13 +157,13 @@ fn test_terminus_durability_round_trip() {
     for durability in durabilities {
         let fe2o3_durability =
             fe2o3_amqp_types::messaging::TerminusDurability::from(durability.clone());
-        let amqp_durability = TerminusDurability::from(fe2o3_durability);
+        let amqp_durability = TerminusDurability::from(&fe2o3_durability);
         assert_eq!(durability, amqp_durability);
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::TerminusExpiryPolicy> for TerminusExpiryPolicy {
-    fn from(expiry_policy: fe2o3_amqp_types::messaging::TerminusExpiryPolicy) -> Self {
+impl From<&fe2o3_amqp_types::messaging::TerminusExpiryPolicy> for TerminusExpiryPolicy {
+    fn from(expiry_policy: &fe2o3_amqp_types::messaging::TerminusExpiryPolicy) -> Self {
         match expiry_policy {
             fe2o3_amqp_types::messaging::TerminusExpiryPolicy::LinkDetach => {
                 TerminusExpiryPolicy::LinkDetach
@@ -208,13 +208,13 @@ fn test_terminus_expiry_policy_round_trip() {
     for expiry_policy in expiry_policies {
         let fe2o3_expiry_policy =
             fe2o3_amqp_types::messaging::TerminusExpiryPolicy::from(expiry_policy.clone());
-        let amqp_expiry_policy = TerminusExpiryPolicy::from(fe2o3_expiry_policy);
+        let amqp_expiry_policy = TerminusExpiryPolicy::from(&fe2o3_expiry_policy);
         assert_eq!(expiry_policy, amqp_expiry_policy);
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::DistributionMode> for DistributionMode {
-    fn from(distribution_mode: fe2o3_amqp_types::messaging::DistributionMode) -> Self {
+impl From<&fe2o3_amqp_types::messaging::DistributionMode> for DistributionMode {
+    fn from(distribution_mode: &fe2o3_amqp_types::messaging::DistributionMode) -> Self {
         match distribution_mode {
             fe2o3_amqp_types::messaging::DistributionMode::Move => DistributionMode::Move,
             fe2o3_amqp_types::messaging::DistributionMode::Copy => DistributionMode::Copy,
@@ -222,7 +222,7 @@ impl From<fe2o3_amqp_types::messaging::DistributionMode> for DistributionMode {
     }
 }
 
-impl From<crate::messaging::DistributionMode> for fe2o3_amqp_types::messaging::DistributionMode {
+impl From<DistributionMode> for fe2o3_amqp_types::messaging::DistributionMode {
     fn from(distribution_mode: crate::messaging::DistributionMode) -> Self {
         match distribution_mode {
             DistributionMode::Move => fe2o3_amqp_types::messaging::DistributionMode::Move,
@@ -238,7 +238,7 @@ fn test_distribution_mode_round_trip() {
     for distribution_mode in distribution_modes {
         let fe2o3_distribution_mode =
             fe2o3_amqp_types::messaging::DistributionMode::from(distribution_mode.clone());
-        let amqp_distribution_mode = DistributionMode::from(fe2o3_distribution_mode);
+        let amqp_distribution_mode = DistributionMode::from(&fe2o3_distribution_mode);
         assert_eq!(distribution_mode, amqp_distribution_mode);
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -64,8 +64,8 @@ impl AmqpDeliveryApis for Fe2o3AmqpDelivery {
     }
 }
 
-impl From<&fe2o3_amqp_types::messaging::Outcome> for AmqpOutcome {
-    fn from(outcome: &fe2o3_amqp_types::messaging::Outcome) -> Self {
+impl From<fe2o3_amqp_types::messaging::Outcome> for AmqpOutcome {
+    fn from(outcome: fe2o3_amqp_types::messaging::Outcome) -> Self {
         match outcome {
             fe2o3_amqp_types::messaging::Outcome::Accepted(_) => AmqpOutcome::Accepted,
             fe2o3_amqp_types::messaging::Outcome::Released(_) => AmqpOutcome::Released,
@@ -109,15 +109,15 @@ fn test_outcome_round_trip() {
 
     for outcome in outcomes {
         let fe2o3_outcome: fe2o3_amqp_types::messaging::Outcome = outcome.clone().into();
-        let amqp_outcome: AmqpOutcome = (&fe2o3_outcome).into();
+        let amqp_outcome: AmqpOutcome = (fe2o3_outcome).into();
         assert_eq!(outcome, amqp_outcome);
     }
 }
 
-impl From<&fe2o3_amqp_types::messaging::TerminusDurability>
+impl From<fe2o3_amqp_types::messaging::TerminusDurability>
     for crate::messaging::TerminusDurability
 {
-    fn from(durability: &fe2o3_amqp_types::messaging::TerminusDurability) -> Self {
+    fn from(durability: fe2o3_amqp_types::messaging::TerminusDurability) -> Self {
         match durability {
             fe2o3_amqp_types::messaging::TerminusDurability::None => TerminusDurability::None,
             fe2o3_amqp_types::messaging::TerminusDurability::Configuration => {
@@ -157,13 +157,13 @@ fn test_terminus_durability_round_trip() {
     for durability in durabilities {
         let fe2o3_durability =
             fe2o3_amqp_types::messaging::TerminusDurability::from(durability.clone());
-        let amqp_durability = TerminusDurability::from(&fe2o3_durability);
+        let amqp_durability = TerminusDurability::from(fe2o3_durability);
         assert_eq!(durability, amqp_durability);
     }
 }
 
-impl From<&fe2o3_amqp_types::messaging::TerminusExpiryPolicy> for TerminusExpiryPolicy {
-    fn from(expiry_policy: &fe2o3_amqp_types::messaging::TerminusExpiryPolicy) -> Self {
+impl From<fe2o3_amqp_types::messaging::TerminusExpiryPolicy> for TerminusExpiryPolicy {
+    fn from(expiry_policy: fe2o3_amqp_types::messaging::TerminusExpiryPolicy) -> Self {
         match expiry_policy {
             fe2o3_amqp_types::messaging::TerminusExpiryPolicy::LinkDetach => {
                 TerminusExpiryPolicy::LinkDetach
@@ -208,13 +208,13 @@ fn test_terminus_expiry_policy_round_trip() {
     for expiry_policy in expiry_policies {
         let fe2o3_expiry_policy =
             fe2o3_amqp_types::messaging::TerminusExpiryPolicy::from(expiry_policy.clone());
-        let amqp_expiry_policy = TerminusExpiryPolicy::from(&fe2o3_expiry_policy);
+        let amqp_expiry_policy = TerminusExpiryPolicy::from(fe2o3_expiry_policy);
         assert_eq!(expiry_policy, amqp_expiry_policy);
     }
 }
 
-impl From<&fe2o3_amqp_types::messaging::DistributionMode> for DistributionMode {
-    fn from(distribution_mode: &fe2o3_amqp_types::messaging::DistributionMode) -> Self {
+impl From<fe2o3_amqp_types::messaging::DistributionMode> for DistributionMode {
+    fn from(distribution_mode: fe2o3_amqp_types::messaging::DistributionMode) -> Self {
         match distribution_mode {
             fe2o3_amqp_types::messaging::DistributionMode::Move => DistributionMode::Move,
             fe2o3_amqp_types::messaging::DistributionMode::Copy => DistributionMode::Copy,
@@ -238,7 +238,7 @@ fn test_distribution_mode_round_trip() {
     for distribution_mode in distribution_modes {
         let fe2o3_distribution_mode =
             fe2o3_amqp_types::messaging::DistributionMode::from(distribution_mode.clone());
-        let amqp_distribution_mode = DistributionMode::from(&fe2o3_distribution_mode);
+        let amqp_distribution_mode = DistributionMode::from(fe2o3_distribution_mode);
         assert_eq!(distribution_mode, amqp_distribution_mode);
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/messaging_types.rs
@@ -40,7 +40,7 @@ impl AmqpDeliveryApis for Fe2o3AmqpDelivery {
     // Return a reference to the message contained in the delivery.
     fn message(&self) -> &AmqpMessage {
         self.message
-            .get_or_init(|| AmqpMessage::from(self.delivery.message().clone()))
+            .get_or_init(|| AmqpMessage::from(self.delivery.message()))
     }
 
     fn delivery_id(&self) -> DeliveryNumber {
@@ -56,8 +56,11 @@ impl AmqpDeliveryApis for Fe2o3AmqpDelivery {
         self.delivery.message_format()
     }
 
-    fn into_message(self) -> crate::messaging::AmqpMessage {
-        self.delivery.into_message().into()
+    fn into_message(mut self) -> crate::messaging::AmqpMessage {
+        self.message();
+        self.message.take().unwrap_or_else(|| {
+            panic!("Message not set. This should never happen. Please report this issue.")
+        })
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -453,15 +453,6 @@ fn fe2o3_message_from_amqp_message(
     }
 }
 
-impl From<AmqpMessage>
-    for fe2o3_amqp_types::messaging::Message<
-        fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-    >
-{
-    fn from(message: AmqpMessage) -> Self {
-        fe2o3_message_from_amqp_message(&message)
-    }
-}
 impl From<&AmqpMessage>
     for fe2o3_amqp_types::messaging::Message<
         fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
@@ -816,7 +807,7 @@ mod tests {
 
         let round_trip: fe2o3_amqp_types::messaging::Message<
             fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-        > = amqp_message.into();
+        > = (&amqp_message).into();
 
         assert!(round_trip.body.is_value());
     }
@@ -873,7 +864,7 @@ mod tests {
         assert!(amqp_message.footer().is_none());
         let round_trip: fe2o3_amqp_types::messaging::Message<
             fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-        > = amqp_message.into();
+        > = (&amqp_message).into();
 
         assert!(round_trip.body.is_sequence());
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -220,12 +220,12 @@ impl From<AmqpMessage>
 {
     fn from(message: AmqpMessage) -> Self {
         let message_builder = fe2o3_amqp_types::messaging::Message::builder()
-            .application_properties(message.application_properties.map(|x| x.into()))
-            .properties(message.properties.map(|p| p.into()))
-            .header(message.header.map(|x| x.into()))
-            .delivery_annotations(message.delivery_annotations.map(|x| x.into()))
-            .message_annotations(message.message_annotations.map(|x| x.into()))
-            .footer(message.footer.map(|x| x.into()));
+            .application_properties(message.application_properties.map(Into::into))
+            .properties(message.properties.map(Into::into))
+            .header(message.header.map(Into::into))
+            .delivery_annotations(message.delivery_annotations.map(Into::into))
+            .message_annotations(message.message_annotations.map(Into::into))
+            .footer(message.footer.map(Into::into));
 
         match message.body {
             AmqpMessageBody::Empty => message_builder
@@ -273,12 +273,12 @@ impl From<&AmqpMessage>
 {
     fn from(message: &AmqpMessage) -> Self {
         let message_builder = fe2o3_amqp_types::messaging::Message::builder()
-            .application_properties(message.application_properties.as_ref().map(|x| x.into()))
-            .properties(message.properties.as_ref().map(|p| p.into()))
-            .header(message.header.as_ref().map(|x| x.into()))
-            .delivery_annotations(message.delivery_annotations.as_ref().map(|x| x.into()))
-            .message_annotations(message.message_annotations.as_ref().map(|x| x.into()))
-            .footer(message.footer.as_ref().map(|x| x.into()));
+            .application_properties(message.application_properties.as_ref().map(Into::into))
+            .properties(message.properties.as_ref().map(Into::into))
+            .header(message.header.as_ref().map(Into::into))
+            .delivery_annotations(message.delivery_annotations.as_ref().map(Into::into))
+            .message_annotations(message.message_annotations.as_ref().map(Into::into))
+            .footer(message.footer.as_ref().map(Into::into));
 
         match &(message.body) {
             AmqpMessageBody::Empty => message_builder
@@ -434,11 +434,11 @@ impl
 impl From<AmqpMessage> for fe2o3_amqp_types::messaging::Message<EmptyBody> {
     fn from(message: AmqpMessage) -> Self {
         let message_builder = fe2o3_amqp_types::messaging::Message::builder()
-            .application_properties(message.application_properties.map(|x| x.into()))
-            .header(message.header.map(|x| x.into()))
-            .delivery_annotations(message.delivery_annotations.map(|x| x.into()))
-            .message_annotations(message.message_annotations.map(|x| x.into()))
-            .footer(message.footer.map(|x| x.into()));
+            .application_properties(message.application_properties.map(Into::into))
+            .header(message.header.map(Into::into))
+            .delivery_annotations(message.delivery_annotations.map(Into::into))
+            .message_annotations(message.message_annotations.map(Into::into))
+            .footer(message.footer.map(Into::into));
         match message.body {
             AmqpMessageBody::Empty => message_builder.body(EmptyBody {}).build(),
             _ => panic!("Expected EmptyBody"),
@@ -455,11 +455,11 @@ impl From<AmqpMessage>
 {
     fn from(message: AmqpMessage) -> Self {
         let message_builder = fe2o3_amqp_types::messaging::Message::builder()
-            .application_properties(message.application_properties.map(|x| x.into()))
-            .header(message.header.map(|x| x.into()))
-            .delivery_annotations(message.delivery_annotations.map(|x| x.into()))
-            .message_annotations(message.message_annotations.map(|x| x.into()))
-            .footer(message.footer.map(|x| x.into()));
+            .application_properties(message.application_properties.map(Into::into))
+            .header(message.header.map(Into::into))
+            .delivery_annotations(message.delivery_annotations.map(Into::into))
+            .message_annotations(message.message_annotations.map(Into::into))
+            .footer(message.footer.map(Into::into));
 
         match message.body {
             AmqpMessageBody::Sequence(sequence) => {
@@ -486,11 +486,11 @@ impl From<AmqpMessage>
 {
     fn from(message: AmqpMessage) -> Self {
         let message_builder = fe2o3_amqp_types::messaging::Message::builder()
-            .application_properties(message.application_properties.map(|x| x.into()))
-            .header(message.header.map(|x| x.into()))
-            .delivery_annotations(message.delivery_annotations.map(|x| x.into()))
-            .message_annotations(message.message_annotations.map(|x| x.into()))
-            .footer(message.footer.map(|x| x.into()));
+            .application_properties(message.application_properties.map(Into::into))
+            .header(message.header.map(Into::into))
+            .delivery_annotations(message.delivery_annotations.map(Into::into))
+            .message_annotations(message.message_annotations.map(Into::into))
+            .footer(message.footer.map(Into::into));
 
         match message.body {
             AmqpMessageBody::Binary(data) => {

--- a/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/receiver.rs
@@ -57,9 +57,9 @@ impl AmqpReceiverApis for Fe2o3AmqpReceiver {
         }
         let options = options.unwrap_or_default();
         let name = options.name.unwrap_or_default();
-        let credit_mode = options.credit_mode.clone().unwrap_or_default();
+        let credit_mode = options.credit_mode.unwrap_or_default();
         let auto_accept = options.auto_accept;
-        let properties = options.properties.clone().unwrap_or_default();
+        let properties = options.properties.unwrap_or_default();
         let source = source.into();
 
         let receiver = fe2o3_amqp::Receiver::builder()

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -168,20 +168,22 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
             }
             fe2o3_amqp_types::messaging::Outcome::Released(_) => AmqpSendOutcome::Released,
             fe2o3_amqp_types::messaging::Outcome::Modified(m) => {
-                AmqpSendOutcome::Modified(m.into())
+                AmqpSendOutcome::Modified((&m).into())
             }
         })
     }
 }
 
-impl From<fe2o3_amqp_types::messaging::Modified> for SendModification {
-    fn from(m: fe2o3_amqp_types::messaging::Modified) -> Self {
+impl From<&fe2o3_amqp_types::messaging::Modified> for SendModification {
+    fn from(m: &fe2o3_amqp_types::messaging::Modified) -> Self {
         Self {
             delivery_failed: m.delivery_failed,
             undeliverable_here: m.undeliverable_here,
-            message_annotations: m
-                .message_annotations
-                .map(AmqpOrderedMap::<AmqpSymbol, AmqpValue>::from),
+            message_annotations: m.message_annotations.as_ref().map(|m| {
+                m.iter()
+                    .map(|(k, v)| (k.into(), v.into()))
+                    .collect::<AmqpOrderedMap<AmqpSymbol, AmqpValue>>()
+            }),
         }
     }
 }

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -67,12 +67,12 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
             }
             if let Some(offered_capabilities) = options.offered_capabilities {
                 session_builder = session_builder.set_offered_capabilities(
-                    offered_capabilities.into_iter().map(|c| c.into()).collect(),
+                    offered_capabilities.into_iter().map(Into::into).collect(),
                 );
             }
             if let Some(desired_capabilities) = options.desired_capabilities {
                 session_builder = session_builder.set_desired_capabilities(
-                    desired_capabilities.into_iter().map(|c| c.into()).collect(),
+                    desired_capabilities.into_iter().map(Into::into).collect(),
                 );
             }
             if let Some(properties) = options.properties {
@@ -167,8 +167,8 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
                 AmqpSendOutcome::Rejected(rejected.error.map(AmqpDescribedError::from))
             }
             fe2o3_amqp_types::messaging::Outcome::Released(_) => AmqpSendOutcome::Released,
-            fe2o3_amqp_types::messaging::Outcome::Modified(m) => {
-                AmqpSendOutcome::Modified((&m).into())
+            fe2o3_amqp_types::messaging::Outcome::Modified(ref m) => {
+                AmqpSendOutcome::Modified(m.into())
             }
         })
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -67,12 +67,12 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
             }
             if let Some(offered_capabilities) = options.offered_capabilities {
                 session_builder = session_builder.set_offered_capabilities(
-                    offered_capabilities.iter().map(|c| c.into()).collect(),
+                    offered_capabilities.into_iter().map(|c| c.into()).collect(),
                 );
             }
             if let Some(desired_capabilities) = options.desired_capabilities {
                 session_builder = session_builder.set_desired_capabilities(
-                    desired_capabilities.iter().map(|c| c.into()).collect(),
+                    desired_capabilities.into_iter().map(|c| c.into()).collect(),
                 );
             }
             if let Some(properties) = options.properties {
@@ -137,7 +137,7 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
         let message: AmqpMessage = message.into();
         let message: fe2o3_amqp_types::messaging::Message<
             fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-        > = (&message).into();
+        > = message.into();
         let mut sendable = fe2o3_amqp::link::delivery::Sendable {
             message,
             message_format: 0,

--- a/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/sender.rs
@@ -66,12 +66,14 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
                 session_builder = session_builder.source(source);
             }
             if let Some(offered_capabilities) = options.offered_capabilities {
-                let capabilities = offered_capabilities.into_iter().map(|c| c.into()).collect();
-                session_builder = session_builder.set_offered_capabilities(capabilities);
+                session_builder = session_builder.set_offered_capabilities(
+                    offered_capabilities.iter().map(|c| c.into()).collect(),
+                );
             }
             if let Some(desired_capabilities) = options.desired_capabilities {
-                let capabilities = desired_capabilities.into_iter().map(|c| c.into()).collect();
-                session_builder = session_builder.set_desired_capabilities(capabilities);
+                session_builder = session_builder.set_desired_capabilities(
+                    desired_capabilities.iter().map(|c| c.into()).collect(),
+                );
             }
             if let Some(properties) = options.properties {
                 session_builder = session_builder.properties(properties.into());
@@ -135,7 +137,7 @@ impl AmqpSenderApis for Fe2o3AmqpSender {
         let message: AmqpMessage = message.into();
         let message: fe2o3_amqp_types::messaging::Message<
             fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-        > = message.into();
+        > = (&message).into();
         let mut sendable = fe2o3_amqp::link::delivery::Sendable {
             message,
             message_format: 0,

--- a/sdk/core/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/session.rs
@@ -92,18 +92,12 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
             }
             if let Some(offered_capabilities) = options.offered_capabilities() {
                 session_builder = session_builder.set_offered_capabilities(
-                    offered_capabilities
-                        .iter()
-                        .map(|capability| capability.into())
-                        .collect(),
+                    offered_capabilities.iter().map(Into::into).collect(),
                 );
             }
             if let Some(desired_capabilities) = options.desired_capabilities() {
                 session_builder = session_builder.set_desired_capabilities(
-                    desired_capabilities
-                        .iter()
-                        .map(|capability| capability.into())
-                        .collect(),
+                    desired_capabilities.iter().map(Into::into).collect(),
                 );
             }
             if let Some(properties) = options.properties() {

--- a/sdk/core/azure_core_amqp/src/fe2o3/session.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/session.rs
@@ -91,28 +91,28 @@ impl AmqpSessionApis for Fe2o3AmqpSession {
                 session_builder = session_builder.handle_max(handle_max);
             }
             if let Some(offered_capabilities) = options.offered_capabilities() {
-                for capability in offered_capabilities {
-                    let capability: fe2o3_amqp_types::primitives::Symbol =
-                        capability.clone().into();
-                    session_builder = session_builder.add_offered_capabilities(capability);
-                }
+                session_builder = session_builder.set_offered_capabilities(
+                    offered_capabilities
+                        .iter()
+                        .map(|capability| capability.into())
+                        .collect(),
+                );
             }
             if let Some(desired_capabilities) = options.desired_capabilities() {
-                for capability in desired_capabilities {
-                    let capability: fe2o3_amqp_types::primitives::Symbol =
-                        capability.clone().into();
-                    session_builder = session_builder.add_desired_capabilities(capability);
-                }
+                session_builder = session_builder.set_desired_capabilities(
+                    desired_capabilities
+                        .iter()
+                        .map(|capability| capability.into())
+                        .collect(),
+                );
             }
             if let Some(properties) = options.properties() {
-                let mut fields = fe2o3_amqp::types::definitions::Fields::new();
-                for property in properties.iter() {
-                    fields.insert(
-                        fe2o3_amqp_types::primitives::Symbol::from(property.0),
-                        fe2o3_amqp_types::primitives::Value::from(property.1),
-                    );
-                }
-                session_builder = session_builder.properties(fields);
+                session_builder = session_builder.properties(
+                    properties
+                        .iter()
+                        .map(|(k, v)| (k.0.into(), v.into()))
+                        .collect(),
+                );
             }
             if let Some(buffer_size) = options.buffer_size() {
                 session_builder = session_builder.buffer_size(buffer_size);

--- a/sdk/core/azure_core_amqp/src/fe2o3/value.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/value.rs
@@ -155,8 +155,12 @@ impl From<&fe2o3_amqp_types::primitives::SimpleValue> for AmqpSimpleValue {
             fe2o3_amqp_types::primitives::SimpleValue::Binary(b) => {
                 AmqpSimpleValue::Binary(b.to_vec())
             }
-            fe2o3_amqp_types::primitives::SimpleValue::String(s) => AmqpValue::String(s),
-            fe2o3_amqp_types::primitives::SimpleValue::Symbol(s) => AmqpValue::Symbol(s.into()),
+            fe2o3_amqp_types::primitives::SimpleValue::String(s) => {
+                AmqpSimpleValue::String(s.clone())
+            }
+            fe2o3_amqp_types::primitives::SimpleValue::Symbol(s) => {
+                AmqpSimpleValue::Symbol(s.into())
+            }
             _ => panic!("Expected a simple value."),
         }
     }
@@ -324,63 +328,6 @@ impl From<AmqpValue> for fe2o3_amqp_types::primitives::Value {
                     value: d.value().into(),
                 },
             )),
-        }
-    }
-}
-
-impl From<fe2o3_amqp_types::primitives::Value> for AmqpValue {
-    fn from(value: fe2o3_amqp_types::primitives::Value) -> Self {
-        match value {
-            fe2o3_amqp_types::primitives::Value::Null => AmqpValue::Null,
-            fe2o3_amqp_types::primitives::Value::Bool(b) => AmqpValue::Boolean(b),
-            fe2o3_amqp_types::primitives::Value::Ubyte(b) => AmqpValue::UByte(b),
-            fe2o3_amqp_types::primitives::Value::Ushort(s) => AmqpValue::UShort(s),
-            fe2o3_amqp_types::primitives::Value::Uint(i) => AmqpValue::UInt(i),
-            fe2o3_amqp_types::primitives::Value::Ulong(l) => AmqpValue::ULong(l),
-            fe2o3_amqp_types::primitives::Value::Byte(b) => AmqpValue::Byte(b),
-            fe2o3_amqp_types::primitives::Value::Short(s) => AmqpValue::Short(s),
-            fe2o3_amqp_types::primitives::Value::Int(i) => AmqpValue::Int(i),
-            fe2o3_amqp_types::primitives::Value::Long(l) => AmqpValue::Long(l),
-            fe2o3_amqp_types::primitives::Value::Float(f) => AmqpValue::Float(f.into()),
-            fe2o3_amqp_types::primitives::Value::Double(d) => AmqpValue::Double(d.into()),
-            fe2o3_amqp_types::primitives::Value::Char(c) => AmqpValue::Char(c),
-            fe2o3_amqp_types::primitives::Value::Timestamp(t) => AmqpValue::TimeStamp((&t).into()),
-            fe2o3_amqp_types::primitives::Value::Uuid(u) => {
-                AmqpValue::Uuid(azure_core::Uuid::from_bytes(*u.as_inner()))
-            }
-            fe2o3_amqp_types::primitives::Value::Binary(b) => AmqpValue::Binary(b.to_vec()),
-            fe2o3_amqp_types::primitives::Value::String(s) => AmqpValue::String(s),
-            fe2o3_amqp_types::primitives::Value::Symbol(s) => AmqpValue::Symbol((&s).into()),
-            fe2o3_amqp_types::primitives::Value::Decimal128(d) => {
-                AmqpValue::Decimal128(d.into_inner())
-            }
-            fe2o3_amqp_types::primitives::Value::Decimal32(d) => {
-                AmqpValue::Decimal32(d.into_inner())
-            }
-            fe2o3_amqp_types::primitives::Value::Decimal64(d) => {
-                AmqpValue::Decimal64(d.into_inner())
-            }
-            fe2o3_amqp_types::primitives::Value::List(l) => {
-                let l = l.into_iter().map(|v| v.into()).collect::<Vec<AmqpValue>>();
-                AmqpValue::List(AmqpList(l))
-            }
-            fe2o3_amqp_types::primitives::Value::Map(m) => {
-                AmqpValue::Map(m.iter().map(|(k, v)| (k.into(), v.into())).collect())
-            }
-            fe2o3_amqp_types::primitives::Value::Array(a) => {
-                AmqpValue::Array(a.iter().map(|v| v.into()).collect())
-            }
-            fe2o3_amqp_types::primitives::Value::Described(d) => {
-                //                let descriptor: serde_amqp::descriptor::Descriptor = d.descriptor;
-                //                let value: AmqpValue = d.value.into();
-                let descriptor = match d.descriptor {
-                    serde_amqp::descriptor::Descriptor::Code(code) => AmqpDescriptor::Code(code),
-                    serde_amqp::descriptor::Descriptor::Name(symbol) => {
-                        AmqpDescriptor::Name((&symbol).into())
-                    }
-                };
-                AmqpValue::Described(Box::new(AmqpDescribed::new(descriptor, &d.value)))
-            }
         }
     }
 }
@@ -652,8 +599,8 @@ impl From<crate::SenderSettleMode> for fe2o3_amqp_types::definitions::SenderSett
     }
 }
 
-impl From<fe2o3_amqp_types::definitions::SenderSettleMode> for crate::SenderSettleMode {
-    fn from(mode: fe2o3_amqp_types::definitions::SenderSettleMode) -> crate::SenderSettleMode {
+impl From<&fe2o3_amqp_types::definitions::SenderSettleMode> for crate::SenderSettleMode {
+    fn from(mode: &fe2o3_amqp_types::definitions::SenderSettleMode) -> crate::SenderSettleMode {
         match mode {
             fe2o3_amqp_types::definitions::SenderSettleMode::Mixed => {
                 crate::SenderSettleMode::Mixed
@@ -681,8 +628,8 @@ impl From<crate::ReceiverSettleMode> for fe2o3_amqp_types::definitions::Receiver
     }
 }
 
-impl From<fe2o3_amqp_types::definitions::ReceiverSettleMode> for crate::ReceiverSettleMode {
-    fn from(mode: fe2o3_amqp_types::definitions::ReceiverSettleMode) -> crate::ReceiverSettleMode {
+impl From<&fe2o3_amqp_types::definitions::ReceiverSettleMode> for crate::ReceiverSettleMode {
+    fn from(mode: &fe2o3_amqp_types::definitions::ReceiverSettleMode) -> crate::ReceiverSettleMode {
         match mode {
             fe2o3_amqp_types::definitions::ReceiverSettleMode::First => {
                 crate::ReceiverSettleMode::First
@@ -737,7 +684,7 @@ mod tests {
     #[test]
     fn test_from_fe2o3_amqp_types_primitives_value_to_amqp_value() {
         let value = fe2o3_amqp_types::primitives::Value::String("test".to_string());
-        let value2: AmqpValue = value.into();
+        let value2: AmqpValue = (&value).into();
         assert_eq!(value2, AmqpValue::String("test".to_string()));
     }
 
@@ -745,7 +692,7 @@ mod tests {
     fn test_from_fe2o3_amqp_types_to_amqp_value() {
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Null;
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -754,7 +701,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Bool(true);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -763,7 +710,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Ubyte(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -772,7 +719,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Ushort(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -781,7 +728,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Uint(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -790,7 +737,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Ulong(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -799,7 +746,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Byte(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -808,7 +755,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Short(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -817,7 +764,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Int(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -826,7 +773,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Long(1);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -835,7 +782,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Float(1.0f32.into());
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -844,7 +791,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Double(10.0f64.into());
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -853,7 +800,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Char('a');
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -863,7 +810,7 @@ mod tests {
         {
             let fe2o3 =
                 fe2o3_amqp_types::primitives::Value::Timestamp(Timestamp::from_milliseconds(1));
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -873,7 +820,7 @@ mod tests {
         {
             let uuid = Uuid::new_v4();
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Uuid(uuid.into());
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -882,7 +829,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Binary(ByteBuf::from(vec![1]));
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -891,7 +838,7 @@ mod tests {
 
         {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::String("test".to_string());
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -902,7 +849,7 @@ mod tests {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Symbol(
                 fe2o3_amqp_types::primitives::Symbol("test".to_string()),
             );
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -913,7 +860,7 @@ mod tests {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::List(vec![
                 fe2o3_amqp_types::primitives::Value::String("test".to_string()),
             ]);
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -924,7 +871,7 @@ mod tests {
             let fe2o3 = fe2o3_amqp_types::primitives::Value::Map(
                 fe2o3_amqp_types::primitives::OrderedMap::new(),
             );
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -938,7 +885,7 @@ mod tests {
                 )]
                 .into(),
             );
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
@@ -952,34 +899,42 @@ mod tests {
                     value: fe2o3_amqp_types::primitives::Value::String("test".to_string()),
                 },
             ));
-            let amqp: AmqpValue = fe2o3.clone().into();
+            let amqp: AmqpValue = (&fe2o3).into();
             let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.clone().into();
             assert_eq!(fe2o3, fe2o3_2);
             assert_eq!(fe2o3_2, amqp);
             assert_eq!(amqp, fe2o3_2);
         }
 
-        // {
-        //     let fe2o3 = fe2o3_amqp_types::primitives::Value::Decimal128(Decimal128::from(1));
-        //     let amqp: AmqpValue = fe2o3.into();
-        //     let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.into();
+        {
+            let fe2o3 = fe2o3_amqp_types::primitives::Value::Decimal128(
+                fe2o3_amqp_types::primitives::Dec128::from([
+                    1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17,
+                ]),
+            );
+            let amqp: AmqpValue = (&fe2o3).into();
+            let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.into();
 
-        //     assert_eq!(fe2o3, fe2o3_2);
-        // }
+            assert_eq!(fe2o3, fe2o3_2);
+        }
 
-        // {
-        //     let fe2o3 = fe2o3_amqp_types::primitives::Value::Decimal32(Decimal32::from(1));
-        //     let amqp: AmqpValue = fe2o3.into();
-        //     let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.into();
+        {
+            let fe2o3 = fe2o3_amqp_types::primitives::Value::Decimal32(
+                fe2o3_amqp_types::primitives::Dec32::from([1u8, 2, 3, 4]),
+            );
+            let amqp: AmqpValue = (&fe2o3).into();
+            let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.into();
 
-        //     assert_eq!(fe2o3, fe2o3_2);
-        // }
+            assert_eq!(fe2o3, fe2o3_2);
+        }
 
-        // {
-        //     let fe2o3 = fe2o3_amqp_types::primitives::Value::Decimal64(Decimal64::from(1));
-        //     let amqp: AmqpValue = fe2o3.into();
-        //     let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.into();
-        //     assert_eq!(fe2o3, fe2o3_2);
-        // }
+        {
+            let fe2o3 = fe2o3_amqp_types::primitives::Value::Decimal64(
+                fe2o3_amqp_types::primitives::Dec64::from([1u8, 2, 3, 4, 5, 6, 7, 8]),
+            );
+            let amqp: AmqpValue = (&fe2o3).into();
+            let fe2o3_2: fe2o3_amqp_types::primitives::Value = amqp.into();
+            assert_eq!(fe2o3, fe2o3_2);
+        }
     }
 }

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) mod messaging;
 pub(crate) mod receiver;
 pub(crate) mod sender;
 pub(crate) mod session;
+pub(crate) mod simple_value;
 pub(crate) mod value;
 
 pub use cbs::{AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis};
@@ -32,6 +33,7 @@ pub use messaging::{
 pub use receiver::{AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode};
 pub use sender::{AmqpSendOptions, AmqpSendOutcome, AmqpSender, AmqpSenderApis, AmqpSenderOptions};
 pub use session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions};
+pub use simple_value::AmqpSimpleValue;
 use std::fmt::Debug;
 pub use value::{AmqpDescribed, AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
 

--- a/sdk/core/azure_core_amqp/src/management.rs
+++ b/sdk/core/azure_core_amqp/src/management.rs
@@ -3,6 +3,7 @@
 
 use super::{
     session::AmqpSession,
+    simple_value::AmqpSimpleValue,
     value::{AmqpOrderedMap, AmqpValue},
 };
 use async_trait::async_trait;
@@ -23,7 +24,7 @@ pub trait AmqpManagementApis {
     async fn call(
         &self,
         operation_type: String,
-        application_properties: AmqpOrderedMap<String, AmqpValue>,
+        application_properties: AmqpOrderedMap<String, AmqpSimpleValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>>;
 }
 
@@ -42,7 +43,7 @@ impl AmqpManagementApis for AmqpManagement {
     async fn call(
         &self,
         operation_type: String,
-        application_properties: AmqpOrderedMap<String, AmqpValue>,
+        application_properties: AmqpOrderedMap<String, AmqpSimpleValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>> {
         self.implementation
             .call(operation_type, application_properties)

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -179,9 +179,9 @@ pub enum AmqpMessageId {
     Ulong(u64),
 }
 
-impl From<azure_core::Uuid> for AmqpMessageId {
-    fn from(uuid: Uuid) -> Self {
-        AmqpMessageId::Uuid(uuid)
+impl AsRef<AmqpMessageId> for AmqpMessageId {
+    fn as_ref(&self) -> &AmqpMessageId {
+        self
     }
 }
 
@@ -206,6 +206,12 @@ impl From<Vec<u8>> for AmqpMessageId {
 impl From<u64> for AmqpMessageId {
     fn from(ulong: u64) -> Self {
         AmqpMessageId::Ulong(ulong)
+    }
+}
+
+impl From<azure_core::Uuid> for AmqpMessageId {
+    fn from(uuid: azure_core::Uuid) -> Self {
+        AmqpMessageId::Uuid(uuid)
     }
 }
 
@@ -940,6 +946,12 @@ pub enum AmqpAnnotationKey {
 impl Default for AmqpAnnotationKey {
     fn default() -> Self {
         Self::Ulong(0)
+    }
+}
+
+impl AsRef<AmqpAnnotationKey> for AmqpAnnotationKey {
+    fn as_ref(&self) -> &AmqpAnnotationKey {
+        self
     }
 }
 

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -1180,12 +1180,13 @@ impl AmqpMessage {
         self.body = body.into();
     }
 
+    #[allow(unused_variables)]
     pub fn serialize(message: &AmqpMessage) -> Result<Vec<u8>> {
         #[cfg(all(feature = "fe2o3_amqp", not(target_arch = "wasm32")))]
         {
             let amqp_message: fe2o3_amqp_types::messaging::Message<
                 fe2o3_amqp_types::messaging::Body<fe2o3_amqp_types::primitives::Value>,
-            > = message.clone().into();
+            > = message.into();
             let res = serde_amqp::ser::to_vec(
                 &fe2o3_amqp_types::messaging::message::__private::Serializable(amqp_message),
             )

--- a/sdk/core/azure_core_amqp/src/noop.rs
+++ b/sdk/core/azure_core_amqp/src/noop.rs
@@ -13,6 +13,7 @@ use super::{
     receiver::{AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode},
     sender::{AmqpSendOptions, AmqpSendOutcome, AmqpSenderApis, AmqpSenderOptions},
     session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions},
+    simple_value::AmqpSimpleValue,
     value::{AmqpOrderedMap, AmqpSymbol, AmqpValue},
 };
 use async_trait::async_trait;
@@ -138,7 +139,7 @@ impl AmqpManagementApis for NoopAmqpManagement {
     async fn call(
         &self,
         operation_type: String,
-        application_properties: AmqpOrderedMap<String, AmqpValue>,
+        application_properties: AmqpOrderedMap<String, AmqpSimpleValue>,
     ) -> Result<AmqpOrderedMap<String, AmqpValue>> {
         unimplemented!();
     }

--- a/sdk/core/azure_core_amqp/src/simple_value.rs
+++ b/sdk/core/azure_core_amqp/src/simple_value.rs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All Rights reserved
+// Licensed under the MIT license.
+
+//! Defines an AMQP `SimpleValue` type, which is a simple value type in AMQP 1.0.
+//! Simple types are defined in the [AMQP specification](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html#section-types)
+//! and are used to represent simple values such as integers, strings, and booleans.
+//!
+
+use crate::value::{AmqpSymbol, AmqpTimestamp};
+use azure_core::Uuid;
+
+/// A simple value type in AMQP 1.0.
+///
+/// Simple types are the AMQP primitive types (basically the same as [`AmqpValue`] without
+/// the `Map`, `List`, `Array`, and `Described` types).
+#[derive(Debug, Clone, PartialEq, Default)]
+pub enum AmqpSimpleValue {
+    /// A null value.
+    #[default]
+    Null,
+    /// A boolean value.
+    Boolean(bool),
+    /// An unsigned 8-bit integer.
+    UByte(u8),
+    /// A signed 8-bit integer.
+    Byte(i8),
+
+    /// A UTF-32BE encoded Unicode character.
+    Char(char),
+
+    /// An unsigned 16-bit integer.
+    UShort(u16),
+    /// A signed 16-bit integer.
+    Short(i16),
+    /// An unsigned 32-bit integer.
+    UInt(u32),
+    /// A signed 32-bit integer.
+    Int(i32),
+    /// An unsigned 64-bit integer.
+    ULong(u64),
+    /// A signed 64-bit integer.
+    Long(i64),
+    /// A 32-bit floating point number.
+    Float(f32),
+    /// A 64-bit floating point number.
+    Double(f64),
+    /// An IEEE 754-2008 Decimal128 value.
+    Decimal128([u8; 16]),
+    /// An IEEE 754-2008 Decimal64 value.
+    Decimal64([u8; 8]),
+    /// An IEEE 754-2008 Decimal32 value.
+    Decimal32([u8; 4]),
+
+    /// A timestamp value.
+    TimeStamp(AmqpTimestamp),
+    /// A UUID value.
+    Uuid(Uuid),
+    /// A string value.
+    String(String),
+    /// A symbol value.
+    Symbol(AmqpSymbol),
+    /// A binary value.
+    Binary(Vec<u8>),
+}
+
+// Note: There is intentionally no conversion from AmqpValue to AmqpSimpleValue. This is because we want a compile time error if you attempt to pass an AmqpValue into something expecting an AmqpSimpleValue.
+// This is to prevent accidental misuse of the API. If you need to convert an AmqpValue to an AmqpSimpleValue, you should do so explicitly.
+
+macro_rules! conversions_for_amqp_simple_types {
+    ($(($t:ty, $field:ident)),*) => {
+        $(
+            impl From<$t> for AmqpSimpleValue {
+                fn from(v: $t) -> Self {
+                    AmqpSimpleValue::$field(v)
+                }
+            }
+
+            impl From<AmqpSimpleValue> for $t {
+                fn from(v: AmqpSimpleValue) -> Self {
+                    match v {
+                        AmqpSimpleValue::$field(v) => v,
+                        _ => panic!("Expected a {}", stringify!($t)),
+                    }
+                }
+            }
+            impl From<&AmqpSimpleValue> for $t {
+                fn from(v: &AmqpSimpleValue) -> Self {
+                    match v {
+                        AmqpSimpleValue::$field(v) => v.clone(),
+                        _ => panic!("Expected a {}", stringify!($t)),
+                    }
+                }
+            }
+
+            impl PartialEq<$t> for AmqpSimpleValue {
+                fn eq(&self, other: &$t) -> bool {
+                    match self {
+                        AmqpSimpleValue::$field(v) => v == other,
+                        _ => false,
+                    }
+                }
+            }
+            impl PartialEq<AmqpSimpleValue> for $t {
+                fn eq(&self, other: &AmqpSimpleValue) -> bool {
+                    match other {
+                        AmqpSimpleValue::$field(v) => self == v,
+                        _ => false,
+                    }
+                }
+            }
+        )*
+    }
+}
+
+conversions_for_amqp_simple_types!(
+    (bool, Boolean),
+    (u8, UByte),
+    (u16, UShort),
+    (u32, UInt),
+    (u64, ULong),
+    (i8, Byte),
+    (i16, Short),
+    (i32, Int),
+    (i64, Long),
+    (f32, Float),
+    (f64, Double),
+    (char, Char),
+    (Uuid, Uuid),
+    (Vec<u8>, Binary),
+    (std::string::String, String),
+    (AmqpSymbol, Symbol),
+    (AmqpTimestamp, TimeStamp),
+    ([u8; 4], Decimal32),
+    ([u8; 8], Decimal64),
+    ([u8; 16], Decimal128)
+);
+
+impl From<&str> for AmqpSimpleValue {
+    fn from(value: &str) -> Self {
+        AmqpSimpleValue::String(value.to_string())
+    }
+}

--- a/sdk/core/azure_core_amqp/src/simple_value.rs
+++ b/sdk/core/azure_core_amqp/src/simple_value.rs
@@ -6,7 +6,7 @@
 //! and are used to represent simple values such as integers, strings, and booleans.
 //!
 
-use crate::value::{AmqpSymbol, AmqpTimestamp};
+use crate::value::{AmqpSymbol, AmqpTimestamp, AmqpValue};
 use azure_core::Uuid;
 
 /// A simple value type in AMQP 1.0.

--- a/sdk/core/azure_core_amqp/src/simple_value.rs
+++ b/sdk/core/azure_core_amqp/src/simple_value.rs
@@ -6,14 +6,12 @@
 //! and are used to represent simple values such as integers, strings, and booleans.
 //!
 
-// AmqpValue is used in the doccomment for AmqpSimpleValue.
-#[allow(unused_imports)]
 use crate::value::{AmqpSymbol, AmqpTimestamp};
 use azure_core::Uuid;
 
 /// A simple value type in AMQP 1.0.
 ///
-/// Simple types are the AMQP primitive types (basically the same as [`azure_core_amqp::AmqpValue`] without
+/// Simple types are the AMQP primitive types (basically the same as [`crate::value::AmqpValue`] without
 /// the `Map`, `List`, and `Array` types).
 ///
 /// They are used to represent the `Value` of an Amqp Message's `ApplicationProperties` field.

--- a/sdk/core/azure_core_amqp/src/simple_value.rs
+++ b/sdk/core/azure_core_amqp/src/simple_value.rs
@@ -6,13 +6,21 @@
 //! and are used to represent simple values such as integers, strings, and booleans.
 //!
 
-use crate::value::{AmqpSymbol, AmqpTimestamp, AmqpValue};
+// AmqpValue is used in the doccomment for AmqpSimpleValue.
+#[allow(unused_imports)]
+use crate::value::{AmqpSymbol, AmqpTimestamp};
 use azure_core::Uuid;
 
 /// A simple value type in AMQP 1.0.
 ///
-/// Simple types are the AMQP primitive types (basically the same as [`AmqpValue`] without
-/// the `Map`, `List`, `Array`, and `Described` types).
+/// Simple types are the AMQP primitive types (basically the same as [`azure_core_amqp::AmqpValue`] without
+/// the `Map`, `List`, and `Array` types).
+///
+/// They are used to represent the `Value` of an Amqp Message's `ApplicationProperties` field.
+///
+/// See the [AMQP specification](https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-application-properties) for
+/// more information.
+///
 #[derive(Debug, Clone, PartialEq, Default)]
 pub enum AmqpSimpleValue {
     /// A null value.

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -326,7 +326,7 @@ impl Deserializable<AmqpValue> for AmqpValue {
                 .map_err(|e| {
                     azure_core::Error::new(azure_core::error::ErrorKind::DataConversion, e)
                 })?;
-            Ok((&fe2o3_value).into())
+            Ok(fe2o3_value.into())
         }
         #[cfg(any(not(feature = "fe2o3_amqp"), target_arch = "wasm32"))]
         {

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/common/management.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/common/management.rs
@@ -9,7 +9,8 @@ use crate::{
 use azure_core::error::{ErrorKind as AzureErrorKind, Result};
 use azure_core_amqp::{
     error::{AmqpErrorCondition, AmqpErrorKind},
-    AmqpError, AmqpManagement, AmqpManagementApis, AmqpOrderedMap, AmqpTimestamp, AmqpValue,
+    AmqpError, AmqpManagement, AmqpManagementApis, AmqpOrderedMap, AmqpSimpleValue, AmqpTimestamp,
+    AmqpValue,
 };
 use std::{error::Error, time::SystemTime};
 use tracing::{debug, warn};
@@ -107,7 +108,7 @@ impl ManagementInstance {
     pub async fn get_eventhub_properties(&self, eventhub: &str) -> Result<EventHubProperties> {
         let response = retry_azure_operation(
             || async move {
-                let mut application_properties: AmqpOrderedMap<String, AmqpValue> =
+                let mut application_properties: AmqpOrderedMap<String, AmqpSimpleValue> =
                     AmqpOrderedMap::new();
                 application_properties.insert(EVENTHUB_PROPERTY_NAME.to_string(), eventhub.into());
                 let response = self
@@ -164,7 +165,7 @@ impl ManagementInstance {
     ) -> Result<EventHubPartitionProperties> {
         let response = retry_azure_operation(
             || async move {
-                let mut application_properties: AmqpOrderedMap<String, AmqpValue> =
+                let mut application_properties: AmqpOrderedMap<String, AmqpSimpleValue> =
                     AmqpOrderedMap::new();
                 application_properties.insert(EVENTHUB_PROPERTY_NAME.to_string(), eventhub.into());
                 application_properties

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
@@ -1,4 +1,4 @@
-use crate::models::{AmqpMessage, AmqpValue, MessageId};
+use crate::models::{AmqpMessage, AmqpSimpleValue, AmqpValue, MessageId};
 use azure_core_amqp::{AmqpAnnotationKey, AmqpMessageBody, AmqpMessageProperties};
 use std::{
     collections::HashMap,
@@ -35,7 +35,7 @@ pub struct EventData {
     content_type: Option<String>,
     correlation_id: Option<MessageId>,
     message_id: Option<MessageId>,
-    properties: Option<HashMap<String, AmqpValue>>,
+    properties: Option<HashMap<String, AmqpSimpleValue>>,
 }
 
 impl EventData {
@@ -45,7 +45,7 @@ impl EventData {
     }
 
     /// The properties of the event.
-    pub fn properties(&self) -> Option<&HashMap<String, AmqpValue>> {
+    pub fn properties(&self) -> Option<&HashMap<String, AmqpSimpleValue>> {
         self.properties.as_ref()
     }
 
@@ -84,8 +84,7 @@ impl EventData {
 
         if let Some(properties) = message.properties() {
             if let Some(content_type) = &properties.content_type {
-                event_data_builder =
-                    event_data_builder.with_content_type(content_type.clone().into());
+                event_data_builder = event_data_builder.with_content_type(content_type.into());
             }
             if let Some(correlation_id) = &properties.correlation_id {
                 event_data_builder = event_data_builder.with_correlation_id(correlation_id.clone());
@@ -392,7 +391,7 @@ pub mod builders {
         ///
         /// A reference to the updated builder.
         ///
-        pub fn add_property(mut self, key: String, value: impl Into<AmqpValue>) -> Self {
+        pub fn add_property(mut self, key: String, value: impl Into<AmqpSimpleValue>) -> Self {
             if let Some(mut properties) = self.event_data.properties {
                 properties.insert(key, value.into());
                 self.event_data.properties = Some(properties);
@@ -461,7 +460,7 @@ mod tests {
     #[test]
     fn test_event_data_builder_add_property() {
         let key = "key".to_string();
-        let value: AmqpValue = "value".into();
+        let value: AmqpSimpleValue = "value".into();
         let event_data = EventData::builder()
             .add_property(key.clone(), value.clone())
             .build();
@@ -476,7 +475,7 @@ mod tests {
         let correlation_id = MessageId::String("correlation-id".to_string());
         let message_id = MessageId::String("message-id".to_string());
         let key = "key".to_string();
-        let value: AmqpValue = "value".into();
+        let value: AmqpSimpleValue = "value".into();
 
         let event_data = EventData::builder()
             .with_body(body.clone())

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
@@ -10,6 +10,13 @@ pub use azure_core_amqp::AmqpMessage;
 /// An AMQP Value.
 pub use azure_core_amqp::AmqpValue;
 
+/// An AMQP Simple Value.
+///
+/// An AMQP Simple Value is a primitive type in AMQP 1.0.
+/// Simple types are the AMQP primitive types (basically the same as [`AmqpValue`] without
+/// the `Map`, `List`, `Array`, and `Described` types).
+pub use azure_core_amqp::AmqpSimpleValue;
+
 /// An event received from an Event Hub.
 pub use event_data::ReceivedEventData;
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_producer.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use azure_core::http::StatusCode;
-use azure_core_amqp::{AmqpError, AmqpList, AmqpMessageProperties};
+use azure_core_amqp::{AmqpError, AmqpList, AmqpMessageProperties, AmqpSimpleValue};
 use azure_core_test::{recorded, TestContext};
 use azure_messaging_eventhubs::{EventDataBatchOptions, ProducerClient};
 use std::{env, error::Error};
@@ -233,7 +233,7 @@ async fn send_message(ctx: TestContext) -> Result<(), Box<dyn Error>> {
         let data = b"hello world";
         let em1 = AmqpMessage::builder()
             .with_body(AmqpValue::Binary(data.to_vec()))
-            .add_application_property("key".to_string(), AmqpValue::from("value"))
+            .add_application_property("key".to_string(), AmqpSimpleValue::from("value"))
             .with_properties(AmqpMessageProperties {
                 message_id: Some(35u64.into()),
                 content_type: Some("text/plain".into()),


### PR DESCRIPTION
There are two major parts to this PR. The first is purely functional, the second should significantly reduce the overhead of converting messages to and from Fe2o3.

1. Adds support for `AmqpSimpleValue`, which is defined by the AMQP specification as an AmqpValue without `Map`, `List`, or `Array` fields. This ensures that we have a compile time error when attempting to put an unsupported value into an `AmqpApplicationProperties` (or `EventData` `properties`
2. Reworks all the fe2o3 conversion functions with an eye to minimizing the number of conversions back and forth. 
3. Also adds in the 3 missing AMQP fundamental types - `Decimal32`, `Decimal64 `and `Decimal128` - these are implemented as opaque arrays of 4, 8, and 16 bytes.

As an example of this, when receiving a message from EventHubs, the code uses the `AmqpDelivery::into_message` function to convert the received (owned) fe2o3 message into an `AmqpMessage`. Before this change, the code would convert the received fe2o3 message by reference into an `AmqpMessage` (thus copying the contents of the fe2o3 message into the `AmqpMessage`) and then extract the converted `AmqpMessage` from the `AmqpDelivery`, only freeing the fe2o3 message when the `AmqpDelivery` is freed.

In the new version, the code consumes the fe2o3 AMQP message directly converting it to an `AmqpMessage` without actually copying the original message. That should result in many elements being moved out of the fe2o3 message rather than being copied.

This change also removes most (all?) of the use of the anti-pattern `.clone().into()` which is typically used when converting between a reference to a type and another type - this change adds `From<&Type>` specializations to enable direct conversion from the reference to type and the underlying type. 