### PR TITLE
Request.method() returns a copy of the method, not a reference

### DIFF
--- a/sdk/core/azure_core/examples/core_remove_user_agent.rs
+++ b/sdk/core/azure_core/examples/core_remove_user_agent.rs
@@ -88,7 +88,7 @@ fn setup() -> Result<(Arc<dyn TokenCredential>, Arc<dyn HttpClient>), Box<dyn st
     let client = MockHttpClient::new(|request| {
         async move {
             assert!(request.url().path().starts_with("/secrets/my-secret"));
-            assert_eq!(*request.method(), Method::Get);
+            assert_eq!(request.method(), Method::Get);
             assert!(
                 !request
                     .headers()

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/authorization_policy.rs
@@ -83,7 +83,7 @@ impl Policy for AuthorizationPolicy {
         let auth = generate_authorization(
             &self.credential,
             request.url(),
-            SignatureTarget::new(*request.method(), resource_link, &date_string),
+            SignatureTarget::new(request.method(), resource_link, &date_string),
         )
         .await?;
 

--- a/sdk/identity/azure_identity/src/client_assertion_credential.rs
+++ b/sdk/identity/azure_identity/src/client_assertion_credential.rs
@@ -185,7 +185,7 @@ pub(crate) mod tests {
             FAKE_TENANT_ID
         );
         move |req: &Request| {
-            assert_eq!(&Method::Post, req.method());
+            assert_eq!(Method::Post, req.method());
             assert_eq!(expected_url, req.url().to_string());
             assert_eq!(
                 content_type::APPLICATION_X_WWW_FORM_URLENCODED.as_str(),

--- a/sdk/identity/azure_identity/src/client_secret_credential.rs
+++ b/sdk/identity/azure_identity/src/client_secret_credential.rs
@@ -147,7 +147,7 @@ mod tests {
     fn is_valid_request(authority_host: &str, tenant_id: &str) -> impl Fn(&Request) -> Result<()> {
         let expected_url = format!("{}{}/oauth2/v2.0/token", authority_host, tenant_id);
         move |req: &Request| {
-            assert_eq!(&Method::Post, req.method());
+            assert_eq!(Method::Post, req.method());
             assert_eq!(expected_url, req.url().to_string());
             assert_eq!(
                 req.headers().get_str(&headers::CONTENT_TYPE).unwrap(),

--- a/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
+++ b/sdk/typespec/typespec_client_core/src/http/clients/reqwest.rs
@@ -42,7 +42,7 @@ impl HttpClient for ::reqwest::Client {
     async fn execute_request(&self, request: &Request) -> Result<RawResponse> {
         let url = request.url().clone();
         let method = request.method();
-        let mut req = self.request(from_method(*method), url.clone());
+        let mut req = self.request(from_method(method), url.clone());
         for (name, value) in request.headers().iter() {
             req = req.header(name.as_str(), value.as_str());
         }

--- a/sdk/typespec/typespec_client_core/src/http/policies/transport.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/transport.rs
@@ -36,10 +36,7 @@ impl Policy for TransportPolicy {
         assert_eq!(0, next.len());
 
         if request.body().is_empty()
-            && matches!(
-                *request.method(),
-                Method::Patch | Method::Post | Method::Put
-            )
+            && matches!(request.method(), Method::Patch | Method::Post | Method::Put)
         {
             request.add_mandatory_header(EMPTY_CONTENT_LENGTH);
         }

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -151,8 +151,8 @@ impl Request {
     }
 
     /// Gets the request HTTP method.
-    pub fn method(&self) -> &Method {
-        &self.method
+    pub fn method(&self) -> Method {
+        self.method
     }
 
     /// Sets the request HTTP method.


### PR DESCRIPTION
@analogrelay noticed that the `http::Request.method()` function returned a reference to the `Method` rather than a copy of the `Method`.

Since `Method` implements `Copy` and is a simple scalar, it is more efficient to simply return a copy of the value rather than returning a reference to the field within the `Request`.

@heaths Tagging you explicitly so this is in your inbox when you return.
