### PR TITLE
Update UserAgentPolicy to better align with guidelines

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Features Added
 
 - Added `get_async_runtime()` and `set_async_runtime()` to allow customers to replace the asynchronous runtime used by the Azure SDK.
-- Added `UserAgentOptions::enabled` to allow disabling sending the `User-Agent` header.
 
 ### Breaking Changes
 

--- a/sdk/core/azure_core/examples/core_remove_user_agent.rs
+++ b/sdk/core/azure_core/examples/core_remove_user_agent.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use async_trait::async_trait;
+use azure_core::{
+    credentials::TokenCredential,
+    http::{
+        headers::Headers,
+        policies::{Policy, PolicyResult},
+        Context, HttpClient, Method, RawResponse, Request, StatusCode, TransportOptions,
+    },
+};
+use azure_core_test::{credentials::MockCredential, http::MockHttpClient};
+use azure_security_keyvault_secrets::{SecretClient, SecretClientOptions};
+use futures::FutureExt;
+use std::sync::Arc;
+
+// Define a policy that will remove the User-Agent header.
+#[derive(Debug)]
+struct RemoveUserAgent;
+
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl Policy for RemoveUserAgent {
+    async fn send(
+        &self,
+        ctx: &Context,
+        request: &mut Request,
+        next: &[Arc<dyn Policy>],
+    ) -> PolicyResult {
+        let headers = request.headers_mut();
+
+        // Note: HTTP headers are case-insensitive but client-added headers are normalized to lowercase.
+        headers.remove("user-agent");
+
+        next[0].send(ctx, request, &next[1..]).await
+    }
+}
+
+async fn test_remove_user_agent() -> Result<(), Box<dyn std::error::Error>> {
+    // Policies are created in an Arc to be generally shared.
+    let remove_user_agent = Arc::new(RemoveUserAgent);
+
+    // Construct client options with your policy that runs after the built-in per-call UserAgentPolicy.
+    let mut options = SecretClientOptions::default();
+    options
+        .client_options
+        .per_call_policies
+        .push(remove_user_agent);
+
+    // Ignore: this is only set up for testing.
+    // You normally would create credentials from `azure_identity` and
+    // use the default transport in production.
+    let (credential, transport) = setup()?;
+    options.client_options.transport = Some(TransportOptions::new(transport));
+
+    // Construct the client with these options and a shared credential.
+    let client = SecretClient::new(
+        "https://my-vault.vault.azure.net",
+        credential.clone(),
+        Some(options),
+    )?;
+
+    // We'll fetch a secret and let the mock client assert the User-Agent header was removed.
+    let secret = client
+        .get_secret("my-secret", "", None)
+        .await?
+        .into_body()
+        .await?;
+    assert_eq!(secret.value.as_deref(), Some("secret-value"));
+
+    Ok(())
+}
+
+// ----- BEGIN TEST SETUP -----
+#[tokio::test]
+async fn test_core_remove_user_agent() -> Result<(), Box<dyn std::error::Error>> {
+    test_remove_user_agent().await
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    test_remove_user_agent().await
+}
+
+#[allow(clippy::type_complexity)]
+fn setup() -> Result<(Arc<dyn TokenCredential>, Arc<dyn HttpClient>), Box<dyn std::error::Error>> {
+    let client = MockHttpClient::new(|request| {
+        async move {
+            assert!(request.url().path().starts_with("/secrets/my-secret"));
+            assert_eq!(*request.method(), Method::Get);
+            assert!(
+                !request
+                    .headers()
+                    .iter()
+                    .any(|(name, _)| name.as_str().eq_ignore_ascii_case("user-agent")),
+                "user-agent header should be absent"
+            );
+            Ok(RawResponse::from_bytes(
+                StatusCode::Ok,
+                Headers::new(),
+                r#"{"value":"secret-value"}"#,
+            ))
+        }
+        .boxed()
+    });
+
+    Ok((MockCredential::new()?, Arc::new(client)))
+}
+// ----- END TEST SETUP -----

