### PR TITLE
Make native-tls dependency optional for azure_messaging_eventhubs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ cargo_metadata = "0.18.1"
 clap = { version = "4.4.16", features = ["derive"] }
 criterion = { version = "0.5", features = ["async_tokio"] }
 dyn-clone = "1.0"
-fe2o3-amqp = { version = "0.14", features = ["native-tls", "tracing", "uuid"] }
+fe2o3-amqp = { version = "0.14", features = ["tracing", "uuid"] }
 fe2o3-amqp-ext = { version = "0.14" }
 fe2o3-amqp-management = { version = "0.14", features = ["tracing"] }
 fe2o3-amqp-cbs = { version = "0.14" }

--- a/sdk/core/azure_core_amqp/Cargo.toml
+++ b/sdk/core/azure_core_amqp/Cargo.toml
@@ -49,6 +49,8 @@ fe2o3_amqp = [
   "serde_amqp",
   "serde_bytes",
 ]
+native_tls = ["fe2o3-amqp?/native-tls"]
+rustls = ["fe2o3-amqp?/rustls"]
 
 [lints]
 workspace = true

--- a/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
+++ b/sdk/eventhubs/azure_messaging_eventhubs/Cargo.toml
@@ -43,8 +43,11 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 
 [features]
+default = ["native_tls"]
 test = []
 blob_checkpoint_store = []
+native_tls = ["azure_core_amqp/native_tls"]
+rustls = ["azure_core_amqp/rustls"]
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
resolves #2796 