### PR TITLE
Removed --locked from typespec_macros tests

### DIFF
--- a/sdk/typespec/typespec_macros/tests/safe-debug-tests.rs
+++ b/sdk/typespec/typespec_macros/tests/safe-debug-tests.rs
@@ -18,7 +18,6 @@ fn debug_tests() {
 
     let output = Command::new(env!("CARGO"))
         .arg("test")
-        .arg("--locked")
         .arg("--no-fail-fast")
         .arg("--test")
         .arg("debug")
@@ -48,7 +47,6 @@ fn safe_debug_tests() {
 
     let output = Command::new(env!("CARGO"))
         .arg("test")
-        .arg("--locked")
         .arg("--no-fail-fast")
         .arg("--test")
         .arg("safe-debug")


### PR DESCRIPTION
Probably don't need it, and it fails the build when we try to automatically upgrade versions after a release.
