### PR TITLE
Fix clippy 1.90 lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ zerofrom = "0.1.5"
 zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
 
 [workspace.lints.clippy]
+infallible_try_from = "allow"
 large_futures = "deny"
 uninlined_format_args = "allow"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,6 @@ zerofrom = "0.1.5"
 zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
 
 [workspace.lints.clippy]
-infallible_try_from = "allow"
 large_futures = "deny"
 uninlined_format_args = "allow"
 

--- a/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
+++ b/sdk/core/azure_core/src/http/policies/bearer_token_policy.rs
@@ -198,7 +198,11 @@ mod tests {
         let mut req = Request::new("https://localhost".parse().unwrap(), Method::Get);
 
         let err = policy
-            .send(&Context::default(), &mut req, &[transport.clone()])
+            .send(
+                &Context::default(),
+                &mut req,
+                std::slice::from_ref(&(transport.clone() as Arc<dyn Policy>)),
+            )
             .await
             .expect_err("request should fail");
 
@@ -236,7 +240,11 @@ mod tests {
                 let ctx = Context::default();
                 let mut req = Request::new("https://localhost".parse().unwrap(), Method::Get);
                 policy
-                    .send(&ctx, &mut req, &[transport.clone()])
+                    .send(
+                        &ctx,
+                        &mut req,
+                        std::slice::from_ref(&(transport.clone() as Arc<dyn Policy>)),
+                    )
                     .await
                     .expect("successful request");
             });

--- a/sdk/core/azure_core/src/http/policies/instrumentation/public_api_instrumentation.rs
+++ b/sdk/core/azure_core/src/http/policies/instrumentation/public_api_instrumentation.rs
@@ -273,9 +273,9 @@ mod tests {
             }
         }
 
-        if api_information.is_some() {
+        if let Some(api_information) = api_information {
             // If we have public API information, add it to the context.
-            ctx = ctx.with_value(api_information.unwrap());
+            ctx = ctx.with_value(api_information);
         }
         let _result = public_api_policy.send(&ctx, request, &next).await;
 

--- a/sdk/core/azure_core_test/src/proxy/mod.rs
+++ b/sdk/core/azure_core_test/src/proxy/mod.rs
@@ -314,6 +314,7 @@ impl FromStr for RecordingId {
     }
 }
 
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 #[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
 struct Version {
     major: i32,

--- a/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/tests/ownership_unit_tests.rs
+++ b/sdk/eventhubs/azure_messaging_eventhubs_checkpointstore_blob/tests/ownership_unit_tests.rs
@@ -231,7 +231,7 @@ async fn claim_ownership_update_existing(ctx: TestContext) -> Result<()> {
     };
 
     let initial_claimed = checkpoint_store
-        .claim_ownership(&[initial_ownership.clone()])
+        .claim_ownership(std::slice::from_ref(&initial_ownership))
         .await?;
     assert_eq!(initial_claimed.len(), 1);
     let initial_etag = initial_claimed[0].etag.clone();

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -36,7 +36,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-#[cfg_attr(feature = "tokio", allow(dead_code))]
+#[cfg(not(feature = "tokio"))]
 mod standard_runtime;
 
 #[cfg(feature = "tokio")]

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -36,6 +36,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+#[cfg_attr(feature = "tokio", allow(dead_code))]
 mod standard_runtime;
 
 #[cfg(feature = "tokio")]

--- a/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/mod.rs
@@ -36,7 +36,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-#[cfg(not(feature = "tokio"))]
+#[cfg_attr(feature = "tokio", allow(dead_code))]
 mod standard_runtime;
 
 #[cfg(feature = "tokio")]

--- a/sdk/typespec/typespec_client_core/src/async_runtime/standard_runtime.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/standard_runtime.rs
@@ -80,7 +80,6 @@ impl Future for ThreadJoinFuture {
 }
 
 /// An [`AsyncRuntime`] using [`std::thread::spawn`].
-#[allow(dead_code)]
 pub(crate) struct StdRuntime;
 
 impl AsyncRuntime for StdRuntime {
@@ -163,9 +162,9 @@ impl AsyncRuntime for StdRuntime {
     }
 }
 
-#[derive(Debug)]
 #[cfg(not(target_arch = "wasm32"))]
-pub struct Sleep {
+#[derive(Debug)]
+struct Sleep {
     signal: Option<Arc<AtomicBool>>,
     duration: Duration,
 }

--- a/sdk/typespec/typespec_client_core/src/async_runtime/tests.rs
+++ b/sdk/typespec/typespec_client_core/src/async_runtime/tests.rs
@@ -6,7 +6,6 @@ use crate::time::Duration;
 use futures::FutureExt;
 use std::sync::{Arc, Mutex};
 
-#[cfg(not(feature = "tokio"))]
 #[test]
 fn test_task_spawner_execution() {
     let runtime = get_async_runtime();
@@ -172,7 +171,6 @@ fn std_multiple_tasks() {
 
 // When the "tokio" feature is enabled, the azure_core::sleep::sleep function uses tokio::time::sleep which requires a tokio runtime.
 // When the "tokio" feature is not enabled, it uses std::thread::sleep which does not require a tokio runtime.
-#[cfg(not(feature = "tokio"))]
 #[test]
 fn std_task_execution() {
     let runtime = Arc::new(standard_runtime::StdRuntime);
@@ -199,7 +197,6 @@ fn std_task_execution() {
 // Basic test that launches 10k futures and waits for them to complete:
 // it has a high chance of failing if there is a race condition in the sleep method;
 // otherwise, it runs quickly.
-#[cfg(not(feature = "tokio"))]
 #[tokio::test]
 async fn test_timeout() {
     use super::*;

--- a/sdk/typespec/typespec_client_core/src/http/request/mod.rs
+++ b/sdk/typespec/typespec_client_core/src/http/request/mod.rs
@@ -321,6 +321,10 @@ impl<T, F> TryFrom<&'static str> for RequestContent<T, F> {
     }
 }
 
+#[allow(
+    clippy::infallible_try_from,
+    reason = "maintain a consistent pattern of `try_into()`"
+)]
 impl<F> TryFrom<bool> for RequestContent<bool, F> {
     type Error = Infallible;
     fn try_from(body: bool) -> Result<Self, Infallible> {
@@ -349,6 +353,10 @@ mod decimal {
     use super::*;
     use rust_decimal::Decimal;
 
+    #[allow(
+        clippy::infallible_try_from,
+        reason = "maintain a consistent pattern of `try_into()`"
+    )]
     impl<T, F> TryFrom<Decimal> for RequestContent<T, F> {
         type Error = Infallible;
         fn try_from(value: Decimal) -> Result<Self, Infallible> {
@@ -359,6 +367,10 @@ mod decimal {
         }
     }
 
+    #[allow(
+        clippy::infallible_try_from,
+        reason = "maintain a consistent pattern of `try_into()`"
+    )]
     impl<T, F> TryFrom<Option<Decimal>> for RequestContent<T, F> {
         type Error = Infallible;
         fn try_from(value: Option<Decimal>) -> Result<Self, Infallible> {


### PR DESCRIPTION
After update to `+nightly` clippy 0.1.90 (7d82b83ed5 2025-08-06) we discovered a few more lints.
