### PR TITLE
Expose more types for C++; reorganized some public types a bit

### DIFF
--- a/sdk/core/azure_core_amqp/src/error.rs
+++ b/sdk/core/azure_core_amqp/src/error.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 
 use azure_core::{create_enum, create_extensible_enum};
 
-//pub use crate::sender::error::AmqpSenderError;
 use crate::{AmqpOrderedMap, AmqpSymbol, AmqpValue};
 
 /// Type of AMQP error.

--- a/sdk/core/azure_core_amqp/src/fe2o3/error.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/error.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     error::{AmqpDescribedError, AmqpErrorCondition, AmqpErrorKind},
+    value::AmqpSymbol,
     AmqpError,
 };
 use std::str::FromStr;
@@ -62,7 +63,7 @@ impl From<&fe2o3_amqp_types::definitions::ErrorCondition> for AmqpErrorCondition
                 AmqpErrorCondition::from(link_error)
             }
             fe2o3_amqp_types::definitions::ErrorCondition::Custom(symbol) => {
-                AmqpErrorCondition::from(crate::AmqpSymbol::from(symbol))
+                AmqpErrorCondition::from(AmqpSymbol::from(symbol))
             }
         }
     }

--- a/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
+++ b/sdk/core/azure_core_amqp/src/fe2o3/messaging/mod.rs
@@ -7,10 +7,10 @@ pub(crate) mod message_target;
 pub(crate) mod messaging_types;
 
 use crate::{
-    messaging::{AmqpMessage, AmqpMessageBody},
+    messaging::{AmqpMessage, AmqpMessageBody, AmqpMessageProperties},
     value::AmqpValue,
-    AmqpMessageProperties,
 };
+
 use azure_core::{error::ErrorKind, Error};
 use fe2o3_amqp_types::messaging::{message::EmptyBody, IntoBody};
 use serde_amqp::{extensions::TransparentVec, Value};

--- a/sdk/core/azure_core_amqp/src/lib.rs
+++ b/sdk/core/azure_core_amqp/src/lib.rs
@@ -10,32 +10,42 @@ mod fe2o3;
 #[cfg(any(not(feature = "fe2o3_amqp"), target_arch = "wasm32"))]
 mod noop;
 
-pub(crate) mod cbs;
-pub(crate) mod connection;
+mod cbs;
+mod connection;
 pub mod error;
-pub(crate) mod management;
-pub(crate) mod messaging;
-pub(crate) mod receiver;
-pub(crate) mod sender;
-pub(crate) mod session;
-pub(crate) mod simple_value;
-pub(crate) mod value;
+mod management;
+mod messaging;
+mod receiver;
+mod sender;
+mod session;
+mod simple_value;
+mod value;
 
 pub use cbs::{AmqpClaimsBasedSecurity, AmqpClaimsBasedSecurityApis};
 pub use connection::{AmqpConnection, AmqpConnectionApis, AmqpConnectionOptions};
 pub use error::{AmqpDescribedError, AmqpError};
 pub use management::{AmqpManagement, AmqpManagementApis};
-pub use messaging::{
-    AmqpAnnotationKey, AmqpAnnotations, AmqpDelivery, AmqpDeliveryApis, AmqpMessage,
-    AmqpMessageBody, AmqpMessageHeader, AmqpMessageId, AmqpMessageProperties, AmqpSource,
-    AmqpSourceFilter, AmqpTarget,
-};
+pub use messaging::{AmqpDelivery, AmqpDeliveryApis, AmqpMessage, AmqpSource, AmqpTarget};
 pub use receiver::{AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, ReceiverCreditMode};
 pub use sender::{AmqpSendOptions, AmqpSendOutcome, AmqpSender, AmqpSenderApis, AmqpSenderOptions};
 pub use session::{AmqpSession, AmqpSessionApis, AmqpSessionOptions};
 pub use simple_value::AmqpSimpleValue;
 use std::fmt::Debug;
 pub use value::{AmqpDescribed, AmqpList, AmqpOrderedMap, AmqpSymbol, AmqpTimestamp, AmqpValue};
+
+pub mod builder {
+    pub use crate::messaging::builders::{
+        AmqpMessageBuilder, AmqpSourceBuilder, AmqpTargetBuilder,
+    };
+}
+
+pub mod message {
+    pub use crate::messaging::{
+        AmqpAnnotationKey, AmqpAnnotations, AmqpApplicationProperties, AmqpMessageBody,
+        AmqpMessageHeader, AmqpMessageId, AmqpMessageProperties, AmqpOutcome, AmqpSourceFilter,
+        DistributionMode, TerminusDurability, TerminusExpiryPolicy,
+    };
+}
 
 // AMQP Settle mode:
 // https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-transport-v1.0-os.html#type-sender-settle-mode
