### PR TITLE
Use PagerState, PollerState instead of Option for callbacks

### DIFF
--- a/sdk/core/azure_core/CHANGELOG.md
+++ b/sdk/core/azure_core/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Breaking Changes
 
+- `Pager::from_callback` and `PageIterator::from_callback` define a parameter of type `PagerState<C>` instead of `Option<C>`, where `None` => `Initial` and `Some(C)` => `More(C)`.
+- `Poller::from_callback` defines a parameter of type `PollerState<N>` instead of `Option<N>`, where `None` => `Initial` and `Some(N)` => `More(N)`.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/core/azure_core/src/http/pager.rs
+++ b/sdk/core/azure_core/src/http/pager.rs
@@ -7,11 +7,79 @@ use futures::{stream::unfold, FutureExt, Stream};
 use std::{
     fmt,
     future::Future,
+    ops::Deref,
     pin::Pin,
     str::FromStr,
     sync::{Arc, Mutex},
     task,
 };
+
+/// Represents the state of a [`Pager`] or [`PageIterator`].
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum PagerState<C: AsRef<str>> {
+    /// The pager should fetch the initial page.
+    #[default]
+    Initial,
+    /// The pager should fetch a subsequent page using the next link/continuation token `C`.
+    More(C),
+}
+
+impl<C: AsRef<str>> PagerState<C> {
+    /// Maps a `PagerState<C>` to a `PagerState<U>` by applying a function to a next link/continuation token `C` (if `PagerState::More`) or returns `PagerState::Initial` (if `PagerState::Initial`).
+    #[inline]
+    pub fn map<U, F>(self, f: F) -> PagerState<U>
+    where
+        U: AsRef<str>,
+        F: FnOnce(C) -> U,
+    {
+        match self {
+            PagerState::Initial => PagerState::Initial,
+            PagerState::More(c) => PagerState::More(f(c)),
+        }
+    }
+
+    /// Converts from `&PagerState<C>` to `PagerState<&C>`.
+    #[inline]
+    pub const fn as_ref(&self) -> PagerState<&C> {
+        match *self {
+            PagerState::Initial => PagerState::Initial,
+            PagerState::More(ref x) => PagerState::More(x),
+        }
+    }
+
+    /// Converts from `PagerState<C>` (or `&PagerState<C>`) to `PagerState<&C::Target>`.
+    ///
+    /// Leaves the original `PagerState` in-place, creating a new one with a reference
+    /// to the original one, additionally coercing the contents via [`Deref`].
+    #[inline]
+    pub fn as_deref(&self) -> PagerState<&C::Target>
+    where
+        C: Deref,
+        C::Target: AsRef<str>,
+    {
+        self.as_ref().map(|t| t.deref())
+    }
+
+    fn to_opt(&self) -> Option<C>
+    where
+        C: Clone,
+    {
+        match self {
+            PagerState::Initial => None,
+            PagerState::More(c) => Some(c.clone()),
+        }
+    }
+}
+
+impl<C: Clone + AsRef<str>> Clone for PagerState<C> {
+    #[inline]
+    fn clone(&self) -> Self {
+        match self {
+            PagerState::Initial => PagerState::Initial,
+            PagerState::More(c) => PagerState::More(c.clone()),
+        }
+    }
+}
 
 /// The result of fetching a single page from a [`Pager`], whether there are more pages or paging is done.
 pub enum PagerResult<P, C: AsRef<str>> {
@@ -102,7 +170,7 @@ pub struct ItemIterator<P: Page> {
 impl<P: Page> ItemIterator<P> {
     /// Creates a [`ItemIterator<P>`] from a callback that will be called repeatedly to request each page.
     ///
-    /// This method expect a callback that accepts a single `Option<C>` parameter, and returns a [`PagerResult<T, C>`] value asynchronously.
+    /// This method expect a callback that accepts a single [`PagerState<C>`] parameter, and returns a [`PagerResult<T, C>`] value asynchronously.
     /// The `C` type parameter is the type of the next link/continuation token. It may be any [`Send`]able type.
     /// The result will be an asynchronous stream of [`Result<T>`](typespec::Result<T>) values.
     ///
@@ -117,7 +185,7 @@ impl<P: Page> ItemIterator<P> {
     /// To page results using a next link:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, ItemIterator, Page, PagerResult, Pipeline, RawResponse, Request, Response, Method, Url}, json};
+    /// # use azure_core::{Result, http::{Context, ItemIterator, Page, PagerResult, PagerState, Pipeline, RawResponse, Request, Response, Method, Url}, json};
     /// # let api_version = "2025-06-04".to_string();
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
@@ -136,13 +204,13 @@ impl<P: Page> ItemIterator<P> {
     /// }
     /// let url = "https://example.com/my_paginated_api".parse().unwrap();
     /// let mut base_req = Request::new(url, Method::Get);
-    /// let pager = ItemIterator::from_callback(move |next_link: Option<Url>| {
+    /// let pager = ItemIterator::from_callback(move |next_link: PagerState<Url>| {
     ///     // The callback must be 'static, so you have to clone and move any values you want to use.
     ///     let pipeline = pipeline.clone();
     ///     let api_version = api_version.clone();
     ///     let mut req = base_req.clone();
     ///     async move {
-    ///         if let Some(next_link) = next_link {
+    ///         if let PagerState::More(next_link) = next_link {
     ///             // Ensure the api-version from the client is appended.
     ///             let qp = next_link
     ///                 .query_pairs()
@@ -175,7 +243,7 @@ impl<P: Page> ItemIterator<P> {
     /// To page results using headers:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, ItemIterator, Page, PagerResult, Pipeline, Request, Response, Method, headers::HeaderName}};
+    /// # use azure_core::{Result, http::{Context, ItemIterator, Page, PagerResult, PagerState, Pipeline, Request, Response, Method, headers::HeaderName}};
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
     /// struct ListItemsResult {
@@ -197,7 +265,7 @@ impl<P: Page> ItemIterator<P> {
     ///     let pipeline = pipeline.clone();
     ///     let mut req = base_req.clone();
     ///     async move {
-    ///         if let Some(continuation) = continuation {
+    ///         if let PagerState::More(continuation) = continuation {
     ///             req.insert_header("x-ms-continuation", continuation);
     ///         }
     ///         let resp: Response<ListItemsResult> = pipeline
@@ -211,15 +279,19 @@ impl<P: Page> ItemIterator<P> {
     pub fn from_callback<
         // This is a bit gnarly, but the only thing that differs between the WASM/non-WASM configs is the presence of Send bounds.
         #[cfg(not(target_arch = "wasm32"))] C: AsRef<str> + Send + 'static,
-        #[cfg(not(target_arch = "wasm32"))] F: Fn(Option<C>) -> Fut + Send + 'static,
+        #[cfg(not(target_arch = "wasm32"))] F: Fn(PagerState<C>) -> Fut + Send + 'static,
         #[cfg(not(target_arch = "wasm32"))] Fut: Future<Output = crate::Result<PagerResult<P, C>>> + Send + 'static,
         #[cfg(target_arch = "wasm32")] C: AsRef<str> + 'static,
-        #[cfg(target_arch = "wasm32")] F: Fn(Option<C>) -> Fut + 'static,
+        #[cfg(target_arch = "wasm32")] F: Fn(PagerState<C>) -> Fut + 'static,
         #[cfg(target_arch = "wasm32")] Fut: Future<Output = crate::Result<PagerResult<P, C>>> + 'static,
     >(
         make_request: F,
     ) -> Self {
-        Self::from_stream(iter_from_callback(make_request, || None, |_| {}))
+        Self::from_stream(iter_from_callback(
+            make_request,
+            || PagerState::Initial,
+            |_| {},
+        ))
     }
 
     /// Creates a [`ItemIterator<P>`] from a raw stream of [`Result<P>`](crate::Result<P>) values.
@@ -298,17 +370,17 @@ impl<P: Page> fmt::Debug for ItemIterator<P> {
 pub struct PageIterator<P> {
     #[pin]
     stream: Pin<BoxedStream<P>>,
-    continuation_token: Arc<Mutex<Option<String>>>,
+    continuation_token: Arc<Mutex<PagerState<String>>>,
 }
 
 impl<P> PageIterator<P> {
     /// Creates a [`PageIterator<P>`] from a callback that will be called repeatedly to request each page.
     ///
-    /// This method expect a callback that accepts a single `Option<C>` parameter, and returns a [`PagerResult<T, C>`] value asynchronously.
+    /// This method expect a callback that accepts a single [`PagerState<C>`] parameter, and returns a [`PagerResult<T, C>`] value asynchronously.
     /// The `C` type parameter is the type of the next link/continuation token. It may be any [`Send`]able type.
     /// The result will be an asynchronous stream of [`Result<T>`](typespec::Result<T>) values.
     ///
-    /// The first time your callback is called, it will be called with [`Option::None`], indicating no next link/continuation token is present.
+    /// The first time your callback is called, it will be called with [`PagerState::Initial`], indicating no next link/continuation token is present.
     ///
     /// Your callback must return one of:
     /// * `Ok(result)` - The request succeeded, and the provided [`PagerResult`] indicates the value to return and if there are more pages.
@@ -319,7 +391,7 @@ impl<P> PageIterator<P> {
     /// To page results using a next link:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, PageIterator, PagerResult, Pipeline, RawResponse, Request, Response, Method, Url}, json};
+    /// # use azure_core::{Result, http::{Context, PageIterator, PagerResult, PagerState, Pipeline, RawResponse, Request, Response, Method, Url}, json};
     /// # let api_version = "2025-06-04".to_string();
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
@@ -329,13 +401,13 @@ impl<P> PageIterator<P> {
     /// }
     /// let url = "https://example.com/my_paginated_api".parse().unwrap();
     /// let mut base_req = Request::new(url, Method::Get);
-    /// let pager = PageIterator::from_callback(move |next_link: Option<Url>| {
+    /// let pager = PageIterator::from_callback(move |next_link: PagerState<Url>| {
     ///     // The callback must be 'static, so you have to clone and move any values you want to use.
     ///     let pipeline = pipeline.clone();
     ///     let api_version = api_version.clone();
     ///     let mut req = base_req.clone();
     ///     async move {
-    ///         if let Some(next_link) = next_link {
+    ///         if let PagerState::More(next_link) = next_link {
     ///             // Ensure the api-version from the client is appended.
     ///             let qp = next_link
     ///                 .query_pairs()
@@ -368,7 +440,7 @@ impl<P> PageIterator<P> {
     /// To page results using headers:
     ///
     /// ```rust,no_run
-    /// # use azure_core::{Result, http::{Context, PageIterator, PagerResult, Pipeline, Request, Response, Method, headers::HeaderName}};
+    /// # use azure_core::{Result, http::{Context, PageIterator, PagerResult, PagerState, Pipeline, Request, Response, Method, headers::HeaderName}};
     /// # let pipeline: Pipeline = panic!("Not a runnable example");
     /// #[derive(serde::Deserialize)]
     /// struct ListItemsResult {
@@ -381,7 +453,7 @@ impl<P> PageIterator<P> {
     ///     let pipeline = pipeline.clone();
     ///     let mut req = base_req.clone();
     ///     async move {
-    ///         if let Some(continuation) = continuation {
+    ///         if let PagerState::More(continuation) = continuation {
     ///             req.insert_header("x-ms-continuation", continuation);
     ///         }
     ///         let resp: Response<ListItemsResult> = pipeline
@@ -395,10 +467,10 @@ impl<P> PageIterator<P> {
     pub fn from_callback<
         // This is a bit gnarly, but the only thing that differs between the WASM/non-WASM configs is the presence of Send bounds.
         #[cfg(not(target_arch = "wasm32"))] C: AsRef<str> + FromStr + Send + 'static,
-        #[cfg(not(target_arch = "wasm32"))] F: Fn(Option<C>) -> Fut + Send + 'static,
+        #[cfg(not(target_arch = "wasm32"))] F: Fn(PagerState<C>) -> Fut + Send + 'static,
         #[cfg(not(target_arch = "wasm32"))] Fut: Future<Output = crate::Result<PagerResult<P, C>>> + Send + 'static,
         #[cfg(target_arch = "wasm32")] C: AsRef<str> + FromStr + 'static,
-        #[cfg(target_arch = "wasm32")] F: Fn(Option<C>) -> Fut + 'static,
+        #[cfg(target_arch = "wasm32")] F: Fn(PagerState<C>) -> Fut + 'static,
         #[cfg(target_arch = "wasm32")] Fut: Future<Output = crate::Result<PagerResult<P, C>>> + 'static,
     >(
         make_request: F,
@@ -406,7 +478,7 @@ impl<P> PageIterator<P> {
     where
         <C as FromStr>::Err: fmt::Debug,
     {
-        let continuation_token = Arc::new(Mutex::new(None::<String>));
+        let continuation_token = Arc::new(Mutex::new(PagerState::Initial::<String>));
 
         let get_clone = continuation_token.clone();
         let set_clone = continuation_token.clone();
@@ -419,7 +491,7 @@ impl<P> PageIterator<P> {
                         .map(|n| n.parse().expect("valid continuation_token"));
                 }
 
-                None
+                PagerState::Initial
             },
             move |next_token| {
                 if let Ok(mut token_guard) = set_clone.lock() {
@@ -487,7 +559,7 @@ impl<P> PageIterator<P> {
     /// ```
     pub fn with_continuation_token(self, continuation_token: String) -> Self {
         if let Ok(mut token_guard) = self.continuation_token.lock() {
-            *token_guard = Some(continuation_token);
+            *token_guard = PagerState::More(continuation_token);
         }
 
         self
@@ -499,7 +571,7 @@ impl<P> PageIterator<P> {
     /// will return the next page. You can use this to page results across separate processes.
     pub fn continuation_token(&self) -> Option<String> {
         if let Ok(token) = self.continuation_token.lock() {
-            return token.clone();
+            return token.to_opt();
         }
 
         None
@@ -534,15 +606,15 @@ fn iter_from_callback<
     P,
     // This is a bit gnarly, but the only thing that differs between the WASM/non-WASM configs is the presence of Send bounds.
     #[cfg(not(target_arch = "wasm32"))] C: AsRef<str> + Send + 'static,
-    #[cfg(not(target_arch = "wasm32"))] F: Fn(Option<C>) -> Fut + Send + 'static,
+    #[cfg(not(target_arch = "wasm32"))] F: Fn(PagerState<C>) -> Fut + Send + 'static,
     #[cfg(not(target_arch = "wasm32"))] Fut: Future<Output = crate::Result<PagerResult<P, C>>> + Send + 'static,
-    #[cfg(not(target_arch = "wasm32"))] G: Fn() -> Option<C> + Send + 'static,
-    #[cfg(not(target_arch = "wasm32"))] S: Fn(Option<&str>) + Send + 'static,
+    #[cfg(not(target_arch = "wasm32"))] G: Fn() -> PagerState<C> + Send + 'static,
+    #[cfg(not(target_arch = "wasm32"))] S: Fn(PagerState<&str>) + Send + 'static,
     #[cfg(target_arch = "wasm32")] C: AsRef<str> + 'static,
-    #[cfg(target_arch = "wasm32")] F: Fn(Option<C>) -> Fut + 'static,
+    #[cfg(target_arch = "wasm32")] F: Fn(PagerState<C>) -> Fut + 'static,
     #[cfg(target_arch = "wasm32")] Fut: Future<Output = crate::Result<PagerResult<P, C>>> + 'static,
-    #[cfg(target_arch = "wasm32")] G: Fn() -> Option<C> + 'static,
-    #[cfg(target_arch = "wasm32")] S: Fn(Option<&str>) + 'static,
+    #[cfg(target_arch = "wasm32")] G: Fn() -> PagerState<C> + 'static,
+    #[cfg(target_arch = "wasm32")] S: Fn(PagerState<&str>) + 'static,
 >(
     make_request: F,
     get_next: G,
@@ -552,14 +624,14 @@ fn iter_from_callback<
         // We flow the `make_request` callback, 'get_next', and `set_next` through the state value so that we can avoid cloning.
         (State::Init, make_request, get_next, set_next),
         |(mut state, make_request, get_next, set_next)| async move {
-            if let Some(next_token) = get_next() {
+            if let PagerState::More(next_token) = get_next() {
                 state = State::More(next_token);
             }
             let result = match state {
-                State::Init => make_request(None).await,
-                State::More(n) => make_request(Some(n)).await,
+                State::Init => make_request(PagerState::Initial).await,
+                State::More(n) => make_request(PagerState::More(n)).await,
                 State::Done => {
-                    set_next(None);
+                    set_next(PagerState::Initial);
                     return None;
                 }
             };
@@ -569,11 +641,11 @@ fn iter_from_callback<
                     response,
                     continuation: next_token,
                 }) => {
-                    set_next(Some(next_token.as_ref()));
+                    set_next(PagerState::More(next_token.as_ref()));
                     (Ok(response), State::More(next_token))
                 }
                 Ok(PagerResult::Done { response }) => {
-                    set_next(None);
+                    set_next(PagerState::Initial);
                     (Ok(response), State::Done)
                 }
             };
@@ -588,7 +660,7 @@ fn iter_from_callback<
 mod tests {
     use crate::http::{
         headers::{HeaderName, HeaderValue},
-        PageIterator, Pager, PagerResult, RawResponse, Response, StatusCode,
+        PageIterator, Pager, PagerResult, PagerState, RawResponse, Response, StatusCode,
     };
     use async_trait::async_trait;
     use futures::{StreamExt as _, TryStreamExt as _};
@@ -616,7 +688,7 @@ mod tests {
     async fn callback_item_pagination() {
         let pager: Pager<Page> = Pager::from_callback(|continuation| async move {
             match continuation {
-                None => Ok(PagerResult::More {
+                PagerState::Initial => Ok(PagerResult::More {
                     response: RawResponse::from_bytes(
                         StatusCode::Ok,
                         HashMap::from([(
@@ -629,7 +701,7 @@ mod tests {
                     .into(),
                     continuation: "1",
                 }),
-                Some("1") => Ok(PagerResult::More {
+                PagerState::More("1") => Ok(PagerResult::More {
                     response: RawResponse::from_bytes(
                         StatusCode::Ok,
                         HashMap::from([(
@@ -642,7 +714,7 @@ mod tests {
                     .into(),
                     continuation: "2",
                 }),
-                Some("2") => Ok(PagerResult::Done {
+                PagerState::More("2") => Ok(PagerResult::Done {
                     response: RawResponse::from_bytes(
                         StatusCode::Ok,
                         HashMap::from([(
@@ -667,7 +739,7 @@ mod tests {
     async fn callback_item_pagination_error() {
         let pager: Pager<Page> = Pager::from_callback(|continuation| async move {
             match continuation {
-                None => Ok(PagerResult::More {
+                PagerState::Initial => Ok(PagerResult::More {
                     response: RawResponse::from_bytes(
                         StatusCode::Ok,
                         HashMap::from([(
@@ -680,7 +752,7 @@ mod tests {
                     .into(),
                     continuation: "1",
                 }),
-                Some("1") => Err(typespec::Error::message(
+                PagerState::More("1") => Err(typespec::Error::message(
                     typespec::error::ErrorKind::Other,
                     "yon request didst fail",
                 )),
@@ -722,9 +794,9 @@ mod tests {
     #[tokio::test]
     async fn page_iterator_with_continuation_token() {
         let make_callback = || {
-            |continuation: Option<String>| async move {
+            |continuation: PagerState<String>| async move {
                 match continuation.as_deref() {
-                    None => Ok(PagerResult::More {
+                    PagerState::Initial => Ok(PagerResult::More {
                         response: RawResponse::from_bytes(
                             StatusCode::Ok,
                             Default::default(),
@@ -733,7 +805,7 @@ mod tests {
                         .into(),
                         continuation: "next-token-1".to_string(),
                     }),
-                    Some("next-token-1") => Ok(PagerResult::More {
+                    PagerState::More("next-token-1") => Ok(PagerResult::More {
                         response: RawResponse::from_bytes(
                             StatusCode::Ok,
                             HashMap::from([(
@@ -746,7 +818,7 @@ mod tests {
                         .into(),
                         continuation: "next-token-2".to_string(),
                     }),
-                    Some("next-token-2") => Ok(PagerResult::Done {
+                    PagerState::More("next-token-2") => Ok(PagerResult::Done {
                         response: RawResponse::from_bytes(
                             StatusCode::Ok,
                             HashMap::from([(

--- a/sdk/core/azure_core/src/http/poller.rs
+++ b/sdk/core/azure_core/src/http/poller.rs
@@ -433,7 +433,7 @@ fn create_poller_stream<
     #[cfg(not(target_arch = "wasm32"))] F: Fn(PollerState<N>) -> Fut + Send + 'static,
     #[cfg(not(target_arch = "wasm32"))] Fut: Future<Output = crate::Result<PollerResult<M, N>>> + Send + 'static,
     #[cfg(target_arch = "wasm32")] N: 'static,
-    #[cfg(target_arch = "wasm32")] F: Fn(PollerState) -> Fut + 'static,
+    #[cfg(target_arch = "wasm32")] F: Fn(PollerState<N>) -> Fut + 'static,
     #[cfg(target_arch = "wasm32")] Fut: Future<Output = crate::Result<PollerResult<M, N>>> + 'static,
 >(
     make_request: F,

--- a/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/pipeline/mod.rs
@@ -10,7 +10,7 @@ pub use authorization_policy::AuthorizationPolicy;
 use azure_core::http::{
     request::{options::ContentType, Request},
     response::Response,
-    ClientOptions, Context, Method, RawResponse,
+    ClientOptions, Context, Method, PagerState, RawResponse,
 };
 use futures::TryStreamExt;
 use serde::de::DeserializeOwned;
@@ -101,7 +101,7 @@ impl CosmosPipeline {
             let mut req = base_request.clone();
             let ctx = ctx.clone();
             async move {
-                if let Some(continuation) = continuation {
+                if let PagerState::More(continuation) = continuation {
                     req.insert_header(constants::CONTINUATION, continuation);
                 }
 

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/generated/clients/certificate_client.rs
@@ -33,8 +33,8 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, Pipeline, RawResponse,
-        Request, RequestContent, Response, Url,
+        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, PagerState, Pipeline,
+        RawResponse, Request, RequestContent, Response, Url,
     },
     json, tracing, Error, Result,
 };
@@ -633,9 +633,9 @@ impl CertificateClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -647,7 +647,7 @@ impl CertificateClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");
@@ -709,9 +709,9 @@ impl CertificateClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -723,7 +723,7 @@ impl CertificateClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");
@@ -787,9 +787,9 @@ impl CertificateClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -801,7 +801,7 @@ impl CertificateClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");
@@ -859,9 +859,9 @@ impl CertificateClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -873,7 +873,7 @@ impl CertificateClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");

--- a/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/generated/clients/key_client.rs
@@ -26,8 +26,8 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, Pipeline, RawResponse,
-        Request, RequestContent, Response, Url,
+        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, PagerState, Pipeline,
+        RawResponse, Request, RequestContent, Response, Url,
     },
     json, tracing, Error, Result,
 };
@@ -590,9 +590,9 @@ impl KeyClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -604,7 +604,7 @@ impl KeyClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");
@@ -663,9 +663,9 @@ impl KeyClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -677,7 +677,7 @@ impl KeyClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");
@@ -738,9 +738,9 @@ impl KeyClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -752,7 +752,7 @@ impl KeyClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/generated/clients/secret_client.rs
@@ -20,8 +20,8 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, Pipeline, RawResponse,
-        Request, RequestContent, Response, Url,
+        ClientOptions, Context, Method, NoFormat, Pager, PagerResult, PagerState, Pipeline,
+        RawResponse, Request, RequestContent, Response, Url,
     },
     json, tracing, Error, Result,
 };
@@ -271,9 +271,9 @@ impl SecretClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -285,7 +285,7 @@ impl SecretClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");
@@ -344,9 +344,9 @@ impl SecretClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -358,7 +358,7 @@ impl SecretClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");
@@ -420,9 +420,9 @@ impl SecretClient {
                 .append_pair("maxresults", &maxresults.to_string());
         }
         let api_version = self.api_version.clone();
-        Ok(Pager::from_callback(move |next_link: Option<Url>| {
+        Ok(Pager::from_callback(move |next_link: PagerState<Url>| {
             let url = match next_link {
-                Some(next_link) => {
+                PagerState::More(next_link) => {
                     let qp = next_link
                         .query_pairs()
                         .filter(|(name, _)| name.ne("api-version"));
@@ -434,7 +434,7 @@ impl SecretClient {
                         .append_pair("api-version", &api_version);
                     next_link
                 }
-                None => first_url.clone(),
+                PagerState::Initial => first_url.clone(),
             };
             let mut request = Request::new(url, Method::Get);
             request.insert_header("accept", "application/json");

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_container_client.rs
@@ -30,8 +30,8 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, Pipeline, RawResponse,
-        Request, RequestContent, Response, Url, XmlFormat,
+        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, PagerState, Pipeline,
+        RawResponse, Request, RequestContent, Response, Url, XmlFormat,
     },
     time::to_rfc7231,
     tracing, xml, Error, Result,
@@ -628,9 +628,9 @@ impl BlobContainerClient {
         }
         let version = self.version.clone();
         Ok(PageIterator::from_callback(
-            move |marker: Option<String>| {
+            move |marker: PagerState<String>| {
                 let mut url = first_url.clone();
-                if let Some(marker) = marker {
+                if let PagerState::More(marker) = marker {
                     if url.query_pairs().any(|(name, _)| name.eq("marker")) {
                         let mut new_url = url.clone();
                         new_url
@@ -732,9 +732,9 @@ impl BlobContainerClient {
         }
         let version = self.version.clone();
         Ok(PageIterator::from_callback(
-            move |marker: Option<String>| {
+            move |marker: PagerState<String>| {
                 let mut url = first_url.clone();
-                if let Some(marker) = marker {
+                if let PagerState::More(marker) = marker {
                     if url.query_pairs().any(|(name, _)| name.eq("marker")) {
                         let mut new_url = url.clone();
                         new_url

--- a/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
+++ b/sdk/storage/azure_storage_blob/src/generated/clients/blob_service_client.rs
@@ -20,8 +20,8 @@ use azure_core::{
     fmt::SafeDebug,
     http::{
         policies::{BearerTokenCredentialPolicy, Policy},
-        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, Pipeline, RawResponse,
-        Request, RequestContent, Response, Url, XmlFormat,
+        ClientOptions, Context, Method, NoFormat, PageIterator, PagerResult, PagerState, Pipeline,
+        RawResponse, Request, RequestContent, Response, Url, XmlFormat,
     },
     tracing, xml, Error, Result,
 };
@@ -369,9 +369,9 @@ impl BlobServiceClient {
         }
         let version = self.version.clone();
         Ok(PageIterator::from_callback(
-            move |marker: Option<String>| {
+            move |marker: PagerState<String>| {
                 let mut url = first_url.clone();
-                if let Some(marker) = marker {
+                if let PagerState::More(marker) = marker {
                     if url.query_pairs().any(|(name, _)| name.eq("marker")) {
                         let mut new_url = url.clone();
                         new_url


### PR DESCRIPTION
For `ItemIterator`, `PageIterator`, and `Poller`, define a bespoke enum that works like an `Option` but that we can add to or redefine as needed, as will most likely be the case for `Poller`.
