### PR TITLE
Remove CertificateClientExt and impl directly on CertificateClient

### DIFF
--- a/sdk/core/azure_core/README.md
+++ b/sdk/core/azure_core/README.md
@@ -254,7 +254,7 @@ The `Poller<T>` implements `futures::Stream` so you can asynchronously iterate o
 ```rust no_run
 use azure_identity::DefaultAzureCredential;
 use azure_security_keyvault_certificates::{
-    CertificateClient, CertificateClientExt,
+    CertificateClient,
     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
 };
 use futures::stream::TryStreamExt as _;
@@ -310,7 +310,7 @@ If you just want to wait until the `Poller<T>` is complete and get the last stat
 ```rust no_run
 use azure_identity::DefaultAzureCredential;
 use azure_security_keyvault_certificates::{
-    CertificateClient, CertificateClientExt,
+    CertificateClient,
     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
 };
 

--- a/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Breaking Changes
 
+- Removed the `CertificateClientExt` trait for `CertificateClient`. The `begin_create_certificate` and `resume_certificate_operation` methods are implemented for `CertificateClient` with the same method signatures.
+
 ### Bugs Fixed
 
 ### Other Changes

--- a/sdk/keyvault/azure_security_keyvault_certificates/README.md
+++ b/sdk/keyvault/azure_security_keyvault_certificates/README.md
@@ -83,7 +83,7 @@ Before we can create a new certificate, though, we need to define a certificate 
 ```rust no_run
 use azure_identity::DefaultAzureCredential;
 use azure_security_keyvault_certificates::{
-    CertificateClient, CertificateClientExt,
+    CertificateClient,
     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
 };
 use futures::stream::TryStreamExt as _;
@@ -139,7 +139,7 @@ If you just want to wait until the `Poller<CertificateOperation>` is complete an
 ```rust no_run
 use azure_identity::DefaultAzureCredential;
 use azure_security_keyvault_certificates::{
-    CertificateClient, CertificateClientExt,
+    CertificateClient,
     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
 };
 
@@ -333,7 +333,7 @@ use azure_security_keyvault_certificates::{
         CertificatePolicy, CreateCertificateParameters, CurveName, IssuerParameters, KeyProperties,
         KeyType, KeyUsageType, X509CertificateProperties,
     },
