### PR TITLE
[Storage] Remove duplicate auth policy in handwritten layer

### DIFF
--- a/sdk/storage/azure_storage_blob/src/clients/append_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/append_blob_client.rs
@@ -53,15 +53,6 @@ impl AppendBlobClient {
             .per_call_policies
             .push(storage_headers_policy);
 
-        let oauth_token_policy = BearerTokenCredentialPolicy::new(
-            credential.clone(),
-            ["https://storage.azure.com/.default"],
-        );
-        options
-            .client_options
-            .per_try_policies
-            .push(Arc::new(oauth_token_policy) as Arc<dyn Policy>);
-
         let client = GeneratedAppendBlobClient::new(
             endpoint,
             credential.clone(),

--- a/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_client.rs
@@ -61,15 +61,6 @@ impl BlobClient {
             .per_call_policies
             .push(storage_headers_policy);
 
-        let oauth_token_policy = BearerTokenCredentialPolicy::new(
-            credential.clone(),
-            ["https://storage.azure.com/.default"],
-        );
-        options
-            .client_options
-            .per_try_policies
-            .push(Arc::new(oauth_token_policy) as Arc<dyn Policy>);
-
         let client = GeneratedBlobClient::new(
             endpoint,
             credential.clone(),

--- a/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_container_client.rs
@@ -58,15 +58,6 @@ impl BlobContainerClient {
             .per_call_policies
             .push(storage_headers_policy);
 
-        let oauth_token_policy = BearerTokenCredentialPolicy::new(
-            credential.clone(),
-            ["https://storage.azure.com/.default"],
-        );
-        options
-            .client_options
-            .per_try_policies
-            .push(Arc::new(oauth_token_policy) as Arc<dyn Policy>);
-
         let client = GeneratedBlobContainerClient::new(
             endpoint,
             credential.clone(),

--- a/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/blob_service_client.rs
@@ -47,15 +47,6 @@ impl BlobServiceClient {
             .per_call_policies
             .push(storage_headers_policy);
 
-        let oauth_token_policy = BearerTokenCredentialPolicy::new(
-            credential.clone(),
-            ["https://storage.azure.com/.default"],
-        );
-        options
-            .client_options
-            .per_try_policies
-            .push(Arc::new(oauth_token_policy) as Arc<dyn Policy>);
-
         let client = GeneratedBlobServiceClient::new(endpoint, credential.clone(), Some(options))?;
 
         Ok(Self {

--- a/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/block_blob_client.rs
@@ -59,15 +59,6 @@ impl BlockBlobClient {
             .per_call_policies
             .push(storage_headers_policy);
 
-        let oauth_token_policy = BearerTokenCredentialPolicy::new(
-            credential.clone(),
-            ["https://storage.azure.com/.default"],
-        );
-        options
-            .client_options
-            .per_try_policies
-            .push(Arc::new(oauth_token_policy) as Arc<dyn Policy>);
-
         let client = GeneratedBlockBlobClient::new(
             endpoint,
             credential.clone(),

--- a/sdk/storage/azure_storage_blob/src/clients/page_blob_client.rs
+++ b/sdk/storage/azure_storage_blob/src/clients/page_blob_client.rs
@@ -53,15 +53,6 @@ impl PageBlobClient {
             .per_call_policies
             .push(storage_headers_policy);
 
-        let oauth_token_policy = BearerTokenCredentialPolicy::new(
-            credential.clone(),
-            ["https://storage.azure.com/.default"],
-        );
-        options
-            .client_options
-            .per_try_policies
-            .push(Arc::new(oauth_token_policy) as Arc<dyn Policy>);
-
         let client = GeneratedPageBlobClient::new(
             endpoint,
             credential.clone(),


### PR DESCRIPTION
As title states, previous versions did not have the auth policy spun up in generated code, but now that it is spun up on the generated client, we no longer need to pass this in from the handwritten convenience layer.