### PR TITLE
Enable json submodule if json feature is used

### DIFF
--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -333,6 +333,9 @@ impl<T> TryFrom<Option<Decimal>> for RequestContent<T> {
     }
 }
 
+#[cfg(feature = "json")]
+/// JSON-specific conversions for `RequestContent<T>`.
+/// These conversions allow for easy serialization of common types into the request body.
 pub mod json {
     use super::*;
 
@@ -530,6 +533,9 @@ pub mod json {
         }
     }
 }
+
+#[cfg(feature = "json")]
+pub use json::*;
 
 impl<T> FromStr for RequestContent<T> {
     type Err = crate::Error;

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -534,6 +534,7 @@ pub mod json {
     }
 }
 
+#[allow(unused_imports)]
 #[cfg(feature = "json")]
 pub use json::*;
 

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -333,9 +333,10 @@ impl<T> TryFrom<Option<Decimal>> for RequestContent<T> {
     }
 }
 
-#[cfg(feature = "json")]
 /// JSON-specific conversions for `RequestContent<T>`.
+///
 /// These conversions allow for easy serialization of common types into the request body.
+#[cfg(feature = "json")]
 pub mod json {
     use super::*;
 
@@ -533,10 +534,6 @@ pub mod json {
         }
     }
 }
-
-#[allow(unused_imports)]
-#[cfg(feature = "json")]
-pub use json::*;
 
 impl<T> FromStr for RequestContent<T> {
     type Err = crate::Error;


### PR DESCRIPTION
Follow-up for https://github.com/Azure/azure-sdk-for-rust/pull/2790#discussion_r2237922684

PR that updates Spector tests: https://github.com/Azure/typespec-rust/pull/530