-    CertificateClient, CertificateClientExt, ResourceExt, ResourceId,
+    CertificateClient, ResourceExt, ResourceId,
 };
 use azure_security_keyvault_keys::{
     models::{SignParameters, SignatureAlgorithm},

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/clients.rs
@@ -15,7 +15,7 @@ use azure_core::{
     json, Result,
 };
 
-pub trait CertificateClientExt: private::Sealed {
+impl CertificateClient {
     /// Creates a new certificate and returns a [`Poller<CertificateOperation>`] to monitor the status.
     ///
     /// If this is the first version, the certificate resource is created. This operation requires the certificates/create permission.
@@ -32,7 +32,7 @@ pub trait CertificateClientExt: private::Sealed {
     /// ```no_run
     /// use azure_identity::DefaultAzureCredential;
     /// use azure_security_keyvault_certificates::{
-    ///     CertificateClient, CertificateClientExt,
+    ///     CertificateClient,
     ///     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
     /// };
     ///
@@ -77,86 +77,7 @@ pub trait CertificateClientExt: private::Sealed {
     ///
     /// # Ok(()) }
     /// ```
-    fn begin_create_certificate(
-        &self,
-        certificate_name: &str,
-        parameters: RequestContent<CreateCertificateParameters>,
-        options: Option<CertificateClientBeginCreateCertificateOptions<'_>>,
-    ) -> Result<Poller<CertificateOperation>>;
-
-    /// Resumes the [`CertificateClientExt::begin_create_certificate`] operation by returning a [`Poller<CertificateOperation>`] already in progress or completed.
-    ///
-    /// Gets the creation operation associated with a specified certificate. This operation requires the certificates/get permission.
-    ///
-    /// # Arguments
-    ///
-    /// * `certificate_name` - The name of the certificate.
-    /// * `options` - Optional parameters for the request.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use azure_identity::DefaultAzureCredential;
-    /// use azure_security_keyvault_certificates::{
-    ///     CertificateClient, CertificateClientExt,
-    ///     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
-    /// };
-    ///
-    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let credential = DefaultAzureCredential::new()?;
-    /// let client = CertificateClient::new(
-    ///     "https://your-key-vault-name.vault.azure.net/",
-    ///     credential.clone(),
-    ///     None,
-    /// )?;
-    ///
-    /// // Create a self-signed certificate.
-    /// let policy = CertificatePolicy {
-    ///     x509_certificate_properties: Some(X509CertificateProperties {
-    ///         subject: Some("CN=DefaultPolicy".into()),
-    ///         ..Default::default()
-    ///     }),
-    ///     issuer_parameters: Some(IssuerParameters {
-    ///         name: Some("Self".into()),
-    ///         ..Default::default()
-    ///     }),
-    ///     ..Default::default()
-    /// };
-    /// let body = CreateCertificateParameters {
-    ///     certificate_policy: Some(policy),
-    ///     ..Default::default()
-    /// };
-    ///
-    /// // Wait for the certificate operation to complete and get the last status monitor.
-    /// let operation = client
-    ///     .resume_certificate_operation("certificate-name",  None)?
-    ///     .wait()
-    ///     .await?
-    ///     // Deserialize the CertificateOperation:
-    ///     .into_body()
-    ///     .await?;
-    ///
-    /// if matches!(operation.status, Some(status) if status == "completed") {
-    ///     let target = operation.target.ok_or("expected target")?;
-    ///     println!("Created certificate {}", target);
-    /// }
-    ///
-    /// # Ok(()) }
-    /// ```
-    fn resume_certificate_operation(
-        &self,
-        certificate_name: &str,
-        options: Option<CertificateClientResumeCertificateOperationOptions<'_>>,
-    ) -> Result<Poller<CertificateOperation>>;
-}
-
-mod private {
-    pub trait Sealed {}
-    impl Sealed for super::CertificateClient {}
-}
-
-impl CertificateClientExt for CertificateClient {
-    fn begin_create_certificate(
+    pub fn begin_create_certificate(
         &self,
         certificate_name: &str,
         parameters: RequestContent<CreateCertificateParameters>,
@@ -235,7 +156,66 @@ impl CertificateClientExt for CertificateClient {
         ))
     }
 
-    fn resume_certificate_operation(
+    /// Resumes the [`CertificateClient::begin_create_certificate`] operation by returning a [`Poller<CertificateOperation>`] already in progress or completed.
+    ///
+    /// Gets the creation operation associated with a specified certificate. This operation requires the certificates/get permission.
+    ///
+    /// # Arguments
+    ///
+    /// * `certificate_name` - The name of the certificate.
+    /// * `options` - Optional parameters for the request.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use azure_identity::DefaultAzureCredential;
+    /// use azure_security_keyvault_certificates::{
+    ///     CertificateClient,
+    ///     models::{CreateCertificateParameters, CertificatePolicy, X509CertificateProperties, IssuerParameters},
+    /// };
+    ///
+    /// # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let credential = DefaultAzureCredential::new()?;
+    /// let client = CertificateClient::new(
+    ///     "https://your-key-vault-name.vault.azure.net/",
+    ///     credential.clone(),
+    ///     None,
+    /// )?;
+    ///
+    /// // Create a self-signed certificate.
+    /// let policy = CertificatePolicy {
+    ///     x509_certificate_properties: Some(X509CertificateProperties {
+    ///         subject: Some("CN=DefaultPolicy".into()),
+    ///         ..Default::default()
+    ///     }),
+    ///     issuer_parameters: Some(IssuerParameters {
+    ///         name: Some("Self".into()),
+    ///         ..Default::default()
+    ///     }),
+    ///     ..Default::default()
+    /// };
+    /// let body = CreateCertificateParameters {
+    ///     certificate_policy: Some(policy),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// // Wait for the certificate operation to complete and get the last status monitor.
+    /// let operation = client
+    ///     .resume_certificate_operation("certificate-name",  None)?
+    ///     .wait()
+    ///     .await?
+    ///     // Deserialize the CertificateOperation:
+    ///     .into_body()
+    ///     .await?;
+    ///
+    /// if matches!(operation.status, Some(status) if status == "completed") {
+    ///     let target = operation.target.ok_or("expected target")?;
+    ///     println!("Created certificate {}", target);
+    /// }
+    ///
+    /// # Ok(()) }
+    /// ```
+    pub fn resume_certificate_operation(
         &self,
         certificate_name: &str,
         options: Option<CertificateClientResumeCertificateOperationOptions<'_>>,

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/lib.rs
@@ -9,5 +9,5 @@ mod generated;
 pub mod models;
 mod resource;
 
-pub use clients::{CertificateClient, CertificateClientExt, CertificateClientOptions};
+pub use clients::{CertificateClient, CertificateClientOptions};
 pub use resource::*;

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/models.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/models.rs
@@ -19,7 +19,7 @@ impl StatusMonitor for CertificateOperation {
     }
 }
 
-/// Options to be passed to [`CertificateClientExt::begin_create_certificate()`](crate::clients::CertificateClientExt::begin_create_certificate())
+/// Options to be passed to [`CertificateClient::begin_create_certificate()`](crate::clients::CertificateClient::begin_create_certificate())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CertificateClientBeginCreateCertificateOptions<'a> {
     /// Allows customization of the method call.
@@ -40,7 +40,7 @@ impl CertificateClientBeginCreateCertificateOptions<'_> {
     }
 }
 
-/// Options to be passed to [`CertificateClientExt::resume_certificate_operation()`](crate::clients::CertificateClientExt::resume_certificate_operation())
+/// Options to be passed to [`CertificateClient::resume_certificate_operation()`](crate::clients::CertificateClient::resume_certificate_operation())
 #[derive(Clone, Default, SafeDebug)]
 pub struct CertificateClientResumeCertificateOperationOptions<'a> {
     /// Allows customization of the method call.

--- a/sdk/keyvault/azure_security_keyvault_certificates/tests/certificate_client.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/tests/certificate_client.rs
@@ -10,7 +10,7 @@ use azure_security_keyvault_certificates::{
         CertificatePolicy, CreateCertificateParameters, CurveName, IssuerParameters, KeyProperties,
         KeyType, UpdateCertificatePropertiesParameters, X509CertificateProperties,
     },
-    CertificateClient, CertificateClientExt as _, CertificateClientOptions, ResourceExt as _,
+    CertificateClient, CertificateClientOptions, ResourceExt as _,
 };
 use azure_security_keyvault_keys::{
     models::{SignParameters, SignatureAlgorithm},


### PR DESCRIPTION
Turns out we don't need extension traits within the same crate. Better discoverability and usage.
