### PR TITLE
Add Context::to_borrowed

### DIFF
--- a/sdk/core/azure_core_test/src/proxy/client.rs
+++ b/sdk/core/azure_core_test/src/proxy/client.rs
@@ -14,7 +14,7 @@ use azure_core::{
     http::{
         headers::{AsHeaders, ACCEPT, CONTENT_TYPE},
         request::{Request, RequestContent},
-        ClientMethodOptions, ClientOptions, Context, Method, Pipeline, Response, Url,
+        ClientMethodOptions, ClientOptions, Method, Pipeline, Response, Url,
     },
     Bytes, Result,
 };
@@ -56,7 +56,7 @@ impl Client {
         options: Option<ClientRecordStartOptions<'_>>,
     ) -> Result<RecordStartResult> {
         let options = options.unwrap_or_default();
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Record/Start")?;
         let mut request = Request::new(url, Method::Post);
@@ -77,7 +77,7 @@ impl Client {
         options: Option<ClientRecordStopOptions<'_>>,
     ) -> Result<()> {
         let options = options.unwrap_or_default();
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Record/Stop")?;
         let mut request = Request::new(url, Method::Post);
@@ -100,7 +100,7 @@ impl Client {
             stringify!(recording_id),
             options.recording_id.map(AsRef::as_ref),
         );
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Playback/Start")?;
         let mut request = Request::new(url, Method::Post);
@@ -123,7 +123,7 @@ impl Client {
         options: Option<ClientPlaybackStopOptions<'_>>,
     ) -> Result<()> {
         let options = options.unwrap_or_default();
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Playback/Stop")?;
         let mut request = Request::new(url, Method::Post);
@@ -145,7 +145,7 @@ impl Client {
             stringify!(recording_id),
             options.recording_id.map(AsRef::as_ref),
         );
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/SetMatcher")?;
         let mut request = Request::new(url, Method::Post);
@@ -174,7 +174,7 @@ impl Client {
             stringify!(recording_id),
             options.recording_id.map(AsRef::as_ref),
         );
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/AddSanitizer")?;
         let mut request = Request::new(url, Method::Post);
@@ -197,7 +197,7 @@ impl Client {
             stringify!(recording_id),
             options.recording_id.map(AsRef::as_ref),
         );
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/RemoveSanitizers")?;
         let mut request = Request::new(url, Method::Post);
@@ -220,7 +220,7 @@ impl Client {
             stringify!(recording_id),
             options.recording_id.map(AsRef::as_ref),
         );
-        let ctx = Context::with_context(&options.method_options.context);
+        let ctx = options.method_options.context.to_borrowed();
         let mut url = self.endpoint.clone();
         url = url.join("/Admin/Reset")?;
         let mut request = Request::new(url, Method::Post);

--- a/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
+++ b/sdk/cosmos/azure_data_cosmos/src/query/executor.rs
@@ -79,7 +79,7 @@ impl<T: DeserializeOwned + Send + 'static> QueryExecutor<T> {
                 let query_plan = get_query_plan(
                     &self.http_pipeline,
                     &self.items_link,
-                    Context::with_context(&self.context),
+                    self.context.to_borrowed(),
                     &self.query,
                     self.query_engine.supported_features()?,
                 )
@@ -90,7 +90,7 @@ impl<T: DeserializeOwned + Send + 'static> QueryExecutor<T> {
                 let pkranges = get_pkranges(
                     &self.http_pipeline,
                     &self.container_link,
-                    Context::with_context(&self.context),
+                    self.context.to_borrowed(),
                 )
                 .await?
                 .into_body()
@@ -145,7 +145,7 @@ impl<T: DeserializeOwned + Send + 'static> QueryExecutor<T> {
                 let resp = self
                     .http_pipeline
                     .send_raw(
-                        Context::with_context(&self.context),
+                        self.context.to_borrowed(),
                         &mut query_request,
                         self.items_link.clone(),
                     )

--- a/sdk/keyvault/azure_security_keyvault_certificates/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_certificates/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod clients;
 #[allow(unused_imports)]
+#[expect(deprecated, reason = "requires emitter update")]
 mod generated;
 pub mod models;
 mod resource;

--- a/sdk/keyvault/azure_security_keyvault_keys/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_keys/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![doc = include_str!("../README.md")]
 
+#[expect(deprecated, reason = "requires emitter update")]
 mod generated;
 mod resource;
 

--- a/sdk/keyvault/azure_security_keyvault_secrets/src/lib.rs
+++ b/sdk/keyvault/azure_security_keyvault_secrets/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![doc = include_str!("../README.md")]
 
+#[expect(deprecated, reason = "requires emitter update")]
 mod generated;
 mod resource;
 

--- a/sdk/storage/azure_storage_blob/src/lib.rs
+++ b/sdk/storage/azure_storage_blob/src/lib.rs
@@ -8,6 +8,7 @@
 #![allow(unused_imports)]
 
 pub mod clients;
+#[expect(deprecated, reason = "requires emitter update")]
 mod generated;
 mod parsers;
 mod pipeline;

--- a/sdk/typespec/typespec_client_core/src/http/context.rs
+++ b/sdk/typespec/typespec_client_core/src/http/context.rs
@@ -26,6 +26,7 @@ impl<'a> Context<'a> {
     /// Returns a new `Context` that borrows the type map of the given `context`.
     ///
     /// Once you [`Context::insert`] entities the type map is copied.
+    #[deprecated(since = "0.7.0", note = "use to_borrowed() instead")]
     #[must_use]
     pub fn with_context<'b>(context: &'a Context) -> Context<'b>
     where
@@ -119,6 +120,20 @@ impl<'a> Context<'a> {
         };
         Context {
             type_map: Cow::Owned(type_map),
+        }
+    }
+
+    /// Returns a new `Context` that borrows the type map of the given `context`.
+    ///
+    /// Once you [`Context::insert`] entities the type map is copied.
+    #[must_use]
+    pub fn to_borrowed<'b>(&'a self) -> Context<'b>
+    where
+        'a: 'b,
+    {
+        let type_map = self.type_map.as_ref();
+        Context {
+            type_map: Cow::Borrowed(type_map),
         }
     }
 }
@@ -223,7 +238,7 @@ mod tests {
     #[test]
     fn with_context_borrows() {
         let a = Context::new().with_value("a".to_string());
-        let mut b = Context::with_context(&a);
+        let mut b = a.to_borrowed();
 
         // TODO: Use is_owned(), is_borrowed() once stabilized.
         let a_ptr = std::ptr::addr_of!(*a.type_map);


### PR DESCRIPTION
Resolves #2591, though we need to eventually remove `with_context` so I've added `expect` to crates until we get an emitter fix. As is, this can target `main` for now.