--- a/sdk/core/azure_core/src/http/options/user_agent.rs
+++ b/sdk/core/azure_core/src/http/options/user_agent.rs
@@ -5,8 +5,10 @@
 #[derive(Clone, Debug, Default)]
 pub struct UserAgentOptions {
     /// Set the application ID in the `User-Agent` header that can be telemetered.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`UserAgentOptions::application_id`] is greater than 24 characters.
+    /// See [guidelines](https://azure.github.io/azure-sdk/general_azurecore.html#azurecore-http-telemetry-appid-length) for details.
     pub application_id: Option<String>,
-
-    /// Disable to prevent sending the `User-Agent` header in requests.
-    pub disabled: bool,
 }

--- a/sdk/core/azure_core/src/http/policies/user_agent.rs
+++ b/sdk/core/azure_core/src/http/policies/user_agent.rs
@@ -10,13 +10,19 @@ use std::sync::Arc;
 use typespec_client_core::http::policies::{Policy, PolicyResult};
 use typespec_client_core::http::{Context, Request};
 
-/// Sets the User-Agent header with useful information in a typical format for Azure SDKs.
+/// Sets the `User-Agent` header with useful information in a typical format for Azure SDKs.
 #[derive(Clone, Debug)]
 pub struct UserAgentPolicy {
     header: String,
 }
 
 impl<'a> UserAgentPolicy {
+    /// Create a new `UserAgentPolicy`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`UserAgentOptions::application_id`] is greater than 24 characters.
+    /// See [guidelines](https://azure.github.io/azure-sdk/general_azurecore.html#azurecore-http-telemetry-appid-length) for details.
     pub fn new(
         crate_name: Option<&'a str>,
         crate_version: Option<&'a str>,
@@ -46,8 +52,15 @@ impl<'a> UserAgentPolicy {
             crate_name = name;
         }
 
