### PR TITLE
typespec_client_core: New `web_runtime` to support wasm32-unknown-unknown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "minicov"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+dependencies = [
+ "cc",
+ "walkdir",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3185,6 +3195,7 @@ dependencies = [
  "url",
  "uuid",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -3386,6 +3397,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-bindgen-test"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c8d5e33ca3b6d9fa3b4676d774c5778031d27a578c2b007f905acf816152c3"
+dependencies = [
+ "js-sys",
+ "minicov",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,6 +3184,7 @@ dependencies = [
  "typespec_macros",
  "url",
  "uuid",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,6 +1276,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "half"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3156,6 +3168,7 @@ dependencies = [
  "dyn-clone",
  "futures",
  "getrandom 0.3.3",
+ "gloo-timers",
  "pin-project",
  "quick-xml",
  "rand 0.9.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ tracing-subscriber = "0.3"
 url = "2.2"
 uuid = { version = "1.18", features = ["v4"] }
 wasm-bindgen-futures = "0.4"
+wasm-bindgen-test = "0.3"
 zerofrom = "0.1.5"
 zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ fe2o3-amqp-types = { version = "0.14" }
 flate2 = "1.1.0"
 futures = "0.3"
 getrandom = { version = "0.3" }
+gloo-timers = { version = "0.3", features = ["futures"] }
 hmac = { version = "0.12" }
 litemap = "0.7.4"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ fe2o3-amqp-types = { version = "0.14" }
 flate2 = "1.1.0"
 futures = "0.3"
 getrandom = { version = "0.3" }
-gloo-timers = { version = "0.3", features = ["futures"] }
+gloo-timers = { version = "0.3" }
 hmac = { version = "0.12" }
 litemap = "0.7.4"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3"
 url = "2.2"
 uuid = { version = "1.18", features = ["v4"] }
+wasm-bindgen-futures = "0.4"
 zerofrom = "0.1.5"
 zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
 

--- a/eng/dict/crates.txt
+++ b/eng/dict/crates.txt
@@ -32,6 +32,7 @@ fe2o3-amqp-types
 flate2
 futures
 getrandom
+gloo
 hmac
 litemap
 log

--- a/sdk/typespec/typespec_client_core/CHANGELOG.md
+++ b/sdk/typespec/typespec_client_core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 
+- Added support for WASM to the `async_runtime` module.
+
 ### Breaking Changes
 
 - Removed the `fs` module including the `FileStream` and `FileStreamBuilder` types. Moved to `examples/` to copy if needed.

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -16,6 +16,7 @@ base64.workspace = true
 bytes.workspace = true
 dyn-clone.workspace = true
 futures.workspace = true
+gloo-timers = { workspace = true, optional = true }
 pin-project.workspace = true
 quick-xml = { workspace = true, optional = true }
 rand.workspace = true
@@ -37,11 +38,9 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom.workspace = true
-gloo-timers = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [dev-dependencies]
-tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 typespec_macros.path = "../typespec_macros"
@@ -50,6 +49,7 @@ typespec_macros.path = "../typespec_macros"
 tokio = { workspace = true, features = ["fs"] }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
+tokio.workspace = true
 getrandom = { workspace = true, features = ["wasm_js"] }
 uuid = { workspace = true, features = ["v4", "js"] }
 wasm-bindgen-test.workspace = true
@@ -73,6 +73,10 @@ wasm_bindgen = ["dep:wasm-bindgen-futures", "gloo-timers/futures"]
 xml = ["dep:quick-xml"]
 
 [[example]]
+name = "core_binary_data_request"
+required-features = ["tokio"]
+
+[[example]]
 name = "core_stream_response"
 required-features = ["derive"]
 
@@ -87,6 +91,7 @@ features = [
   "reqwest_gzip",
   "reqwest_rustls",
   "tokio",
+  "wasm_bindgen",
   "xml",
 ]
 

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -16,6 +16,7 @@ base64.workspace = true
 bytes.workspace = true
 dyn-clone.workspace = true
 futures.workspace = true
+gloo-timers = { workspace = true, optional = true }
 pin-project.workspace = true
 quick-xml = { workspace = true, optional = true }
 rand.workspace = true
@@ -30,6 +31,7 @@ typespec = { workspace = true, default-features = false }
 typespec_macros = { workspace = true, optional = true }
 url.workspace = true
 uuid.workspace = true
+wasm-bindgen-futures = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
@@ -37,8 +39,6 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
-gloo-timers = { workspace = true, features = ["futures"] }
-wasm-bindgen-futures.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["fs"] }
@@ -61,6 +61,7 @@ reqwest_rustls = [
 ] # Remove dependency on banned `ring` crate; requires manually configuring crypto provider.
 test = [] # Enables extra tracing including error bodies that may contain PII.
 tokio = ["tokio/sync", "tokio/time"]
+wasm-bindgen = ["dep:wasm-bindgen-futures", "gloo-timers/futures"]
 xml = ["dep:quick-xml"]
 
 [[example]]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -35,9 +35,9 @@ uuid.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-getrandom = { workspace = true, features = ["wasm_js"] }
+getrandom.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
-gloo-timers.workspace = true
+gloo-timers = { workspace = true, features = ["futures"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["fs"] }

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -45,6 +45,9 @@ tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 typespec_macros.path = "../typespec_macros"
+wasm-bindgen-test = "0.3"
+getrandom = { version = "0.3" , features = ["wasm_js"]}
+uuid = { version = "1", features = ["v4", "js"] }
 
 [features]
 default = ["http", "json", "reqwest", "reqwest_deflate", "reqwest_gzip"]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -35,8 +35,9 @@ uuid.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-getrandom.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
+gloo-timers.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["fs"] }

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -16,7 +16,6 @@ base64.workspace = true
 bytes.workspace = true
 dyn-clone.workspace = true
 futures.workspace = true
-gloo-timers = { workspace = true, optional = true }
 pin-project.workspace = true
 quick-xml = { workspace = true, optional = true }
 rand.workspace = true
@@ -38,16 +37,22 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom.workspace = true
+gloo-timers = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["fs"] }
+tokio.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 typespec_macros.path = "../typespec_macros"
-wasm-bindgen-test = "0.3"
-getrandom = { version = "0.3" , features = ["wasm_js"]}
-uuid = { version = "1", features = ["v4", "js"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+tokio = { workspace = true, features = ["fs"] }
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+uuid = { workspace = true, features = ["v4", "js"] }
+wasm-bindgen-test.workspace = true
 
 [features]
 default = ["http", "json", "reqwest", "reqwest_deflate", "reqwest_gzip"]
@@ -64,7 +69,7 @@ reqwest_rustls = [
 ] # Remove dependency on banned `ring` crate; requires manually configuring crypto provider.
 test = [] # Enables extra tracing including error bodies that may contain PII.
 tokio = ["tokio/sync", "tokio/time"]
-wasm-bindgen = ["dep:wasm-bindgen-futures", "gloo-timers/futures"]
+wasm_bindgen = ["dep:wasm-bindgen-futures", "gloo-timers/futures"]
 xml = ["dep:quick-xml"]
 
 [[example]]

--- a/sdk/typespec/typespec_client_core/Cargo.toml
+++ b/sdk/typespec/typespec_client_core/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 getrandom.workspace = true
 tokio = { workspace = true, features = ["macros", "rt", "time"] }
 gloo-timers = { workspace = true, features = ["futures"] }
+wasm-bindgen-futures.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["fs"] }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -193,15 +193,15 @@ pub fn set_async_runtime(runtime: Arc<dyn AsyncRuntime>) -> crate::Result<()> {
 }
 
 fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(feature = "wasm-bindgen")]
     {
-        Arc::new(web_runtime::WebRuntime) as Arc<dyn AsyncRuntime>
+        Arc::new(web_runtime::WasmBindgenRuntime) as Arc<dyn AsyncRuntime>
     }
     #[cfg(feature = "tokio")]
     {
         Arc::new(tokio_runtime::TokioRuntime) as Arc<dyn AsyncRuntime>
     }
-    #[cfg(not(any(feature = "tokio", target_arch = "wasm32")))]
+    #[cfg(not(any(feature = "tokio", feature = "wasm-bindgen")))]
     {
         Arc::new(standard_runtime::StdRuntime)
     }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -7,28 +7,22 @@
 //!
 //! It abstracts away the underlying implementation details, allowing for different task execution strategies based on the target architecture and features enabled.
 //!
-//!
-//! Example usage:
+//! # Examples
 //!
 //! ```
 //! use typespec_client_core::async_runtime::get_async_runtime;
-//! use futures::FutureExt;
 //!
-//! #[tokio::main]
-//! async fn main() {
-//!     let async_runtime = get_async_runtime();
-//!     let handle = async_runtime.spawn(async {
-//!         // Simulate some work
-//!         std::thread::sleep(std::time::Duration::from_secs(1));
-//!     }.boxed());
-//!
-//!     handle.await.expect("Task should complete successfully");
-//!
-//!     println!("Task completed");
-//! }
+//! # #[tokio::main]
+//! # async fn main() {
+//! let async_runtime = get_async_runtime();
+//! let handle = async_runtime.spawn(Box::pin(async {
+//!     // Simulate some work
+//!     std::thread::sleep(std::time::Duration::from_secs(1));
+//! }));
+//! handle.await.expect("Task should complete successfully");
+//! println!("Task completed");
+//! # }
 //! ```
-//!
-//!
 use crate::time::Duration;
 use std::{
     future::Future,
@@ -36,13 +30,13 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-#[cfg_attr(feature = "tokio", allow(dead_code))]
+#[cfg_attr(any(feature = "tokio", feature = "wasm_bindgen"), allow(dead_code))]
 mod standard_runtime;
 
 #[cfg(feature = "tokio")]
 mod tokio_runtime;
 
-#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+#[cfg(all(target_arch = "wasm32", feature = "wasm_bindgen"))]
 mod web_runtime;
 
 #[cfg(test)]
@@ -83,32 +77,32 @@ pub trait AsyncRuntime: Send + Sync {
     ///   from its environment by reference, as it will be executed in a different thread or context.
     ///
     /// # Returns
+    ///
     /// A future which can be awaited to block until the task has completed.
     ///
-    /// # Example
+    /// # Examples
+    ///
     /// ```
     /// use typespec_client_core::async_runtime::get_async_runtime;
-    /// use futures::FutureExt;
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///   let async_runtime = get_async_runtime();
-    ///   let future = async_runtime.spawn(async {
-    ///     // Simulate some work
-    ///     std::thread::sleep(std::time::Duration::from_secs(1));
-    ///   }.boxed());
-    ///   future.await.expect("Task should complete successfully");
-    /// }
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let async_runtime = get_async_runtime();
+    /// let handle = async_runtime.spawn(Box::pin(async {
+    ///   // Simulate some work
+    ///   std::thread::sleep(std::time::Duration::from_secs(1));
+    /// }));
+    /// handle.await.expect("Task should complete successfully");
+    /// # }
     /// ```
     ///
-    /// # Note
+    /// # Notes
     ///
     /// This trait intentionally does not use the *`async_trait`* macro because when the
     /// `async_trait` attribute is applied to a trait  implementation, the rewritten
     /// method cannot directly return a future, instead they wrap the return value
     /// in a future, and we want the `spawn` method to directly return a future
     /// that can be awaited.
-    ///
     fn spawn(&self, f: TaskFuture) -> SpawnedTask;
 
     fn sleep(&self, duration: Duration) -> TaskFuture;
@@ -127,22 +121,20 @@ static ASYNC_RUNTIME_IMPLEMENTATION: OnceLock<Arc<dyn AsyncRuntime>> = OnceLock:
 /// # Returns
 ///  An instance of a [`AsyncRuntime`] which can be used to spawn background tasks or perform other asynchronous operations.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use typespec_client_core::async_runtime::get_async_runtime;
-/// use futures::FutureExt;
 ///
-/// #[tokio::main]
-/// async fn main() {
-///   let async_runtime = get_async_runtime();
-///   let handle = async_runtime.spawn(async {
-///     // Simulate some work
-///     std::thread::sleep(std::time::Duration::from_secs(1));
-///   }.boxed());
-/// }
+/// # #[tokio::main]
+/// # async fn main() {
+/// let async_runtime = get_async_runtime();
+/// let handle = async_runtime.spawn(Box::pin(async {
+///   // Simulate some work
+///   std::thread::sleep(std::time::Duration::from_secs(1));
+/// }));
+/// # }
 /// ```
-///
 pub fn get_async_runtime() -> Arc<dyn AsyncRuntime> {
     ASYNC_RUNTIME_IMPLEMENTATION
         .get_or_init(|| create_async_runtime())
@@ -158,7 +150,7 @@ pub fn get_async_runtime() -> Arc<dyn AsyncRuntime> {
 /// # Returns
 ///  Ok if the async runtime was set successfully, or an error if it has already been set.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use typespec_client_core::async_runtime::{
@@ -193,7 +185,7 @@ pub fn set_async_runtime(runtime: Arc<dyn AsyncRuntime>) -> crate::Result<()> {
 }
 
 fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
-    #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
+    #[cfg(all(target_arch = "wasm32", feature = "wasm_bindgen"))]
     {
         Arc::new(web_runtime::WasmBindgenRuntime) as Arc<dyn AsyncRuntime>
     }
@@ -201,8 +193,12 @@ fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
     {
         Arc::new(tokio_runtime::TokioRuntime) as Arc<dyn AsyncRuntime>
     }
-    #[cfg(not(any(feature = "tokio", feature = "wasm-bindgen")))]
+    #[cfg(not(any(feature = "tokio", feature = "wasm_bindgen")))]
     {
         Arc::new(standard_runtime::StdRuntime)
+    }
+    #[cfg(all(target_arch = "wasm32", not(feature = "wasm_bindgen")))]
+    {
+        panic!("no async runtime available")
     }
 }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -195,10 +195,6 @@ fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
     }
     #[cfg(not(any(feature = "tokio", feature = "wasm_bindgen")))]
     {
-        Arc::new(standard_runtime::StdRuntime)
-    }
-    #[cfg(all(target_arch = "wasm32", not(feature = "wasm_bindgen")))]
-    {
-        panic!("no async runtime available")
+        Arc::new(standard_runtime::StdRuntime) as Arc<dyn AsyncRuntime>
     }
 }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -42,7 +42,7 @@ mod standard_runtime;
 #[cfg(feature = "tokio")]
 mod tokio_runtime;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 mod web_runtime;
 
 #[cfg(test)]

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -42,6 +42,9 @@ mod standard_runtime;
 #[cfg(feature = "tokio")]
 mod tokio_runtime;
 
+#[cfg(target_arch = "wasm32")]
+mod web_runtime;
+
 #[cfg(test)]
 mod tests;
 
@@ -108,7 +111,7 @@ pub trait AsyncRuntime: Send + Sync {
     ///
     fn spawn(&self, f: TaskFuture) -> SpawnedTask;
 
-    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+    fn sleep(&self, duration: Duration) -> TaskFuture;
 }
 
 static ASYNC_RUNTIME_IMPLEMENTATION: OnceLock<Arc<dyn AsyncRuntime>> = OnceLock::new();
@@ -190,12 +193,16 @@ pub fn set_async_runtime(runtime: Arc<dyn AsyncRuntime>) -> crate::Result<()> {
 }
 
 fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
-    #[cfg(not(feature = "tokio"))]
+    #[cfg(target_arch = "wasm32")]
     {
-        Arc::new(standard_runtime::StdRuntime)
+        Arc::new(web_runtime::WebRuntime) as Arc<dyn AsyncRuntime>
     }
     #[cfg(feature = "tokio")]
     {
         Arc::new(tokio_runtime::TokioRuntime) as Arc<dyn AsyncRuntime>
+    }
+    #[cfg(not(any(feature = "tokio", target_arch = "wasm32")))]
+    {
+        Arc::new(standard_runtime::StdRuntime)
     }
 }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -42,7 +42,7 @@ mod standard_runtime;
 #[cfg(feature = "tokio")]
 mod tokio_runtime;
 
-#[cfg(feature = "wasm-bindgen")]
+#[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
 mod web_runtime;
 
 #[cfg(test)]
@@ -193,7 +193,7 @@ pub fn set_async_runtime(runtime: Arc<dyn AsyncRuntime>) -> crate::Result<()> {
 }
 
 fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
-    #[cfg(feature = "wasm-bindgen")]
+    #[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
     {
         Arc::new(web_runtime::WasmBindgenRuntime) as Arc<dyn AsyncRuntime>
     }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -193,7 +193,7 @@ pub fn set_async_runtime(runtime: Arc<dyn AsyncRuntime>) -> crate::Result<()> {
 }
 
 fn create_async_runtime() -> Arc<dyn AsyncRuntime> {
-    #[cfg(all(feature = "wasm-bindgen", target_arch = "wasm32"))]
+    #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))]
     {
         Arc::new(web_runtime::WasmBindgenRuntime) as Arc<dyn AsyncRuntime>
     }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/standard_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/standard_runtime.rs
@@ -149,7 +149,7 @@ impl AsyncRuntime for StdRuntime {
     /// Uses a simple thread based implementation for sleep. A more efficient
     /// implementation is available by using the `tokio` crate feature.
     #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
-    fn sleep(&self, duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+    fn sleep(&self, duration: Duration) -> TaskFuture {
         #[cfg(target_arch = "wasm32")]
         {
             panic!("sleep is not supported on wasm32")

--- a/sdk/typespec/typespec_client_core/src/async_runtime/standard_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/standard_runtime.rs
@@ -14,6 +14,7 @@ use std::{
     task::{Context, Poll, Waker},
     thread,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use std::{future::Future, pin::Pin};
 #[cfg(not(target_arch = "wasm32"))]
 use tracing::debug;

--- a/sdk/typespec/typespec_client_core/src/async_runtime/tests.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/tests.rs
@@ -3,9 +3,12 @@
 
 use super::*;
 use crate::time::Duration;
-use futures::FutureExt;
 use std::sync::{Arc, Mutex};
 
+#[cfg(not(feature = "wasm-bindgen"))]
+use futures::FutureExt;
+
+#[cfg(not(any(feature = "tokio", feature = "wasm-bindgen")))]
 #[test]
 fn test_task_spawner_execution() {
     let runtime = get_async_runtime();
@@ -123,6 +126,7 @@ async fn tokio_task_execution() {
 
 // When the "tokio" feature is enabled, the azure_core::sleep::sleep function uses tokio::time::sleep which requires a tokio runtime.
 // When the "tokio" feature is not enabled, it uses std::thread::sleep which does not require a tokio runtime.
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn std_specific_handling() {
     let spawner = Arc::new(standard_runtime::StdRuntime);
@@ -143,6 +147,7 @@ fn std_specific_handling() {
 }
 
 #[test]
+#[cfg(not(target_arch = "wasm32"))]
 fn std_multiple_tasks() {
     let spawner = Arc::new(standard_runtime::StdRuntime);
     let counter = Arc::new(Mutex::new(0));
@@ -171,6 +176,7 @@ fn std_multiple_tasks() {
 
 // When the "tokio" feature is enabled, the azure_core::sleep::sleep function uses tokio::time::sleep which requires a tokio runtime.
 // When the "tokio" feature is not enabled, it uses std::thread::sleep which does not require a tokio runtime.
+#[cfg(not(any(feature = "tokio", feature = "wasm-bindgen")))]
 #[test]
 fn std_task_execution() {
     let runtime = Arc::new(standard_runtime::StdRuntime);
@@ -197,6 +203,7 @@ fn std_task_execution() {
 // Basic test that launches 10k futures and waits for them to complete:
 // it has a high chance of failing if there is a race condition in the sleep method;
 // otherwise, it runs quickly.
+#[cfg(not(any(feature = "tokio", feature = "wasm-bindgen")))]
 #[tokio::test]
 async fn test_timeout() {
     use super::*;
@@ -223,6 +230,7 @@ async fn test_timeout() {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[tokio::test]
 async fn test_sleep() {
     let runtime = get_async_runtime();
@@ -230,6 +238,37 @@ async fn test_sleep() {
     runtime.sleep(Duration::milliseconds(100)).await;
     let elapsed = start.elapsed();
     assert!(elapsed >= Duration::milliseconds(100));
+}
+
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen_test::*;
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen_test]
+async fn test_sleep() {
+    let runtime = get_async_runtime();
+    runtime.sleep(Duration::milliseconds(100)).await;
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen_test]
+async fn wasm_bindgen_task_execution() {
+    let spawner = Arc::new(web_runtime::WasmBindgenRuntime);
+    let result = Arc::new(Mutex::new(false));
+    let result_clone = Arc::clone(&result);
+
+    let handle = spawner.spawn(Box::pin(async move {
+        // Simulate some work
+        crate::sleep::sleep(Duration::milliseconds(50)).await;
+        let mut value = result_clone.lock().unwrap();
+        *value = true;
+    }));
+
+    // Wait for task completion
+    handle.await.expect("Task should complete successfully");
+
+    // Verify the task executed
+    assert!(*result.lock().unwrap());
 }
 
 #[test]
@@ -245,7 +284,7 @@ impl AsyncRuntime for TestRuntime {
         unimplemented!("TestRuntime does not support spawning tasks");
     }
 
-    fn sleep(&self, _duration: Duration) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> {
+    fn sleep(&self, _duration: Duration) -> TaskFuture {
         unimplemented!("TestRuntime does not support sleeping");
     }
 }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
@@ -3,7 +3,6 @@
 
 use super::{AsyncRuntime, SpawnedTask, TaskFuture};
 use crate::time::Duration;
-use std::pin::Pin;
 
 /// An [`AsyncRuntime`] using `tokio` based APIs.
 pub(crate) struct WebRuntime;

--- a/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
@@ -29,7 +29,6 @@ impl AsyncRuntime for WasmBindgenRuntime {
                 gloo_timers::future::sleep(d).await;
             } else {
                 // This means the duration is negative, don't sleep at all.
-                return;
             }
         })
     }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
@@ -6,9 +6,9 @@ use crate::time::Duration;
 use futures::channel::oneshot;
 
 /// An [`AsyncRuntime`] using `tokio` based APIs.
-pub(crate) struct WebRuntime;
+pub(crate) struct WasmBindgenRuntime;
 
-impl AsyncRuntime for WebRuntime {
+impl AsyncRuntime for WasmBindgenRuntime {
     fn spawn(&self, f: TaskFuture) -> SpawnedTask {
         let (tx, rx) = oneshot::channel();
 

--- a/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
@@ -17,7 +17,10 @@ impl AsyncRuntime for WebRuntime {
             let _ = tx.send(result);
         });
 
-        Box::pin(async { Ok(rx.await?) })
+        Box::pin(async {
+            rx.await
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+        })
     }
 
     fn sleep(&self, duration: Duration) -> TaskFuture {

--- a/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+use super::{AsyncRuntime, SpawnedTask, TaskFuture};
+use crate::time::Duration;
+use std::pin::Pin;
+
+/// An [`AsyncRuntime`] using `tokio` based APIs.
+pub(crate) struct WebRuntime;
+
+impl AsyncRuntime for WebRuntime {
+    fn spawn(&self, f: TaskFuture) -> SpawnedTask {
+        Box::pin(async {
+            wasm_bindgen_futures::spawn_local(f);
+            Ok(())
+        })
+    }
+
+    fn sleep(&self, duration: Duration) -> TaskFuture {
+        Box::pin(async move {
+            if let Ok(d) = duration.try_into() {
+                gloo_timers::future::sleep(d).await;
+            } else {
+                // This means the duration is negative, don't sleep at all.
+                return;
+            }
+        })
+    }
+}

--- a/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/web_runtime.rs
@@ -5,7 +5,7 @@ use super::{AsyncRuntime, SpawnedTask, TaskFuture};
 use crate::time::Duration;
 use futures::channel::oneshot;
 
-/// An [`AsyncRuntime`] using `tokio` based APIs.
+/// An [`AsyncRuntime`] using `wasm-bindgen-futures` for task spawning and `gloo-timers` for sleep functionality.
 pub(crate) struct WasmBindgenRuntime;
 
 impl AsyncRuntime for WasmBindgenRuntime {

--- a/sdk/typespec/typespec_client_core/src/fmt.rs
+++ b/sdk/typespec/typespec_client_core/src/fmt.rs
@@ -90,6 +90,7 @@ pub mod as_string {
     }
 }
 
+#[cfg(feature = "json")]
 #[cfg(test)]
 mod tests {
     use crate::json::{from_json, to_json};

--- a/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
@@ -239,7 +239,8 @@ mod test {
         status: StatusCode,
     }
 
-    #[async_trait]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
     impl Policy for StatusResponder {
         async fn send(&self, _: &Context, _: &mut Request, _: &[Arc<dyn Policy>]) -> PolicyResult {
             let mut count = self.request_count.lock().unwrap();

--- a/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/policies/retry/mod.rs
@@ -89,7 +89,8 @@ impl Deref for RetryPolicyCount {
 ///
 /// `wait` can be implemented in more complex cases where a simple test of time
 /// is not enough.
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait RetryPolicy: std::fmt::Debug + Send + Sync {
     /// Determine if no more retries should be performed.
     ///

--- a/sdk/typespec/typespec_client_core/src/sleep.rs
+++ b/sdk/typespec/typespec_client_core/src/sleep.rs
@@ -34,7 +34,7 @@ pub async fn sleep(duration: Duration) {
 
 #[cfg(target_family = "wasm")]
 pub async fn sleep(duration: Duration) {
-    if let Ok(d) = duration.try_into::<std::time::Duration>() {
+    if let Ok(d) = duration.try_into() {
         gloo_timers::future::sleep(d).await;
     } else {
         // This means the duration is negative, don't sleep at all.

--- a/sdk/typespec/typespec_client_core/src/sleep.rs
+++ b/sdk/typespec/typespec_client_core/src/sleep.rs
@@ -3,12 +3,9 @@
 
 //! Sleep functions.
 
+use crate::async_runtime::get_async_runtime;
 use crate::time::Duration;
 
-#[cfg(not(target_family = "wasm"))]
-use crate::async_runtime::get_async_runtime;
-
-#[cfg(not(target_family = "wasm"))]
 /// Sleeps for the specified duration using the configured async runtime.
 ///
 /// # Arguments
@@ -30,14 +27,4 @@ use crate::async_runtime::get_async_runtime;
 /// ```
 pub async fn sleep(duration: Duration) {
     get_async_runtime().sleep(duration).await
-}
-
-#[cfg(target_family = "wasm")]
-pub async fn sleep(duration: Duration) {
-    if let Ok(d) = duration.try_into() {
-        gloo_timers::future::sleep(d).await;
-    } else {
-        // This means the duration is negative, don't sleep at all.
-        return;
-    }
 }

--- a/sdk/typespec/typespec_client_core/src/sleep.rs
+++ b/sdk/typespec/typespec_client_core/src/sleep.rs
@@ -13,16 +13,17 @@ use crate::{async_runtime::get_async_runtime, time::Duration};
 /// # Returns
 /// A future that resolves when the sleep duration has elapsed.
 ///
-/// # Example
-/// ```
+/// # Examples
+///
+/// ``` no_run
 /// use typespec_client_core::{sleep, time::Duration};
 ///
-/// #[tokio::main]
-/// async fn main() {
-///     // Sleep for 1 second
-///     sleep(Duration::seconds(1)).await;
-///     println!("Slept for 1 second");
-/// }
+/// # #[tokio::main]
+/// # async fn main() {
+/// // Sleep for 1 second
+/// sleep(Duration::seconds(1)).await;
+/// println!("Slept for 1 second");
+/// # }
 /// ```
 pub async fn sleep(duration: Duration) {
     get_async_runtime().sleep(duration).await

--- a/sdk/typespec/typespec_client_core/src/sleep.rs
+++ b/sdk/typespec/typespec_client_core/src/sleep.rs
@@ -3,8 +3,7 @@
 
 //! Sleep functions.
 
-use crate::async_runtime::get_async_runtime;
-use crate::time::Duration;
+use crate::{async_runtime::get_async_runtime, time::Duration};
 
 /// Sleeps for the specified duration using the configured async runtime.
 ///

--- a/sdk/typespec/typespec_client_core/src/sleep.rs
+++ b/sdk/typespec/typespec_client_core/src/sleep.rs
@@ -3,7 +3,10 @@
 
 //! Sleep functions.
 
-use crate::{async_runtime::get_async_runtime, time::Duration};
+use crate::time::Duration;
+
+#[cfg(not(target_family = "wasm"))]
+use crate::async_runtime::get_async_runtime;
 
 #[cfg(not(target_family = "wasm"))]
 /// Sleeps for the specified duration using the configured async runtime.

--- a/sdk/typespec/typespec_client_core/src/sleep.rs
+++ b/sdk/typespec/typespec_client_core/src/sleep.rs
@@ -34,5 +34,10 @@ pub async fn sleep(duration: Duration) {
 
 #[cfg(target_family = "wasm")]
 pub async fn sleep(duration: Duration) {
-    gloo_timers::future::sleep(duration.try_into().unwrap()).await;
+    if let Ok(d) = duration.try_into::<std::time::Duration>() {
+        gloo_timers::future::sleep(d).await;
+    } else {
+        // This means the duration is negative, don't sleep at all.
+        return;
+    }
 }

--- a/sdk/typespec/typespec_client_core/src/sleep.rs
+++ b/sdk/typespec/typespec_client_core/src/sleep.rs
@@ -5,6 +5,7 @@
 
 use crate::{async_runtime::get_async_runtime, time::Duration};
 
+#[cfg(not(target_family = "wasm"))]
 /// Sleeps for the specified duration using the configured async runtime.
 ///
 /// # Arguments
@@ -26,4 +27,9 @@ use crate::{async_runtime::get_async_runtime, time::Duration};
 /// ```
 pub async fn sleep(duration: Duration) {
     get_async_runtime().sleep(duration).await
+}
+
+#[cfg(target_family = "wasm")]
+pub async fn sleep(duration: Duration) {
+    gloo_timers::future::sleep(duration.try_into().unwrap()).await;
 }

--- a/sdk/typespec/typespec_client_core/src/time/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/time/mod.rs
@@ -138,6 +138,7 @@ pub fn diff(first: OffsetDateTime, second: OffsetDateTime) -> Duration {
     (first - second).abs()
 }
 
+#[cfg(feature = "json")]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/sdk/typespec/typespec_client_core/src/time/unix_time.rs
+++ b/sdk/typespec/typespec_client_core/src/time/unix_time.rs
@@ -58,6 +58,7 @@ pub mod option {
     }
 }
 
+#[cfg(feature = "json")]
 #[cfg(test)]
 mod tests {
     use crate::json::{from_json, to_json};


### PR DESCRIPTION
The `typespec_client_core::sleep::sleep` is using the async_runtime's sleep implementation, which is complicated to support `wasm32`, and will panic now when targeting to `wasm32`. Instead of make the `standard_runtime` to support wasm32 sleep (I wonder if it's feasible), we can instead just introduce another `sleep` implementation to simply use the `gloo_timers::future::sleep`.

Also, this PR adds a `cfg_attr` for conditionally remove the `Send` trait from the `async_trait` for the `RetryPolicy`, as the other parts of the code do.

Fix #2754
Supersedes: https://github.com/Azure/azure-sdk-for-rust/pull/2770

## Test

```
sdk/typespec/typespec_client_core on  wasm_sleep is 📦 v0.6.0 via 🦀 v1.88.0
💤  cargo test -q

running 90 tests
i.................................................................i.................... 87/90
...
test result: ok. 88 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.84s


running 23 tests
.......................
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.27s


sdk/typespec/typespec_client_core on  wasm_sleep is 📦 v0.6.0 via 🦀 v1.88.0 took 4s
💤  cargo test --features=tokio -q

running 91 tests
i.....................................................................i................ 87/91
....
test result: ok. 89 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.10s


running 23 tests
.......................
test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.21s


sdk/typespec/typespec_client_core on  wasm_sleep is 📦 v0.6.0 via 🦀 v1.88.0 took 3s
💤  RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --node --features wasm-bindgen
[INFO]: 🎯  Checking for the Wasm target...
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
[INFO]: ⬇️   Installing wasm-bindgen...
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running unittests src/lib.rs (/home/magodo/github/azure-sdk-for-rust/target/wasm32-unknown-unknown/debug/deps/typespec_client_core-365ee3948d4ee278.wasm)
running 2 tests
test async_runtime::tests::wasm_bindgen_task_execution ... ok
test async_runtime::tests::test_sleep ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.17s
```

Some note about the wasm32 test:

- We can't run the spawned job using `futures::executor::block_on(handle)`, as it introduces a deadlock in browser (since the `block_on` blocks the current thread)
- The sleep test I can't use `Instant::now()` when using `node` as runtime