@@ -73,3 +83,6 @@ pub trait Serializable {
 pub trait Deserializable<T> {
     fn decode(data: &[u8]) -> azure_core::Result<T>;
 }
+
+#[cfg(feature = "cplusplus")]
+pub use value::{AmqpComposite, AmqpDescriptor};

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -1318,7 +1318,7 @@ impl Deserializable<AmqpMessage> for AmqpMessage {
     }
 }
 
-mod builders {
+pub(crate) mod builders {
     use super::*;
 
     pub struct AmqpSourceBuilder {

--- a/sdk/core/azure_core_amqp/src/messaging.rs
+++ b/sdk/core/azure_core_amqp/src/messaging.rs
@@ -1169,7 +1169,7 @@ impl AmqpMessage {
     ///
     /// ```
     /// use azure_core_amqp::AmqpMessage;
-    /// use azure_core_amqp::AmqpMessageBody;
+    /// use azure_core_amqp::message::AmqpMessageBody;
     ///
     /// let mut message = AmqpMessage::default();
     /// message.set_message_body(AmqpMessageBody::Value("Hello, world!".into()));

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -196,6 +196,7 @@ impl AmqpDescribed {
 }
 
 /// An AMQP Composite type.
+///
 /// This is a complex type that is composed of a descriptor and a value.
 /// The descriptor is used to identify the type of the value.
 /// The value is the actual value.
@@ -208,6 +209,12 @@ pub struct AmqpComposite {
 
 #[cfg(feature = "cplusplus")]
 impl AmqpComposite {
+    /// Creates a new AMQP Composite type.
+    ///
+    /// # Arguments
+    ///
+    /// * `descriptor` - The descriptor of the composite type.
+    /// * `value` - The value of the composite type.
     pub fn new(descriptor: impl Into<AmqpDescriptor>, value: impl Into<AmqpList>) -> Self {
         Self {
             descriptor: descriptor.into(),
@@ -215,14 +222,17 @@ impl AmqpComposite {
         }
     }
 
+    /// Returns a reference to the descriptor.
     pub fn descriptor(&self) -> &AmqpDescriptor {
         &self.descriptor
     }
 
+    /// Returns a reference to the value.
     pub fn value(&self) -> &AmqpList {
         &self.value
     }
 
+    /// Returns a mutable reference to the value.
     pub fn value_mut(&mut self) -> &mut AmqpList {
         &mut self.value
     }

--- a/sdk/core/azure_core_amqp/src/value.rs
+++ b/sdk/core/azure_core_amqp/src/value.rs
@@ -222,6 +222,10 @@ impl AmqpComposite {
     pub fn value(&self) -> &AmqpList {
         &self.value
     }
+
+    pub fn value_mut(&mut self) -> &mut AmqpList {
+        &mut self.value
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]

--- a/sdk/eventhubs/azure_messaging_eventhubs/benches/benchmarks.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/benches/benchmarks.rs
@@ -27,7 +27,9 @@ fn send_batch_benchmark(c: &mut Criterion) {
     setup();
 
     // Check if the environment variable is set thus allowing the benchmarks to run
-    if azure_core_test::TestMode::current().unwrap() != azure_core_test::TestMode::Live {
+    if azure_core_test::TestMode::current().unwrap_or(azure_core_test::TestMode::Playback)
+        != azure_core_test::TestMode::Live
+    {
         println!("Skipping benchmarks. Set AZURE_TEST_MODE to run.");
         return;
     }
@@ -73,7 +75,10 @@ fn send_batch_benchmark(c: &mut Criterion) {
 
 criterion_group!(
     name = send_batch_benchmarks;
-    config = Criterion::default().sample_size(100).warm_up_time(std::time::Duration::new(1, 0));
+    config = Criterion::default()
+        .sample_size(100)
+        .warm_up_time(std::time::Duration::new(1, 0))
+        .measurement_time(std::time::Duration::new(250, 0));
     targets = send_batch_benchmark
 );
 
@@ -81,7 +86,9 @@ fn send_benchmark(c: &mut Criterion) {
     setup();
 
     // Check if the environment variable is set thus allowing the benchmarks to run
-    if azure_core_test::TestMode::current().unwrap() != azure_core_test::TestMode::Live {
+    if azure_core_test::TestMode::current().unwrap_or(azure_core_test::TestMode::Playback)
+        != azure_core_test::TestMode::Live
+    {
         println!("Skipping benchmarks. Set AZURE_TEST_MODE to run.");
         return;
     }
@@ -132,7 +139,10 @@ fn send_benchmark(c: &mut Criterion) {
 
 criterion_group!(
     name = send_benchmarks;
-    config = Criterion::default().sample_size(1000).warm_up_time(std::time::Duration::new(1, 0)).measurement_time(std::time::Duration::new(205, 0));
+    config = Criterion::default()
+        .sample_size(1000)
+        .warm_up_time(std::time::Duration::new(1, 0))
+        .measurement_time(std::time::Duration::new(2200, 0));
     targets =  send_benchmark
 );
 

--- a/sdk/eventhubs/azure_messaging_eventhubs/benches/benchmarks.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/benches/benchmarks.rs
@@ -27,9 +27,7 @@ fn send_batch_benchmark(c: &mut Criterion) {
     setup();
 
     // Check if the environment variable is set thus allowing the benchmarks to run
-    if azure_core_test::TestMode::current().unwrap_or(azure_core_test::TestMode::Playback)
-        != azure_core_test::TestMode::Live
-    {
+    if azure_core_test::TestMode::current().unwrap_or_default() != azure_core_test::TestMode::Live {
         println!("Skipping benchmarks. Set AZURE_TEST_MODE to run.");
         return;
     }
@@ -86,9 +84,7 @@ fn send_benchmark(c: &mut Criterion) {
     setup();
 
     // Check if the environment variable is set thus allowing the benchmarks to run
-    if azure_core_test::TestMode::current().unwrap_or(azure_core_test::TestMode::Playback)
-        != azure_core_test::TestMode::Live
-    {
+    if azure_core_test::TestMode::current().unwrap_or_default() != azure_core_test::TestMode::Live {
         println!("Skipping benchmarks. Set AZURE_TEST_MODE to run.");
         return;
     }

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/consumer/mod.rs
@@ -19,9 +19,9 @@ use azure_core::{
     Uuid,
 };
 use azure_core_amqp::{
-    AmqpDescribed, AmqpManagement, AmqpManagementApis, AmqpOrderedMap, AmqpReceiver,
-    AmqpReceiverApis, AmqpReceiverOptions, AmqpSession, AmqpSessionApis, AmqpSource,
-    AmqpSourceFilter, AmqpSymbol, AmqpValue, ReceiverCreditMode,
+    message::AmqpSourceFilter, AmqpDescribed, AmqpManagement, AmqpManagementApis, AmqpOrderedMap,
+    AmqpReceiver, AmqpReceiverApis, AmqpReceiverOptions, AmqpSession, AmqpSessionApis, AmqpSource,
+    AmqpSymbol, AmqpValue, ReceiverCreditMode,
 };
 pub use event_receiver::EventReceiver;
 use std::{

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/event_data.rs
@@ -1,5 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
 use crate::models::{AmqpMessage, AmqpSimpleValue, AmqpValue, MessageId};
-use azure_core_amqp::{AmqpAnnotationKey, AmqpMessageBody, AmqpMessageProperties};
+use azure_core_amqp::message::{AmqpAnnotationKey, AmqpMessageBody, AmqpMessageProperties};
 use std::{
     collections::HashMap,
     fmt::{Debug, Formatter},

--- a/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/src/models/mod.rs
@@ -30,7 +30,7 @@ pub mod builders {
 pub use event_data::EventData;
 
 use azure_core::Uuid;
-use azure_core_amqp::AmqpMessageId;
+use azure_core_amqp::message::AmqpMessageId;
 use std::fmt::Debug;
 use std::time::SystemTime;
 
@@ -259,7 +259,7 @@ pub(crate) struct ConsumerClientDetails {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use azure_core_amqp::AmqpMessageId;
+    use azure_core_amqp::message::AmqpMessageId;
 
     #[test]
     fn test_message_id_from_u64() {

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_producer.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_producer.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 use azure_core::http::StatusCode;
-use azure_core_amqp::{AmqpError, AmqpList, AmqpMessageProperties, AmqpSimpleValue};
+use azure_core_amqp::{message::AmqpMessageProperties, AmqpError, AmqpList, AmqpSimpleValue};
 use azure_core_test::{recorded, TestContext};
 use azure_messaging_eventhubs::{EventDataBatchOptions, ProducerClient};
 use std::{env, error::Error};

--- a/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_round_trip.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs/tests/eventhubs_round_trip.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All Rights reserved
 // Licensed under the MIT license.
 
-use azure_core_amqp::{AmqpList, AmqpMessageProperties};
+use azure_core_amqp::{message::AmqpMessageProperties, AmqpList};
 use azure_core_test::{recorded, TestContext};
 use azure_messaging_eventhubs::{
     models::{AmqpMessage, AmqpValue, EventData, MessageId},


### PR DESCRIPTION
This PR adds a few public types which are needed for the C++ AMQP implementation.

It also moves some types from the global namespace and into a `builder` and `message` namespace.

Verified that the C++ codebase builds and works with all of these changes.

Bonus: Fixed two late breaking suggestions for the EventHubs performance tests.
