### PR TITLE
Do not use workspace dependency for AMQP, EH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ path = "sdk/typespec/typespec_macros"
 [workspace.dependencies.azure_core]
 version = "0.25.0"
 path = "sdk/core/azure_core"
-default-features = false
 
 [workspace.dependencies.azure_core_amqp]
 version = "0.4.0"

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -19,7 +19,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-azure_core = { workspace = true, default-features = false }
+azure_core = { path = "../azure_core", version = "0.25.0", default-features = false }
 fe2o3-amqp = { workspace = true, optional = true }
 fe2o3-amqp-cbs = { workspace = true, optional = true }
 fe2o3-amqp-ext = { workspace = true, optional = true }

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -21,7 +21,7 @@ edition.workspace = true
 async-lock.workspace = true
 async-stream.workspace = true
 async-trait.workspace = true
-azure_core = { workspace = true, default-features = false }
+azure_core = { path = "../../core/azure_core", version = "0.25.0", default-features = false }
 azure_core_amqp.workspace = true
 futures.workspace = true
 rand.workspace = true


### PR DESCRIPTION
This shifts the burden of feature selection to a few crates as opposed to the vast majority. Why this is necessary:

1. #2551 removed the features we otherwise selected by default for `azure_core`. Note that `default-features = false` was left in `Cargo.toml`. This was to fix #2574 since, as the author explained, this was causing those features *not* to be optional since they were explicitly referenced by our crates.
2. That then had a negative effect that was breaking tests because the `reqwest_deflate` and `reqwest_gzip` features weren't pulled in because they were removed and `default-features = false` left. This was causing failures in subsequent PRs; though, I'm not sure why it wasn't caught in the initial PR. I think it's likely because the impact wasn't directly to `sdk/core/azure_core` and, thus, the change detection didn't pick it up (@hallir we might want to test the core crates for any workspace changes).
3. So instead of requiring that ~99% of our crates now and in the future have to add the default declared features of `azure_core` - which then means we have to manage that feature set if/when it changes across all those crates - we change the `azure_core` workspace dependency to take default features and just manage the small set of default features for those crates that need to change them i.e., `azure_core_amqp` and `azure_messaging_eventhubs` currently. Like Service Bus and maybe one or two others, but far easier to manage. But this means they do have to take a `path` dependency, which also means they need a separate `version` or we can't `cargo package` or `cargo publish` them later.

I successfully ran the following as a test:

```bash
eng/scripts/verify-dependencies.rs
cargo test -p azure_security_keyvault_secrets
cargo +nightly -Zpackage-workspace package --allow-dirty -p typespec -p typespec_client_core -p typespec_macros -p azure_core -p azure_core_amqp -p azure_messaging_eventhubs -p azure_security_keyvault_secrets
```
