### PR TITLE
Remove AccessToken::is_expired()

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### Breaking Changes
 
+- Removed `AccessToken::is_expired()`
+
 ### Bugs Fixed
+
+- `BearerTokenCredentialPolicy` returns an error when a proactive token refresh attempt fails
 
 ### Other Changes
 

--- a/sdk/core/azure_core/src/credentials.rs
+++ b/sdk/core/azure_core/src/credentials.rs
@@ -4,7 +4,7 @@
 //! Azure authentication and authorization.
 
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, fmt::Debug, time::Duration};
+use std::{borrow::Cow, fmt::Debug};
 use typespec_client_core::date::OffsetDateTime;
 
 /// Default Azure authorization scope.
@@ -84,13 +84,6 @@ impl AccessToken {
             token: token.into(),
             expires_on,
         }
-    }
-
-    /// Check if the token is expired within a given duration.
-    ///
-    /// If no duration is provided, then the default duration of 30 seconds is used.
-    pub fn is_expired(&self, window: Option<Duration>) -> bool {
-        self.expires_on < OffsetDateTime::now_utc() + window.unwrap_or(Duration::from_secs(30))
     }
 }
 

--- a/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
+++ b/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
@@ -163,8 +163,8 @@ mod tests {
     // in a test case i.e., that the policy called get_token() as expected
     impl Drop for MockCredential {
         fn drop(&mut self) {
-            if self.tokens.len() > 0 {
-                assert_eq!(self.calls.load(Ordering::SeqCst), self.tokens.len());
+            if !self.tokens.is_empty() {
+                assert_eq!(self.tokens.len(), self.calls.load(Ordering::SeqCst));
             }
         }
     }


### PR DESCRIPTION
...because it's unnecessary and its name is misleading. This PR also adds test coverage and fixes a bug: the policy currently returns errors from proactive refresh attempts even when it has a valid cached token. (There's no value in doing that because the client request could otherwise succeed.)