### PR TITLE
add Into conversions from Etag to String and HeaderValue

### DIFF
--- a/sdk/typespec/typespec_client_core/src/http/models/etag.rs
+++ b/sdk/typespec/typespec_client_core/src/http/models/etag.rs
@@ -4,16 +4,22 @@
 use serde::{Deserialize, Serialize};
 use std::{fmt, str::FromStr};
 
+use crate::http::headers::HeaderValue;
+
 /// Represents an ETag for versioned resources.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Etag(String);
 
-impl<T> From<T> for Etag
-where
-    T: Into<String>,
-{
-    fn from(t: T) -> Self {
-        Self(t.into())
+// Implementation for common string types
+impl From<&str> for Etag {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for Etag {
+    fn from(s: String) -> Self {
+        Self(s)
     }
 }
 
@@ -33,5 +39,61 @@ impl FromStr for Etag {
 impl fmt::Display for Etag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl From<Etag> for String {
+    fn from(etag: Etag) -> Self {
+        etag.0
+    }
+}
+
+impl From<Etag> for HeaderValue {
+    fn from(etag: Etag) -> Self {
+        HeaderValue::from(String::from(etag))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http::headers::HeaderValue;
+
+    #[test]
+    fn from_string() {
+        let etag = Etag::from("test-etag");
+        assert_eq!("test-etag", etag.0);
+    }
+
+    #[test]
+    fn from_str() {
+        let etag = "test-etag".parse::<Etag>().unwrap();
+        assert_eq!("test-etag", etag.0);
+    }
+
+    #[test]
+    fn as_ref() {
+        let etag = Etag::from("test-etag");
+        assert_eq!("test-etag", etag.as_ref());
+    }
+
+    #[test]
+    fn display() {
+        let etag = Etag::from("test-etag");
+        assert_eq!("test-etag", etag.to_string());
+    }
+
+    #[test]
+    fn to_string() {
+        let etag = Etag::from("test-etag");
+        let s: String = etag.into();
+        assert_eq!("test-etag", s);
+    }
+
+    #[test]
+    fn to_header_value() {
+        let etag = Etag::from("test-etag");
+        let header_value: HeaderValue = etag.into();
+        assert_eq!("test-etag", header_value.as_str());
     }
 }


### PR DESCRIPTION
While starting to look at implementing some etag-related headers in Cosmos, I noticed that it's a little clunky to get an `Etag` (from `typespec_client_core`) into a `HeaderValue`. We only expose the etag as a `&str`, but `HeaderValue`s require owned string. This means we'll have to clone the underlying string in order to use it. Since, in our case at least, we only need the Etag once, I added some `Into` conversions that consume the `Etag` and return the underlying string. While I was there, I added a similar conversion to `HeaderValue`, allowing an `Etag` to be passed straight in to `Request::insert_header`.

To do that I had to remove the `impl From<T: Into<String>> for Etag` implementation because it's too generic. I replaced it with `From<&str>` and `From<String>` which should cover most cases. A user can always call `Etag::from(s.into())` if they have an `s` that is `Into<String>` but isn't `&str` or `String`.