### PR TITLE
Added ability to test distributed tracing functionality.

### DIFF
--- a/sdk/core/azure_core_opentelemetry/assets.json
+++ b/sdk/core/azure_core_opentelemetry/assets.json
@@ -1,6 +1,6 @@
 {
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
-  "Tag": "rust/azure_core_opentelemetry_2bc5efc404",
+  "Tag": "rust/azure_core_opentelemetry_3a7ac50edd",
   "TagPrefix": "rust/azure_core_opentelemetry"
 }

--- a/sdk/keyvault/assets.json
+++ b/sdk/keyvault/assets.json
@@ -2,5 +2,5 @@
   "AssetsRepo": "Azure/azure-sdk-assets",
   "AssetsRepoPrefixPath": "rust",
   "TagPrefix": "rust/keyvault",
-  "Tag": "rust/keyvault_6c9f540438"
+  "Tag": "rust/keyvault_faa717aa41"
 }


### PR DESCRIPTION
Fixes #2769 - Adds ability to easily test distributed tracing.

Also adds a test example for KeyVault Secrets APIs.
