### PR TITLE
[Storage] `list_containers` for BlobServiceClient

### DIFF
--- a/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     generated::clients::BlobServiceClient as GeneratedBlobServiceClient,
-    models::{BlobServiceClientGetPropertiesOptions, StorageServiceProperties},
+    models::{
+        BlobServiceClientGetPropertiesOptions, BlobServiceClientListContainersSegmentOptions,
+        ListContainersSegmentResponse, StorageServiceProperties,
+    },
     pipeline::StorageHeadersPolicy,
     BlobContainerClient, BlobServiceClientOptions,
 };
@@ -11,7 +14,7 @@ use azure_core::{
     credentials::TokenCredential,
     http::{
         policies::{BearerTokenCredentialPolicy, Policy},
-        Response, Url, XmlFormat,
+        PageIterator, Response, Url, XmlFormat,
     },
     Result,
 };
@@ -88,5 +91,17 @@ impl BlobServiceClient {
         options: Option<BlobServiceClientGetPropertiesOptions<'_>>,
     ) -> Result<Response<StorageServiceProperties, XmlFormat>> {
         self.client.get_properties(options).await
+    }
+
+    /// Returns a list of the containers under the specified Storage account.
+    ///
+    /// # Arguments
+    ///
+    /// * `options` - Optional configuration for the request.
+    pub fn list_containers(
+        &self,
+        options: Option<BlobServiceClientListContainersSegmentOptions<'_>>,
+    ) -> Result<PageIterator<Response<ListContainersSegmentResponse, XmlFormat>>> {
+        self.client.list_containers_segment(options)
     }
 }

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -23,12 +23,13 @@ pub mod models {
         BlobContainerClientGetPropertiesOptions, BlobContainerClientGetPropertiesResult,
         BlobContainerClientGetPropertiesResultHeaders,
         BlobContainerClientListBlobFlatSegmentOptions, BlobContainerClientSetMetadataOptions,
-        BlobImmutabilityPolicyMode, BlobServiceClientGetPropertiesOptions, BlobType,
+        BlobImmutabilityPolicyMode, BlobServiceClientGetPropertiesOptions,
+        BlobServiceClientListContainersSegmentOptions, BlobType,
         BlockBlobClientCommitBlockListOptions, BlockBlobClientCommitBlockListResult,
         BlockBlobClientGetBlockListOptions, BlockBlobClientStageBlockOptions,
         BlockBlobClientStageBlockResult, BlockBlobClientUploadOptions, BlockBlobClientUploadResult,
         BlockList, BlockListType, BlockLookupList, CopyStatus, LeaseState, LeaseStatus,
-        ListBlobsFlatSegmentResponse, PublicAccessType, RehydratePriority,
-        StorageServiceProperties,
+        ListBlobsFlatSegmentResponse, ListContainersSegmentResponse, PublicAccessType,
+        RehydratePriority, StorageServiceProperties,
     };
 }

--- a/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/tests/blob_service_client.rs
@@ -4,6 +4,7 @@
 use azure_core_test::{recorded, TestContext};
 use azure_storage_blob::models::BlobServiceClientGetPropertiesOptions;
 use azure_storage_blob_test::get_blob_service_client;
+use futures::StreamExt;
 use std::error::Error;
 
 #[recorded::test]
@@ -20,5 +21,71 @@ async fn test_get_service_properties(ctx: TestContext) -> Result<(), Box<dyn Err
     let storage_service_properties = response.into_body().await?;
     let hour_metrics = storage_service_properties.hour_metrics;
     assert!(hour_metrics.is_some());
+    Ok(())
+}
+
+// #[recorded::test]
+// async fn test_list_containers(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+//     // Recording Setup
+//     let recording = ctx.recording();
+//     let service_client = get_blob_service_client(recording)?;
+//     let container_names = [
+//         "testcontainer1".to_string(),
+//         "testcontainer2".to_string(),
+//         "testcontainer3".to_string(),
+//         "testcontainer4".to_string(),
+//     ];
+//     let mut container_clients = Vec::new();
+//     for container_name in container_names.clone() {
+//         let container_client = service_client.blob_container_client(container_name);
+//         container_client.create_container(None).await?;
+//         container_clients.push(container_client);
+//     }
+
+//     // Assert
+//     let mut pager_response = service_client.list_containers(None)?;
+//     while let Some(page) = pager_response.next().await {
+//         let current_page = page.unwrap().into_body().await?;
+//         let container_list = current_page.container_items;
+//         for container in container_list {
+//             let container_name = container.name.unwrap();
+//             assert!(container_names.contains(&container_name));
+//         }
+//     }
+
+//     for container_client in container_clients {
+//         container_client.delete_container(None).await?;
+//     }
+
+//     Ok(())
+// }
+
+#[recorded::test]
+async fn test_list_containers_singleton(ctx: TestContext) -> Result<(), Box<dyn Error>> {
+    // Recording Setup
+    let recording = ctx.recording();
+    let service_client = get_blob_service_client(recording)?;
+    let container_client = service_client.blob_container_client("testcontainer".to_string());
+    container_client.create_container(None).await?;
+
+    // Assert
+    let mut pager_response = service_client.list_containers(None)?;
+    while let Some(page) = pager_response.next().await {
+        let current_page = page.unwrap().into_body().await?;
+        let container_list = current_page.container_items;
+        for container in container_list {
+            println!("Is Deleted Option Some: {}", container.delete.is_some());
+            println!("Is Metadata Option Some: {}", container.metadata.is_some());
+            println!("Is Name Option Some: {}", container.name.is_some());
+            println!(
+                "Is Properties Option Some: {}",
+                container.properties.is_some()
+            );
+            println!("Is Version Option Some: {}", container.version.is_some());
+        }
+    }
+
+    container_client.delete_container(None).await?;
+
     Ok(())
 }


### PR DESCRIPTION
WIP

Current sysout:
>Is Deleted Option Some: false
Is Metadata Option Some: false
Is Name Option Some: false
Is Properties Option Some: false
Is Version Option Some: false

Issue seems to be related to deserializing into `ContainerItem` as the fields do exist on the response, but don't seem to be properly set on the item.

Sample Response
```xml
HTTP/1.1 200 OK
Content-Type: application/xml
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
x-ms-request-id: 1267e11b-601e-001b-0940-dac970000000
x-ms-client-request-id: 0e8c8184-9e79-43a2-855b-04ae13ffc650
x-ms-version: 2025-01-05
Date: Tue, 10 Jun 2025 19:46:07 GMT
Content-Length: 115153


<?xml version="1.0" encoding="utf-8"?>
<EnumerationResults ServiceEndpoint="https://ruststoragedev.blob.core.windows.net/">
	<Containers>
		<Container>
			<Name>container0oqovzx8</Name>
			<Properties>
				<Last-Modified>Fri, 02 May 2025 22:01:10 GMT</Last-Modified>
				<Etag>"0x8DD89C4D92560B5"</Etag>
				<LeaseStatus>unlocked</LeaseStatus>
				<LeaseState>available</LeaseState>
				<DefaultEncryptionScope>$account-encryption-key</DefaultEncryptionScope>
				<DenyEncryptionScopeOverride>false</DenyEncryptionScopeOverride>
				<HasImmutabilityPolicy>false</HasImmutabilityPolicy>
				<HasLegalHold>false</HasLegalHold>
				<ImmutableStorageWithVersioningEnabled>false</ImmutableStorageWithVersioningEnabled>
			</Properties>
		</Container>
```