### PR TITLE
Support CosmosClient Creation via Connection String

### DIFF
--- a/sdk/core/azure_core/src/credentials.rs
+++ b/sdk/core/azure_core/src/credentials.rs
@@ -3,6 +3,7 @@
 
 //! Azure authentication and authorization.
 
+use crate::error::ErrorKind;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, fmt::Debug};
 use typespec_client_core::date::OffsetDateTime;
@@ -26,6 +27,46 @@ impl Secret {
 
     pub fn secret(&self) -> &str {
         &self.0
+    }
+}
+
+/// Represents a Cosmos DB connection string.
+///
+/// The [`Debug`] implementation will not print the secret.
+#[derive(Clone, Deserialize, Serialize)]
+pub struct CosmosConnectionString {
+    pub account_endpoint: Cow<'static, str>,
+    pub account_key: Cow<'static, str>,
+}
+
+impl CosmosConnectionString {
+    pub fn from_secret(secret: &Secret) -> crate::Result<Self> {
+        let split = secret.secret().split(";");
+        let collection = split.collect::<Vec<&str>>();
+
+        match collection.len() {
+            2 => {
+                if (collection[0].contains("AccountEndpoint=")
+                    && collection[1].contains("AccountKey="))
+                {
+                    Ok(Self {
+                        account_endpoint: collection[0][16..collection[0].len() - 1]
+                            .to_owned()
+                            .into(),
+                        account_key: collection[0][11..collection[0].len() - 1].to_owned().into(),
+                    })
+                } else {
+                    Err(crate::Error::message(
+                        ErrorKind::Other,
+                        "Invalid Cosmos connection string",
+                    ))
+                }
+            }
+            _ => Err(crate::Error::message(
+                ErrorKind::Other,
+                "Invalid Cosmos connection string",
+            )),
+        }
     }
 }
 
@@ -62,6 +103,17 @@ impl From<&'static str> for Secret {
 impl Debug for Secret {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("Secret")
+    }
+}
+
+impl Debug for CosmosConnectionString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let debug_string = format!(
+            "AccountEndpoint={};AccountKey=Secret;",
+            self.account_endpoint
+        );
+
+        f.write_str(&debug_string)
     }
 }
 

--- a/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
+++ b/sdk/cosmos/azure_data_cosmos/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+* Added a function `CosmosClient::with_connection_string` to enable `CosmosClient` creation via connection string. (pr link)
+
 ### Breaking Changes
 
 ### Bugs Fixed

--- a/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/clients/cosmos_client.rs
@@ -96,6 +96,41 @@ impl CosmosClient {
         })
     }
 
+    /// Creates a new CosmosClient, using a connection string.
+    ///
+    /// # Arguments
+    ///
+    /// * `connection_string` - the connection string to use for the client. E.g.: AccountEndpoint=https://accountname.documents.azure.com:443/‌​;AccountKey=accountk‌​ey
+    /// * `options` - Optional configuration for the client.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use azure_data_cosmos::CosmosClient;
+    /// use azure_core::credentials::Secret;
+    ///
+    /// let client = CosmosClient::with_key("https://myaccount.documents.azure.com/", Secret::from("my_key"), None).unwrap();
+    /// ```
+    #[cfg(feature = "key_auth")]
+    pub fn with_connection_string(
+        connection_string: Secret,
+        options: Option<CosmosClientOptions>,
+    ) -> azure_core::Result<Self> {
+        use azure_core::credentials::CosmosConnectionString;
+        let options = options.unwrap_or_default();
+        let connection_str = CosmosConnectionString::from_secret(&connection_string)?;
+        let key = Secret::new(connection_str.account_key);
+
+        Ok(Self {
+            databases_link: ResourceLink::root(ResourceType::Databases),
+            pipeline: CosmosPipeline::new(
+                connection_str.account_endpoint.parse()?,
+                AuthorizationPolicy::from_shared_key(key),
+                options.client_options,
+            ),
+        })
+    }
+
     /// Gets a [`DatabaseClient`] that can be used to access the database with the specified ID.
     ///
     /// # Arguments

