### PR TITLE
AzureCliCredential::get_token() always invokes the Azure CLI

### DIFF
--- a/sdk/identity/azure_identity/CHANGELOG.md
+++ b/sdk/identity/azure_identity/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Other Changes
 
+- `AzureCliCredential::get_token()` always invokes the Azure CLI
+
 ## 0.24.0 (2025-05-06)
 
 ### Features Added


### PR DESCRIPTION
This change aligns the implementation with other languages and serves to keep the credential in sync with the CLI in that `get_token()` will consistently return a token for the identity logged in to the CLI. That makes the credential's behavior easier to understand and prevents weirdness such as the credential's identity depending on the requested scopes.