### PR TITLE
[Storage] Prepare `azure_storage_blob` for `v0.2.0` release

### DIFF
--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 0.2.0 (2025-06-09)
+## 0.2.0 (2025-06-10)
 
 ### Features Added
 

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -1,14 +1,21 @@
 # Release History
 
-## 0.2.0 (Unreleased)
+## 0.2.0 (2025-06-09)
 
 ### Features Added
 
+* Added navigation methods to access sub-clients from existing clients.
+* Added a new blob client type, `BlockBlobClient`.
+* Added support for `list_blobs`, `set_metadata` to `ContainerClient`.
+* Added support for `set_metadata`, `set_properties`, and `set_tier` to `BlobClient`.
+
 ### Breaking Changes
+
+* Moved `commit_block_list`, `get_block_list`, and `stage_block` from `BlobClient` to `BlockBlobClient`.
 
 ### Bugs Fixed
 
-### Other Changes
+* Fixed an issue where blob type would be present in RequestURI for certain APIs extraneously.
 
 ## 0.1.0 (2025-04-08)
 

--- a/sdk/storage/azure_storage_blob/CHANGELOG.md
+++ b/sdk/storage/azure_storage_blob/CHANGELOG.md
@@ -4,8 +4,12 @@
 
 ### Features Added
 
-* Added navigation methods to access sub-clients from existing clients.
 * Added a new blob client type, `BlockBlobClient`.
+* Added navigation methods to access sub-clients from existing clients:
+  * `BlobServiceClient::blob_container_client()`
+  * `BlobContainerClient::blob_client()`
+  * `BlobClient::block_blob_client()`
+
 * Added support for `list_blobs`, `set_metadata` to `ContainerClient`.
 * Added support for `set_metadata`, `set_properties`, and `set_tier` to `BlobClient`.
 
@@ -15,7 +19,7 @@
 
 ### Bugs Fixed
 
-* Fixed an issue where blob type would be present in RequestURI for certain APIs extraneously.
+* Fixed an issue where the blob type string would appear as a query parameter in the request URL for certain APIs extraneously.
 
 ## 0.1.0 (2025-04-08)
 


### PR DESCRIPTION
This PR prepares `azure_storage_blob` crate for a follow-up release, and adds the changelog entries for the changes found between versions.