### PR TITLE
add FeedRange APIs

### DIFF
--- a/sdk/cosmos/assets.json
+++ b/sdk/cosmos/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_data_cosmos_a39b424a5b",
+  "Tag": "rust/azure_data_cosmos_8671767119",
   "TagPrefix": "rust/azure_data_cosmos"
 }

--- a/sdk/cosmos/azure_data_cosmos/src/models/feed_range.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/feed_range.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use serde::{Deserialize, Serialize};
+
+/// Represents a feed range for a container.
+///
+/// A feed range represents a contiguous range of partition key values that can be used
+/// to scope queries or change feed operations to a specific subset of data.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct FeedRange {
+    /// The minimum partition key value (inclusive) for this feed range.
+    pub min_inclusive: String,
+    /// The maximum partition key value (exclusive) for this feed range.
+    pub max_exclusive: String,
+}
+
+/// Represents a partition key range with its ID and feed range information.
+///
+/// This is used internally to represent the full partition key range information
+/// returned by the Cosmos DB service.
+///
+/// Partition Key Ranges are only used by the query engine as part of executing queries.
+/// Applications should use [`FeedRange`](crate::models::FeedRange) when specifying ranges for queries or change feed operations.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PartitionKeyRange {
+    /// The ID of the partition key range.
+    pub id: String,
+    /// The feed range information for this partition key range.
+    #[serde(flatten)]
+    pub range: FeedRange,
+}

--- a/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/models/mod.rs
@@ -7,12 +7,14 @@ use azure_core::{http::Etag, time::OffsetDateTime};
 use serde::{Deserialize, Deserializer, Serialize};
 
 mod container_properties;
+mod feed_range;
 mod indexing_policy;
 mod partition_key_definition;
 mod patch_operations;
 mod throughput_properties;
 
 pub use container_properties::*;
+pub use feed_range::*;
 pub use indexing_policy::*;
 pub use partition_key_definition::*;
 pub use patch_operations::*;

--- a/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/options/mod.rs
@@ -111,3 +111,9 @@ pub struct ReadDatabaseOptions<'a> {
 pub struct ThroughputOptions<'a> {
     pub method_options: ClientMethodOptions<'a>,
 }
+
+/// Options to be passed to [`ContainerClient::get_feed_ranges()`](crate::clients::ContainerClient::get_feed_ranges()).
+#[derive(Clone, Default)]
+pub struct FeedRangeOptions<'a> {
+    pub method_options: ClientMethodOptions<'a>,
+}

--- a/sdk/cosmos/azure_data_cosmos/src/query/engine.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/engine.rs
@@ -1,3 +1,5 @@
+use crate::models::PartitionKeyRange;
+
 /// Represents a request from the query pipeline for data from a specific partition key range.
 pub struct QueryRequest {
     /// The ID of the partition key range to query.
@@ -53,7 +55,7 @@ pub trait QueryEngine {
     /// ## Arguments
     /// * `query` - The query to be executed.
     /// * `plan` - The JSON-encoded query plan describing the query (usually provided by the gateway).
-    /// * `pkranges` - The JSON-encoded partition key ranges to be queried (usually provided by the gateway).
+    /// * `pkranges` - A slice of [`PartitionKeyRange`]s that the query should be executed against.
     ///
     /// ## Shared Access
     ///
@@ -65,7 +67,7 @@ pub trait QueryEngine {
         &self,
         query: &str,
         plan: &[u8],
-        pkranges: &[u8],
+        pkranges: &[PartitionKeyRange],
     ) -> azure_core::Result<OwnedQueryPipeline>;
 
     /// Gets a comma-separates list of features supported by this query engine, suitable for use in the `x-ms-cosmos-supported-query-features` header when requesting a query plan.


### PR DESCRIPTION
We recently had a contribution to the Go SDK to add this API, and I realized it would be useful to have it here in the Rust SDK now for integration with the query engine. So, this PR introduces a new API: `ContainerClient::get_feed_ranges` which returns a `Vec<FeedRange>` which describes the _current_ physical partition layout. Like in other SDKs, `FeedRange`s map on to Partition Key Range IDs, but we don't expose the actual range IDs to the user, so that when a user _specifies_ FeedRanges somewhere, we can adapt the ranges to the current partition topology (adjusting based on merges/splits, etc.).

Internally, we also have a `ContainerClient::get_partition_key_ranges` which uses the `/pkranges` REST API to fetch the full Partition Key Range metadata. This is used in the query engine, which already has to be updated with merge/split awareness and needs the exact PKRangeID for issuing queries. This API isn't part of the public surface area.

The _model_ type returned by `get_partition_key_ranges` is `PartitionKeyRange` and that struct **is** part of the public surface area. It has to be in order to put it on the `QueryEngine` abstraction. But there's no way, using our public APIs, for a user to get the **actual** PK Range IDs from the REST API, nor do any of our APIs accept `PartitionKeyRange` objects. With a little bit of `#[cfg]` fiddling, I may actually be able to make it so these APIs are only public in the `preview_query_engine` feature, which is the only place we actually need them to be exported outside the crate.

This PR also adjusts the `QueryEngine` API to take the Partition Key Ranges as objects, since now the Rust SDK itself has the model and APIs to deserialize them. Before, it was passing the PKRanges as raw JSON and the query engine did the deserializing. This just removes some code duplication. I'll update the query engine to fix this shortly.