### PR TITLE
Support reconstituting pageables

### DIFF
--- a/eng/scripts/verify-dependencies.rs
+++ b/eng/scripts/verify-dependencies.rs
@@ -20,9 +20,9 @@ use std::{
 static EXEMPTIONS: &[(&str, &str)] = &[
     ("azure_core_test", "dotenvy"),
     ("azure_template", "serde"),
-    ("azure_core_tracing_opentelemetry", "opentelemetry"),
-    ("azure_core_tracing_opentelemetry", "opentelemetry_sdk"),
-    ("azure_core_tracing_opentelemetry", "tracing-opentelemetry"),
+    ("azure_core_opentelemetry", "opentelemetry"),
+    ("azure_core_opentelemetry", "opentelemetry_sdk"),
+    ("azure_core_opentelemetry", "tracing-opentelemetry"),
 ];
 
 fn main() {

--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Features Added
 
 - Added `get_async_runtime()` and `set_async_runtime()` to allow customers to replace the asynchronous runtime used by the Azure SDK.
-- Added `PageIterator::with_next_link()` to support reconstructing a `PageIterator` in another process or on another machine to continue paging.
+- Added `PageIterator::continuation_token()` and `PageIterator::with_continuation_token()` to support reconstructing a `PageIterator` in another process or on another machine to continue paging.
 
 ### Breaking Changes
 
@@ -13,6 +13,7 @@
 - Moved `process::Executor` to `azure_identity`.
 - Removed `Pipeline::replace_policy`.
 - Renamed `azure_core::date` to `azure_core::time` and added `azure_core::time::Duration` as the standard "duration" type for the SDK.
+- Renamed `PagerResult::More { next }` to `continuation`.
 - Renamed `TelemetryOptions` to `UserAgentOptions`.
 - Renamed `TelemetryPolicy` to `UserAgentPolicy`.
 

--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features Added
 
 - Added `get_async_runtime()` and `set_async_runtime()` to allow customers to replace the asynchronous runtime used by the Azure SDK.
+- Added `PageIterator::with_next_link()` to support reconstructing a `PageIterator` in another process or on another machine to continue paging.
 
 ### Breaking Changes
 

--- a/sdk/core/azure_core/src/http/pager.rs
+++ b/sdk/core/azure_core/src/http/pager.rs
@@ -4,12 +4,11 @@
 use crate::http::{headers::HeaderName, response::Response};
 use async_trait::async_trait;
 use futures::{stream::unfold, FutureExt, Stream};
-#[cfg(not(target_arch = "wasm32"))]
-use std::str::FromStr;
 use std::{
     fmt,
     future::Future,
     pin::Pin,
+    str::FromStr,
     sync::{Arc, Mutex},
     task,
 };

--- a/sdk/cosmos/azure_data_cosmos/src/feed.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/feed.rs
@@ -70,7 +70,7 @@ impl<T> From<FeedPage<T>> for PagerResult<FeedPage<T>, String> {
         match continuation {
             Some(continuation) => PagerResult::More {
                 response: value,
-                next: continuation,
+                continuation,
             },
             None => PagerResult::Done { response: value },
         }

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
@@ -515,7 +515,7 @@ impl CertificateClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })
@@ -581,7 +581,7 @@ impl CertificateClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })
@@ -649,7 +649,7 @@ impl CertificateClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })
@@ -711,7 +711,7 @@ impl CertificateClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -494,7 +494,7 @@ impl KeyClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })
@@ -557,7 +557,7 @@ impl KeyClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })
@@ -622,7 +622,7 @@ impl KeyClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
@@ -252,7 +252,7 @@ impl SecretClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })
@@ -315,7 +315,7 @@ impl SecretClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })
@@ -381,7 +381,7 @@ impl SecretClient {
                 Ok(match res.next_link {
                     Some(next_link) if !next_link.is_empty() => PagerResult::More {
                         response: rsp,
-                        next: next_link.parse()?,
+                        continuation: next_link.parse()?,
                     },
                     _ => PagerResult::Done { response: rsp },
                 })

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -554,7 +554,7 @@ impl BlobContainerClient {
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
-                            next: next_marker,
+                            continuation: next_marker,
                         },
                         _ => PagerResult::Done { response: rsp },
                     })
@@ -648,7 +648,7 @@ impl BlobContainerClient {
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
-                            next: next_marker,
+                            continuation: next_marker,
                         },
                         _ => PagerResult::Done { response: rsp },
                     })

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -340,7 +340,7 @@ impl BlobServiceClient {
                     Ok(match res.next_marker {
                         Some(next_marker) if !next_marker.is_empty() => PagerResult::More {
                             response: rsp,
-                            next: next_marker,
+                            continuation: next_marker,
                         },
                         _ => PagerResult::Done { response: rsp },
                     })


### PR DESCRIPTION
Adds PageIterator::with_next_link to support general guidelines: https://azure.github.io/azure-sdk/general_design.html#general-pagination-expose-paging-apis