+        const MAX_APPLICATION_ID_LEN: usize = 24;
         let header = match &options.application_id {
             Some(application_id) => {
+                if application_id.len() > MAX_APPLICATION_ID_LEN {
+                    panic!(
+                        "application_id must be shorter than {} characters",
+                        MAX_APPLICATION_ID_LEN + 1
+                    );
+                }
                 format!("{application_id} azsdk-rust-{crate_name}/{crate_version} {platform_info}")
             }
             None => format!("azsdk-rust-{crate_name}/{crate_version} {platform_info}"),
@@ -94,7 +107,6 @@ mod tests {
     fn with_application_id() {
         let options = UserAgentOptions {
             application_id: Some("my_app".to_string()),
-            ..Default::default()
         };
         let policy = UserAgentPolicy::new_with_rustc_version(
             Some("test"),
@@ -116,6 +128,39 @@ mod tests {
         assert_eq!(
             policy.header,
             format!("azsdk-rust-unknown/unknown (unknown; {OS}; {ARCH})")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "application_id must be shorter than 25 characters")]
+    fn panics_when_application_id_too_long() {
+        let options = UserAgentOptions {
+            application_id: Some(
+                "this_application_id_is_way_too_long_and_exceeds_limit".to_string(),
+            ), // 53 characters
+        };
+        let _policy = UserAgentPolicy::new_with_rustc_version(
+            Some("test"),
+            Some("1.2.3"),
+            Some("4.5.6"),
+            &options,
+        );
+    }
+
+    #[test]
+    fn works_with_application_id_at_limit() {
+        let options = UserAgentOptions {
+            application_id: Some("exactly_24_characters!".to_string()), // Exactly 24 characters
+        };
+        let policy = UserAgentPolicy::new_with_rustc_version(
+            Some("test"),
+            Some("1.2.3"),
+            Some("4.5.6"),
+            &options,
+        );
+        assert_eq!(
+            policy.header,
+            format!("exactly_24_characters! azsdk-rust-test/1.2.3 (4.5.6; {OS}; {ARCH})")
         );
     }
 }

--- a/sdk/core/azure_core_test/src/credentials.rs
+++ b/sdk/core/azure_core_test/src/credentials.rs
@@ -13,6 +13,13 @@ use std::{env, sync::Arc};
 #[derive(Clone, Debug, Default)]
 pub struct MockCredential;
 
+impl MockCredential {
+    /// Create a new `MockCredential`.
+    pub fn new() -> azure_core::Result<Arc<Self>> {
+        Ok(Arc::new(MockCredential {}))
+    }
+}
+
 #[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
 impl TokenCredential for MockCredential {

--- a/sdk/core/azure_core_test/src/lib.rs
+++ b/sdk/core/azure_core_test/src/lib.rs
@@ -8,6 +8,8 @@ pub mod http;
 pub mod proxy;
 pub mod recorded;
 mod recording;
+#[cfg(doctest)]
+mod root_readme;
 pub mod stream;
 
 use azure_core::Error;

--- a/sdk/core/azure_core_test/src/root_readme.rs
+++ b/sdk/core/azure_core_test/src/root_readme.rs
@@ -1,0 +1,3 @@
+#![doc = include_str!("../../../../README.md")]
+
+// Make sure the repository's root README.md has no syntactical errors.

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -120,14 +120,17 @@ impl Request {
         }
     }
 
+    /// Gets the request [`Url`].
     pub fn url(&self) -> &Url {
         &self.url
     }
 
+    /// Gets a mutable request [`Url`].
     pub fn url_mut(&mut self) -> &mut Url {
         &mut self.url
     }
 
+    /// Gets the request URL path and query string.
     pub fn path_and_query(&self) -> String {
         let mut result = self.url.path().to_owned();
         if let Some(query) = self.url.query() {
@@ -137,10 +140,12 @@ impl Request {
         result
     }
 
+    /// Gets the request HTTP method.
     pub fn method(&self) -> &Method {
         &self.method
     }
 
+    /// Inserts zero or more headers from a type that implements [`AsHeaders`].
     pub fn insert_headers<T: AsHeaders>(&mut self, headers: &T) -> Result<(), T::Error> {
         for (name, value) in headers.as_headers()? {
             self.insert_header(name, value);
@@ -148,14 +153,22 @@ impl Request {
         Ok(())
     }
 
+    /// Gets the request [`Headers`].
     pub fn headers(&self) -> &Headers {
         &self.headers
     }
 
+    /// Gets a mutable request [`Headers`].
+    pub fn headers_mut(&mut self) -> &mut Headers {
+        &mut self.headers
+    }
+
+    /// Gets the request body.
     pub fn body(&self) -> &Body {
         &self.body
     }
 
+    /// Sets request body JSON.
     pub fn set_json<T>(&mut self, data: &T) -> crate::Result<()>
     where
         T: ?Sized + Serialize,
@@ -164,10 +177,12 @@ impl Request {
         Ok(())
     }
 
+    /// Sets the request body.
     pub fn set_body(&mut self, body: impl Into<Body>) {
         self.body = body.into();
     }
 
+    /// Inserts a header from the `key` and `value`.
     pub fn insert_header<K, V>(&mut self, key: K, value: V)
     where
         K: Into<HeaderName>,
@@ -176,12 +191,14 @@ impl Request {
         self.headers.insert(key, value);
     }
 
+    /// Inserts a [`Header`] if `item` is `Some`.
     pub fn add_optional_header<T: Header>(&mut self, item: &Option<T>) {
         if let Some(item) = item {
             self.insert_header(item.name(), item.value());
         }
     }
 
+    /// Inserts a [`Header`].
     pub fn add_mandatory_header<T: Header>(&mut self, item: &T) {
         self.insert_header(item.name(), item.value());
     }


### PR DESCRIPTION
Adds documentation to our repo's root README - which is also now syntactically verified when testing `azure_core_test`, and removes the `UserAgentOptions::disabled` in favor of, like most languages, recommending a user policy to remove the `User-Agent` header.