--- a/sdk/cosmos/azure_data_cosmos/src/models/connection_string.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/connection_string.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use std::borrow::Cow;
+
+use azure_core::{credentials::Secret, http::Model, Error};
+use serde::Deserialize;
+use std::fmt::Debug;
+
+/// Represents a Cosmos DB connection string.
+///
+/// The [`Debug`] implementation will not print the account key.
+#[derive(Model, Clone, Deserialize, PartialEq, Eq)]
+pub struct ConnectionString {
+    pub account_endpoint: Cow<'static, str>,
+    pub account_key: Secret,
+}
+
+impl ConnectionString {
+    pub fn from_connection_string(connection_string: &str) -> Result<Self, Error> {
+        let splat = connection_string.split(';');
+        let mut account_endpoint = None;
+        let mut account_key = None;
+        for part in splat {
+            let part = part.trim();
+            if part.is_empty() {
+                continue;
+            }
+
+            let (key, value) = part.split_once('=').ok_or(Error::new(
+                azure_core::error::ErrorKind::Other,
+                "invalid connection string",
+            ))?;
+            match key {
+                "AccountEndpoint" => account_endpoint = Some(value.to_string()),
+                "AccountKey" => account_key = Some(Secret::new(value.to_string())),
+                _ => {}
+            }
+        }
+
+        let Some(endpoint) = account_endpoint else {
+            return Err(Error::new(
+                azure_core::error::ErrorKind::Other,
+                "invalid connection string, missing 'AccountEndpoint",
+            ));
+        };
+
+        let Some(key) = account_key else {
+            return Err(Error::new(
+                azure_core::error::ErrorKind::Other,
+                "invalid connection string, missing 'AccountKey",
+            ));
+        };
+
+        Ok(Self {
+            account_endpoint: Cow::Owned(endpoint),
+            account_key: key,
+        })
+    }
+
+    pub fn from_secret(secret: &Secret) -> azure_core::Result<Self> {
+        ConnectionString::from_connection_string(secret.secret())
+    }
+}
+
+impl Debug for ConnectionString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let debug_string = format!(
+            "AccountEndpoint={};AccountKey=Secret;",
+            self.account_endpoint
+        );
+
+        f.write_str(&debug_string)
+    }
+}

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -12,12 +12,14 @@ use azure_core::{
 };
 use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 
+mod connection_string;
 mod container_properties;
 mod indexing_policy;
 mod partition_key_definition;
 mod patch_operations;
 mod throughput_properties;
 
+pub use connection_string::*;
 pub use container_properties::*;
 pub use indexing_policy::*;
 pub use partition_key_definition::*;

--- a/sdk/cosmos/azure_data_cosmos/tests/framework/test_account.rs
+++ b/sdk/cosmos/azure_data_cosmos/tests/framework/test_account.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, sync::Arc};
 
 use azure_core::{credentials::Secret, http::TransportOptions, test::TestMode};
 use azure_core_test::TestContext;
-use azure_data_cosmos::{CosmosClientOptions, Query};
+use azure_data_cosmos::{models::ConnectionString, CosmosClientOptions, Query};
 use reqwest::ClientBuilder;
 
 /// Represents a Cosmos DB account for testing purposes.
@@ -74,30 +74,7 @@ impl TestAccount {
         options: Option<TestAccountOptions>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let options = options.unwrap_or_default();
-        let splat = connection_string.split(';');
-        let mut account_endpoint = None;
-        let mut account_key = None;
-        for part in splat {
-            let part = part.trim();
-            if part.is_empty() {
-                continue;
-            }
-
-            let (key, value) = part.split_once('=').ok_or("invalid connection string")?;
-            match key {
-                "AccountEndpoint" => account_endpoint = Some(value.to_string()),
-                "AccountKey" => account_key = Some(Secret::new(value.to_string())),
-                _ => {}
-            }
-        }
-
-        let Some(endpoint) = account_endpoint else {
-            return Err("invalid connection string, missing 'AccountEndpoint'".into());
-        };
-
-        let Some(key) = account_key else {
-            return Err("invalid connection string, missing 'AccountKey'".into());
-        };
+        let connection_str = ConnectionString::from_connection_string(connection_string)?;
 
         // We need the context_id to be constant, so that record/replay work.
         let context_id = context.name().to_string();
@@ -105,8 +82,8 @@ impl TestAccount {
         Ok(TestAccount {
             context,
             context_id,
-            endpoint,
-            key,
+            endpoint: connection_str.account_endpoint.to_string(),
+            key: connection_str.account_key,
             options,
         })
     }


### PR DESCRIPTION
### Issue(s) Closed:
Closes https://github.com/Azure/azure-sdk-for-rust/issues/1939
### Description:
Added a new function `CosmosClient::with_connection_string` to create a client via connection string, where the connection string is a secret.
### Approach:
We previously had connection string parsing logic in `test_account.rs` - moved this logic out into a separate file and struct, and made use of it in `with_connection_string` and `TestAccount` setup.
### Testing:
Added unit tests for connection string parsing logic.