### PR TITLE
Convert to consuming unified pool

### DIFF
--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -2,18 +2,18 @@
 
 variables:
   - name: LINUXPOOL
-    value: azsdk-pool-mms-ubuntu-2004-general
+    value: azsdk-pool
   - name: WINDOWSPOOL
-    value: azsdk-pool-mms-win-2022-general
+    value: azsdk-pool
   - name: MACPOOL
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: azsdk-pool-mms-ubuntu-2004-1espt
-  - name: LINUXNEXTVMIMAGE
     value: ubuntu-22.04
+  - name: LINUXNEXTVMIMAGE
+    value: ubuntu-24.04
   - name: WINDOWSVMIMAGE
-    value: azsdk-pool-mms-win-2022-1espt
+    value: windows-2022
   - name: MACVMIMAGE
     value: macos-latest
 


### PR DESCRIPTION
This `azsdk-pool` can share allocation of agents for multiple different OS. FYI @hallipr 